### PR TITLE
Network: When using MicroOVN get Northbound DB addresses from `ovn.env`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3012,3 +3012,9 @@ use the defaults set in the Ceph cluster.
 ## `bulk_operations`
 
 Adds a `recursion=2` mode to `GET /1.0/operations`, enabling retrieval of parent-child relationships between operations. The parent-child operations are now also returned by the `GET /1.0/operations/{id}` endpoint when `recursion=1` is specified.
+
+(extension-ovn-dynamic-northbound-connection)=
+## `ovn_dynamic_northbound_connection`
+
+Starting with this extension, if the {config:option}`server-miscellaneous:network.ovn.northbound_connection` server configuration is not specified, LXD dynamically determines the OVN Northbound database connection string based on the environment. 
+If the MicroOVN snap is used, LXD reads the configuration from the MicroOVN `ovn.env` file. Otherwise, it defaults to using the `unix:/var/run/ovn/ovnnb_db.sock` socket.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4883,11 +4883,14 @@ If set to `mac`, generate a host name in the form `lxd<mac_address>` (MAC withou
 ```
 
 ```{config:option} network.ovn.northbound_connection server-miscellaneous
-:defaultdesc: "`unix:/var/run/ovn/ovnnb_db.sock`"
+:defaultdesc: "`unix:/var/run/ovn/ovnnb_db.sock` or MicroOVN configuration"
 :scope: "global"
-:shortdesc: "OVN northbound database connection string"
+:shortdesc: "OVN northbound database connection string (default determined by environment)"
 :type: "string"
-
+Specify a connection string for OVN Northbound database.
+If value is not specified, LXD will determine the connection string based on the environment.
+LXD snap will use the MicroOVN environment settings if connected to MicroOVN snap.
+Otherwise, LXD will use `unix:/var/run/ovn/ovnnb_db.sock` as the connection string.
 ```
 
 ```{config:option} storage.backups_volume server-miscellaneous

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/websocket v1.5.1
+	github.com/hashicorp/go-envparse v0.1.0
 	github.com/j-keck/arping v1.0.3
 	github.com/jaypipes/pcidb v1.1.1
 	github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
+github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -789,13 +789,16 @@ var ConfigSchema = config.Schema{
 		//  shortdesc: OVS integration bridge to use for OVN networks
 		"network.ovn.integration_bridge": {Default: "br-int"},
 		// lxdmeta:generate(entities=server; group=miscellaneous; key=network.ovn.northbound_connection)
-		//
+		// Specify a connection string for OVN Northbound database.
+		// If value is not specified, LXD will determine the connection string based on the environment.
+		// LXD snap will use the MicroOVN environment settings if connected to MicroOVN snap.
+		// Otherwise, LXD will use `unix:/var/run/ovn/ovnnb_db.sock` as the connection string.
 		// ---
 		//  type: string
 		//  scope: global
-		//  defaultdesc: `unix:/var/run/ovn/ovnnb_db.sock`
-		//  shortdesc: OVN northbound database connection string
-		"network.ovn.northbound_connection": {Default: "unix:/var/run/ovn/ovnnb_db.sock"},
+		//  defaultdesc: `unix:/var/run/ovn/ovnnb_db.sock` or MicroOVN configuration
+		//  shortdesc: OVN northbound database connection string (default determined by environment)
+		"network.ovn.northbound_connection": {Default: ""},
 
 		// lxdmeta:generate(entities=server; group=miscellaneous; key=network.ovn.ca_cert)
 		//

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5445,10 +5445,10 @@
 					},
 					{
 						"network.ovn.northbound_connection": {
-							"defaultdesc": "`unix:/var/run/ovn/ovnnb_db.sock`",
-							"longdesc": "",
+							"defaultdesc": "`unix:/var/run/ovn/ovnnb_db.sock` or MicroOVN configuration",
+							"longdesc": "Specify a connection string for OVN Northbound database.\nIf value is not specified, LXD will determine the connection string based on the environment.\nLXD snap will use the MicroOVN environment settings if connected to MicroOVN snap.\nOtherwise, LXD will use `unix:/var/run/ovn/ovnnb_db.sock` as the connection string.",
 							"scope": "global",
-							"shortdesc": "OVN northbound database connection string",
+							"shortdesc": "OVN northbound database connection string (default determined by environment)",
 							"type": "string"
 						}
 					},

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -298,10 +298,6 @@ type OVN struct {
 
 // getNorthboundDB returns connection string to use for northbound database.
 func (o *OVN) getNorthboundDB() string {
-	if o.nbDBAddr == "" {
-		return "unix:/var/run/ovn/ovnnb_db.sock"
-	}
-
 	return o.nbDBAddr
 }
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-envparse"
 
 	"github.com/canonical/lxd/lxd/linux"
 	"github.com/canonical/lxd/shared"
@@ -180,12 +183,50 @@ type OVNRouterPeering struct {
 	TargetRouterRoutes  []net.IPNet
 }
 
-// NewOVN initialises new OVN client wrapper with the connection set in network.ovn.northbound_connection config.
+// NewOVN initialises a new OVN client wrapper with the provided Northbound DB connection string (usually "network.ovn.northbound_connection" value).
+// If the nbConnection string is empty and MicroOVN is used, the function will read the `ovn.env` file provided by MicroOVN via the snap content interface
+// to determine the connection string for the Northbound DB. If the nbConnection string is empty and MicroOVN is not used, the function will use
+// the `unix:/var/run/ovn/ovnnb_db.sock` value.
 func NewOVN(nbConnection string, sslSettings func() (sslCACert string, sslClientCert string, sslClientKey string)) (*OVN, error) {
 	// Get database connection strings.
 	sbConnection, err := NewOVS().OVNSouthboundDBRemoteAddress()
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting OVN southbound connection string: %w", err)
+	}
+
+	// If the connection string is not specified, determine based on the environment.
+	if nbConnection == "" {
+		if shared.IsMicroOVNUsed() {
+			snapDataRoot := os.Getenv("SNAP_DATA")
+			if snapDataRoot == "" {
+				return nil, errors.New("SNAP_DATA environment variable is not set but MicroOVN snap is connected")
+			}
+
+			// If MicroOVN is used, get the candidate DB addresses for Northbound DB from the `$SNAP_DATA/microovn/ovn-env/env/ovn.env` file.
+			envFilePath := filepath.Join(snapDataRoot, "microovn", "ovn-env", "env", "ovn.env")
+			envFile, err := os.Open(envFilePath)
+			if err != nil {
+				return nil, fmt.Errorf("Failed opening MicroOVN env file %s: %w", envFilePath, err)
+			}
+
+			defer envFile.Close()
+
+			ovnEnvVars, err := envparse.Parse(envFile)
+			if err != nil {
+				return nil, fmt.Errorf("Failed parsing MicroOVN env file %s: %w", envFilePath, err)
+			}
+
+			nbConn, ok := ovnEnvVars["OVN_NB_CONNECT"]
+			if !ok || nbConn == "" {
+				return nil, errors.New("OVN_NB_CONNECT not found in MicroOVN env file " + envFilePath)
+			}
+
+			// Override the nbConnection value with OVN_NB_CONNECT value.
+			nbConnection = nbConn
+		} else {
+			// Otherwise, fallback to `unix:/var/run/ovn/ovnnb_db.sock`.
+			nbConnection = "unix:/var/run/ovn/ovnnb_db.sock"
+		}
 	}
 
 	// Create the OVN struct.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -481,6 +481,7 @@ var APIExtensions = []string{
 	"storage_remote_drop_source",
 	"storage_ceph_use_rbd_defaults",
 	"bulk_operations",
+	"ovn_dynamic_northbound_connection",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR updates the `NewOVN()` function to determine the connection string for the Northbound DB based on the environment, if it was not specified by the caller.

If `nbConnection` parameter is empty and MicroOVN snap is used, the `NewOVN()` function will read the `ovn.env` file provided by MicroOVN snap slot [`ovn-env`](https://github.com/canonical/microovn/blob/e860d3abf65c077a1b6524e11459e90e1c10a106/snap/snapcraft.yaml#L22-L26) to determine the connection string.

If `nbConnection` parameter is empty and MicroOVN is NOT used, the `NewOVN()` function will use the `unix:/var/run/ovn/ovnnb_db.sock` as the connection string.

This also updates the default value and description for the `network.ovn.northbound_connection` config option.

Closes https://github.com/canonical/lxd/issues/16856.

This should be merged together with https://github.com/canonical/lxd-pkg-snap/pull/1112.