### PR TITLE
Add support for --column/-c flag everywhere that --format csv is supported

### DIFF
--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -103,11 +103,26 @@ func (c *cmdAliasAdd) run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
+// aliasListEntry represents a row in the alias list output, combining an alias name with its target.
+type aliasListEntry struct {
+	name   string
+	target string
+}
+
 type cmdAliasList struct {
 	global *cmdGlobal
 	alias  *cmdAlias
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for alias list.
+func (c *cmdAliasList) columns() []cli.ShorthandColumn[aliasListEntry] {
+	return []cli.ShorthandColumn[aliasListEntry]{
+		{Shorthand: 'a', Name: "ALIAS", Data: c.aliasColumnData},
+		{Shorthand: 't', Name: "TARGET", Data: c.targetColumnData},
+	}
 }
 
 // Command is a method of the cmdAliasList structure that returns a new cobra Command for listing command aliases.
@@ -119,6 +134,7 @@ func (c *cmdAliasList) command() *cobra.Command {
 	cmd.Short = "List aliases"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -136,20 +152,31 @@ func (c *cmdAliasList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// List the aliases
-	data := [][]string{}
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
+	}
+
+	// List the aliases.
+	entries := make([]aliasListEntry, 0, len(conf.Aliases))
 	for k, v := range conf.Aliases {
-		data = append(data, []string{k, v})
+		entries = append(entries, aliasListEntry{name: k, target: v})
 	}
 
+	data := cli.ColumnData(columns, entries)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"ALIAS",
-		"TARGET",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, conf.Aliases)
+}
+
+func (c *cmdAliasList) aliasColumnData(entry aliasListEntry) string {
+	return entry.name
+}
+
+func (c *cmdAliasList) targetColumnData(entry aliasListEntry) string {
+	return entry.target
 }
 
 // Rename.

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -319,9 +319,19 @@ func (c *cmdGroupEdit) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// cmdGroupList lists authentication groups.
 type cmdGroupList struct {
-	global     *cmdGlobal
-	flagFormat string
+	global      *cmdGlobal
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for auth group list.
+func (c *cmdGroupList) columns() []cli.ShorthandColumn[api.AuthGroup] {
+	return []cli.ShorthandColumn[api.AuthGroup]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+	}
 }
 
 func (c *cmdGroupList) command() *cobra.Command {
@@ -333,6 +343,7 @@ func (c *cmdGroupList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	return cmd
 }
@@ -363,19 +374,25 @@ func (c *cmdGroupList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := [][]string{}
-	for _, group := range groups {
-		data = append(data, []string{group.Name, group.Description})
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, groups)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, groups)
+}
+
+func (c *cmdGroupList) nameColumnData(group api.AuthGroup) string {
+	return group.Name
+}
+
+func (c *cmdGroupList) descriptionColumnData(group api.AuthGroup) string {
+	return group.Description
 }
 
 // Rename.
@@ -998,9 +1015,22 @@ func (c *cmdIdentityCreate) createBearerIdentity(remoteName string, identityName
 	return nil
 }
 
+// cmdIdentityList represents the "lxc auth identity list" command and its output configuration.
 type cmdIdentityList struct {
-	global     *cmdGlobal
-	flagFormat string
+	global      *cmdGlobal
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for identity list.
+func (c *cmdIdentityList) columns() []cli.ShorthandColumn[api.Identity] {
+	return []cli.ShorthandColumn[api.Identity]{
+		{Shorthand: 'a', Name: "AUTHENTICATION METHOD", Data: c.authMethodColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'i', Name: "IDENTIFIER", Data: c.identifierColumnData},
+		{Shorthand: 'g', Name: "GROUPS", Data: c.groupsColumnData},
+	}
 }
 
 func (c *cmdIdentityList) command() *cobra.Command {
@@ -1012,6 +1042,7 @@ func (c *cmdIdentityList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	return cmd
 }
@@ -1042,27 +1073,42 @@ func (c *cmdIdentityList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := [][]string{}
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, identities)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
+
+	return cli.RenderTable(c.flagFormat, header, data, identities)
+}
+
+func (c *cmdIdentityList) authMethodColumnData(identity api.Identity) string {
+	return identity.AuthenticationMethod
+}
+
+func (c *cmdIdentityList) typeColumnData(identity api.Identity) string {
+	return identity.Type
+}
+
+func (c *cmdIdentityList) nameColumnData(identity api.Identity) string {
+	return identity.Name
+}
+
+func (c *cmdIdentityList) identifierColumnData(identity api.Identity) string {
+	return identity.Identifier
+}
+
+func (c *cmdIdentityList) groupsColumnData(identity api.Identity) string {
 	delimiter := "\n"
 	if c.flagFormat == cli.TableFormatCSV {
 		delimiter = ","
 	}
 
-	for _, identity := range identities {
-		data = append(data, []string{identity.AuthenticationMethod, identity.Type, identity.Name, identity.Identifier, strings.Join(identity.Groups, delimiter)})
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"AUTHENTICATION METHOD",
-		"TYPE",
-		"NAME",
-		"IDENTIFIER",
-		"GROUPS",
-	}
-
-	return cli.RenderTable(c.flagFormat, header, data, identities)
+	return strings.Join(identity.Groups, delimiter)
 }
 
 // Show.
@@ -1659,7 +1705,10 @@ type cmdPermissionList struct {
 	global              *cmdGlobal
 	flagMaxEntitlements int
 	flagFormat          string
+	flagColumns         string
 }
+
+const defaultPermissionColumns = "tue"
 
 func (c *cmdPermissionList) command() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -1669,6 +1718,7 @@ func (c *cmdPermissionList) command() *cobra.Command {
 
 	cmd.Flags().IntVar(&c.flagMaxEntitlements, "max-entitlements", 3, "Maximum number of unassigned entitlements to display before overflowing (set to zero to display all)")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", cli.TableFormatTable, "Display format (json, yaml, table, compact, csv)")
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultPermissionColumns, cli.FormatStringFlagLabel("Columns"))
 	cmd.RunE = c.run
 
 	return cmd
@@ -1834,7 +1884,24 @@ func (c *cmdPermissionList) run(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	return cli.RenderSlice(displayPermissions, c.flagFormat, "tue", "u", columns)
+	// Normalize the column specification so comma-separated values like "t,u,e" work,
+	// while rejecting empty entries (e.g. ",t", "t,,u", or trailing commas).
+	if c.flagColumns == "" {
+		return fmt.Errorf("Invalid column list %q: column list must not be empty", c.flagColumns)
+	}
+
+	var b strings.Builder
+	for _, p := range strings.Split(c.flagColumns, ",") {
+		if p == "" {
+			return fmt.Errorf("Invalid column list %q: empty column entry", c.flagColumns)
+		}
+
+		b.WriteString(p)
+	}
+
+	normalizedColumns := b.String()
+
+	return cli.RenderSlice(displayPermissions, c.flagFormat, normalizedColumns, "u", columns)
 }
 
 type cmdIdentityProviderGroup struct {
@@ -2088,9 +2155,19 @@ func (c *cmdIdentityProviderGroupEdit) run(cmd *cobra.Command, args []string) er
 	return nil
 }
 
+// cmdIdentityProviderGroupList implements the "list" subcommand for identity provider groups.
 type cmdIdentityProviderGroupList struct {
-	global     *cmdGlobal
-	flagFormat string
+	global      *cmdGlobal
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for identity provider group list.
+func (c *cmdIdentityProviderGroupList) columns() []cli.ShorthandColumn[api.IdentityProviderGroup] {
+	return []cli.ShorthandColumn[api.IdentityProviderGroup]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'g', Name: "GROUPS", Data: c.groupsColumnData},
+	}
 }
 
 func (c *cmdIdentityProviderGroupList) command() *cobra.Command {
@@ -2102,6 +2179,7 @@ func (c *cmdIdentityProviderGroupList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	return cmd
 }
@@ -2132,19 +2210,30 @@ func (c *cmdIdentityProviderGroupList) run(cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	data := [][]string{}
-	for _, group := range groups {
-		data = append(data, []string{group.Name, strings.Join(group.Groups, "\n")})
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, groups)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"GROUPS",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, groups)
+}
+
+func (c *cmdIdentityProviderGroupList) nameColumnData(group api.IdentityProviderGroup) string {
+	return group.Name
+}
+
+func (c *cmdIdentityProviderGroupList) groupsColumnData(group api.IdentityProviderGroup) string {
+	delimiter := "\n"
+	if c.flagFormat == cli.TableFormatCSV {
+		delimiter = ","
+	}
+
+	return strings.Join(group.Groups, delimiter)
 }
 
 // Rename.

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -422,12 +422,22 @@ func (c *cmdClusterGroupEdit) helpTemplate() string {
 ### Any line starting with a '# will be ignored.`
 }
 
-// List.
+// cmdClusterGroupList represents the "lxc cluster group list" command.
 type cmdClusterGroupList struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for cluster group list.
+func (c *cmdClusterGroupList) columns() []cli.ShorthandColumn[api.ClusterGroup] {
+	return []cli.ShorthandColumn[api.ClusterGroup]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'm', Name: "MEMBERS", Data: c.membersColumnData},
+	}
 }
 
 // Command returns a cobra command to list all the cluster groups in a specified format.
