### PR TITLE
Refactor: Push image volume creation logic down to storage drivers

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2148,17 +2148,8 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		return err
 	}
 
-	// Determine whether an optimized image should be used.
-	useOptimizedImage, err := b.shouldUseOptimizedImage(fingerprint, contentType, volumeConfig)
-	if err != nil {
-		return err
-	}
-
 	// Generate the effective root device volume for instance.
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
-
-	// Perform this after checking for optimized image as overwriting the volumes UUID
-	// will cause a non matching configuration which will always fall back to non optimized storage.
 	vol := b.GetNewVolume(volType, contentType, volStorageName, volumeConfig)
 
 	// Set the parent volume UUID.
@@ -2186,76 +2177,40 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 	// Leave reverting on failure to caller, they are expected to call DeleteInstance().
 
-	// If the driver doesn't support optimized image volumes or the optimized image volume should not be used,
-	// create a new empty volume and populate it with the contents of the image archive.
-	if !useOptimizedImage {
-		volFiller := drivers.VolumeFiller{
-			Fingerprint: fingerprint,
-			Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
-		}
+	volFiller := drivers.VolumeFiller{
+		Fingerprint: fingerprint,
+		Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
+	}
 
-		err = b.driver.CreateVolume(vol, &volFiller, op)
-		if err != nil {
-			return err
-		}
-	} else {
-		// If the driver supports optimized images then ensure the optimized image volume has been created
-		// for the images's fingerprint and that it matches the pool's current volume settings, and if not
-		// recreating using the pool's current volume settings.
+	// If the driver supports optimized images and the instance's config is compatible
+	// with pool defaults, ensure the cached image volume exists and pass it to the
+	// driver. Otherwise imgVol is nil and the driver falls back to a direct unpack.
+	var imgVol *drivers.Volume
+	canOptimizedImage, err := drivers.CanUseOptimizedImage(vol)
+	if err != nil {
+		return err
+	}
+
+	if canOptimizedImage {
 		err = b.EnsureImage(fingerprint, op, inst.Project().Name)
 		if err != nil {
 			return err
 		}
 
-		// Try and load existing volume config on this storage pool so we can compare filesystems if needed.
 		imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
 		if err != nil {
 			return err
 		}
 
-		imgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
+		v := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
+		imgVol = &v
+	}
 
-		// Derive the volume size to use for a new volume when copying from a source volume.
-		// Where possible (if the source volume has a volatile.rootfs.size property), it checks that the
-		// source volume isn't larger than the volume's "size" and the pool's "volume.size" setting.
-		l.Debug("Checking volume size")
-		newVolSize, err := vol.ConfigSizeFromSource(imgVol)
-		if err != nil {
-			return err
-		}
-
-		// Set the derived size directly as the "size" property on the new volume so that it is applied.
-		vol.SetConfigSize(newVolSize)
-		l.Debug("Set new volume size", logger.Ctx{"size": newVolSize})
-
-		volCopy := drivers.NewVolumeCopy(vol)
-		imgVolCopy := drivers.NewVolumeCopy(imgVol)
-
-		// Proceed to create a new volume by copying the optimized image volume.
-		err = b.driver.CreateVolumeFromCopy(volCopy, imgVolCopy, false, op)
-
-		// If the driver returns ErrCannotBeShrunk, this means that the cached volume that the new volume
-		// is to be created from is larger than the requested new volume size, and cannot be shrunk.
-		// So we unpack the image directly into a new volume rather than use the optimized snapsot.
-		// This is slower but allows for individual volumes to be created from an image that are smaller
-		// than the pool's volume settings.
-		if err != nil {
-			if !errors.Is(err, drivers.ErrCannotBeShrunk) {
-				return err
-			}
-
-			l.Debug("Cached image volume is larger than new volume and cannot be shrunk, creating non-optimized volume")
-
-			volFiller := drivers.VolumeFiller{
-				Fingerprint: fingerprint,
-				Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
-			}
-
-			err = b.driver.CreateVolume(vol, &volFiller, op)
-			if err != nil {
-				return err
-			}
-		}
+	// The driver decides whether to clone from the cached image volume or unpack
+	// directly, based on whether imgVol is set and config/size constraints.
+	err = b.driver.CreateVolumeFromImage(vol, imgVol, &volFiller, op)
+	if err != nil {
+		return err
 	}
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
@@ -4308,22 +4263,11 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 		// Add existing image volume's config to imgVol.
 		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
 
-		// Check if the volume's block backed mode differs from the pool's current setting for new volumes.
-		blockModeChanged := tmpImgVol.IsBlockBacked() != imgVol.IsBlockBacked()
-
-		// Check if the volume is block backed and its filesystem is different from the pool's current
-		// setting for new volumes.
-		blockFSChanged := imgVol.IsBlockBacked() && imgVol.Config()["block.filesystem"] != tmpImgVol.Config()["block.filesystem"]
-
+		// Check if the volume's config differs from the pool's current configuration for new volumes.
 		// If the existing image volume no longer matches the pool's settings for new volumes then we need
 		// to delete and re-create it.
-		if blockModeChanged || blockFSChanged {
-			if blockModeChanged {
-				l.Debug("Block mode has changed, regenerating image volume")
-			} else {
-				l.Debug("Block volume filesystem of pool has changed since cached image volume created, regenerating image volume")
-			}
-
+		if !b.driver.ImageVolumeConfigMatch(imgVol, tmpImgVol) {
+			l.Debug("Image volume configuration differs from storage pool configuration, regenerating image volume")
 			err = b.DeleteImage(image.Fingerprint, op)
 			if err != nil {
 				return err
@@ -4434,72 +4378,6 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 
 	revert.Success()
 	return nil
-}
-
-// shouldUseOptimizedImage determines if an optimized image should be used based on the provided volume config.
-// It returns true if the volume config aligns with the pool's default configuration, and an optimized image does
-// not exist or also matches the pool's default configuration.
-func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType drivers.ContentType, volConfig map[string]string) (bool, error) {
-	canOptimizeImage := b.driver.Info().OptimizedImages
-
-	// If the volume config is empty, the default pool configuration is used, making the driver's support
-	// for optimized images the determining factor. However, an optimized image cannot be utilized if the
-	// driver lacks support for it.
-	if !canOptimizeImage || len(volConfig) == 0 {
-		return canOptimizeImage, nil
-	}
-
-	// Create the image volume with the provided volume config.
-	newImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, volConfig)
-	err := b.Driver().FillVolumeConfig(newImgVol)
-	if err != nil {
-		return false, err
-	}
-
-	// Create the image volume with pool's default settings.
-	poolDefaultImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
-	err = b.Driver().FillVolumeConfig(poolDefaultImgVol)
-	if err != nil {
-		return false, err
-	}
-
-	// If the new volume's config doesn't match the pool's default configuration, don't use an optimized image.
-	if !volumeConfigsMatch(newImgVol, poolDefaultImgVol) {
-		return false, nil
-	}
-
-	// Load existing optimized image, if it exists.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
-	if err != nil && !response.IsNotFoundError(err) {
-		return false, err
-	}
-
-	if imgDBVol != nil {
-		// Ensure existing optimized image's config matches the pool's default configuration.
-		imgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
-		if !volumeConfigsMatch(newImgVol, imgVol) {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// volumeConfigsMatch checks if the block-backed modes of two volumes match, and if they are block-backed, ensures
-// their filesystem configurations are also identical.
-func volumeConfigsMatch(vol1, vol2 drivers.Volume) bool {
-	blockModeChanged := vol1.IsBlockBacked() != vol2.IsBlockBacked()
-	blockFSChanged := vol1.IsBlockBacked() && vol1.Config()["block.filesystem"] != vol2.Config()["block.filesystem"]
-
-	// TODO: Temporary workaround for zfs.blocksize issue:
-	// When zfs.blocksize changes, a new optimized image isn't generated. This ensures we don't use an
-	// optimized image if initial.zfs.blocksize differs from the default pool settings.
-	//
-	// Note: If initial.zfs.blocksize is set to 8KiB and volume.zfs.blocksize is unset (defaults to 8KiB),
-	// they're considered unequal ("" != "8KiB"), preventing the use of a matching optimized image.
-	blockSizeChanged := vol1.IsBlockBacked() && vol1.Config()["zfs.blocksize"] != vol2.Config()["zfs.blocksize"]
-
-	return !blockModeChanged && !blockFSChanged && !blockSizeChanged
 }
 
 // DeleteImage removes an image from the database and underlying storage device if needed.

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -551,6 +551,11 @@ func (d *alletra) BackupVolume(vol VolumeCopy, projectName string, tarWriter *in
 	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *alletra) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	revert := revert.New()

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -830,6 +830,11 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 	return nil
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *btrfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
 func (d *btrfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, true, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -752,6 +752,11 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 	return nil
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *ceph) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // refreshVolume updates an existing volume to match the state of another.
 // It returns the cleanup hooks required to revert any changes made during the refresh.
 func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) (revert.Hook, error) {

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -68,6 +68,11 @@ func (d *cephfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, s
 	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
+// CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
+func (d *cephfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return d.CreateVolume(vol, filler, op)
+}
+
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
 func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	bwlimit := d.config["rsync.bwlimit"]

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -376,6 +376,11 @@ func (d *common) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 	return ErrNotSupported
 }
 
+// CreateVolumeFromImage creates volume from images.
+func (d *common) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
 // CreateVolumeFromMigration creates a new volume (with or without snapshots) from a migration data stream.
 func (d *common) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	return ErrNotSupported

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -636,3 +636,18 @@ func (d *common) filesystemFreeze(path string) (func() error, error) {
 
 	return unfreezeFS, nil
 }
+
+// ImageVolumeConfigMatch returns whether two image volumes have compatible
+// block-backing mode and filesystem configuration.
+func (d *common) ImageVolumeConfigMatch(vol1, vol2 Volume) bool {
+	isFirstVolumeBlockBacked := vol1.IsBlockBacked()
+	if isFirstVolumeBlockBacked != vol2.IsBlockBacked() {
+		return false
+	}
+
+	if isFirstVolumeBlockBacked && vol1.Config()["block.filesystem"] != vol2.Config()["block.filesystem"] {
+		return false
+	}
+
+	return true
+}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -137,6 +137,11 @@ func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcD
 	return nil, revertHook, nil
 }
 
+// CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
+func (d *dir) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return d.CreateVolume(vol, filler, op)
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *dir) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	var srcSnapshots []string

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -173,6 +173,11 @@ func (d *lvm) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 	return err
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *lvm) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
 func (d *lvm) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	// We can use optimised copying when the pool is backed by an LVM thinpool.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -156,6 +156,11 @@ func (d *powerflex) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info
 	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
+// CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
+func (d *powerflex) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return d.CreateVolume(vol, filler, op)
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	revert := revert.New()

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -175,6 +175,11 @@ func (d *pure) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, src
 	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *pure) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	revert := revert.New()

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3576,3 +3576,17 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 func (d *zfs) isBlockBacked(vol Volume) bool {
 	return shared.IsTrue(vol.Config()["zfs.block_mode"])
 }
