### PR TITLE
lxd: Replace gorilla/mux with stdlib http.ServeMux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/go-envparse v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,6 @@ github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU
 github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/lxd/acme.go
+++ b/lxd/acme.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/acme"
 	"github.com/canonical/lxd/lxd/cluster"
@@ -41,11 +38,7 @@ func acmeProvideChallenge(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(nil)
 	}
 
-	token, err := url.PathUnescape(mux.Vars(r)["token"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	token := r.PathValue("token")
 	if d.http01Provider.Token() != token {
 		return response.NotFound(nil)
 	}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -38,16 +38,6 @@ func restServer(d *Daemon) *http.Server {
 		}
 
 		d.createCmd(mux, "1.0", c)
-
-		// Create any alias endpoints using the same handlers as the parent endpoint but
-		// with a different path and name (so the handler can differentiate being called via
-		// a different endpoint) if it wants to.
-		for _, alias := range c.Aliases {
-			ac := c
-			ac.Name = alias.Name
-			ac.Path = alias.Path
-			d.createCmd(mux, "1.0", ac)
-		}
 	}
 
 	for _, c := range apiInternal {

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/auth/bearer"
@@ -22,10 +22,7 @@ import (
 
 func restServer(d *Daemon) *http.Server {
 	/* Setup the web server */
-	mux := mux.NewRouter()
-	mux.StrictSlash(false) // Don't redirect to URL with trailing slash.
-	mux.SkipClean(true)
-	mux.UseEncodedPath() // Allow encoded values in path segments.
+	mux := &lxdMux{ServeMux: http.NewServeMux()}
 
 	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.identityCache) {
 		mux.HandleFunc(endpoint, f)
@@ -48,7 +45,7 @@ func restServer(d *Daemon) *http.Server {
 		d.createCmd(mux, "", c)
 	}
 
-	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		metrics.TrackStartedRequest(r, entity.TypeServer) // Use TypeServer for not found handler
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
@@ -74,11 +71,9 @@ func isBrowserClient(r *http.Request) bool {
 
 func metricsServer(d *Daemon) *http.Server {
 	/* Setup the web server */
-	mux := mux.NewRouter()
-	mux.StrictSlash(false)
-	mux.SkipClean(true)
+	mux := &lxdMux{ServeMux: http.NewServeMux()}
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/{$}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
@@ -90,7 +85,7 @@ func metricsServer(d *Daemon) *http.Server {
 	d.createCmd(mux, "1.0", api10Cmd)
 	d.createCmd(mux, "1.0", metricsCmd)
 
-	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		metrics.TrackStartedRequest(r, entity.TypeServer) // Use TypeServer for not found handler
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
@@ -106,8 +101,147 @@ func metricsServer(d *Daemon) *http.Server {
 	}
 }
 
+type lxdMux struct {
+	*http.ServeMux
+	prefixHandlers []lxdPrefixHandler
+}
+
+// lxdPrefixHandler handles patterns that could not be registered on ServeMux
+// due to routing conflicts [images/aliases/{name} vs. "images/{fingerprint}/export"]
+// It matches requests by prefix, an optional suffix, and a single-segment variable in between.
+type lxdPrefixHandler struct {
+	prefix  string
+	varName string
+	suffix  string
+	handler http.HandlerFunc
+}
+
+// HandleFunc registers a handler for the given pattern. If the pattern conflicts
+// with an already-registered ServeMux pattern, it falls back to prefix-based matching.
+func (m *lxdMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	if !m.tryRegister(pattern, handler) {
+		// Parse the pattern to extract prefix, variable name, and suffix.
+		// For example, "images/{fingerprint}/export" becomes:
+		// prefix="/1.0/images/", varName="fingerprint", suffix="/export".
+		start := strings.Index(pattern, "{")
+		end := strings.Index(pattern, "}")
+		if start == -1 || end == -1 || end <= start {
+			panic(fmt.Sprintf("Conflicting route pattern without parsable path variable: %q", pattern))
+		}
+
+		prefix := pattern[:start]
+		suffix := pattern[end+1:]
+
+		// Guard against duplicate registrations: a second call with the same
+		// conflicting pattern would append an unreachable entry.
+		for _, existing := range m.prefixHandlers {
+			if existing.prefix == prefix && existing.suffix == suffix {
+				panic(fmt.Sprintf("Duplicate conflicting route registration for pattern %q", pattern))
+			}
+		}
+
+		m.prefixHandlers = append(m.prefixHandlers, lxdPrefixHandler{
+			prefix:  prefix,
+			varName: strings.TrimSuffix(pattern[start+1:end], "..."),
+			suffix:  suffix,
+			handler: handler,
+		})
+	}
+}
+
+// tryRegister attempts to register a pattern on the underlying ServeMux.
+// Returns false if ServeMux panics due to a routing conflict. Any other
+// panic is re-raised so that unexpected issues are not silently swallowed.
+func (m *lxdMux) tryRegister(pattern string, handler http.HandlerFunc) (registered bool) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		msg := fmt.Sprint(r)
+
+		// ServeMux panics with a message containing "conflicts with pattern"
+		// when two patterns overlap. Verified against Go 1.22-1.26. If Go
+		// changes the wording, tryRegister will re-panic (safe failure)
+		// instead of silently dropping routes.
+		if !strings.Contains(msg, "conflicts with pattern") {
+			panic(r)
+		}
+
+		// Distinguish a legitimate overlap (two different patterns that
+		// conflict) from an accidental exact duplicate. Go's panic message
+		// for ServeMux conflicts is of the form:
+		//   pattern "A" ... conflicts with pattern "B" ...
+		// If our pattern appears twice, A == B: the caller registered the
+		// exact same pattern twice, which is a programmer error.
+		quoted := fmt.Sprintf("%q", pattern)
+		if strings.Count(msg, quoted) >= 2 {
+			panic(r)
+		}
+
+		registered = false
+	}()
+
+	m.ServeMux.HandleFunc(pattern, handler)
+
+	return true
+}
+
+func (m *lxdMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// note that we prefer ServeMux when it has a matching pattern. This ensures
+	// that directly-registered routes take priority over prefix fallback
+	// handlers, which matters when both could match. like
+	// /images/aliases/export matches both "images/aliases/{name}" on ServeMux
+	// and the prefix handler for "images/{fingerprint}/export". See
+	// https://github.com/canonical/lxd/pull/17856
+	_, pattern := m.Handler(r)
+	if pattern != "" && pattern != "/" {
+		m.ServeMux.ServeHTTP(w, r)
+		return
+	}
+
+	// prefix handlers
+	escapedPath := r.URL.EscapedPath()
+	pathLen := len(escapedPath)
+
+	for _, ph := range m.prefixHandlers {
+		preLen := len(ph.prefix)
+		sufLen := len(ph.suffix)
+
+		if pathLen < preLen+sufLen || !strings.HasPrefix(escapedPath, ph.prefix) {
+			continue
+		}
+
+		remainder := escapedPath[preLen:]
+		if !strings.HasSuffix(remainder, ph.suffix) {
+			continue
+		}
+
+		val := remainder[:len(remainder)-sufLen]
+
+		if val == "" || strings.Contains(val, "/") {
+			// encoded slashes (%2f) are fine and stay as-is.
+			continue
+		}
+
+		decoded, err := url.PathUnescape(val)
+		if err != nil {
+			decoded = val
+		}
+
+		r.SetPathValue(ph.varName, decoded)
+		ph.handler(w, r)
+
+		return
+	}
+
+	// a legit 404.
+	m.ServeMux.ServeHTTP(w, r)
+}
+
 type lxdHTTPServer struct {
-	r *mux.Router
+	r http.Handler
 	d *Daemon
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	dqlite "github.com/canonical/go-dqlite/v3/client"
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -1591,11 +1590,8 @@ func clusterCheckNetworksMatch(ctx context.Context, cluster *db.Cluster, reqNetw
 func internalClusterRaftNodeDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	address, err := url.PathUnescape(mux.Vars(r)["address"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	address := r.PathValue("address")
+	var err error
 	err = cluster.RemoveRaftNode(d.gateway, address)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/api_cluster_group.go
+++ b/lxd/api_cluster_group.go
@@ -6,10 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -312,11 +309,8 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	if !s.ServerClustered {
 		return response.BadRequest(errors.New("This server is not clustered"))
 	}
@@ -392,11 +386,8 @@ func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	if name == "default" {
 		return response.Forbidden(errors.New(`The "default" group cannot be renamed`))
 	}
@@ -484,11 +475,8 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	if !s.ServerClustered {
 		return response.BadRequest(errors.New("This server is not clustered"))
 	}
@@ -610,11 +598,8 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	if !s.ServerClustered {
 		return response.BadRequest(errors.New("This server is not clustered"))
 	}
@@ -773,11 +758,8 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	// Quick checks.
 	if name == "default" {
 		return response.Forbidden(errors.New("The 'default' cluster group cannot be deleted"))

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -7,14 +7,11 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"net/url"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -452,11 +449,7 @@ func clusterMemberGet(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(cluster.ErrNodeIsNotClustered)
 	}
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	var raftNodes []db.RaftNode
 	err = s.DB.Node.Transaction(r.Context(), func(ctx context.Context, tx *db.NodeTx) error {
 		raftNodes, err = tx.GetRaftNodes(ctx)
@@ -590,11 +583,7 @@ func clusterMemberPut(d *Daemon, r *http.Request) response.Response {
 
 // updateClusterMember is shared between clusterMemberPut and clusterMemberPatch.
 func updateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Request, isPatch bool) response.Response {
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	resp := forwardedResponseToNode(r.Context(), s, name)
 	if resp != nil {
 		return resp
@@ -935,10 +924,8 @@ func clusterValidateConfig(config map[string]string) error {
 func clusterMemberPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	memberName := r.PathValue("name")
+	var err error
 
 	// Forward request.
 	resp := forwardedResponseToNode(r.Context(), s, memberName)
@@ -1006,11 +993,7 @@ func clusterMemberDelete(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(cluster.ErrNodeIsNotClustered)
 	}
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	force := shared.IsTrue(r.FormValue("force"))
 
 	localClusterAddress := s.LocalConfig.ClusterAddress()
@@ -1294,11 +1277,7 @@ func clusterMemberDelete(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func clusterMemberStateGet(d *Daemon, r *http.Request) response.Response {
-	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	memberName := r.PathValue("name")
 	s := d.State()
 
 	// Forward request.
@@ -1343,10 +1322,8 @@ func clusterMemberStateGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	name := r.PathValue("name")
+	var err error
 
 	s := d.State()
 
@@ -1763,10 +1740,8 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, inst insta
 func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Response {
 	s := d.State()
 
-	originName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	originName := r.PathValue("name")
+	var err error
 
 	var instances []instance.Instance
 	var localInstances []instance.Instance

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/auth"
@@ -373,11 +371,7 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 // It detects whether the instance reference is an instance ID or instance name and loads instance accordingly.
 func internalContainerHookLoadFromReference(s *state.State, r *http.Request) (instance.Instance, error) {
 	var inst instance.Instance
-	instanceRef, err := url.PathUnescape(mux.Vars(r)["instanceRef"])
-	if err != nil {
-		return nil, err
-	}
-
+	instanceRef := r.PathValue("instanceRef")
 	projectName := request.ProjectParam(r)
 
 	instanceID, err := strconv.Atoi(instanceRef)

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -15,8 +15,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gorilla/mux"
-
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cluster"
@@ -499,11 +497,7 @@ func projectCreateDefaultProfile(ctx context.Context, tx *db.ClusterTx, project 
 func projectGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeProject, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -578,11 +572,8 @@ func projectGet(d *Daemon, r *http.Request) response.Response {
 func projectPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	// Get the current data
 	var project *api.Project
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -664,11 +655,8 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 func projectPatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	// Get the current data
 	var project *api.Project
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -949,11 +937,8 @@ func projectNodeConfigRename(d *Daemon, ctx context.Context, oldName string, new
 func projectPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	// Parse the request.
 	req := api.ProjectPost{}
 
@@ -1219,11 +1204,7 @@ func doProjectForceDelete(ctx context.Context, clientType request.ClientType, op
 func projectDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	force := shared.IsTrue(r.FormValue("force"))
 
 	// Quick checks.
@@ -1458,11 +1439,8 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 func projectStateGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	// Setup the state struct.
 	state := api.ProjectState{}
 

--- a/lxd/api_root.go
+++ b/lxd/api_root.go
@@ -79,28 +79,24 @@ var acmeChallengeCmd = APIEndpoint{
 }
 
 var oidcLoginCmd = APIEndpoint{
-	Name: "oidcLogin",
 	Path: "oidc/login",
 
 	Get: APIEndpointAction{Handler: oidcLoginGet, AllowUntrusted: true},
 }
 
 var oidcCallbackCmd = APIEndpoint{
-	Name: "oidcCallback",
 	Path: "oidc/callback",
 
 	Get: APIEndpointAction{Handler: oidcCallbackGet, AllowUntrusted: true},
 }
 
 var oidcLogoutCmd = APIEndpoint{
-	Name: "oidcLogout",
 	Path: "oidc/logout",
 
 	Get: APIEndpointAction{Handler: oidcLogoutGet, AllowUntrusted: true},
 }
 
 var bearerLogoutCmd = APIEndpoint{
-	Name: "bearerLogout",
 	Path: "bearer/logout",
 
 	Get: APIEndpointAction{Handler: bearerLogoutGet, AllowUntrusted: true},
@@ -108,7 +104,7 @@ var bearerLogoutCmd = APIEndpoint{
 
 // uiCmd serves the LXD web UI. The path pattern captures any subpath under /ui/.
 var uiCmd = APIEndpoint{
-	Path: "ui/{filepath:.*}",
+	Path: "ui/{filepath...}",
 
 	Get: APIEndpointAction{Handler: uiGet, AllowUntrusted: true},
 }
@@ -122,7 +118,7 @@ var uiRedirectCmd = APIEndpoint{
 
 // documentationCmd serves the LXD documentation. The path pattern captures any subpath under /documentation/.
 var documentationCmd = APIEndpoint{
-	Path: "documentation/{filepath:.*}",
+	Path: "documentation/{filepath...}",
 
 	Get: APIEndpointAction{Handler: documentationGet, AllowUntrusted: true},
 }

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -10,8 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gorilla/mux"
-
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
@@ -26,7 +24,6 @@ import (
 )
 
 var authGroupsCmd = APIEndpoint{
-	Name:        "auth_groups",
 	Path:        "auth/groups",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -40,7 +37,6 @@ var authGroupsCmd = APIEndpoint{
 }
 
 var authGroupCmd = APIEndpoint{
-	Name:        "auth_group",
 	Path:        "auth/groups/{groupName}",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -404,11 +400,7 @@ func createAuthGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func getAuthGroup(d *Daemon, r *http.Request) response.Response {
-	groupName, err := url.PathUnescape(mux.Vars(r)["groupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	groupName := r.PathValue("groupName")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeAuthGroup, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -480,10 +472,8 @@ func getAuthGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
-	groupName, err := url.PathUnescape(mux.Vars(r)["groupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	groupName := r.PathValue("groupName")
+	var err error
 
 	if groupName == api.AuthGroupAdminsName {
 		return response.BadRequest(errors.New("The admins group cannot be modified"))
@@ -579,10 +569,8 @@ func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
-	groupName, err := url.PathUnescape(mux.Vars(r)["groupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	groupName := r.PathValue("groupName")
+	var err error
 
 	if groupName == api.AuthGroupAdminsName {
 		return response.BadRequest(errors.New("The admins group cannot be modified"))
@@ -689,10 +677,8 @@ func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func renameAuthGroup(d *Daemon, r *http.Request) response.Response {
-	groupName, err := url.PathUnescape(mux.Vars(r)["groupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	groupName := r.PathValue("groupName")
+	var err error
 
 	if groupName == api.AuthGroupAdminsName {
 		return response.BadRequest(errors.New("The admins group cannot be renamed"))
@@ -749,10 +735,8 @@ func renameAuthGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func deleteAuthGroup(d *Daemon, r *http.Request) response.Response {
-	groupName, err := url.PathUnescape(mux.Vars(r)["groupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	groupName := r.PathValue("groupName")
+	var err error
 
 	if groupName == api.AuthGroupAdminsName {
 		return response.BadRequest(errors.New("The admins group cannot be deleted"))

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -13,11 +13,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -748,11 +745,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/InternalServerError"
 func certificateGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeCertificate, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -823,12 +816,9 @@ func certificateGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func certificatePut(d *Daemon, r *http.Request) response.Response {
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
 	// Get current database record.
+	var err error
 	var cert *dbCluster.CertificateLegacy
 	var projectMap map[int64][]string
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -896,12 +886,9 @@ func certificatePut(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func certificatePatch(d *Daemon, r *http.Request) response.Response {
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
 	// Get current database record.
+	var err error
 	var cert *dbCluster.CertificateLegacy
 	var projectMap map[int64][]string
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -1122,13 +1109,9 @@ func doCertificateUpdateUnprivileged(ctx context.Context, s *state.State, cert d
 func certificateDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
 	var certInfo *dbCluster.CertificateLegacy
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get current database record.
 		var err error
 		certInfo, err = dbCluster.GetCertificateLegacyByFingerprintPrefix(ctx, tx.Tx(), fingerprint)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -220,22 +220,15 @@ func defaultDaemon() *Daemon {
 
 // APIEndpoint represents a URL in our API.
 type APIEndpoint struct {
-	Name        string             // Name for this endpoint.
-	Path        string             // Path pattern for this endpoint.
-	MetricsType entity.Type        // Main entity type related to this endpoint. Used by the API metrics.
-	Aliases     []APIEndpointAlias // Any aliases for this endpoint.
+	Name        string      // Name for this endpoint.
+	Path        string      // Path pattern for this endpoint.
+	MetricsType entity.Type // Main entity type related to this endpoint. Used by the API metrics.
 	Get         APIEndpointAction
 	Head        APIEndpointAction
 	Put         APIEndpointAction
 	Post        APIEndpointAction
 	Delete      APIEndpointAction
 	Patch       APIEndpointAction
-}
-
-// APIEndpointAlias represents an alias URL of and APIEndpoint in our API.
-type APIEndpointAlias struct {
-	Name string // Name for this alias.
-	Path string // Path pattern for this alias.
 }
 
 // APIEndpointAction represents an action on an API endpoint.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -23,7 +23,6 @@ import (
 
 	dqliteClient "github.com/canonical/go-dqlite/v3/client"
 	"github.com/canonical/go-dqlite/v3/driver"
-	"github.com/gorilla/mux"
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/acme"
@@ -220,7 +219,6 @@ func defaultDaemon() *Daemon {
 
 // APIEndpoint represents a URL in our API.
 type APIEndpoint struct {
-	Name        string      // Name for this endpoint.
 	Path        string      // Path pattern for this endpoint.
 	MetricsType entity.Type // Main entity type related to this endpoint. Used by the API metrics.
 	Get         APIEndpointAction
@@ -274,9 +272,8 @@ func allowPermission(entityType entity.Type, entitlement auth.Entitlement, muxVa
 			entityURL = entity.ProjectURL(request.ProjectParam(r))
 		} else {
 			muxValues := make([]string, 0, len(muxVars))
-			vars := mux.Vars(r)
 			for _, muxVar := range muxVars {
-				muxValue := vars[muxVar]
+				muxValue := r.PathValue(muxVar)
 				if muxValue == "" {
 					return response.InternalError(fmt.Errorf("Failed performing permission check: Path argument label %q not found in request URL %q", muxVar, r.URL))
 				}
@@ -795,9 +792,13 @@ func (d *Daemon) State() *state.State {
 //
 // The created handler also keeps track of handled requests for the API metrics
 // for the main API endpoints.
-func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
+func (d *Daemon) createCmd(restAPI *lxdMux, version string, c APIEndpoint) {
 	var uri string
-	if c.Path == "" {
+	if c.Path == "" && version == "" {
+		// Exact match for root so it does not conflict with the "/" catch-all
+		// handler registered separately for 404 responses.
+		uri = "/{$}"
+	} else if c.Path == "" {
 		uri = "/" + version
 	} else if version != "" {
 		uri = "/" + version + "/" + c.Path
@@ -805,7 +806,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		uri = "/" + c.Path
 	}
 
-	route := restAPI.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
+	restAPI.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		// Only endpoints from the main API (version 1.0) should be counted for the metrics.
 		// This prevents internal endpoints from being included as well.
 		if version == "1.0" {
@@ -1007,12 +1008,6 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 		}
 	})
-
-	// If the endpoint has a canonical name then record it so it can be used to build URLS
-	// and accessed in the context of the request by the handler function.
-	if c.Name != "" {
-		route.Name(c.Name)
-	}
 }
 
 // have we setup shared mounts?

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -5,14 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"slices"
 	"strconv"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/auth/bearer"
@@ -275,11 +272,7 @@ func devLXDConfigKeyGetHandler(d *Daemon, r *http.Request) response.Response {
 		return response.DevLXDErrorResponse(err)
 	}
 
-	key, err := url.PathUnescape(mux.Vars(r)["key"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	key := r.PathValue("key")
 	if !strings.HasPrefix(key, "user.") && !strings.HasPrefix(key, "cloud-init.") {
 		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusForbidden))
 	}
@@ -334,11 +327,7 @@ func devLXDImageExportHandler(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(err)
 	}
 
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
 	projectName := request.ProjectParam(r)
 	if projectName != api.ProjectDefaultName {
 		// Disallow requests made to non-default projects.
@@ -526,8 +515,7 @@ func devLXDUbuntuProTokenPostHandler(d *Daemon, r *http.Request) response.Respon
 }
 
 func devLXDAPI(d *Daemon, authenticator devLXDAuthenticator) http.Handler {
-	m := mux.NewRouter()
-	m.UseEncodedPath() // Allow encoded values in path segments.
+	m := &lxdMux{ServeMux: http.NewServeMux()}
 
 	for _, handler := range apiDevLXD {
 		if !slices.Contains(entity.APIMetricsEntityTypes(), handler.MetricsType) {
@@ -540,9 +528,12 @@ func devLXDAPI(d *Daemon, authenticator devLXDAuthenticator) http.Handler {
 	return m
 }
 
-func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string, ep APIEndpoint, authenticator devLXDAuthenticator) {
+func registerDevLXDEndpoint(d *Daemon, apiRouter *lxdMux, apiVersion string, ep APIEndpoint, authenticator devLXDAuthenticator) {
 	uri := ep.Path
-	if uri != "/" {
+	if uri == "/" {
+		// Use /{$} to match only the exact root path, not as a catch-all.
+		uri = "/{$}"
+	} else {
 		uri = path.Join("/", apiVersion, ep.Path)
 	}
 
@@ -652,13 +643,7 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 		}
 	}
 
-	route := apiRouter.HandleFunc(uri, handleFunc)
-
-	// If the endpoint has a canonical name then record it so it can be used to build URLS
-	// and accessed in the context of the request by the handler function.
-	if ep.Name != "" {
-		route.Name(ep.Name)
-	}
+	apiRouter.HandleFunc(uri, handleFunc)
 }
 
 // enforceDevLXDProject ensures the "project" query parameter matches the instance's project.
@@ -732,9 +717,8 @@ func allowDevLXDPermission(entityType entity.Type, entitlement auth.Entitlement,
 			entityURL = entity.ProjectURL(instProject)
 		} else {
 			muxValues := make([]string, 0, len(muxVars))
-			vars := mux.Vars(r)
 			for _, muxVar := range muxVars {
-				muxValue := vars[muxVar]
+				muxValue := r.PathValue(muxVar)
 				if muxValue == "" {
 					return response.DevLXDErrorResponse(fmt.Errorf("Failed performing permission check: Path argument label %q not found in request URL %q", muxVar, r.URL))
 				}

--- a/lxd/devlxd_instances.go
+++ b/lxd/devlxd_instances.go
@@ -3,9 +3,6 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -39,11 +36,7 @@ func devLXDInstanceGetHandler(d *Daemon, r *http.Request) response.Response {
 	// This is also enforced by the access handler.
 	projectName := inst.Project().Name
 
-	targetInstName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	targetInstName := r.PathValue("name")
 	// Get identity from the request context.
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -58,6 +51,8 @@ func devLXDInstanceGetHandler(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("name", targetInstName)
 
 	resp := instanceGet(d, req)
 	etag, err := response.NewResponseCapture(req).RenderToStruct(resp, &targetInst)
@@ -99,11 +94,7 @@ func devLXDInstancePatchHandler(d *Daemon, r *http.Request) response.Response {
 	// This is also enforced by the access handler.
 	projectName := inst.Project().Name
 
-	targetInstName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	targetInstName := r.PathValue("name")
 	// Get identity from the request context.
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -125,6 +116,8 @@ func devLXDInstancePatchHandler(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("name", targetInstName)
 
 	resp := instanceGet(d, req)
 	etag, err := response.NewResponseCapture(req).RenderToStruct(resp, &targetInst)
@@ -157,6 +150,8 @@ func devLXDInstancePatchHandler(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("name", targetInstName)
 
 	resp = instancePatch(d, req)
 	err = response.NewResponseCapture(req).Render(resp)

--- a/lxd/devlxd_operation.go
+++ b/lxd/devlxd_operation.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
-
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/api"
@@ -32,7 +30,7 @@ func devLXDOperationsWaitHandler(d *Daemon, r *http.Request) response.Response {
 
 	// Allow access only to the project where current instance is running.
 	projectName := inst.Project().Name
-	opID := mux.Vars(r)["id"]
+	opID := r.PathValue("id")
 
 	// Determine the timeout based on the timeout query parameter and the request context's deadline.
 	timeout := -1
@@ -50,6 +48,8 @@ func devLXDOperationsWaitHandler(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("id", opID)
 
 	resp := operationWaitGet(d, req)
 	op, err := response.NewResponseCapture(req).RenderToOperation(resp)
@@ -75,7 +75,7 @@ func devLXDOperationDeleteHandler(d *Daemon, r *http.Request) response.Response 
 
 	// Allow access only to the project where current instance is running.
 	projectName := inst.Project().Name
-	opID := mux.Vars(r)["id"]
+	opID := r.PathValue("id")
 
 	// Delete the operation.
 	url := api.NewURL().Path("1.0", "operations", opID).Project(projectName)
@@ -83,6 +83,8 @@ func devLXDOperationDeleteHandler(d *Daemon, r *http.Request) response.Response 
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("id", opID)
 
 	resp := operationDelete(d, req)
 	err = response.NewResponseCapture(req).Render(resp)

--- a/lxd/devlxd_storage.go
+++ b/lxd/devlxd_storage.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/url"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -69,11 +66,7 @@ func devLXDStoragePoolGetHandler(d *Daemon, r *http.Request) response.Response {
 		return response.DevLXDErrorResponse(err)
 	}
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	poolName := r.PathValue("poolName")
 	// Get storage pool.
 	projectName := inst.Project().Name
 	pool := api.StoragePool{}
@@ -83,6 +76,8 @@ func devLXDStoragePoolGetHandler(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("poolName", poolName)
 
 	resp := storagePoolGet(d, req)
 	etag, err := response.NewResponseCapture(req).RenderToStruct(resp, &pool)
@@ -109,18 +104,9 @@ func devLXDStoragePoolVolumesGetHandler(d *Daemon, r *http.Request) response.Res
 	}
 
 	projectName := inst.Project().Name
-	pathVars := mux.Vars(r)
 
-	poolName, err := url.PathUnescape(pathVars["poolName"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
-	volType, err := url.PathUnescape(pathVars["type"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	poolName := r.PathValue("poolName")
+	volType := r.PathValue("type")
 	// Get identity from the request context.
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -157,6 +143,9 @@ func devLXDStoragePoolVolumesGetHandler(d *Daemon, r *http.Request) response.Res
 		return response.DevLXDErrorResponse(err)
 	}
 
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+
 	resp := storagePoolVolumesGet(d, req)
 	_, err = response.NewResponseCapture(req).RenderToStruct(resp, &vols)
 	if err != nil {
@@ -192,18 +181,9 @@ func devLXDStoragePoolVolumesPostHandler(d *Daemon, r *http.Request) response.Re
 	}
 
 	projectName := inst.Project().Name
-	pathVars := mux.Vars(r)
 
-	poolName, err := url.PathUnescape(pathVars["poolName"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
-	volType, err := url.PathUnescape(pathVars["type"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	poolName := r.PathValue("poolName")
+	volType := r.PathValue("type")
 	// Get identity from the request context.
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -278,11 +258,9 @@ func devLXDStoragePoolVolumesPostHandler(d *Daemon, r *http.Request) response.Re
 
 		// Set path variables for the request, required when populating the request using volume details.
 		// Source volume is not part of the original request URL.
-		req = mux.SetURLVars(req, map[string]string{
-			"volumeName": sourceVolName,
-			"poolName":   vol.Source.Pool,
-			"type":       "custom",
-		})
+		req.SetPathValue("volumeName", sourceVolName)
+		req.SetPathValue("poolName", vol.Source.Pool)
+		req.SetPathValue("type", "custom")
 
 		// Populate request context with source volume details.
 		err = addStoragePoolVolumeDetailsToRequestContext(d.State(), req)
@@ -327,6 +305,9 @@ func devLXDStoragePoolVolumesPostHandler(d *Daemon, r *http.Request) response.Re
 		return response.DevLXDErrorResponse(err)
 	}
 
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+
 	resp := storagePoolVolumesPost(d, req)
 	op, err := response.NewResponseCapture(req).RenderToOperation(resp)
 	if err != nil {
@@ -363,6 +344,10 @@ func devLXDStoragePoolVolumeGet(ctx context.Context, d *Daemon, target string, p
 	if err != nil {
 		return nil, "", err
 	}
+
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
 
 	resp := storagePoolVolumeGet(d, req)
 	etag, err := response.NewResponseCapture(req).RenderToStruct(resp, &vol)
@@ -477,6 +462,10 @@ func devLXDStoragePoolVolumePutHandler(d *Daemon, r *http.Request) response.Resp
 		return response.DevLXDErrorResponse(err)
 	}
 
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
+
 	var resp response.Response
 	if r.Method == http.MethodPatch {
 		resp = storagePoolVolumePatch(d, req)
@@ -524,6 +513,10 @@ func devLXDStoragePoolVolumeDeleteHandler(d *Daemon, r *http.Request) response.R
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
 
 	resp := storagePoolVolumeDelete(d, req)
 	op, err := response.NewResponseCapture(req).RenderToOperation(resp)
@@ -577,6 +570,10 @@ func devLXDStoragePoolVolumeSnapshotsGetHandler(d *Daemon, r *http.Request) resp
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
 
 	var snapshots []api.StorageVolumeSnapshot
 
@@ -650,6 +647,10 @@ func devLXDStoragePoolVolumeSnapshotsPostHandler(d *Daemon, r *http.Request) res
 		return response.DevLXDErrorResponse(err)
 	}
 
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
+
 	resp := storagePoolVolumeSnapshotsTypePost(d, req)
 	op, err := response.NewResponseCapture(req).RenderToOperation(resp)
 	if err != nil {
@@ -672,11 +673,7 @@ func devLXDStoragePoolVolumeSnapshotGetHandler(d *Daemon, r *http.Request) respo
 		return response.DevLXDErrorResponse(err)
 	}
 
-	snapName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	snapName := r.PathValue("snapshotName")
 	projectName := inst.Project().Name
 	target := r.URL.Query().Get("target")
 
@@ -701,6 +698,11 @@ func devLXDStoragePoolVolumeSnapshotGetHandler(d *Daemon, r *http.Request) respo
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
+	req.SetPathValue("snapshotName", snapName)
 
 	var snapshot api.StorageVolumeSnapshot
 
@@ -734,11 +736,7 @@ func devLXDStoragePoolVolumeSnapshotDeleteHandler(d *Daemon, r *http.Request) re
 		return response.DevLXDErrorResponse(err)
 	}
 
-	snapName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusBadRequest))
-	}
-
+	snapName := r.PathValue("snapshotName")
 	projectName := inst.Project().Name
 	target := r.URL.Query().Get("target")
 
@@ -763,6 +761,11 @@ func devLXDStoragePoolVolumeSnapshotDeleteHandler(d *Daemon, r *http.Request) re
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
+
+	req.SetPathValue("poolName", poolName)
+	req.SetPathValue("type", volType)
+	req.SetPathValue("volumeName", volName)
+	req.SetPathValue("snapshotName", snapName)
 
 	resp := storagePoolVolumeSnapshotTypeDelete(d, req)
 	op, err := response.NewResponseCapture(req).RenderToOperation(resp)
@@ -808,22 +811,8 @@ func devLXDStoragePoolVolumeTypeAccessHandler(entityType entity.Type, entitlemen
 
 // extractVolumeParams extracts the pool name, volume type and volume name from the request URL.
 func extractVolumeParams(r *http.Request) (poolName string, volType string, volName string, err error) {
-	pathVars := mux.Vars(r)
-
-	poolName, err = url.PathUnescape(pathVars["poolName"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
-	volType, err = url.PathUnescape(pathVars["type"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
-	volName, err = url.PathUnescape(pathVars["volumeName"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
+	poolName = r.PathValue("poolName")
+	volType = r.PathValue("type")
+	volName = r.PathValue("volumeName")
 	return poolName, volType, volName, nil
 }

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -8,12 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -43,7 +41,6 @@ const (
 )
 
 var identitiesCmd = APIEndpoint{
-	Name:        "identities",
 	Path:        "auth/identities",
 	MetricsType: entity.TypeIdentity,
 
@@ -55,7 +52,6 @@ var identitiesCmd = APIEndpoint{
 }
 
 var currentIdentityCmd = APIEndpoint{
-	Name:        "identities",
 	Path:        "auth/identities/current",
 	MetricsType: entity.TypeIdentity,
 
@@ -66,7 +62,6 @@ var currentIdentityCmd = APIEndpoint{
 }
 
 var tlsIdentitiesCmd = APIEndpoint{
-	Name:        "identities",
 	Path:        "auth/identities/tls",
 	MetricsType: entity.TypeIdentity,
 
@@ -81,7 +76,6 @@ var tlsIdentitiesCmd = APIEndpoint{
 }
 
 var oidcIdentitiesCmd = APIEndpoint{
-	Name:        "identities",
 	Path:        "auth/identities/oidc",
 	MetricsType: entity.TypeIdentity,
 
@@ -92,7 +86,6 @@ var oidcIdentitiesCmd = APIEndpoint{
 }
 
 var bearerIdentitiesCmd = APIEndpoint{
-	Name:        "identities",
 	Path:        "auth/identities/bearer",
 	MetricsType: entity.TypeIdentity,
 
@@ -107,7 +100,6 @@ var bearerIdentitiesCmd = APIEndpoint{
 }
 
 var tlsIdentityCmd = APIEndpoint{
-	Name:        "identity",
 	Path:        "auth/identities/tls/{nameOrIdentifier}",
 	MetricsType: entity.TypeIdentity,
 
@@ -130,7 +122,6 @@ var tlsIdentityCmd = APIEndpoint{
 }
 
 var oidcIdentityCmd = APIEndpoint{
-	Name:        "identity",
 	Path:        "auth/identities/oidc/{nameOrIdentifier}",
 	MetricsType: entity.TypeIdentity,
 
@@ -153,7 +144,6 @@ var oidcIdentityCmd = APIEndpoint{
 }
 
 var bearerIdentityCmd = APIEndpoint{
-	Name:        "identity",
 	Path:        "auth/identities/bearer/{nameOrIdentifier}",
 	MetricsType: entity.TypeIdentity,
 
@@ -204,12 +194,8 @@ const (
 // of the identity matching what is expected by the authorizer. It returns the Identity for convenience, and also adds
 // it to the request context with the ctxClusterDBIdentity context key for later use.
 func addIdentityDetailsToContext(s *state.State, r *http.Request, authenticationMethod string) (*dbCluster.IdentitiesRow, error) {
-	muxVars := mux.Vars(r)
-	nameOrID, err := url.PathUnescape(muxVars["nameOrIdentifier"])
-	if err != nil {
-		return nil, fmt.Errorf("Failed unescaping path argument: %w", err)
-	}
-
+	nameOrID := r.PathValue("nameOrIdentifier")
+	var err error
 	var id *dbCluster.IdentitiesRow
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		id, err = dbCluster.GetIdentityByNameOrIdentifier(ctx, tx.Tx(), authenticationMethod, nameOrID)

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -5,10 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -22,7 +19,6 @@ import (
 )
 
 var identityProviderGroupsCmd = APIEndpoint{
-	Name:        "identity_provider_groups",
 	Path:        "auth/identity-provider-groups",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -36,7 +32,6 @@ var identityProviderGroupsCmd = APIEndpoint{
 }
 
 var identityProviderGroupCmd = APIEndpoint{
-	Name:        "identity_provider_group",
 	Path:        "auth/identity-provider-groups/{idpGroupName}",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -248,11 +243,7 @@ func getIdentityProviderGroups(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func getIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
-	idpGroupName, err := url.PathUnescape(mux.Vars(r)["idpGroupName"])
-	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed unescaping identity provider group name path parameter: %w", err))
-	}
-
+	idpGroupName := r.PathValue("idpGroupName")
 	s := d.State()
 	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
@@ -382,11 +373,8 @@ func createIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func renameIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
-	idpGroupName, err := url.PathUnescape(mux.Vars(r)["idpGroupName"])
-	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed unescaping path argument: %w", err))
-	}
-
+	idpGroupName := r.PathValue("idpGroupName")
+	var err error
 	var idpGroupPost api.IdentityProviderGroupPost
 	err = json.NewDecoder(r.Body).Decode(&idpGroupPost)
 	if err != nil {
@@ -435,11 +423,8 @@ func renameIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
-	idpGroupName, err := url.PathUnescape(mux.Vars(r)["idpGroupName"])
-	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed unescaping path argument: %w", err))
-	}
-
+	idpGroupName := r.PathValue("idpGroupName")
+	var err error
 	var idpGroupPut api.IdentityProviderGroupPut
 	err = json.NewDecoder(r.Body).Decode(&idpGroupPut)
 	if err != nil {
@@ -504,11 +489,8 @@ func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
-	idpGroupName, err := url.PathUnescape(mux.Vars(r)["idpGroupName"])
-	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed unescaping path argument: %w", err))
-	}
-
+	idpGroupName := r.PathValue("idpGroupName")
+	var err error
 	var idpGroupPut api.IdentityProviderGroupPut
 	err = json.NewDecoder(r.Body).Decode(&idpGroupPut)
 	if err != nil {
@@ -572,11 +554,8 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func deleteIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
-	idpGroupName, err := url.PathUnescape(mux.Vars(r)["idpGroupName"])
-	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed unescaping path argument: %w", err))
-	}
-
+	idpGroupName := r.PathValue("idpGroupName")
+	var err error
 	s := d.State()
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		return dbCluster.DeleteIdentityProviderGroup(ctx, tx.Tx(), idpGroupName)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/kballard/go-shellquote"
 	"go.yaml.in/yaml/v2"
 
@@ -111,7 +110,7 @@ var imageAliasesCmd = APIEndpoint{
 }
 
 var imageAliasCmd = APIEndpoint{
-	Path:        "images/aliases/{name:.*}",
+	Path:        "images/aliases/{name}",
 	MetricsType: entity.TypeImage,
 
 	Delete: APIEndpointAction{Handler: imageAliasDelete, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanDelete)},
@@ -156,11 +155,8 @@ type imageDetails struct {
 // addImageDetailsToRequestContext sets the effective project in the request.Info and sets ctxImageDetails (imageDetails)
 // in the request context.
 func addImageDetailsToRequestContext(s *state.State, r *http.Request) error {
-	imageFingerprintPrefix, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return err
-	}
-
+	imageFingerprintPrefix := r.PathValue("fingerprint")
+	var err error
 	err = validateImageFingerprintPrefix(imageFingerprintPrefix)
 	if err != nil {
 		return err
@@ -252,11 +248,8 @@ func imageAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Re
 
 func imageAliasAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
 	return func(d *Daemon, r *http.Request) response.Response {
-		imageAliasName, err := url.PathUnescape(mux.Vars(r)["name"])
-		if err != nil {
-			return response.SmartError(err)
-		}
-
+		imageAliasName := r.PathValue("name")
+		var err error
 		requestProjectName := request.ProjectParam(r)
 		var effectiveProjectName string
 		s := d.State()
@@ -3361,11 +3354,8 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
+	var err error
 	err = validateImageFingerprintPrefix(fingerprint)
 	if err != nil {
 		return response.SmartError(err)
@@ -4036,11 +4026,7 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/InternalServerError"
 func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	s := d.State()
 
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeImageAlias, false)
@@ -4117,11 +4103,8 @@ func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		_, _, err = tx.GetImageAlias(ctx, projectName, name, true)
 		if err != nil {
@@ -4184,11 +4167,8 @@ func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	req := api.ImageAliasesEntryPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -4275,11 +4255,8 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	req := shared.Jmap{}
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -4378,11 +4355,8 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
+	var err error
 	req := api.ImageAliasesEntryPost{}
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -4476,11 +4450,8 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	fingerprint := r.PathValue("fingerprint")
+	var err error
 	err = validateImageFingerprintPrefix(fingerprint)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -6,12 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -134,11 +131,7 @@ func instanceBackupsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	cname, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	cname := r.PathValue("name")
 	if shared.IsSnapshot(cname) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -239,11 +232,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -444,20 +433,12 @@ func instanceBackupGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
 
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, projectName, name, instanceType)
 	if err != nil {
@@ -518,20 +499,12 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
 
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, projectName, name, instanceType)
 	if err != nil {
@@ -625,20 +598,12 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
 
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, projectName, name, instanceType)
 	if err != nil {
@@ -711,20 +676,12 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
 
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, projectName, name, instanceType)
 	if err != nil {

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -9,14 +9,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"slices"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	liblxc "github.com/lxc/go-lxc"
 	"golang.org/x/sys/unix"
@@ -457,11 +455,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -604,11 +598,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -703,11 +693,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func instanceConsoleLogDelete(d *Daemon, r *http.Request) response.Response {
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/instance"
@@ -62,11 +59,7 @@ func instanceDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"golang.org/x/sys/unix"
 
@@ -546,11 +544,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -7,14 +7,12 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/pkg/sftp"
 
 	"github.com/canonical/lxd/lxd/instance"
@@ -32,11 +30,7 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -4,9 +4,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/instance"
@@ -122,11 +119,7 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -4,13 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/instance"
@@ -27,7 +24,6 @@ import (
 )
 
 var instanceLogCmd = APIEndpoint{
-	Name:        "instanceLog",
 	Path:        "instances/{name}/logs/{file}",
 	MetricsType: entity.TypeInstance,
 
@@ -35,7 +31,6 @@ var instanceLogCmd = APIEndpoint{
 }
 
 var instanceLogsCmd = APIEndpoint{
-	Name:        "instanceLogs",
 	Path:        "instances/{name}/logs",
 	MetricsType: entity.TypeInstance,
 
@@ -43,7 +38,6 @@ var instanceLogsCmd = APIEndpoint{
 }
 
 var instanceExecOutputCmd = APIEndpoint{
-	Name:        "instanceExecOutput",
 	Path:        "instances/{name}/logs/exec-output/{file}",
 	MetricsType: entity.TypeInstance,
 
@@ -55,7 +49,6 @@ var instanceExecOutputCmd = APIEndpoint{
 var instanceProtectedLogFiles = []string{"edk2.log", "lxc.log", "qemu.log", "qemu.early.log"}
 
 var instanceExecOutputsCmd = APIEndpoint{
-	Name:        "instanceExecOutputs",
 	Path:        "instances/{name}/logs/exec-output",
 	MetricsType: entity.TypeInstance,
 
@@ -127,11 +120,7 @@ func instanceLogsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -213,11 +202,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -238,11 +223,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	file, err := url.PathUnescape(mux.Vars(r)["file"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	file := r.PathValue("file")
 	if !validLogFileName(file) {
 		return response.BadRequest(fmt.Errorf("Log file name %q not valid", file))
 	}
@@ -316,11 +297,7 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -421,11 +398,7 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -446,11 +419,7 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	file, err := url.PathUnescape(mux.Vars(r)["file"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	file := r.PathValue("file")
 	if !validExecOutputFileName(file) {
 		return response.BadRequest(fmt.Errorf("Exec record-output file name %q not valid", file))
 	}
@@ -521,11 +490,7 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -546,11 +511,7 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	file, err := url.PathUnescape(mux.Vars(r)["file"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	file := r.PathValue("file")
 	if !validExecOutputFileName(file) {
 		return response.BadRequest(fmt.Errorf("Exec record-output file name %q not valid", file))
 	}

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 
-	"github.com/gorilla/mux"
 	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/lxd/instance"
@@ -74,11 +72,7 @@ func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -178,11 +172,7 @@ func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -291,11 +281,7 @@ func instanceMetadataPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -415,11 +401,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -568,11 +550,7 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -686,11 +664,7 @@ func instanceMetadataTemplatesDelete(d *Daemon, r *http.Request) response.Respon
 
 	projectName := request.ProjectParam(r)
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -7,9 +7,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
@@ -69,11 +66,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
 
 	// Get the container
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -9,10 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
-	"net/url"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cluster"
@@ -83,11 +80,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 	projectName := request.ProjectParam(r)
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -5,10 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/url"
 
 	"github.com/google/uuid"
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
@@ -73,11 +71,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
 
 	// Get the container
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -6,9 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
@@ -62,11 +59,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 
 	targetProjectName := request.ProjectParam(r)
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -7,10 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"sync"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/instance"
@@ -48,11 +45,7 @@ func instanceSFTPHandler(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	instName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	instName := r.PathValue("name")
 	if shared.IsSnapshot(instName) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -132,11 +129,7 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	cname, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	cname := r.PathValue("name")
 	if shared.IsSnapshot(cname) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -267,11 +260,7 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -378,16 +367,8 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	instName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	instName := r.PathValue("name")
+	snapshotName := r.PathValue("snapshotName")
 	resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, projectName, instName, instanceType)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -7,10 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/instance"
@@ -77,11 +74,7 @@ func instanceState(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -151,11 +144,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instance_uefi_vars.go
+++ b/lxd/instance_uefi_vars.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
@@ -66,11 +63,7 @@ func instanceUEFIVarsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	projectName := request.ProjectParam(r)
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}
@@ -151,11 +144,7 @@ func instanceUEFIVarsPut(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
 
 	// Get the container
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	name := r.PathValue("name")
 	if shared.IsSnapshot(name) {
 		return response.BadRequest(errors.New("Invalid instance name"))
 	}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -27,7 +27,6 @@ import (
 )
 
 var instancesCmd = APIEndpoint{
-	Name:        "instances",
 	Path:        "instances",
 	MetricsType: entity.TypeInstance,
 
@@ -37,7 +36,6 @@ var instancesCmd = APIEndpoint{
 }
 
 var instanceCmd = APIEndpoint{
-	Name:        "instance",
 	Path:        "instances/{name}",
 	MetricsType: entity.TypeInstance,
 
@@ -49,7 +47,6 @@ var instanceCmd = APIEndpoint{
 }
 
 var instanceUEFIVarsCmd = APIEndpoint{
-	Name:        "instanceUEFIVars",
 	Path:        "instances/{name}/uefi-vars",
 	MetricsType: entity.TypeInstance,
 
@@ -58,7 +55,6 @@ var instanceUEFIVarsCmd = APIEndpoint{
 }
 
 var instanceRebuildCmd = APIEndpoint{
-	Name:        "instanceRebuild",
 	Path:        "instances/{name}/rebuild",
 	MetricsType: entity.TypeInstance,
 
@@ -66,7 +62,6 @@ var instanceRebuildCmd = APIEndpoint{
 }
 
 var instanceStateCmd = APIEndpoint{
-	Name:        "instanceState",
 	Path:        "instances/{name}/state",
 	MetricsType: entity.TypeInstance,
 
@@ -75,7 +70,6 @@ var instanceStateCmd = APIEndpoint{
 }
 
 var instanceSFTPCmd = APIEndpoint{
-	Name:        "instanceFile",
 	Path:        "instances/{name}/sftp",
 	MetricsType: entity.TypeInstance,
 
@@ -83,7 +77,6 @@ var instanceSFTPCmd = APIEndpoint{
 }
 
 var instanceFileCmd = APIEndpoint{
-	Name:        "instanceFile",
 	Path:        "instances/{name}/files",
 	MetricsType: entity.TypeInstance,
 
@@ -94,7 +87,6 @@ var instanceFileCmd = APIEndpoint{
 }
 
 var instanceSnapshotsCmd = APIEndpoint{
-	Name:        "instanceSnapshots",
 	Path:        "instances/{name}/snapshots",
 	MetricsType: entity.TypeInstance,
 
@@ -103,7 +95,6 @@ var instanceSnapshotsCmd = APIEndpoint{
 }
 
 var instanceSnapshotCmd = APIEndpoint{
-	Name:        "instanceSnapshot",
 	Path:        "instances/{name}/snapshots/{snapshotName}",
 	MetricsType: entity.TypeInstance,
 
@@ -115,7 +106,6 @@ var instanceSnapshotCmd = APIEndpoint{
 }
 
 var instanceConsoleCmd = APIEndpoint{
-	Name:        "instanceConsole",
 	Path:        "instances/{name}/console",
 	MetricsType: entity.TypeInstance,
 
@@ -125,7 +115,6 @@ var instanceConsoleCmd = APIEndpoint{
 }
 
 var instanceExecCmd = APIEndpoint{
-	Name:        "instanceExec",
 	Path:        "instances/{name}/exec",
 	MetricsType: entity.TypeInstance,
 
@@ -133,7 +122,6 @@ var instanceExecCmd = APIEndpoint{
 }
 
 var instanceMetadataCmd = APIEndpoint{
-	Name:        "instanceMetadata",
 	Path:        "instances/{name}/metadata",
 	MetricsType: entity.TypeInstance,
 
@@ -143,7 +131,6 @@ var instanceMetadataCmd = APIEndpoint{
 }
 
 var instanceMetadataTemplatesCmd = APIEndpoint{
-	Name:        "instanceMetadataTemplates",
 	Path:        "instances/{name}/metadata/templates",
 	MetricsType: entity.TypeInstance,
 
@@ -153,7 +140,6 @@ var instanceMetadataTemplatesCmd = APIEndpoint{
 }
 
 var instanceBackupsCmd = APIEndpoint{
-	Name:        "instanceBackups",
 	Path:        "instances/{name}/backups",
 	MetricsType: entity.TypeInstance,
 
@@ -162,7 +148,6 @@ var instanceBackupsCmd = APIEndpoint{
 }
 
 var instanceBackupCmd = APIEndpoint{
-	Name:        "instanceBackup",
 	Path:        "instances/{name}/backups/{backupName}",
 	MetricsType: entity.TypeInstance,
 
@@ -172,7 +157,6 @@ var instanceBackupCmd = APIEndpoint{
 }
 
 var instanceBackupExportCmd = APIEndpoint{
-	Name:        "instanceBackupExport",
 	Path:        "instances/{name}/backups/{backupName}/export",
 	MetricsType: entity.TypeInstance,
 

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -7,10 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -384,10 +381,7 @@ func networkACLDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	aclName := r.PathValue("name")
 
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -488,11 +482,7 @@ func networkACLGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	aclName := r.PathValue("name")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeNetworkACL, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -599,11 +589,7 @@ func networkACLPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	aclName := r.PathValue("name")
 	// Get the existing Network ACL.
 	netACL, err := acl.LoadByName(r.Context(), s, projectName, aclName)
 	if err != nil {
@@ -717,11 +703,7 @@ func networkACLPut(d *Daemon, r *http.Request) response.Response {
 func networkACLPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	aclName := r.PathValue("name")
 	projectName, _, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
 	if err != nil {
 		return response.SmartError(err)
@@ -807,11 +789,7 @@ func networkACLLogGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	aclName := r.PathValue("name")
 	netACL, err := acl.LoadByName(r.Context(), s, projectName, aclName)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -350,11 +347,7 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support forwards", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
 		return response.SmartError(err)
@@ -443,11 +436,7 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support forwards", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	targetMember := request.QueryParam(r, "target")
 	memberSpecific := targetMember != ""
 
@@ -567,11 +556,7 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support forwards", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	// Decode the request.
 	req := api.NetworkForwardPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -351,11 +348,7 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support load balancers", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
 		return response.SmartError(err)
@@ -444,11 +437,7 @@ func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support load balancers", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	targetMember := request.QueryParam(r, "target")
 	memberSpecific := targetMember != ""
 
@@ -568,11 +557,7 @@ func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support load balancers", n.Type()))
 	}
 
-	listenAddress, err := url.PathUnescape(mux.Vars(r)["listenAddress"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	listenAddress := r.PathValue("listenAddress")
 	// Decode the request.
 	req := api.NetworkLoadBalancerPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -345,11 +342,7 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support peering", n.Type()))
 	}
 
-	peerName, err := url.PathUnescape(mux.Vars(r)["peerName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	peerName := r.PathValue("peerName")
 	err = n.PeerDelete(peerName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed deleting peer: %w", err))
@@ -433,11 +426,7 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support peering", n.Type()))
 	}
 
-	peerName, err := url.PathUnescape(mux.Vars(r)["peerName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	peerName := r.PathValue("peerName")
 	var peer *api.NetworkPeer
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -557,11 +546,7 @@ func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support peering", n.Type()))
 	}
 
-	peerName, err := url.PathUnescape(mux.Vars(r)["peerName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	peerName := r.PathValue("peerName")
 	// Decode the request.
 	req := api.NetworkPeerPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -6,9 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -55,11 +52,7 @@ type networkZoneDetails struct {
 // addNetworkZoneDetailsToRequestContext sets the effective project in the request.Info and sets ctxNetworkZoneDetails (networkZoneDetails)
 // in the request context.
 func addNetworkZoneDetailsToRequestContext(s *state.State, r *http.Request) error {
-	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])
-	if err != nil {
-		return err
-	}
-
+	zoneName := r.PathValue("zone")
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, requestProject, err := project.NetworkZoneProject(s.DB.Cluster, requestProjectName)
 	if err != nil {

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -3,9 +3,6 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/lifecycle"
@@ -281,11 +278,7 @@ func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	recordName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	recordName := r.PathValue("name")
 	// Get the network zone.
 	netzone, err := zone.LoadByNameAndProject(r.Context(), s, effectiveProjectName, details.zoneName)
 	if err != nil {
@@ -356,11 +349,7 @@ func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	recordName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	recordName := r.PathValue("name")
 	// Get the network zone.
 	netzone, err := zone.LoadByNameAndProject(r.Context(), s, effectiveProjectName, details.zoneName)
 	if err != nil {
@@ -458,11 +447,7 @@ func networkZoneRecordPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	recordName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	recordName := r.PathValue("name")
 	// Get the network zone.
 	netzone, err := zone.LoadByNameAndProject(r.Context(), s, effectiveProjectName, details.zoneName)
 	if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -8,14 +8,11 @@ import (
 	"maps"
 	"net"
 	"net/http"
-	"net/url"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -94,11 +91,7 @@ type networkDetails struct {
 // addNetworkDetailsToRequestContext sets the effective project on the request.Info and sets ctxNetworkDetails (networkDetails)
 // in the request context.
 func addNetworkDetailsToRequestContext(s *state.State, r *http.Request) error {
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
-	if err != nil {
-		return err
-	}
-
+	networkName := r.PathValue("networkName")
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, requestProject, err := project.NetworkProject(s.DB.Cluster, requestProjectName)
 	if err != nil {
@@ -1782,11 +1775,7 @@ func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	networkName := r.PathValue("networkName")
 	// Attempt to load the network.
 	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
@@ -2233,11 +2222,7 @@ func networkStateGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	networkName := r.PathValue("networkName")
 	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))

--- a/lxd/oidc_sessions.go
+++ b/lxd/oidc_sessions.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/auth/oidc"
@@ -28,7 +26,6 @@ import (
 )
 
 var oidcSessionsCmd = APIEndpoint{
-	Name:        "oidc_sessions",
 	Path:        "auth/oidc-sessions",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -38,7 +35,6 @@ var oidcSessionsCmd = APIEndpoint{
 }
 
 var oidcSessionCmd = APIEndpoint{
-	Name:        "oidc_session",
 	Path:        "auth/oidc-sessions/{id}",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{
@@ -60,11 +56,7 @@ const ctxOIDCSessionDetails request.CtxKey = "session-details"
 func oidcSessionAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
 	return func(d *Daemon, r *http.Request) response.Response {
 		s := d.State()
-		sessionIDStr, err := url.PathUnescape(mux.Vars(r)["id"])
-		if err != nil {
-			return response.SmartError(err)
-		}
-
+		sessionIDStr := r.PathValue("id")
 		sessionID, err := uuid.Parse(sessionIDStr)
 		if err != nil {
 			return response.BadRequest(fmt.Errorf("Bad session ID: %w", err))

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
-
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
@@ -161,11 +159,8 @@ func runningInstanceOperations() map[string]map[string][]*operations.Operation {
 func operationGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
+	var err error
 	recursion, _ := util.IsRecursionRequest(r)
 
 	// Load the operation from the database.
@@ -284,11 +279,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 func operationDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
 	// First check if the query is for a local operation from this node
 	op, err := operations.OperationGetInternal(id)
 	if err == nil {
@@ -868,11 +859,7 @@ func operationsGetByType(ctx context.Context, s *state.State, projectName string
 func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
 	secret := r.FormValue("secret")
 
 	requestor, err := request.GetRequestor(r.Context())
@@ -1071,11 +1058,7 @@ func checkOperationViewAccess(ctx context.Context, op *operations.Operation, aut
 func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
 	// First check if the query is for a local operation from this node
 	op, err := operations.OperationGetInternal(id)
 	if err == nil {

--- a/lxd/permissions.go
+++ b/lxd/permissions.go
@@ -17,7 +17,6 @@ import (
 )
 
 var permissionsCmd = APIEndpoint{
-	Name:        "permissions",
 	Path:        "auth/permissions",
 	MetricsType: entity.TypeIdentity,
 	Get: APIEndpointAction{

--- a/lxd/placement_groups.go
+++ b/lxd/placement_groups.go
@@ -6,10 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -352,11 +349,8 @@ func placementGroupsPost(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/InternalServerError"
 func placementGroupDelete(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	placementGroupName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	placementGroupName := r.PathValue("name")
+	var err error
 	s := d.State()
 
 	err = doPlacementGroupDelete(r.Context(), s, placementGroupName, projectName)
@@ -441,11 +435,7 @@ func doPlacementGroupDelete(ctx context.Context, s *state.State, name string, pr
 //	    $ref: "#/responses/InternalServerError"
 func placementGroupGet(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	placementGroupName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	placementGroupName := r.PathValue("name")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypePlacementGroup, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -566,11 +556,8 @@ func placementGroupGet(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/InternalServerError"
 func placementGroupPut(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	placementGroupName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	placementGroupName := r.PathValue("name")
+	var err error
 	req := api.PlacementGroupPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -687,11 +674,8 @@ func placementGroupPut(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/InternalServerError"
 func placementGroupPost(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	placementGroupName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	placementGroupName := r.PathValue("name")
+	var err error
 	req := api.PlacementGroupPost{}
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -8,11 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"slices"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -69,11 +66,7 @@ type profileDetails struct {
 // addProfileDetailsToRequestContext sets the effective project in the request.Info and sets ctxProfileDetails (profileDetails)
 // in the request context.
 func addProfileDetailsToRequestContext(s *state.State, r *http.Request) error {
-	profileName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return err
-	}
-
+	profileName := r.PathValue("name")
 	requestProjectName := request.ProjectParam(r)
 	effectiveProject, err := project.ProfileProject(s.DB.Cluster, requestProjectName)
 	if err != nil {

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"net/http"
-	"net/url"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/request"
@@ -139,11 +136,7 @@ func storagePoolResourcesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get the existing storage pool
-	poolName, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("name")
 	var res *api.ResourcesStoragePool
 
 	pool, err := storagePools.LoadByName(s, poolName)

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -6,10 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -225,11 +222,7 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
@@ -461,11 +454,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	// Parse the request into a record.
 	req := api.StorageBucketsPost{}
 	err = json.NewDecoder(r.Body).Decode(&req)
@@ -1097,10 +1086,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	keyName, err := url.PathUnescape(mux.Vars(r)["keyName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
+	keyName := r.PathValue("keyName")
 
 	location := ""
 	if !details.pool.Driver().Info().Remote {
@@ -1199,11 +1185,7 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(errors.New("Storage pool does not support buckets"))
 	}
 
-	keyName, err := url.PathUnescape(mux.Vars(r)["keyName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	keyName := r.PathValue("keyName")
 	targetMember := request.QueryParam(r, "target")
 	memberSpecific := targetMember != ""
 
@@ -1286,11 +1268,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	keyName, err := url.PathUnescape(mux.Vars(r)["keyName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	keyName := r.PathValue("keyName")
 	// Decode the request.
 	req := api.StorageBucketKeyPut{}
 	err = json.NewDecoder(r.Body).Decode(&req)
@@ -1365,11 +1343,7 @@ func addStorageBucketDetailsToContext(d *Daemon, r *http.Request) error {
 
 	request.SetContextValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return err
-	}
-
+	poolName := r.PathValue("poolName")
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return fmt.Errorf("Failed loading storage pool: %w", err)
@@ -1377,11 +1351,7 @@ func addStorageBucketDetailsToContext(d *Daemon, r *http.Request) error {
 
 	details.pool = pool
 
-	bucketName, err := url.PathUnescape(mux.Vars(r)["bucketName"])
-	if err != nil {
-		return err
-	}
-
+	bucketName := r.PathValue("bucketName")
 	details.bucketName = bucketName
 	return nil
 }

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -7,12 +7,9 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"net/url"
 	"slices"
 	"strings"
 	"sync"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
@@ -676,11 +673,7 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStoragePool, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -805,11 +798,7 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	// Get the existing storage pool.
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
@@ -1069,11 +1058,7 @@ func doStoragePoolUpdate(s *state.State, pool storagePools.Pool, req api.Storage
 func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/lxd/archive"
@@ -120,18 +119,10 @@ func checkStoragePoolVolumeTypeAccess(s *state.State, r *http.Request, entityTyp
 	case entity.TypeStorageVolume:
 		u = entity.StorageVolumeURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName)
 	case entity.TypeStorageVolumeBackup:
-		backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-		if err != nil {
-			return err
-		}
-
+		backupName := r.PathValue("backupName")
 		u = entity.StorageVolumeBackupURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, backupName)
 	case entity.TypeStorageVolumeSnapshot:
-		snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-		if err != nil {
-			return err
-		}
-
+		snapshotName := r.PathValue("snapshotName")
 		u = entity.StorageVolumeSnapshotURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, snapshotName)
 	default:
 		return fmt.Errorf("Cannot use storage volume access handler with entities of type %q", entityType)
@@ -632,11 +623,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	targetMember := request.QueryParam(r, "target")
 	memberSpecific := targetMember != ""
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	// Detect if we want to also return entitlements for each volume.
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStorageVolume, true)
 	if err != nil {
@@ -647,11 +634,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	allPools := poolName == ""
 
 	// Get the name of the volume type.
-	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	volumeTypeName := r.PathValue("type")
 	// Convert volume type name to internal integer representation if requested.
 	var volumeType cluster.StoragePoolVolumeType
 	if volumeTypeName != "" {
@@ -995,11 +978,7 @@ func filterVolumes(volumes []*db.StorageVolume, clauses *filter.ClauseSet, allPr
 func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	requestProjectName := request.ProjectParam(r)
 	projectName, err := project.StorageVolumeProject(s.DB.Cluster, requestProjectName, cluster.StoragePoolVolumeTypeCustom)
 	if err != nil {
@@ -1049,12 +1028,9 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle being called through the typed URL.
-	_, ok := mux.Vars(r)["type"]
-	if ok {
-		req.Type, err = url.PathUnescape(mux.Vars(r)["type"])
-		if err != nil {
-			return response.SmartError(err)
-		}
+	volumeType := r.PathValue("type")
+	if volumeType != "" {
+		req.Type = volumeType
 	}
 
 	// We currently only allow to create storage volumes of type storagePoolVolumeTypeCustom.
@@ -2956,22 +2932,14 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 		request.SetContextValue(r, ctxStorageVolumeDetails, details)
 	}()
 
-	volumeName, err := url.PathUnescape(mux.Vars(r)["volumeName"])
-	if err != nil {
-		return err
-	}
-
+	volumeName := r.PathValue("volumeName")
 	details.volumeName = volumeName
 
 	if shared.IsSnapshot(volumeName) {
 		return api.StatusErrorf(http.StatusBadRequest, "Invalid storage volume %q", volumeName)
 	}
 
-	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
-	if err != nil {
-		return err
-	}
-
+	volumeTypeName := r.PathValue("type")
 	details.volumeTypeName = volumeTypeName
 
 	// Convert the volume type name to our internal integer representation.
@@ -2983,11 +2951,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	details.volumeType = volumeType
 
 	// Get the name of the storage pool the volume is supposed to be attached to.
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return err
-	}
-
+	poolName := r.PathValue("poolName")
 	// Load the storage pool containing the volume. This is required by the access handler as all remote volumes
 	// do not have a location (regardless of whether the caller used a target parameter to send the request to a
 	// particular member).

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -6,12 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -516,11 +513,7 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 	}
 
 	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -598,11 +591,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 	}
 
 	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -714,11 +703,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 	}
 
 	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -812,11 +797,7 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 	}
 
 	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	backupName := r.PathValue("backupName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -6,12 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 	"sync"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -500,11 +497,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	}
 
 	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	snapshotName := r.PathValue("snapshotName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != dbCluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -636,11 +629,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	snapshotName := r.PathValue("snapshotName")
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
@@ -740,11 +729,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	snapshotName := r.PathValue("snapshotName")
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
@@ -875,11 +860,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	}
 
 	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	snapshotName := r.PathValue("snapshotName")
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
@@ -1032,11 +1013,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	}
 
 	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	snapshotName := r.PathValue("snapshotName")
 	// Check that the storage volume type is valid.
 	if details.volumeType != dbCluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -3,10 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db/cluster"
@@ -83,23 +80,11 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Get the name of the pool the storage volume is supposed to be attached to.
-	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	poolName := r.PathValue("poolName")
 	// Get the name of the volume type.
-	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	volumeTypeName := r.PathValue("type")
 	// Get the name of the volume type.
-	volumeName, err := url.PathUnescape(mux.Vars(r)["volumeName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	volumeName := r.PathValue("volumeName")
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := cluster.StoragePoolVolumeTypeFromName(volumeTypeName)
 	if err != nil {

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -7,10 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -265,11 +262,8 @@ func warningsGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func warningGet(d *Daemon, r *http.Request) response.Response {
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
+	var err error
 	var resp api.Warning
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbWarning, err := cluster.GetWarning(ctx, tx.Tx(), id)
@@ -354,11 +348,8 @@ func warningPatch(d *Daemon, r *http.Request) response.Response {
 func warningPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
+	var err error
 	req := api.WarningPut{}
 
 	err = json.NewDecoder(r.Body).Decode(&req)
@@ -421,11 +412,8 @@ func warningPut(d *Daemon, r *http.Request) response.Response {
 func warningDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	id, err := url.PathUnescape(mux.Vars(r)["id"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	id := r.PathValue("id")
+	var err error
 	var warning *cluster.Warning
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		warning, err = cluster.GetWarning(ctx, tx.Tx(), id)


### PR DESCRIPTION
Go 1.22+ added path variables and wildcard support to http.ServeMux,
   making gorilla/mux redundant. This removes the dependency.

One complication: ServeMux panics when `/images/aliases/{name...}` and `/images/{fingerprint}/export` are both registered, since both match `/images/aliases/export`. Image aliases can contain slashes, so the wildcard is necessary. `lxdMux` (a thin wrapper around `ServeMux`) handles `{var...}` patterns via prefix matching before delegating to `ServeMux`.  

Behavioral notes:
- `ServeMux` cleans paths (`//` → `/`) unlike gorilla's `SkipClean(true)`
- `r.PathValue()` returns decoded values; existing `url.PathUnescape()` calls become no-ops but are harmless
 
Close #16587 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
