### PR TITLE
lxd/dnsmasq: do not swallow errors in `DHCPAllAllocations`

### DIFF
--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -86,7 +86,7 @@ func RemoveStaticEntry(network, projectName, instanceName, deviceName string) er
 
 	err := os.Rename(filePath, tmpPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 
@@ -205,7 +205,7 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 
 	// First read all statically allocated IPs.
 	files, err := os.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
The condition `err != nil && os.IsNotExist(err)` had an inverted logic. It returned an error only when the `dnsmasq.hosts` dir did not exist while silently swallowing any other I/O errors.

Switch to modern `errors.Is` while at it.