@@ -438,6 +448,7 @@ func (c *cmdClusterGroupList) command() *cobra.Command {
 	cmd.Short = "List all the cluster groups"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -488,22 +499,30 @@ func (c *cmdClusterGroupList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Render the table
-	data := [][]string{}
-	for _, group := range groups {
-		line := []string{group.Name, group.Description, strconv.Itoa(len(group.Members))}
-		data = append(data, line)
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	// Render the table.
+	data := cli.ColumnData(columns, groups)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"MEMBERS",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, groups)
+}
+
+func (c *cmdClusterGroupList) nameColumnData(group api.ClusterGroup) string {
+	return group.Name
+}
+
+func (c *cmdClusterGroupList) descriptionColumnData(group api.ClusterGroup) string {
+	return group.Description
+}
+
+func (c *cmdClusterGroupList) membersColumnData(group api.ClusterGroup) string {
+	return strconv.Itoa(len(group.Members))
 }
 
 // Remove.

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -257,7 +257,15 @@ type cmdConfigTemplateList struct {
 	config         *cmdConfig
 	configTemplate *cmdConfigTemplate
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for config template list.
+func (c *cmdConfigTemplateList) columns() []cli.ShorthandColumn[string] {
+	return []cli.ShorthandColumn[string]{
+		{Shorthand: 'f', Name: "FILENAME", Data: c.filenameColumnData},
+	}
 }
 
 func (c *cmdConfigTemplateList) command() *cobra.Command {
@@ -266,6 +274,7 @@ func (c *cmdConfigTemplateList) command() *cobra.Command {
 	cmd.Short = "List instance file templates"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -306,18 +315,21 @@ func (c *cmdConfigTemplateList) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the table
-	data := [][]string{}
-	for _, template := range templates {
-		data = append(data, []string{template})
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, templates)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"FILENAME",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, templates)
+}
+
+func (c *cmdConfigTemplateList) filenameColumnData(template string) string {
+	return template
 }
 
 // Show.

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -337,12 +337,34 @@ func (c *cmdConfigTrustEdit) run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
+type trustEntry struct {
+	certType    string
+	name        string
+	commonName  string
+	fingerprint string
+	issueDate   string
+	expiryDate  string
+}
+
 type cmdConfigTrustList struct {
 	global      *cmdGlobal
 	config      *cmdConfig
 	configTrust *cmdConfigTrust
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for config trust list.
+func (c *cmdConfigTrustList) columns() []cli.ShorthandColumn[trustEntry] {
+	return []cli.ShorthandColumn[trustEntry]{
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'c', Name: "COMMON NAME", Data: c.commonNameColumnData},
+		{Shorthand: 'f', Name: "FINGERPRINT", Data: c.fingerprintColumnData},
+		{Shorthand: 'i', Name: "ISSUE DATE", Data: c.issueDateColumnData},
+		{Shorthand: 'e', Name: "EXPIRY DATE", Data: c.expiryDateColumnData},
+	}
 }
 
 func (c *cmdConfigTrustList) command() *cobra.Command {
@@ -352,6 +374,7 @@ func (c *cmdConfigTrustList) command() *cobra.Command {
 	cmd.Short = "List trusted clients"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -384,7 +407,8 @@ func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := [][]string{}
+	// Build trust entries.
+	entries := make([]trustEntry, 0, len(trust))
 	for _, cert := range trust {
 		fp := cert.Fingerprint[0:12]
 
@@ -399,25 +423,76 @@ func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 		}
 
 		const layout = "Jan 2, 2006 at 3:04pm (MST)"
-		issue := tlsCert.NotBefore.Format(layout)
-		expiry := tlsCert.NotAfter.Format(layout)
-		data = append(data, []string{cert.Type, cert.Name, tlsCert.Subject.CommonName, fp, issue, expiry})
+		entries = append(entries, trustEntry{
+			certType:    cert.Type,
+			name:        cert.Name,
+			commonName:  tlsCert.Subject.CommonName,
+			fingerprint: fp,
+			issueDate:   tlsCert.NotBefore.Format(layout),
+			expiryDate:  tlsCert.NotAfter.Format(layout),
+		})
 	}
 
-	sort.Sort(cli.StringList(data))
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
+	}
 
-	header := []string{"TYPE", "NAME", "COMMON NAME", "FINGERPRINT", "ISSUE DATE", "EXPIRY DATE"}
+	data := cli.ColumnData(columns, entries)
+	sort.Sort(cli.StringList(data))
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, trust)
 }
 
+func (c *cmdConfigTrustList) typeColumnData(entry trustEntry) string {
+	return entry.certType
+}
+
+func (c *cmdConfigTrustList) nameColumnData(entry trustEntry) string {
+	return entry.name
+}
+
+func (c *cmdConfigTrustList) commonNameColumnData(entry trustEntry) string {
+	return entry.commonName
+}
+
+func (c *cmdConfigTrustList) fingerprintColumnData(entry trustEntry) string {
+	return entry.fingerprint
+}
+
+func (c *cmdConfigTrustList) issueDateColumnData(entry trustEntry) string {
+	return entry.issueDate
+}
+
+func (c *cmdConfigTrustList) expiryDateColumnData(entry trustEntry) string {
+	return entry.expiryDate
+}
+
 // List tokens.
+type displayToken struct {
+	ClientName string
+	Token      string
+	ExpiresAt  string
+}
+
 type cmdConfigTrustListTokens struct {
 	global      *cmdGlobal
 	config      *cmdConfig
 	configTrust *cmdConfigTrust
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for config trust list tokens.
+func (c *cmdConfigTrustListTokens) columns() []cli.ShorthandColumn[displayToken] {
+	return []cli.ShorthandColumn[displayToken]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 't', Name: "TOKEN", Data: c.tokenColumnData},
+		{Shorthand: 'e', Name: "EXPIRES AT", Data: c.expiresAtColumnData},
+	}
 }
 
 func (c *cmdConfigTrustListTokens) command() *cobra.Command {
@@ -426,6 +501,7 @@ func (c *cmdConfigTrustListTokens) command() *cobra.Command {
 	cmd.Short = "List all active certificate add tokens"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -459,12 +535,6 @@ func (c *cmdConfigTrustListTokens) run(cmd *cobra.Command, args []string) error 
 	}
 
 	// Convert the join token operation into encoded form for display.
-	type displayToken struct {
-		ClientName string
-		Token      string
-		ExpiresAt  string
-	}
-
 	displayTokens := make([]displayToken, 0)
 
 	for _, op := range ops {
@@ -496,17 +566,29 @@ func (c *cmdConfigTrustListTokens) run(cmd *cobra.Command, args []string) error 
 	}
 
 	// Render the table.
-	data := [][]string{}
-	for _, token := range displayTokens {
-		line := []string{token.ClientName, token.Token, token.ExpiresAt}
-		data = append(data, line)
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, displayTokens)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{"NAME", "TOKEN", "EXPIRES AT"}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, displayTokens)
+}
+
+func (c *cmdConfigTrustListTokens) nameColumnData(token displayToken) string {
+	return token.ClientName
+}
+
+func (c *cmdConfigTrustListTokens) tokenColumnData(token displayToken) string {
+	return token.Token
+}
+
+func (c *cmdConfigTrustListTokens) expiresAtColumnData(token displayToken) string {
+	return token.ExpiresAt
 }
 
 // Remove.

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -22,11 +22,6 @@ import (
 	"github.com/canonical/lxd/shared/termios"
 )
 
-type imageColumn struct {
-	Name string
-	Data func(api.Image) string
-}
-
 type cmdImage struct {
 	global *cmdGlobal
 }
@@ -1067,7 +1062,7 @@ The -c option takes a (optionally comma-separated) list of arguments
 that control which image attributes to output when displaying in table
 or csv format.
 
-Default column layout is: lfpdasu
+Default column layout is: lfpdatsu
 
 Column shorthand chars:
 
@@ -1077,13 +1072,13 @@ Column shorthand chars:
     F - Fingerprint (long)
     p - Whether image is public
     d - Description
