### PR TITLE
lxd/storage/block: Fix race between symlink evaluation during search for the disk device path and multipath modifying symlinks in the /dev/disk/by-id directory

### DIFF
--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -14,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
 )
 
 // DevDiskByID represents the system's path for disks identified by their ID.
@@ -214,9 +216,6 @@ func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
 // once it is found. If the device does not appear within the timeout, an error
 // is returned.
 func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
-	var err error
-	var diskPath string
-
 	_, ok := ctx.Deadline()
 	if !ok {
 		// Set a default timeout of 30 seconds for the context
@@ -226,28 +225,62 @@ func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilt
 		defer cancel()
 	}
 
-	for {
-		// Check if the device is already present.
-		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter)
+	// Inner fetching logic.
+	getDevPath := func() (string, error) {
+		// Check if the device is present.
+		devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter)
 		if err != nil && !errors.Is(err, unix.ENOENT) {
 			return "", err
 		}
 
+		if devPath == "" {
+			// If the device is not found, break the wait loop.
+			return "", nil
+		}
+
+		// Wait for udev to settle as it may change the disk path or create
+		// holders.
+		err = WaitUdevSettle(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		// Check if the found device has holders or is it ready to use.
+		hasHolders, err := HasDiskHaveHolders(devPath)
+		if err != nil {
+			return "", err
+		}
+
+		if hasHolders {
+			// Wait for either the holders to release the device or update the path.
+			return "", nil
+		}
+
+		// Successful attempt - we found the path, udev has settled and there are
+		// no holders.
+		return devPath, nil
+	}
+
+	for {
+		// Attempt to get the device path.
+		devPath, err := getDevPath()
+		if err != nil {
+			return "", err
+		}
+
 		// If the device is found, return the device path.
-		if diskPath != "" {
-			break
+		if devPath != "" {
+			return devPath, nil
 		}
 
 		// Check if context is cancelled.
-		err := ctx.Err()
+		err = ctx.Err()
 		if err != nil {
 			return "", err
 		}
 
 		time.Sleep(500 * time.Millisecond)
 	}
-
-	return diskPath, nil
 }
 
 // GetDiskDevicePath checks whether the disk device with a given prefix and suffix
@@ -284,6 +317,70 @@ func GetDisksByID(filterPrefix string) ([]string, error) {
 	}
 
 	return filteredDisks, nil
+}
+
+// WaitUdevSettle waits for the udev processing completion.
+func WaitUdevSettle(ctx context.Context) error {
+	_, ok := ctx.Deadline()
+	if !ok {
+		// Set a default timeout of 30 seconds for the context
+		// if no deadline is already configured.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+
+	stdout, stderr, err := shared.RunCommandSplit(ctx, nil, nil, "udevadm", "settle")
+	if err != nil {
+		if ctx.Err() == nil {
+			// Debug log non context related errors.
+			logger.Debug("storage: udevadm settle failure", logger.Ctx{
+				"err":    err,
+				"stdout": stdout,
+				"stderr": stderr,
+			})
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// HasDiskHaveHolders check if the given disk device have holders.
+func HasDiskHaveHolders(diskPath string) (bool, error) {
+	devPath, err := filepath.EvalSymlinks(diskPath)
+	if err != nil {
+		// Return any symlink evaluation error (if disk do not exists return unix.ENOENT).
+		return false, err
+	}
+
+	devName := filepath.Base(devPath)
+	f, err := os.Open("/sys/block/" + devName + "/holders")
+	if err != nil && (errors.Is(err, unix.ENOENT) || errors.Is(err, os.ErrNotExist)) {
+		// If the directory itself do not exists there are no holders.
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	defer f.Close()
+
+	// Do not load more than a single entry to determine if there are any holders.
+	entries, err := f.ReadDir(1)
+	if err != nil && errors.Is(err, io.EOF) {
+		// ReadDir returns io.EOF if there are no more entires. Since this is
+		// the first call it means there are no entries at all (no holders).
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return len(entries) > 0, nil
 }
 
 // LoopDeviceSetupAlign creates a forced 512-byte aligned loop device.


### PR DESCRIPTION
There is a race between symlink evaluation during search for the disk device path and multipath modifying symlinks in the /dev/disk/by-id directory when a new disk device is freshly attached to the system.

This PR aims to fix it by after final (evaluated) path is found it waits for `udev` to settle, then is check if the device has no holders an only after those conditions are met uses the device. Otherwise it reattempts to discover the device path (as `udev` rules or holders may have change paths). This works because if wrong device is picked (ex. before multipath points symlinks to it) the device will have holders (assuming `udev` is done processing its rules).

> Previous, unsuccessful fix attempt of this issue is in PR #17829.

## Observed problem

1. After attaching a new disk device drivers attempt to locate the device in `/dev/disk/by-id` directory (ex. found path may be `/dev/disk/by-id/new-disk-id`). This path is a symlink to the actual device (ex. `/dev/disk/by-id/new-disk-id -> /dev/sdx` before multipath, or `/dev/disk/by-id/new-disk-id -> /dev/dm-x` after multipath).
2. Driver evaluates the symlink. If the symlink is evaluated before multipath, old path will be used by the driver (ex. `/dev/sdx`).
3. Mount is called (on failure mount attempt is repeated, but arguments stay the same) (ex. mount invoked with invalid path `/dev/sdx` instead to the device mapper `/dev/dm-x`). Since the device is used by the multipath all attempt fail with error indicating that the device is busy (and it is not the right device).

## What this PR changes

1. After attaching a new disk device drivers attempt to locate the device in `/dev/disk/by-id` directory (ex. found path may be `/dev/disk/by-id/new-disk-id`). This path is a symlink to the actual device (ex. `/dev/disk/by-id/new-disk-id -> /dev/sdx` before multipath, or `/dev/disk/by-id/new-disk-id -> /dev/dm-x` after multipath).
2. Driver evaluates the symlink. If the symlink is evaluated before multipath, old path will be used by the driver (ex. `/dev/sdx`).
3. Driver waits for `udevadm settle`, then it inspect holders of the found disk device (ex. directory `/sys/block/sdx/holders`). If there are any it goes back to step 1, trying to find a new device path. Otherwise it continues with the found device.
4. Mount is called, but since the disk device have no holders it must be the right device.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