+
+// ImageVolumeConfigMatch extends the common check with a ZFS-specific block size comparison.
+func (d *zfs) ImageVolumeConfigMatch(vol1, vol2 Volume) bool {
+	if !d.common.ImageVolumeConfigMatch(vol1, vol2) {
+		return false
+	}
+
+	// Check if block size config has changed.
+	if vol1.IsBlockBacked() && vol1.Config()["zfs.blocksize"] != vol2.Config()["zfs.blocksize"] {
+		return false
+	}
+
+	return true
+}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1225,6 +1225,11 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 	return nil
 }
 
+// CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
+func (d *zfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return createVolumeFromImage(vol, imgVol, filler, op)
+}
+
 // RefreshVolume updates an existing volume to match the state of another.
 func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	var err error
@@ -3583,7 +3588,11 @@ func (d *zfs) ImageVolumeConfigMatch(vol1, vol2 Volume) bool {
 		return false
 	}
 
-	// Check if block size config has changed.
+	// When zfs.blocksize changes, a new optimized image isn't generated. This ensures we don't use an
+	// optimized image if initial.zfs.blocksize differs from the default pool settings.
+	//
+	// Note: If initial.zfs.blocksize is set to 8KiB and volume.zfs.blocksize is unset (defaults to 8KiB),
+	// they're considered unequal ("" != "8KiB"), preventing the use of a matching optimized image.
 	if vol1.IsBlockBacked() && vol1.Config()["zfs.blocksize"] != vol2.Config()["zfs.blocksize"] {
 		return false
 	}

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -31,6 +31,7 @@ type Driver interface {
 	HasVolume(vol Volume) (bool, error)
 	roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64
 	isBlockBacked(vol Volume) bool
+	ImageVolumeConfigMatch(vol1 Volume, vol2 Volume) bool
 
 	// Export struct details.
 	Name() string

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -70,6 +70,7 @@ type Driver interface {
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
 	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
 	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error
+	CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error
 	RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error
 	DeleteVolume(vol Volume, op *operations.Operation) error
 	RenameVolume(vol Volume, newName string, op *operations.Operation) error

--- a/lxd/storage/drivers/utils_image.go
+++ b/lxd/storage/drivers/utils_image.go
@@ -1,0 +1,100 @@
+package drivers
+
+import (
+	"errors"
+	"maps"
+
+	"github.com/canonical/lxd/lxd/operations"
+)
+
+// imageVolumeConfigMatchesPoolDefault checks whether the instance volume's effective config
+// is compatible with the pool's current defaults for image volumes. If the configs are
+// incompatible, there is no point unpacking the image into a dedicated on-disk image
+// volume because the driver would not be able to clone from it anyway.
+func imageVolumeConfigMatchesPoolDefault(vol Volume) (bool, error) {
+	// Configs are cloned because FillVolumeConfig mutates in place.
+	instImgVol := NewVolume(vol.driver, vol.pool, VolumeTypeImage, vol.contentType, vol.name, maps.Clone(vol.config), maps.Clone(vol.poolConfig))
+	err := vol.driver.FillVolumeConfig(instImgVol)
+	if err != nil {
+		return false, err
+	}
+
+	poolDefaultVol := NewVolume(vol.driver, vol.pool, VolumeTypeImage, vol.contentType, vol.name, make(map[string]string), maps.Clone(vol.poolConfig))
+	err = vol.driver.FillVolumeConfig(poolDefaultVol)
+	if err != nil {
+		return false, err
+	}
+
+	return vol.driver.ImageVolumeConfigMatch(instImgVol, poolDefaultVol), nil
+}
+
+// CanUseOptimizedImage reports whether the driver supports optimized image volumes and
+// the instance volume's config is compatible with the pool's image-volume defaults.
+// Both conditions must hold: if the driver doesn't cache images at all, or if the
+// instance's config would prevent cloning from a cached image, there's no benefit in
+// maintaining a separate image volume.
+func CanUseOptimizedImage(vol Volume) (bool, error) {
+	// vol is passed by value so it is never nil, but its driver field may be unset.
+	if vol.driver == nil {
+		return false, errors.New("Volume has no associated driver")
+	}
+
+	if !vol.driver.Info().OptimizedImages {
+		return false, nil
+	}
+
+	return imageVolumeConfigMatchesPoolDefault(vol)
+}
+
+// createVolumeFromImage creates a new volume from an image. If imgVol is nil (no cached
+// image volume is available), it falls back to unpacking the image directly into a new
+// volume via the filler. Otherwise it verifies that the cached image volume's config still
+// matches the pool's defaults and clones from it, falling back to a direct unpack if the
+// configs have drifted or the image volume cannot be shrunk to the requested size.
+func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+	// vol is passed by value so it is never nil, but its driver field may be unset.
+	if vol.driver == nil {
+		return errors.New("Volume has no associated driver")
+	}
+
+	if imgVol == nil {
+		return vol.driver.CreateVolume(vol, filler, op)
+	}
+
+	// Pool settings may have changed since the cached image volume was created.
+	poolDefaultVol := NewVolume(vol.driver, vol.pool, VolumeTypeImage, vol.contentType, imgVol.name, make(map[string]string), maps.Clone(vol.poolConfig))
+	err := vol.driver.FillVolumeConfig(poolDefaultVol)
+	if err != nil {
+		return err
+	}
+
+	if !vol.driver.ImageVolumeConfigMatch(*imgVol, poolDefaultVol) {
+		return vol.driver.CreateVolume(vol, filler, op)
+	}
+
+	// Derive the volume size to use for the new volume when copying from the image volume.
+	// Where possible (if the image volume has a volatile.rootfs.size property), it checks
+	// that the image volume isn't larger than the volume's "size" and the pool's
+	// "volume.size" setting.
+	newVolSize, err := vol.ConfigSizeFromSource(*imgVol)
+	if err != nil {
+		return err
+	}
+
+	vol.SetConfigSize(newVolSize)
+
+	// Clone the new volume from the cached image volume.
+	err = vol.driver.CreateVolumeFromCopy(NewVolumeCopy(vol), NewVolumeCopy(*imgVol), false, op)
+	if err != nil {
+		if !errors.Is(err, ErrCannotBeShrunk) {
+			return err
+		}
+
+		// The cached image volume is larger than the requested new volume size and cannot
+		// be shrunk. Fall back to unpacking the image directly into a new volume. This is
+		// slower but allows creating volumes smaller than the pool's volume settings.
+		return vol.driver.CreateVolume(vol, filler, op)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.


## Summary

- Adds `VolumeConfigMatch` to the driver interface, moving volume config comparison logic (block-backing mode, filesystem, ZFS blocksize) out of `backend_lxd.go` and into the driver layer where it belongs. ZFS overrides this to add its own `zfs.blocksize` check.

- Adds `CreateVolumeFromImage` to the driver interface with a `genericVFSCreateVolumeFromImage` helper that handles config matching, optimized clone, and fallback to full unpack. Each optimized-image driver (ZFS, Btrfs, Ceph, LVM, Alletra, Pure) implements this via the helper.

- Adds `VolumeConfigMatchesPoolDefault` as an exported check used by the backend to skip `EnsureImage` entirely when the instance's config is incompatible with pool defaults, avoiding unnecessary cached image volume creation.

- Simplifies `CreateInstanceFromImage` in `backend_lxd.go`: it now delegates to `CreateVolumeFromImage` for drivers that support optimized images, removing the `shouldUseOptimizedImage` and `volumeConfigsMatch` functions entirely.


## Motivation
This addresses the layering concern raised in #17630: the backend was making driver-level decisions about whether/how to use optimized image volumes. By pushing this logic into the driver layer, each driver can own its optimization strategy while sharing common behavior via `genericVFSCreateVolumeFromImage`. This also sets the groundwork for drivers (e.g., ZFS) to implement custom optimization strategies in the future.