-    e - Project
+    e - Project (may be empty unless using --all-projects)
     a - Architecture
     s - Size
     u - Upload date
     t - Type`)
 
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultImagesColumns, cli.FormatStringFlagLabel("Columns"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display images from all projects")
 	cmd.RunE = c.run
@@ -1099,48 +1094,17 @@ Column shorthand chars:
 	return cmd
 }
 
-const defaultImagesColumns = "lfpdatsu"
-const defaultImagesColumnsAllProjects = "elfpdatsu"
-
-func (c *cmdImageList) parseColumns() ([]imageColumn, error) {
-	columnsShorthandMap := map[rune]imageColumn{
-		'a': {"ARCHITECTURE", c.architectureColumnData},
-		'd': {"DESCRIPTION", c.descriptionColumnData},
-		'e': {"PROJECT", c.projectColumnData},
-		'f': {"FINGERPRINT", c.fingerprintColumnData},
-		'F': {"FINGERPRINT", c.fingerprintFullColumnData},
-		'l': {"ALIAS", c.aliasColumnData},
-		'L': {"ALIASES", c.aliasesColumnData},
-		'p': {"PUBLIC", c.publicColumnData},
-		's': {"SIZE", c.sizeColumnData},
-		't': {"TYPE", c.typeColumnData},
-		'u': {"UPLOAD DATE", c.uploadDateColumnData},
+func (c *cmdImageList) columns() []cli.ShorthandColumn[api.Image] {
+	return []cli.ShorthandColumn[api.Image]{
+		{Shorthand: 'l', Name: "ALIAS", Data: c.aliasColumnData},
+		{Shorthand: 'f', Name: "FINGERPRINT", Data: c.fingerprintColumnData},
+		{Shorthand: 'p', Name: "PUBLIC", Data: c.publicColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'a', Name: "ARCHITECTURE", Data: c.architectureColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 's', Name: "SIZE", Data: c.sizeColumnData},
+		{Shorthand: 'u', Name: "UPLOAD DATE", Data: c.uploadDateColumnData},
 	}
-
-	// Add project column if --all-projects flag specified and custom columns are not specified.
-	if c.flagAllProjects && c.flagColumns == defaultImagesColumns {
-		c.flagColumns = defaultImagesColumnsAllProjects
-	}
-
-	columnList := strings.Split(c.flagColumns, ",")
-	columns := []imageColumn{}
-
-	for _, columnEntry := range columnList {
-		if columnEntry == "" {
-			return nil, fmt.Errorf("Empty column entry (redundant, leading or trailing command) in %q", c.flagColumns)
-		}
-
-		for _, columnRune := range columnEntry {
-			column, ok := columnsShorthandMap[columnRune]
-			if !ok {
-				return nil, fmt.Errorf("Unknown column shorthand char '%c' in %q", columnRune, columnEntry)
-			}
-
-			columns = append(columns, column)
-		}
-	}
-
-	return columns, nil
 }
 
 func (c *cmdImageList) aliasColumnData(image api.Image) string {
@@ -1324,7 +1288,23 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Process the columns
-	columns, err := c.parseColumns()
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+
+	// Add non-default columns that are available for user selection.
+	cols = append(cols,
+		cli.ShorthandColumn[api.Image]{Shorthand: 'L', Name: "ALIASES", Data: c.aliasesColumnData},
+		cli.ShorthandColumn[api.Image]{Shorthand: 'F', Name: "FINGERPRINT", Data: c.fingerprintFullColumnData},
+		cli.ShorthandColumn[api.Image]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData},
+	)
+
+	if c.flagAllProjects {
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
+	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
 	if err != nil {
 		return err
 	}
@@ -1369,20 +1349,7 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the table
-	data := [][]string{}
-	for _, image := range images {
-		if !c.imageShouldShow(clientFilters, &image) {
-			continue
-		}
-
-		row := []string{}
-		for _, column := range columns {
-			row = append(row, column.Data(image))
-		}
-
-		data = append(data, row)
-	}
-
+	data := cli.ColumnData(columns, images)
 	sort.Sort(cli.StringList(data))
 
 	rawData := make([]*api.Image, len(images))
@@ -1390,10 +1357,7 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		rawData[i] = &images[i]
 	}
 
-	headers := []string{}
-	for _, column := range columns {
-		headers = append(headers, column.Name)
-	}
+	headers := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, headers, data, rawData)
 }

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -156,13 +156,24 @@ func (c *cmdImageAliasDelete) run(cmd *cobra.Command, args []string) error {
 	return resource.server.DeleteImageAlias(resource.name)
 }
 
-// List.
+// cmdImageAliasList implements the "image alias list" command and its column definitions.
 type cmdImageAliasList struct {
 	global     *cmdGlobal
 	image      *cmdImage
 	imageAlias *cmdImageAlias
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for image alias list.
+func (c *cmdImageAliasList) columns() []cli.ShorthandColumn[api.ImageAliasesEntry] {
+	return []cli.ShorthandColumn[api.ImageAliasesEntry]{
+		{Shorthand: 'a', Name: "ALIAS", Data: c.aliasColumnData},
+		{Shorthand: 'f', Name: "FINGERPRINT", Data: c.fingerprintColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+	}
 }
 
 func (c *cmdImageAliasList) command() *cobra.Command {
@@ -175,6 +186,7 @@ func (c *cmdImageAliasList) command() *cobra.Command {
 Filters may be part of the image hash or part of the image alias name.
 `)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -242,8 +254,14 @@ func (c *cmdImageAliasList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Render the table
-	data := [][]string{}
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
+	}
+
+	// Render the table.
+	filteredAliases := make([]api.ImageAliasesEntry, 0, len(aliases))
 	for _, alias := range aliases {
 		if !c.aliasShouldShow(filters, &alias) {
 			continue
@@ -253,19 +271,30 @@ func (c *cmdImageAliasList) run(cmd *cobra.Command, args []string) error {
 			alias.Type = "container"
 		}
 
-		data = append(data, []string{alias.Name, alias.Target[0:12], strings.ToUpper(alias.Type), alias.Description})
+		filteredAliases = append(filteredAliases, alias)
 	}
 
+	data := cli.ColumnData(columns, filteredAliases)
 	sort.Sort(cli.StringList(data))
+	header := cli.ColumnHeaders(columns)
 
-	header := []string{
-		"ALIAS",
-		"FINGERPRINT",
-		"TYPE",
-		"DESCRIPTION",
-	}
+	return cli.RenderTable(c.flagFormat, header, data, filteredAliases)
+}
 
-	return cli.RenderTable(c.flagFormat, header, data, aliases)
+func (c *cmdImageAliasList) aliasColumnData(alias api.ImageAliasesEntry) string {
+	return alias.Name
+}
+
+func (c *cmdImageAliasList) fingerprintColumnData(alias api.ImageAliasesEntry) string {
+	return alias.Target[0:12]
+}
+
+func (c *cmdImageAliasList) typeColumnData(alias api.ImageAliasesEntry) string {
+	return strings.ToUpper(alias.Type)
+}
+
+func (c *cmdImageAliasList) descriptionColumnData(alias api.ImageAliasesEntry) string {
+	return alias.Description
 }
 
 // Rename.

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -991,13 +991,29 @@ func (c *cmdNetworkInfo) run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
+// cmdNetworkList defines the network list command and its flags.
 type cmdNetworkList struct {
 	global  *cmdGlobal
 	network *cmdNetwork
 
 	flagFormat      string
+	flagColumns     string
 	flagTarget      string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for network list.
+func (c *cmdNetworkList) columns() []cli.ShorthandColumn[api.Network] {
+	return []cli.ShorthandColumn[api.Network]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'm', Name: "MANAGED", Data: c.managedColumnData},
+		{Shorthand: '4', Name: "IPV4", Data: c.ipv4ColumnData},
+		{Shorthand: '6', Name: "IPV6", Data: c.ipv6ColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+		{Shorthand: 's', Name: "STATE", Data: c.stateColumnData},
+	}
 }
 
 func (c *cmdNetworkList) command() *cobra.Command {
@@ -1009,6 +1025,7 @@ func (c *cmdNetworkList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", cli.FormatStringFlagLabel("Cluster member name"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display networks from all projects")
 
@@ -1068,54 +1085,78 @@ func (c *cmdNetworkList) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	data := [][]string{}
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.Network]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData})
+
+	if c.flagAllProjects {
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
+	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	filteredNetworks := make([]api.Network, 0, len(networks))
 	for _, network := range networks {
 		if slices.Contains([]string{"loopback", "unknown"}, network.Type) {
 			continue
 		}
 
-		strManaged := "NO"
-		if network.Managed {
-			strManaged = "YES"
-		}
-
-		strUsedBy := strconv.Itoa(len(network.UsedBy))
-		details := []string{
-			network.Name,
-			network.Type,
-			strManaged,
-			network.Config["ipv4.address"],
-			network.Config["ipv6.address"],
-			network.Description,
-			strUsedBy,
-			strings.ToUpper(network.Status),
-		}
-
-		if c.flagAllProjects {
-			details = append([]string{network.Project}, details...)
-		}
-
-		data = append(data, details)
+		filteredNetworks = append(filteredNetworks, network)
 	}
 
+	data := cli.ColumnData(columns, filteredNetworks)
 	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
 
-	header := []string{
-		"NAME",
-		"TYPE",
-		"MANAGED",
-		"IPV4",
-		"IPV6",
-		"DESCRIPTION",
-		"USED BY",
-		"STATE",
+	return cli.RenderTable(c.flagFormat, header, data, filteredNetworks)
+}
+
+func (c *cmdNetworkList) projectColumnData(network api.Network) string {
+	return network.Project
+}
+
+func (c *cmdNetworkList) nameColumnData(network api.Network) string {
+	return network.Name
+}
+
+func (c *cmdNetworkList) typeColumnData(network api.Network) string {
+	return network.Type
+}
+
+func (c *cmdNetworkList) managedColumnData(network api.Network) string {
+	if network.Managed {
+		return "YES"
 	}
 
-	if c.flagAllProjects {
-		header = append([]string{"PROJECT"}, header...)
-	}
+	return "NO"
+}
 
-	return cli.RenderTable(c.flagFormat, header, data, networks)
+func (c *cmdNetworkList) ipv4ColumnData(network api.Network) string {
+	return network.Config["ipv4.address"]
+}
+
+func (c *cmdNetworkList) ipv6ColumnData(network api.Network) string {
+	return network.Config["ipv6.address"]
+}
+
+func (c *cmdNetworkList) descriptionColumnData(network api.Network) string {
+	return network.Description
+}
+
+func (c *cmdNetworkList) usedByColumnData(network api.Network) string {
+	return strconv.Itoa(len(network.UsedBy))
+}
+
+func (c *cmdNetworkList) stateColumnData(network api.Network) string {
+	return strings.ToUpper(network.Status)
 }
 
 // List leases.

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -81,12 +81,23 @@ func (c *cmdNetworkACL) command() *cobra.Command {
 }
 
 // List.
+// cmdNetworkACLList handles listing network ACLs.
 type cmdNetworkACLList struct {
 	global     *cmdGlobal
 	networkACL *cmdNetworkACL
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for network ACL list.
+func (c *cmdNetworkACLList) columns() []cli.ShorthandColumn[api.NetworkACL] {
+	return []cli.ShorthandColumn[api.NetworkACL]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+	}
 }
 
 func (c *cmdNetworkACLList) command() *cobra.Command {
@@ -98,6 +109,7 @@ func (c *cmdNetworkACLList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display network ACLs from all projects")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -149,35 +161,45 @@ func (c *cmdNetworkACLList) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	data := [][]string{}
-	for _, acl := range acls {
-		strUsedBy := strconv.Itoa(len(acl.UsedBy))
-		details := []string{
-			acl.Name,
-			acl.Description,
-			strUsedBy,
-		}
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
 
-		if c.flagAllProjects {
-			details = append([]string{acl.Project}, details...)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"USED BY",
-	}
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.NetworkACL]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData})
 
 	if c.flagAllProjects {
-		header = append([]string{"PROJECT"}, header...)
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
 	}
 
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, acls)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
+
 	return cli.RenderTable(c.flagFormat, header, data, acls)
