### PR TITLE
lxd/operations: Don't send event on schedule

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -284,11 +284,9 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 	}
 
 	op.logger.Debug("New operation")
-	_, md := op.Render()
 
 	operationsLock.Lock()
 	operations[op.id] = &op
-	op.sendEvent(md)
 	operationsLock.Unlock()
 
 	op.start()


### PR DESCRIPTION
Now that operations are created directly in the `running` state and start() routine is called automatically from scheduleOperation(), the events sent by the schedule and start calls are identical. So we remove one to avoid confusion. We keep only the one in start() routine as start() will always report `Running` state of the operation. If operations are not directly created in the `Running` state (such as operations scheduled for later stages), the `scheduleOperation()` can send another event preceding the one sent from start().

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
