### PR TITLE
lxd/storage/block: Fix race between symlink evaluation during search for the disk device path and multipath modifying symlinks in the /dev/disk/by-id directory

### DIFF
--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -23,10 +23,13 @@ const DevDiskByID = "/dev/disk/by-id"
 // if the path matches the required criteria.
 type devicePathFilterFunc func(devPath string) bool
 
-// findDiskDevivePath iterates over device names in /dev/disk/by-id directory and
+// findDiskDevicePath iterates over device names in /dev/disk/by-id directory and
 // returns the path to the disk device that matches the given prefix and suffix.
 // Disk partitions are skipped, and an error is returned if the device is not found.
-func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+// When symlinks evaluation is set to true function attempts to evaluate
+// symlinks, returning (on success) a path to the disk device with all symlinks
+// fully resolved. Otherwise it may return a symlink to the disk device.
+func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc, evalSymlinks bool) (string, error) {
 	var diskPaths []string
 
 	// If there are no other disks on the system by id, the directory might not
@@ -52,6 +55,11 @@ func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFu
 		devPath, err := filepath.EvalSymlinks(diskPath)
 		if err != nil {
 			return "", err
+		}
+
+		// If the user requested no symlink evaluation return disk path.
+		if !evalSymlinks {
+			return diskPath, nil
 		}
 
 		return devPath, nil
@@ -228,7 +236,7 @@ func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilt
 
 	for {
 		// Check if the device is already present.
-		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter)
+		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter, false)
 		if err != nil && !errors.Is(err, unix.ENOENT) {
 			return "", err
 		}
@@ -253,8 +261,11 @@ func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilt
 // GetDiskDevicePath checks whether the disk device with a given prefix and suffix
 // exists in /dev/disk/by-id directory. A device path is returned if the device is
 // found, otherwise an error is returned.
+// When symlinks evaluation is set to true function attempts to evaluate
+// symlinks, returning (on success) a path to the disk device with all symlinks
+// fully resolved. Otherwise it may return a symlink to the disk device.
 func GetDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
-	devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter)
+	devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter, true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
There is a race between symlink evaluation during search for the disk device path and multipath modifying symlinks in the /dev/disk/by-id directory when a new disk device is freshly attached to the system.

This PR aims to fix it by postponing symlink evaluation and passing unevaluated value to mount call faction allowing system kennel to evaluate it. As mount is executed multiple times in a loop (until specified timeout) when path pointed by the symlink is changed by multipart, consecutive invocations of mount have a chance to pick a different (correct) device.

## Observed problem

1. After attaching a new disk device drivers attempt to locate the device in `/dev/disk/by-id` directory (ex. found path may be `/dev/disk/by-id/new-disk-id`). This path is a symlink to the actual device (ex. `/dev/disk/by-id/new-disk-id -> /dev/sdx` before multipath, or `/dev/disk/by-id/new-disk-id -> /dev/dm-x` after multipath).
2. Driver evaluates the symlink. If the symlink is evaluated before multipath, old path will be used by the driver (ex. `/dev/sdx`).
3. Mount is called (on failure mount attempt is repeated, but arguments stay the same) (ex. mount invoked with invalid path `/dev/sdx` instead to the device mapper `/dev/dm-x`). Since the device is used by the multipath all attempt fail with error indicating that the device is busy (and it is not the right device).

## What this PR changes

1. After attaching a new disk device drivers attempt to locate the device in `/dev/disk/by-id` directory (ex. found path may be `/dev/disk/by-id/new-disk-id`). But the found symlink is not evaluated (ex. regardless if `/dev/disk/by-id/new-disk-id -> /dev/sdx` or `/dev/disk/by-id/new-disk-id -> /dev/dm-x` path to the symlnik `/dev/disk/by-id/new-disk-id` is used).
2. Mount is called (on failure mount attempt is repeated, but arguments stay the same) (ex. mount invoked with path `/dev/disk/by-id/new-disk-id`). Kernel evaluates the path separately for each consecutive invocation finally (at some attempt) picking the right device (ex. `/dev/disk/by-id/new-disk-id -> /dev/dm-x`).

## Open esign question

 - [ ] Should `WaitDiskDevicePath` use unevaluated path and `GetDiskDevicePath` evaluate it as is currently done, or should both functions have the same behavior (no symlink evaluation)?

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