+}
+
+func (c *cmdNetworkACLList) projectColumnData(acl api.NetworkACL) string {
+	return acl.Project
+}
+
+func (c *cmdNetworkACLList) nameColumnData(acl api.NetworkACL) string {
+	return acl.Name
+}
+
+func (c *cmdNetworkACLList) descriptionColumnData(acl api.NetworkACL) string {
+	return acl.Description
+}
+
+func (c *cmdNetworkACLList) usedByColumnData(acl api.NetworkACL) string {
+	return strconv.Itoa(len(acl.UsedBy))
 }
 
 // Show.

--- a/lxc/network_allocations.go
+++ b/lxc/network_allocations.go
@@ -9,37 +9,37 @@ import (
 	cli "github.com/canonical/lxd/shared/cmd"
 )
 
+// cmdNetworkListAllocations defines the "network list-allocations" command.
 type cmdNetworkListAllocations struct {
 	global  *cmdGlobal
 	network *cmdNetwork
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
 }
 
+// columns returns the ordered column definitions for network allocations list.
+func (c *cmdNetworkListAllocations) columns() []cli.ShorthandColumn[api.NetworkAllocations] {
+	return []cli.ShorthandColumn[api.NetworkAllocations]{
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+		{Shorthand: 'a', Name: "ADDRESS", Data: c.addressColumnData},
+		{Shorthand: 'n', Name: "NETWORK", Data: c.networkColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'N', Name: "NAT", Data: c.natColumnData},
+		{Shorthand: 'h', Name: "HARDWARE ADDRESS", Data: c.hwaddrColumnData},
+	}
+}
+
 func (c *cmdNetworkListAllocations) pretty(allocs []api.NetworkAllocations) error {
-	header := []string{
-		"USED BY",
-		"ADDRESS",
-		"NETWORK",
-		"TYPE",
-		"NAT",
-		"HARDWARE ADDRESS",
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
-	data := make([][]string, 0, len(allocs))
-	for _, alloc := range allocs {
-		row := []string{
-			alloc.UsedBy,
-			alloc.Address,
-			alloc.Network,
-			alloc.Type,
-			strconv.FormatBool(alloc.NAT),
-			alloc.Hwaddr,
-		}
-
-		data = append(data, row)
-	}
+	data := cli.ColumnData(columns, allocs)
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, allocs)
 }
@@ -55,6 +55,7 @@ func (c *cmdNetworkListAllocations) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Run against all projects")
 	return cmd
 }
@@ -77,4 +78,28 @@ func (c *cmdNetworkListAllocations) run(cmd *cobra.Command, args []string) error
 	}
 
 	return c.pretty(addresses)
+}
+
+func (c *cmdNetworkListAllocations) usedByColumnData(alloc api.NetworkAllocations) string {
+	return alloc.UsedBy
+}
+
+func (c *cmdNetworkListAllocations) addressColumnData(alloc api.NetworkAllocations) string {
+	return alloc.Address
+}
+
+func (c *cmdNetworkListAllocations) networkColumnData(alloc api.NetworkAllocations) string {
+	return alloc.Network
+}
+
+func (c *cmdNetworkListAllocations) typeColumnData(alloc api.NetworkAllocations) string {
+	return alloc.Type
+}
+
+func (c *cmdNetworkListAllocations) natColumnData(alloc api.NetworkAllocations) string {
+	return strconv.FormatBool(alloc.NAT)
+}
+
+func (c *cmdNetworkListAllocations) hwaddrColumnData(alloc api.NetworkAllocations) string {
+	return alloc.Hwaddr
 }

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -81,7 +81,18 @@ type cmdNetworkForwardList struct {
 	global         *cmdGlobal
 	networkForward *cmdNetworkForward
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for network forward list.
+func (c *cmdNetworkForwardList) columns() []cli.ShorthandColumn[api.NetworkForward] {
+	return []cli.ShorthandColumn[api.NetworkForward]{
+		{Shorthand: 'l', Name: "LISTEN ADDRESS", Data: c.listenAddressColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 't', Name: "DEFAULT TARGET ADDRESS", Data: c.defaultTargetAddressColumnData},
+		{Shorthand: 'p', Name: "PORTS", Data: c.portsColumnData},
+	}
 }
 
 func (c *cmdNetworkForwardList) command() *cobra.Command {
@@ -93,6 +104,7 @@ func (c *cmdNetworkForwardList) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -136,36 +148,48 @@ func (c *cmdNetworkForwardList) run(cmd *cobra.Command, args []string) error {
 
 	clustered := resource.server.IsClustered()
 
-	data := make([][]string, 0, len(forwards))
-	for _, forward := range forwards {
-		details := []string{
-			forward.ListenAddress,
-			forward.Description,
-			forward.Config["target_address"],
-			strconv.Itoa(len(forward.Ports)),
-		}
-
-		if clustered {
-			details = append(details, forward.Location)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"LISTEN ADDRESS",
-		"DESCRIPTION",
-		"DEFAULT TARGET ADDRESS",
-		"PORTS",
-	}
-
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
 	if clustered {
-		header = append(header, "LOCATION")
+		cols = append(cols, cli.ShorthandColumn[api.NetworkForward]{Shorthand: 'L', Name: "LOCATION", Data: c.locationColumnData})
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = cli.DefaultColumnString(cols)
+		}
+	} else if strings.ContainsAny(c.flagColumns, "L") {
+		return errors.New("Cannot use column shorthand char 'L' (LOCATION) when not clustered")
 	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, forwards)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, forwards)
+}
+
+func (c *cmdNetworkForwardList) listenAddressColumnData(forward api.NetworkForward) string {
+	return forward.ListenAddress
+}
+
+func (c *cmdNetworkForwardList) descriptionColumnData(forward api.NetworkForward) string {
+	return forward.Description
+}
+
+func (c *cmdNetworkForwardList) defaultTargetAddressColumnData(forward api.NetworkForward) string {
+	return forward.Config["target_address"]
+}
+
+func (c *cmdNetworkForwardList) portsColumnData(forward api.NetworkForward) string {
+	return strconv.Itoa(len(forward.Ports))
+}
+
+func (c *cmdNetworkForwardList) locationColumnData(forward api.NetworkForward) string {
+	return forward.Location
 }
 
 // Show.

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -81,11 +81,22 @@ func (c *cmdNetworkLoadBalancer) command() *cobra.Command {
 }
 
 // List.
+// cmdNetworkLoadBalancerList implements the "network load-balancer list" command.
 type cmdNetworkLoadBalancerList struct {
 	global              *cmdGlobal
 	networkLoadBalancer *cmdNetworkLoadBalancer
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for network load balancer list.
+func (c *cmdNetworkLoadBalancerList) columns() []cli.ShorthandColumn[api.NetworkLoadBalancer] {
+	return []cli.ShorthandColumn[api.NetworkLoadBalancer]{
+		{Shorthand: 'l', Name: "LISTEN ADDRESS", Data: c.listenAddressColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'p', Name: "PORTS", Data: c.portsColumnData},
+	}
 }
 
 func (c *cmdNetworkLoadBalancerList) command() *cobra.Command {
@@ -96,7 +107,8 @@ func (c *cmdNetworkLoadBalancerList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -140,34 +152,44 @@ func (c *cmdNetworkLoadBalancerList) run(cmd *cobra.Command, args []string) erro
 
 	clustered := resource.server.IsClustered()
 
-	data := make([][]string, 0, len(loadBalancers))
-	for _, loadBalancer := range loadBalancers {
-		details := []string{
-			loadBalancer.ListenAddress,
-			loadBalancer.Description,
-			strconv.Itoa(len(loadBalancer.Ports)),
-		}
-
-		if clustered {
-			details = append(details, loadBalancer.Location)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"LISTEN ADDRESS",
-		"DESCRIPTION",
-		"PORTS",
-	}
-
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
 	if clustered {
-		header = append(header, "LOCATION")
+		cols = append(cols, cli.ShorthandColumn[api.NetworkLoadBalancer]{Shorthand: 'L', Name: "LOCATION", Data: c.locationColumnData})
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = cli.DefaultColumnString(cols)
+		}
+	} else if strings.ContainsAny(c.flagColumns, "L") {
+		return errors.New("Cannot use column shorthand char 'L' (LOCATION) when not clustered")
 	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, loadBalancers)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, loadBalancers)
+}
+
+func (c *cmdNetworkLoadBalancerList) listenAddressColumnData(lb api.NetworkLoadBalancer) string {
+	return lb.ListenAddress
+}
+
+func (c *cmdNetworkLoadBalancerList) descriptionColumnData(lb api.NetworkLoadBalancer) string {
+	return lb.Description
+}
+
+func (c *cmdNetworkLoadBalancerList) portsColumnData(lb api.NetworkLoadBalancer) string {
+	return strconv.Itoa(len(lb.Ports))
+}
+
+func (c *cmdNetworkLoadBalancerList) locationColumnData(lb api.NetworkLoadBalancer) string {
+	return lb.Location
 }
 
 // Show.

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -71,7 +71,18 @@ type cmdNetworkPeerList struct {
 	global      *cmdGlobal
 	networkPeer *cmdNetworkPeer
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for network peer list.
+func (c *cmdNetworkPeerList) columns() []cli.ShorthandColumn[api.NetworkPeer] {
+	return []cli.ShorthandColumn[api.NetworkPeer]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'p', Name: "PEER", Data: c.peerColumnData},
+		{Shorthand: 's', Name: "STATE", Data: c.stateColumnData},
+	}
 }
 
 func (c *cmdNetworkPeerList) command() *cobra.Command {
@@ -82,7 +93,8 @@ func (c *cmdNetworkPeerList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -124,34 +136,37 @@ func (c *cmdNetworkPeerList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := make([][]string, 0, len(peers))
-	for _, peer := range peers {
-		targetPeer := "Unknown"
-
-		if peer.TargetProject != "" && peer.TargetNetwork != "" {
-			targetPeer = peer.TargetProject + "/" + peer.TargetNetwork
-		}
-
-		details := []string{
-			peer.Name,
-			peer.Description,
-			targetPeer,
-			strings.ToUpper(peer.Status),
-		}
-
-		data = append(data, details)
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, peers)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"PEER",
-		"STATE",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, peers)
+}
+
+func (c *cmdNetworkPeerList) nameColumnData(peer api.NetworkPeer) string {
+	return peer.Name
+}
+
+func (c *cmdNetworkPeerList) descriptionColumnData(peer api.NetworkPeer) string {
+	return peer.Description
+}
+
+func (c *cmdNetworkPeerList) peerColumnData(peer api.NetworkPeer) string {
+	if peer.TargetProject != "" && peer.TargetNetwork != "" {
+		return peer.TargetProject + "/" + peer.TargetNetwork
+	}
+
+	return "Unknown"
+}
+
+func (c *cmdNetworkPeerList) stateColumnData(peer api.NetworkPeer) string {
+	return strings.ToUpper(peer.Status)
 }
 
 // Show.

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -73,12 +73,23 @@ func (c *cmdNetworkZone) command() *cobra.Command {
 }
 
 // List.
+// cmdNetworkZoneList implements the "lxc network zone list" subcommand.
 type cmdNetworkZoneList struct {
 	global      *cmdGlobal
 	networkZone *cmdNetworkZone
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for network zone list.
+func (c *cmdNetworkZoneList) columns() []cli.ShorthandColumn[api.NetworkZone] {
+	return []cli.ShorthandColumn[api.NetworkZone]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+	}
 }
 
 func (c *cmdNetworkZoneList) command() *cobra.Command {
@@ -89,7 +100,8 @@ func (c *cmdNetworkZoneList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display network zones from all projects")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -141,35 +153,45 @@ func (c *cmdNetworkZoneList) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	data := [][]string{}
-	for _, zone := range zones {
-		strUsedBy := strconv.Itoa(len(zone.UsedBy))
-		details := []string{
-			zone.Name,
-			zone.Description,
-			strUsedBy,
-		}
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
 
-		if c.flagAllProjects {
-			details = append([]string{zone.Project}, details...)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"USED BY",
-	}
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.NetworkZone]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData})
 
 	if c.flagAllProjects {
-		header = append([]string{"PROJECT"}, header...)
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
 	}
 
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, zones)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
+
 	return cli.RenderTable(c.flagFormat, header, data, zones)
+}
+
+func (c *cmdNetworkZoneList) projectColumnData(zone api.NetworkZone) string {
+	return zone.Project
+}
+
+func (c *cmdNetworkZoneList) nameColumnData(zone api.NetworkZone) string {
+	return zone.Name
+}
+
+func (c *cmdNetworkZoneList) descriptionColumnData(zone api.NetworkZone) string {
+	return zone.Description
+}
+
+func (c *cmdNetworkZoneList) usedByColumnData(zone api.NetworkZone) string {
+	return strconv.Itoa(len(zone.UsedBy))
 }
 
 // Show.
@@ -767,12 +789,22 @@ func (c *cmdNetworkZoneRecord) command() *cobra.Command {
 	return cmd
 }
 
-// List.
+// cmdNetworkZoneRecordList implements the "lxc network zone record list" command.
 type cmdNetworkZoneRecordList struct {
 	global            *cmdGlobal
 	networkZoneRecord *cmdNetworkZoneRecord
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for network zone record list.
+func (c *cmdNetworkZoneRecordList) columns() []cli.ShorthandColumn[api.NetworkZoneRecord] {
+	return []cli.ShorthandColumn[api.NetworkZoneRecord]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'e', Name: "ENTRIES", Data: c.entriesColumnData},
+	}
 }
 
 func (c *cmdNetworkZoneRecordList) command() *cobra.Command {
@@ -783,7 +815,8 @@ func (c *cmdNetworkZoneRecordList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -820,32 +853,34 @@ func (c *cmdNetworkZoneRecordList) run(cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	data := [][]string{}
-	for _, record := range records {
-		entries := []string{}
-
-		for _, entry := range record.Entries {
-			entries = append(entries, entry.Type+" "+entry.Value)
-		}
-
-		details := []string{
-			record.Name,
-			record.Description,
-			strings.Join(entries, "\n"),
-		}
-
-		data = append(data, details)
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, records)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"ENTRIES",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, records)
+}
+
+func (c *cmdNetworkZoneRecordList) nameColumnData(record api.NetworkZoneRecord) string {
+	return record.Name
+}
+
+func (c *cmdNetworkZoneRecordList) descriptionColumnData(record api.NetworkZoneRecord) string {
+	return record.Description
+}
+
+func (c *cmdNetworkZoneRecordList) entriesColumnData(record api.NetworkZoneRecord) string {
+	entries := make([]string, 0, len(record.Entries))
+	for _, entry := range record.Entries {
+		entries = append(entries, entry.Type+" "+entry.Value)
+	}
+
+	return strings.Join(entries, "\n")
 }
 
 // Show.

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -93,7 +93,20 @@ type cmdOperationList struct {
 	operation *cmdOperation
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for operation list.
+func (c *cmdOperationList) columns() []cli.ShorthandColumn[api.Operation] {
+	return []cli.ShorthandColumn[api.Operation]{
+		{Shorthand: 'i', Name: "ID", Data: c.idColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 's', Name: "STATUS", Data: c.statusColumnData},
+		{Shorthand: 'c', Name: "CANCELABLE", Data: c.cancelableColumnData},
+		{Shorthand: 'C', Name: "CREATED", Data: c.createdColumnData},
+	}
 }
 
 func (c *cmdOperationList) command() *cobra.Command {
@@ -103,6 +116,7 @@ func (c *cmdOperationList) command() *cobra.Command {
 	cmd.Short = "List background operations"
 	cmd.Long = cli.FormatSection("Description", "List background operations")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "List operations from all projects")
 
@@ -146,36 +160,63 @@ func (c *cmdOperationList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	clustered := resource.server.IsClustered()
+
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+	if clustered {
+		cols = append(cols, cli.ShorthandColumn[api.Operation]{Shorthand: 'L', Name: "LOCATION", Data: c.locationColumnData})
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = cli.DefaultColumnString(cols)
+		}
+	} else if strings.ContainsAny(c.flagColumns, "L") {
+		return errors.New("Cannot use column shorthand char 'L' (LOCATION) when not clustered")
+	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
 	// Render the table
-	data := [][]string{}
-	for _, op := range operations {
-		cancelable := "NO"
-		if op.MayCancel {
-			cancelable = "YES"
-		}
-
-		entry := []string{op.ID, strings.ToUpper(op.Class), op.Description, strings.ToUpper(op.Status), cancelable, op.CreatedAt.UTC().Format("2006/01/02 15:04 UTC")}
-		if resource.server.IsClustered() {
-			entry = append(entry, op.Location)
-		}
-
-		data = append(data, entry)
-	}
-
+	data := cli.ColumnData(columns, operations)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"ID",
-		"TYPE",
-		"DESCRIPTION",
-		"STATUS",
-		"CANCELABLE",
-		"CREATED"}
-	if resource.server.IsClustered() {
-		header = append(header, "LOCATION")
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, operations)
+}
+
+func (c *cmdOperationList) idColumnData(op api.Operation) string {
+	return op.ID
+}
+
+func (c *cmdOperationList) typeColumnData(op api.Operation) string {
+	return strings.ToUpper(op.Class)
+}
+
+func (c *cmdOperationList) descriptionColumnData(op api.Operation) string {
+	return op.Description
+}
+
+func (c *cmdOperationList) statusColumnData(op api.Operation) string {
+	return strings.ToUpper(op.Status)
+}
+
+func (c *cmdOperationList) cancelableColumnData(op api.Operation) string {
+	if op.MayCancel {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdOperationList) createdColumnData(op api.Operation) string {
+	return op.CreatedAt.UTC().Format("2006/01/02 15:04 UTC")
+}
+
+func (c *cmdOperationList) locationColumnData(op api.Operation) string {
+	return op.Location
 }
 
 // Show.

--- a/lxc/placement_group.go
+++ b/lxc/placement_group.go
@@ -77,7 +77,19 @@ type cmdPlacementGroupList struct {
 	placementGroup *cmdPlacementGroup
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for placement group list.
+func (c *cmdPlacementGroupList) columns() []cli.ShorthandColumn[api.PlacementGroup] {
+	return []cli.ShorthandColumn[api.PlacementGroup]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'p', Name: "POLICY", Data: c.policyColumnData},
+		{Shorthand: 'r', Name: "RIGOR", Data: c.rigorColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+	}
 }
 
 func (c *cmdPlacementGroupList) command() *cobra.Command {
@@ -88,7 +100,8 @@ func (c *cmdPlacementGroupList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display placement groups from all projects")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -140,38 +153,53 @@ func (c *cmdPlacementGroupList) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	data := [][]string{}
-	for _, placementGroup := range placementGroups {
-		details := []string{
-			placementGroup.Name,
-			placementGroup.Description,
-			placementGroup.Config["policy"],
-			placementGroup.Config["rigor"],
-			strconv.Itoa(len(placementGroup.UsedBy)),
-		}
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
 
-		if c.flagAllProjects {
-			details = append([]string{placementGroup.Project}, details...)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"POLICY",
-		"RIGOR",
-		"USED BY",
-	}
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.PlacementGroup]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData})
 
 	if c.flagAllProjects {
-		header = append([]string{"PROJECT"}, header...)
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
 	}
 
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, placementGroups)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
+
 	return cli.RenderTable(c.flagFormat, header, data, placementGroups)
+}
+
+func (c *cmdPlacementGroupList) projectColumnData(placementGroup api.PlacementGroup) string {
+	return placementGroup.Project
+}
+
+func (c *cmdPlacementGroupList) nameColumnData(placementGroup api.PlacementGroup) string {
+	return placementGroup.Name
+}
+
+func (c *cmdPlacementGroupList) descriptionColumnData(placementGroup api.PlacementGroup) string {
+	return placementGroup.Description
+}
+
+func (c *cmdPlacementGroupList) policyColumnData(placementGroup api.PlacementGroup) string {
+	return placementGroup.Config["policy"]
+}
+
+func (c *cmdPlacementGroupList) rigorColumnData(placementGroup api.PlacementGroup) string {
+	return placementGroup.Config["rigor"]
+}
+
+func (c *cmdPlacementGroupList) usedByColumnData(placementGroup api.PlacementGroup) string {
+	return strconv.Itoa(len(placementGroup.UsedBy))
 }
 
 // Show.

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -22,11 +22,6 @@ import (
 	"github.com/canonical/lxd/shared/termios"
 )
 
-type profileColumn struct {
-	Name string
-	Data func(api.Profile) string
-}
-
 type cmdProfile struct {
 	global *cmdGlobal
 }
@@ -733,13 +728,13 @@ Default column layout is: ndu
 Column shorthand chars:
 n - Profile Name
 d - Description
-e - Project
+e - Project (only when using --all-projects)
 u - Used By`)
 
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultProfileColumns, cli.FormatStringFlagLabel("Columns"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display profiles from all projects")
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -753,45 +748,12 @@ u - Used By`)
 	return cmd
 }
 
-const (
-	defaultProfileColumns            = "ndu"
-	defaultProfileColumnsAllProjects = "endu"
-)
-
-func (c *cmdProfileList) parseColumns() ([]profileColumn, error) {
-	columnsShorthandMap := map[rune]profileColumn{
-		'n': {"NAME", c.profileNameColumnData},
-		'e': {"PROJECT", c.projectNameColumnData},
-		'd': {"DESCRIPTION", c.descriptionColumnData},
-		'u': {"USED BY", c.usedByColumnData},
+func (c *cmdProfileList) columns() []cli.ShorthandColumn[api.Profile] {
+	return []cli.ShorthandColumn[api.Profile]{
+		{Shorthand: 'n', Name: "NAME", Data: c.profileNameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
 	}
-
-	// Add project column if --all-projects flag specified and no custom column was passed.
-	if c.flagAllProjects {
-		if c.flagColumns == defaultProfileColumns {
-			c.flagColumns = defaultProfileColumnsAllProjects
-		}
-	}
-
-	columnList := strings.Split(c.flagColumns, ",")
-	columns := []profileColumn{}
-
-	for _, columnEntry := range columnList {
-		if columnEntry == "" {
-			return nil, fmt.Errorf("Empty column entry (redundant, leading or trailing command) in %q", c.flagColumns)
-		}
-
-		for _, columnRune := range columnEntry {
-			column, ok := columnsShorthandMap[columnRune]
-			if !ok {
-				return nil, fmt.Errorf("Unknown column shorthand char '%c' in %q", columnRune, columnEntry)
-			}
-
-			columns = append(columns, column)
-		}
-	}
-
-	return columns, nil
 }
 
 func (c *cmdProfileList) profileNameColumnData(profile api.Profile) string {
@@ -844,27 +806,27 @@ func (c *cmdProfileList) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	columns, err := c.parseColumns()
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.Profile]{Shorthand: 'e', Name: "PROJECT", Data: c.projectNameColumnData})
+
+	if c.flagAllProjects {
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
+		}
+	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
 	if err != nil {
 		return err
 	}
 
-	data := [][]string{}
-	for _, profile := range profiles {
-		line := []string{}
-		for _, column := range columns {
-			line = append(line, column.Data(profile))
-		}
-
-		data = append(data, line)
-	}
-
+	data := cli.ColumnData(columns, profiles)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{}
-	for _, column := range columns {
-		header = append(header, column.Name)
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, profiles)
 }

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -470,7 +470,24 @@ type cmdProjectList struct {
 	global  *cmdGlobal
 	project *cmdProject
 
-	flagFormat string
+	flagFormat     string
+	flagColumns    string
+	currentProject string
+}
+
+// columns returns the ordered column definitions for project list.
+func (c *cmdProjectList) columns() []cli.ShorthandColumn[api.Project] {
+	return []cli.ShorthandColumn[api.Project]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'I', Name: "IMAGES", Data: c.imagesColumnData},
+		{Shorthand: 'P', Name: "PROFILES", Data: c.profilesColumnData},
+		{Shorthand: 'v', Name: "STORAGE VOLUMES", Data: c.storageVolumesColumnData},
+		{Shorthand: 'b', Name: "STORAGE BUCKETS", Data: c.storageBucketsColumnData},
+		{Shorthand: 'N', Name: "NETWORKS", Data: c.networksColumnData},
+		{Shorthand: 'z', Name: "NETWORK ZONES", Data: c.networkZonesColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+	}
 }
 
 func (c *cmdProjectList) command() *cobra.Command {
@@ -480,7 +497,8 @@ func (c *cmdProjectList) command() *cobra.Command {
 	cmd.Short = "List projects"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -529,62 +547,84 @@ func (c *cmdProjectList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := [][]string{}
-	for _, project := range projects {
-		images := "NO"
-		if shared.IsTrue(project.Config["features.images"]) {
-			images = "YES"
-		}
+	c.currentProject = info.Project
 
-		profiles := "NO"
-		if shared.IsTrue(project.Config["features.profiles"]) {
-			profiles = "YES"
-		}
-
-		storageVolumes := "NO"
-		if shared.IsTrue(project.Config["features.storage.volumes"]) {
-			storageVolumes = "YES"
-		}
-
-		storageBuckets := "NO"
-		if shared.IsTrue(project.Config["features.storage.buckets"]) {
-			storageBuckets = "YES"
-		}
-
-		networks := "NO"
-		if shared.IsTrue(project.Config["features.networks"]) {
-			networks = "YES"
-		}
-
-		networkZones := "NO"
-		if shared.IsTrue(project.Config["features.networks.zones"]) {
-			networkZones = "YES"
-		}
-
-		name := project.Name
-		if name == info.Project {
-			name = name + " (current)"
-		}
-
-		strUsedBy := strconv.Itoa(len(project.UsedBy))
-		data = append(data, []string{name, images, profiles, storageVolumes, storageBuckets, networks, networkZones, project.Description, strUsedBy})
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, projects)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"IMAGES",
-		"PROFILES",
-		"STORAGE VOLUMES",
-		"STORAGE BUCKETS",
-		"NETWORKS",
-		"NETWORK ZONES",
-		"DESCRIPTION",
-		"USED BY",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, projects)
+}
+
+func (c *cmdProjectList) nameColumnData(project api.Project) string {
+	name := project.Name
+	if name == c.currentProject {
+		name = name + " (current)"
+	}
+
+	return name
+}
+
+func (c *cmdProjectList) imagesColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.images"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) profilesColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.profiles"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) storageVolumesColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.storage.volumes"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) storageBucketsColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.storage.buckets"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) networksColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.networks"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) networkZonesColumnData(project api.Project) string {
+	if shared.IsTrue(project.Config["features.networks.zones"]) {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdProjectList) descriptionColumnData(project api.Project) string {
+	return project.Description
+}
+
+func (c *cmdProjectList) usedByColumnData(project api.Project) string {
+	return strconv.Itoa(len(project.UsedBy))
 }
 
 // Rename.
@@ -918,7 +958,7 @@ func (c *cmdProjectInfo) command() *cobra.Command {
 	cmd.Short = "Get a summary of resource allocations"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
 
 	cmd.RunE = c.run
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -765,11 +765,32 @@ func (c *cmdRemoteGetDefault) run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
+// remoteListEntry represents a row in the remote list output.
+// It combines a remote name with its configuration for use with the column definitions.
+type remoteListEntry struct {
+	name   string
+	remote config.Remote
+}
+
 type cmdRemoteList struct {
 	global *cmdGlobal
 	remote *cmdRemote
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for remote list.
+func (c *cmdRemoteList) columns() []cli.ShorthandColumn[remoteListEntry] {
+	return []cli.ShorthandColumn[remoteListEntry]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'u', Name: "URL", Data: c.urlColumnData},
+		{Shorthand: 'p', Name: "PROTOCOL", Data: c.protocolColumnData},
+		{Shorthand: 'a', Name: "AUTH TYPE", Data: c.authTypeColumnData},
+		{Shorthand: 'P', Name: "PUBLIC", Data: c.publicColumnData},
+		{Shorthand: 'S', Name: "STATIC", Data: c.staticColumnData},
+		{Shorthand: 'g', Name: "GLOBAL", Data: c.globalColumnData},
+	}
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
@@ -781,7 +802,8 @@ func (c *cmdRemoteList) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
 	cmd.RunE = c.run
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	return cmd
 }
@@ -796,24 +818,9 @@ func (c *cmdRemoteList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// List the remotes
-	data := [][]string{}
+	// Prepare remote entries with computed defaults.
+	entries := []remoteListEntry{}
 	for name, rc := range conf.Remotes {
-		strPublic := "NO"
-		if rc.Public {
-			strPublic = "YES"
-		}
-
-		strStatic := "NO"
-		if rc.Static {
-			strStatic = "YES"
-		}
-
-		strGlobal := "NO"
-		if rc.Global {
-			strGlobal = "YES"
-		}
-
 		if rc.Protocol == "" {
 			rc.Protocol = "lxd"
 		}
@@ -828,27 +835,65 @@ func (c *cmdRemoteList) run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		strName := name
-		if name == conf.DefaultRemote {
-			strName = name + " (current)"
-		}
-
-		data = append(data, []string{strName, rc.Addr, rc.Protocol, rc.AuthType, strPublic, strStatic, strGlobal})
+		entries = append(entries, remoteListEntry{name: name, remote: rc})
 	}
 
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
+	}
+
+	// List the remotes.
+	data := cli.ColumnData(columns, entries)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"URL",
-		"PROTOCOL",
-		"AUTH TYPE",
-		"PUBLIC",
-		"STATIC",
-		"GLOBAL",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, conf.Remotes)
+}
+
+func (c *cmdRemoteList) nameColumnData(entry remoteListEntry) string {
+	if entry.name == c.global.conf.DefaultRemote {
+		return entry.name + " (current)"
+	}
+
+	return entry.name
+}
+
+func (c *cmdRemoteList) urlColumnData(entry remoteListEntry) string {
+	return entry.remote.Addr
+}
+
+func (c *cmdRemoteList) protocolColumnData(entry remoteListEntry) string {
+	return entry.remote.Protocol
+}
+
+func (c *cmdRemoteList) authTypeColumnData(entry remoteListEntry) string {
+	return entry.remote.AuthType
+}
+
+func (c *cmdRemoteList) publicColumnData(entry remoteListEntry) string {
+	if entry.remote.Public {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdRemoteList) staticColumnData(entry remoteListEntry) string {
+	if entry.remote.Static {
+		return "YES"
+	}
+
+	return "NO"
+}
+
+func (c *cmdRemoteList) globalColumnData(entry remoteListEntry) string {
+	if entry.remote.Global {
+		return "YES"
+	}
+
+	return "NO"
 }
 
 // Rename.

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -635,7 +635,20 @@ type cmdStorageList struct {
 	global  *cmdGlobal
 	storage *cmdStorage
 
-	flagFormat string
+	flagFormat  string
+	flagColumns string
+}
+
+// columns returns the ordered column definitions for storage pool list.
+func (c *cmdStorageList) columns() []cli.ShorthandColumn[api.StoragePool] {
+	return []cli.ShorthandColumn[api.StoragePool]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'D', Name: "DRIVER", Data: c.driverColumnData},
+		{Shorthand: 's', Name: "SOURCE", Data: c.sourceColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+		{Shorthand: 'S', Name: "STATE", Data: c.stateColumnData},
+	}
 }
 
 func (c *cmdStorageList) command() *cobra.Command {
@@ -645,6 +658,7 @@ func (c *cmdStorageList) command() *cobra.Command {
 	cmd.Short = "List available storage pools"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel(("Format (csv|json|table|yaml|compact)")))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -685,34 +699,62 @@ func (c *cmdStorageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := [][]string{}
-	for _, pool := range pools {
-		usedby := strconv.Itoa(len(pool.UsedBy))
-		details := []string{pool.Name, pool.Driver}
-		if !resource.server.IsClustered() {
-			details = append(details, pool.Config["source"])
+	clustered := resource.server.IsClustered()
+
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+	if clustered {
+		// Remove SOURCE column when clustered.
+		filteredCols := make([]cli.ShorthandColumn[api.StoragePool], 0, len(cols)-1)
+		for _, col := range cols {
+			if col.Shorthand != 's' {
+				filteredCols = append(filteredCols, col)
+			}
 		}
 
-		details = append(details, pool.Description)
-		details = append(details, usedby)
-		details = append(details, strings.ToUpper(pool.Status))
-		data = append(data, details)
+		cols = filteredCols
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = cli.DefaultColumnString(cols)
+		} else if strings.ContainsAny(c.flagColumns, "s") {
+			return errors.New("Cannot use column shorthand char 's' (SOURCE) when clustered")
+		}
 	}
 
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, pools)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DRIVER",
-	}
-
-	if !resource.server.IsClustered() {
-		header = append(header, "SOURCE")
-	}
-
-	header = append(header, "DESCRIPTION", "USED BY", "STATE")
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, pools)
+}
+
+func (c *cmdStorageList) nameColumnData(pool api.StoragePool) string {
+	return pool.Name
+}
+
+func (c *cmdStorageList) driverColumnData(pool api.StoragePool) string {
+	return pool.Driver
+}
+
+func (c *cmdStorageList) sourceColumnData(pool api.StoragePool) string {
+	return pool.Config["source"]
+}
+
+func (c *cmdStorageList) descriptionColumnData(pool api.StoragePool) string {
+	return pool.Description
+}
+
+func (c *cmdStorageList) usedByColumnData(pool api.StoragePool) string {
+	return strconv.Itoa(len(pool.UsedBy))
+}
+
+func (c *cmdStorageList) stateColumnData(pool api.StoragePool) string {
+	return strings.ToUpper(pool.Status)
 }
 
 // Set.

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -443,12 +443,22 @@ func (c *cmdStorageBucketGet) run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
+// cmdStorageBucketList defines the storage bucket list command.
 type cmdStorageBucketList struct {
 	global        *cmdGlobal
 	storageBucket *cmdStorageBucket
 
 	flagFormat      string
+	flagColumns     string
 	flagAllProjects bool
+}
+
+// columns returns the ordered column definitions for storage bucket list.
+func (c *cmdStorageBucketList) columns() []cli.ShorthandColumn[api.StorageBucket] {
+	return []cli.ShorthandColumn[api.StorageBucket]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+	}
 }
 
 func (c *cmdStorageBucketList) command() *cobra.Command {
@@ -458,7 +468,8 @@ func (c *cmdStorageBucketList) command() *cobra.Command {
 	cmd.Short = "List storage buckets"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, "Display storage pool buckets from all projects")
 
 	cmd.RunE = c.run
@@ -502,40 +513,62 @@ func (c *cmdStorageBucketList) run(cmd *cobra.Command, args []string) error {
 
 	clustered := resource.server.IsClustered()
 
-	data := make([][]string, 0, len(buckets))
-	for _, bucket := range buckets {
-		details := []string{
-			bucket.Name,
-			bucket.Description,
+	// Parse column flags.
+	cols := c.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+
+	// Add project column so shorthand 'e' is always valid.
+	cols = append(cols, cli.ShorthandColumn[api.StorageBucket]{Shorthand: 'e', Name: "PROJECT", Data: c.projectColumnData})
+
+	if c.flagAllProjects {
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = "e" + defaultColumns
 		}
-
-		if clustered {
-			details = append(details, bucket.Location)
-		}
-
-		if c.flagAllProjects {
-			details = append([]string{bucket.Project}, details...)
-		}
-
-		data = append(data, details)
-	}
-
-	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
 	}
 
 	if clustered {
-		header = append(header, "LOCATION")
+		// Compute the current default (including PROJECT but without LOCATION).
+		currentDefault := cli.DefaultColumnString(cols)
+		// Add LOCATION column so shorthand 'l' is available on clustered setups.
+		cols = append(cols, cli.ShorthandColumn[api.StorageBucket]{Shorthand: 'l', Name: "LOCATION", Data: c.locationColumnData})
+		// If the user did not customize columns (they are still using one of the defaults),
+		// update the flagColumns to include LOCATION in the default set while preserving
+		// the existing column order (do not regenerate from cols, just append 'l').
+		if c.flagColumns == defaultColumns || c.flagColumns == "e"+defaultColumns || c.flagColumns == currentDefault {
+			if !strings.ContainsRune(c.flagColumns, 'l') {
+				c.flagColumns += "l"
+			}
+		}
+	} else if strings.ContainsAny(c.flagColumns, "l") {
+		return errors.New("Cannot use column shorthand char 'l' (LOCATION) when not clustered")
 	}
 
-	if c.flagAllProjects {
-		header = append([]string{"PROJECT"}, header...)
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
 	}
+
+	data := cli.ColumnData(columns, buckets)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, buckets)
+}
+
+func (c *cmdStorageBucketList) projectColumnData(bucket api.StorageBucket) string {
+	return bucket.Project
+}
+
+func (c *cmdStorageBucketList) nameColumnData(bucket api.StorageBucket) string {
+	return bucket.Name
+}
+
+func (c *cmdStorageBucketList) descriptionColumnData(bucket api.StorageBucket) string {
+	return bucket.Description
+}
+
+func (c *cmdStorageBucketList) locationColumnData(bucket api.StorageBucket) string {
+	return bucket.Location
 }
 
 // Set.
@@ -773,10 +806,21 @@ func (c *cmdStorageBucketKey) command() *cobra.Command {
 }
 
 // List Keys.
+// cmdStorageBucketKeyList implements the "lxc storage bucket key list" command.
 type cmdStorageBucketKeyList struct {
 	global           *cmdGlobal
 	storageBucketKey *cmdStorageBucketKey
 	flagFormat       string
+	flagColumns      string
+}
+
+// columns returns the ordered column definitions for storage bucket key list.
+func (c *cmdStorageBucketKeyList) columns() []cli.ShorthandColumn[api.StorageBucketKey] {
+	return []cli.ShorthandColumn[api.StorageBucketKey]{
+		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
+		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
+		{Shorthand: 'r', Name: "ROLE", Data: c.roleColumnData},
+	}
 }
 
 func (c *cmdStorageBucketKeyList) command() *cobra.Command {
@@ -786,7 +830,8 @@ func (c *cmdStorageBucketKeyList) command() *cobra.Command {
 	cmd.Short = "List storage bucket keys"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", cli.FormatStringFlagLabel("Cluster member name"))
 
 	cmd.RunE = c.run
@@ -829,26 +874,29 @@ func (c *cmdStorageBucketKeyList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data := make([][]string, 0, len(bucketKeys))
-	for _, bucketKey := range bucketKeys {
-		details := []string{
-			bucketKey.Name,
-			bucketKey.Description,
-			bucketKey.Role,
-		}
-
-		data = append(data, details)
+	// Parse column flags.
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	if err != nil {
+		return err
 	}
 
+	data := cli.ColumnData(columns, bucketKeys)
 	sort.Sort(cli.SortColumnsNaturally(data))
-
-	header := []string{
-		"NAME",
-		"DESCRIPTION",
-		"ROLE",
-	}
+	header := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, header, data, bucketKeys)
+}
+
+func (c *cmdStorageBucketKeyList) nameColumnData(key api.StorageBucketKey) string {
+	return key.Name
+}
+
+func (c *cmdStorageBucketKeyList) descriptionColumnData(key api.StorageBucketKey) string {
+	return key.Description
+}
+
+func (c *cmdStorageBucketKeyList) roleColumnData(key api.StorageBucketKey) string {
+	return key.Role
 }
 
 // Create Key.

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1634,7 +1634,7 @@ Column shorthand chars:
     t - Type of volume (custom, image, container or virtual-machine)
     u - Number of references (used by)
     U - Current disk usage`)
-	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
 
 	cmd.RunE = c.run
 

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -14,11 +14,6 @@ import (
 	cli "github.com/canonical/lxd/shared/cmd"
 )
 
-type warningColumn struct {
-	Name string
-	Data func(api.Warning) string
-}
-
 type cmdWarning struct {
 	global *cmdGlobal
 }
@@ -61,7 +56,30 @@ type cmdWarningList struct {
 	flagAll     bool
 }
 
-const defaultWarningColumns = "utSscpLl"
+func (c *cmdWarningList) columns() []cli.ShorthandColumn[api.Warning] {
+	return []cli.ShorthandColumn[api.Warning]{
+		{Shorthand: 'u', Name: "UUID", Data: c.uuidColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'S', Name: "STATUS", Data: c.statusColumnData},
+		{Shorthand: 's', Name: "SEVERITY", Data: c.severityColumnData},
+		{Shorthand: 'c', Name: "COUNT", Data: c.countColumnData},
+		{Shorthand: 'p', Name: "PROJECT", Data: c.projectColumnData},
+		{Shorthand: 'L', Name: "LOCATION", Data: c.locationColumnData},
+		{Shorthand: 'l', Name: "LAST SEEN", Data: c.lastSeenColumnData},
+	}
+}
+
+func (c *cmdWarningList) columnsNonClustered() []cli.ShorthandColumn[api.Warning] {
+	return []cli.ShorthandColumn[api.Warning]{
+		{Shorthand: 'u', Name: "UUID", Data: c.uuidColumnData},
+		{Shorthand: 't', Name: "TYPE", Data: c.typeColumnData},
+		{Shorthand: 'S', Name: "STATUS", Data: c.statusColumnData},
+		{Shorthand: 's', Name: "SEVERITY", Data: c.severityColumnData},
+		{Shorthand: 'c', Name: "COUNT", Data: c.countColumnData},
+		{Shorthand: 'p', Name: "PROJECT", Data: c.projectColumnData},
+		{Shorthand: 'l', Name: "LAST SEEN", Data: c.lastSeenColumnData},
+	}
+}
 
 func (c *cmdWarningList) command() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -88,7 +106,7 @@ Column shorthand chars:
     u - UUID
     t - Type`)
 
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultWarningColumns, cli.FormatStringFlagLabel("Columns"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
 	cmd.Flags().BoolVarP(&c.flagAll, "all", "a", false, "List all warnings")
 
@@ -136,22 +154,33 @@ func (c *cmdWarningList) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Process the columns
-	columns, err := c.parseColumns(remoteServer.IsClustered())
+	defaultColumns := cli.DefaultColumnString(c.columns())
+	var cols []cli.ShorthandColumn[api.Warning]
+	if remoteServer.IsClustered() {
+		cols = c.columns()
+	} else {
+		if c.flagColumns != defaultColumns {
+			if strings.ContainsAny(c.flagColumns, "L") {
+				return errors.New("Cannot specify column L when not clustered")
+			}
+		}
+
+		cols = c.columnsNonClustered()
+		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
+	}
+
+	// Add non-default column that is available for user selection.
+	cols = append(cols,
+		cli.ShorthandColumn[api.Warning]{Shorthand: 'f', Name: "FIRST SEEN", Data: c.firstSeenColumnData},
+	)
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
 	if err != nil {
 		return err
 	}
 
 	// Render the table
-	data := [][]string{}
-	for _, warning := range warnings {
-		row := []string{}
-		for _, column := range columns {
-			row = append(row, column.Data(warning))
-		}
-
-		data = append(data, row)
-	}
-
+	data := cli.ColumnData(columns, warnings)
 	sort.Sort(cli.StringList(data))
 
 	rawData := make([]*api.Warning, len(warnings))
@@ -159,10 +188,7 @@ func (c *cmdWarningList) run(cmd *cobra.Command, args []string) error {
 		rawData[i] = &warnings[i]
 	}
 
-	headers := []string{}
-	for _, column := range columns {
-		headers = append(headers, column.Name)
-	}
+	headers := cli.ColumnHeaders(columns)
 
 	return cli.RenderTable(c.flagFormat, headers, data, rawData)
 }
@@ -201,50 +227,6 @@ func (c *cmdWarningList) typeColumnData(warning api.Warning) string {
 
 func (c *cmdWarningList) uuidColumnData(warning api.Warning) string {
 	return warning.UUID
-}
-
-func (c *cmdWarningList) parseColumns(clustered bool) ([]warningColumn, error) {
-	columnsShorthandMap := map[rune]warningColumn{
-		'c': {"COUNT", c.countColumnData},
-		'f': {"FIRST SEEN", c.firstSeenColumnData},
-		'l': {"LAST SEEN", c.lastSeenColumnData},
-		'p': {"PROJECT", c.projectColumnData},
-		's': {"SEVERITY", c.severityColumnData},
-		'S': {"STATUS", c.statusColumnData},
-		't': {"TYPE", c.typeColumnData},
-		'u': {"UUID", c.uuidColumnData},
-	}
-
-	if clustered {
-		columnsShorthandMap['L'] = warningColumn{"LOCATION", c.locationColumnData}
-	} else {
-		if c.flagColumns != defaultWarningColumns {
-			if strings.ContainsAny(c.flagColumns, "L") {
-				return nil, errors.New("Cannot specify column L when not clustered")
-			}
-		}
-		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
-	}
-
-	columnList := strings.Split(c.flagColumns, ",")
-
-	columns := []warningColumn{}
-	for _, columnEntry := range columnList {
-		if columnEntry == "" {
-			return nil, fmt.Errorf("Empty column entry (redundant, leading or trailing command) in %q", c.flagColumns)
-		}
-
-		for _, columnRune := range columnEntry {
-			column, ok := columnsShorthandMap[columnRune]
-			if !ok {
-				return nil, fmt.Errorf("Unknown column shorthand char '%c' in %q", columnRune, columnEntry)
-			}
-
-			columns = append(columns, column)
-		}
-	}
-
-	return columns, nil
 }
 
 // Acknowledge.

--- a/shared/cmd/column.go
+++ b/shared/cmd/column.go
@@ -34,10 +34,16 @@ func DefaultColumnString[T any](columns []ShorthandColumn[T]) string {
 }
 
 // ParseShorthandColumns builds a shorthand map from the given column definitions
-// and parses the flagColumns string against it.
+// and parses the flagColumns string against it. It returns an error if any
+// duplicate shorthand runes are found in the column definitions.
 func ParseShorthandColumns[T any](flagColumns string, columns []ShorthandColumn[T]) ([]TypedColumn[T], error) {
 	shorthandMap := make(map[rune]TypedColumn[T], len(columns))
 	for _, col := range columns {
+		_, ok := shorthandMap[col.Shorthand]
+		if ok {
+			return nil, fmt.Errorf("Duplicate column shorthand char '%c'", col.Shorthand)
+		}
+
 		shorthandMap[col.Shorthand] = TypedColumn[T]{Name: col.Name, Data: col.Data}
 	}
 

--- a/shared/cmd/column_test.go
+++ b/shared/cmd/column_test.go
@@ -103,6 +103,26 @@ func TestParseShorthandColumns(t *testing.T) {
 	// Verify data functions work.
 	testItem := item{Name: "Alice", Value: "100"}
 	assert.Equal(t, "100", cols[0].Data(testItem))
+
+	// Comma-separated is equivalent to concatenated.
+	colsConcat, err := ParseShorthandColumns("nv", specs)
+	require.NoError(t, err)
+	colsComma, err := ParseShorthandColumns("n,v", specs)
+	require.NoError(t, err)
+	assert.Len(t, colsConcat, 2)
+	assert.Len(t, colsComma, 2)
+	assert.Equal(t, colsConcat[0].Name, colsComma[0].Name)
+	assert.Equal(t, colsConcat[1].Name, colsComma[1].Name)
+
+	// Duplicate shorthand in column definitions.
+	dupeSpecs := []ShorthandColumn[item]{
+		{Shorthand: 'n', Name: "NAME", Data: func(i item) string { return i.Name }},
+		{Shorthand: 'n', Name: "OTHER", Data: func(i item) string { return "" }},
+	}
+
+	_, err = ParseShorthandColumns("n", dupeSpecs)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Duplicate column shorthand char 'n'")
 }
 
 func TestColumnHeaders(t *testing.T) {

--- a/test/lint/bin-size.sh
+++ b/test/lint/bin-size.sh
@@ -12,7 +12,7 @@ echo "Check binaries size limits"
 
 # bin/max (sizes are in MiB)
 declare -rA sizes=(
-    ["lxc"]=16
+    ["lxc"]=17
     ["lxd-agent"]=14
 )
 readonly MIB="$((1024 * 1024))"


### PR DESCRIPTION
Continues https://github.com/canonical/lxd/pull/17823 Closes #15307.   

This PR applies the existing columnsShorthandMap + parseColumns() pattern (previously used by lxc list, lxc image list, lxc profile list, lxc storage volume list, and lxc warning list) across all remaining list commands: 

- cluster list, cluster group list
- network list, network acl list, network forward list,
  network load-balancer list, network peer list, network zone list,
  network zone record list, network list-allocations
- storage list, storage bucket list, storage bucket key list
- project list, operation list, placement group list
- auth group list, auth identity list, auth permission list,
  auth identity-provider-group list
- remote list, alias list
- image alias list
- config trust list, config trust list-tokens, config template list

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
