### PR TITLE
Rebalance raft roles during cluster member evacuation

### DIFF
--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -223,8 +223,15 @@ func (r *ProtocolLXD) UpdateClusterMemberState(name string, state api.ClusterMem
 		return nil, err
 	}
 
-	if state.Action != "" {
+	if state.Action == api.ClusterMemberActionRestore && state.Mode == api.ClusterRestoreModeSkip {
 		err = r.CheckExtension("clustering_restore_skip_mode")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if state.Action == api.ClusterMemberActionEvacuate && state.Force {
+		err = r.CheckExtension("clustering_evacuation_force")
 		if err != nil {
 			return nil, err
 		}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3600,3 +3600,10 @@ This includes the following new endpoints (see {ref}`rest-api` for details):
 * [`GET /1.0/networks/{networkName}/load-balancer-pools/{poolName}`](swagger:/network-load-balancer-pools/network_load_balancer_pool_get)
 * [`PUT /1.0/networks/{networkName}/load-balancer-pools/{poolName}`](swagger:/network-load-balancer-pools/network_load_balancer_pool_put)
 * [`DELETE /1.0/networks/{networkName}/load-balancer-pools/{poolName}`](swagger:/network-load-balancer-pools/network_load_balancer_pool_delete)
+
+(extension-clustering-evacuation-force)=
+## `clustering_evacuation_force`
+
+Adds a `force` field to `POST /1.0/cluster/members/{name}/state` when performing an `evacuate` action.
+
+When `force` is set to `true`, LXD skips the quorum safety check that otherwise would not allow you to evacuate an online raft voter when the remaining online voters would fall below the required majority.

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -133,6 +133,9 @@ To begin this process, use the [`lxc cluster evacuate`](lxc_cluster_evacuate.md)
 
     lxc cluster evacuate <member_name>
 
+Use `--yes` to skip the confirmation prompt.
+Use `--force` only if you want to permit evacuation even when it would leave too few online Raft voters to maintain quorum.
+
 (cluster-restore)=
 ### Restore an evacuated cluster member
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -762,6 +762,11 @@ definitions:
                 example: evacuate
                 type: string
                 x-go-name: Action
+            force:
+                description: Permit evacuation even if it would drop the cluster below the required voter majority.
+                example: false
+                type: boolean
+                x-go-name: Force
             mode:
                 description: |-
                     Override the configured evacuation mode.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1270,6 +1270,7 @@ type cmdClusterEvacuateAction struct {
 
 	flagAction string
 	flagForce  bool
+	flagYes    bool
 }
 
 // Cluster member evacuation.
@@ -1299,7 +1300,8 @@ If no target member is available, an instance is skipped.
 If a live migration attempt fails, the evacuation operation fails.
 `)
 
-	cmd.Flags().BoolVar(&c.action.flagForce, "force", false, "Force evacuation without user confirmation")
+	cmd.Flags().BoolVar(&c.action.flagForce, "force", false, "Allow evacuation even if it would cause loss of Raft quorum")
+	cmd.Flags().BoolVar(&c.action.flagYes, "yes", false, "Do not require user confirmation")
 	cmd.Flags().StringVar(&c.action.flagAction, "action", "", cli.FormatStringFlagLabel("Force a particular instance evacuation action. One of stop, migrate or live-migrate"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -1368,7 +1370,9 @@ func (c *cmdClusterEvacuateAction) run(cmd *cobra.Command, args []string) error 
 		return errors.New("Missing cluster member name")
 	}
 
-	if !c.flagForce {
+	isEvacuate := cmd.Name() == api.ClusterMemberActionEvacuate
+	skipConfirm := (isEvacuate && c.flagYes) || (!isEvacuate && c.flagForce)
+	if !skipConfirm {
 		evacuate, err := c.global.asker.AskBool(fmt.Sprintf("Are you sure you want to %s cluster member %q? (yes/no) [default=no]: ", cmd.Name(), resource.name), "no")
 		if err != nil {
 			return err
@@ -1382,6 +1386,7 @@ func (c *cmdClusterEvacuateAction) run(cmd *cobra.Command, args []string) error 
 	state := api.ClusterMemberStatePost{
 		Action: cmd.Name(),
 		Mode:   c.flagAction,
+		Force:  isEvacuate && c.flagForce,
 	}
 
 	op, err := resource.server.UpdateClusterMemberState(resource.name, state)
@@ -1397,7 +1402,7 @@ func (c *cmdClusterEvacuateAction) run(cmd *cobra.Command, args []string) error 
 
 	var format string
 
-	if cmd.Name() == "restore" {
+	if cmd.Name() == api.ClusterMemberActionRestore {
 		format = "Restoring cluster member: %s"
 	} else {
 		format = "Evacuating cluster member: %s"

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1221,7 +1221,7 @@ func rebalanceMemberRoles(ctx context.Context, s *state.State, gateway *cluster.
 	}
 
 	for {
-		address, nodes, connectivity, err := cluster.GetNextRoleChange(s, gateway, unavailableMembers, memberRoles)
+		address, nodes, connectivity, err := cluster.GetNextRoleChange(s, gateway, unavailableMembers, memberRoles, nil)
 		if err != nil {
 			return err
 		}
@@ -1346,7 +1346,7 @@ findLeader:
 
 	if leaderInfo.Leader {
 		logger.Info("Transferring leadership", logCtx)
-		err := gateway.TransferLeadership(memberRoles)
+		err := gateway.TransferLeadership(memberRoles, nil)
 		if err != nil {
 			return fmt.Errorf("Failed transferring leadership: %w", err)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -779,11 +779,6 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			logger.Errorf("Failed starting networks: %v", err)
 		}
 
-		client, err = cluster.Connect(ctx, req.ClusterAddress, s.Endpoints.NetworkCert(), serverCert, true)
-		if err != nil {
-			return err
-		}
-
 		// Add the cluster flag from the agent
 		features := []string{"cluster"}
 		err = version.UserAgentFeatures(features)
@@ -793,9 +788,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Notify the leader of successful join, possibly triggering
 		// role changes.
-		_, _, err = client.RawQuery(http.MethodPost, "/internal/cluster/rebalance", nil, "")
+		err = triggerClusterRebalance(ctx, s)
 		if err != nil {
-			logger.Warnf("Failed triggering cluster rebalance: %v", err)
+			logger.Warn("Failed triggering cluster rebalance after join", logger.Ctx{"err": err})
 		}
 
 		// Ensure all images are available after this node has joined.
@@ -1640,6 +1635,30 @@ func getClusterMemberRolesAndEvacuatedMembers(ctx context.Context, s *state.Stat
 	}
 
 	return memberRoles, evacuatedMembers, nil
+}
+
+// triggerClusterRebalance asks the current leader to run the internal cluster rebalance flow immediately.
+func triggerClusterRebalance(ctx context.Context, s *state.State) error {
+	leaderInfo, err := s.LeaderInfo()
+	if err != nil {
+		return err
+	}
+
+	if !leaderInfo.Clustered {
+		return cluster.ErrNodeIsNotClustered
+	}
+
+	client, err := cluster.Connect(ctx, leaderInfo.Address, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+	if err != nil {
+		return fmt.Errorf("Failed connecting to leader for rebalance: %w", err)
+	}
+
+	_, _, err = client.RawQuery(http.MethodPost, "/internal/cluster/rebalance", nil, "")
+	if err != nil {
+		return fmt.Errorf("Failed triggering cluster rebalance: %w", err)
+	}
+
+	return nil
 }
 
 func autoHealClusterTask(stateFunc func() *state.State, gateway *cluster.Gateway) (task.Func, task.Schedule) {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1816,7 +1816,7 @@ func healClusterMember(s *state.State, gateway *cluster.Gateway, op *operations.
 		return nil
 	}
 
-	err := evacuateClusterMember(context.Background(), s, gateway, op, name, api.ClusterEvacuateModeHeal, nil, migrateFunc)
+	err := evacuateClusterMember(context.Background(), s, gateway, op, name, api.ClusterEvacuateModeHeal, false, nil, migrateFunc)
 	if err != nil {
 		logger.Error("Failed healing cluster member", logger.Ctx{"member": name, "err": err})
 		return err

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1200,12 +1200,12 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 	d.clusterMembershipMutex.Lock()
 	defer d.clusterMembershipMutex.Unlock()
 
-	memberRoles, err := getClusterMemberRoles(r.Context(), s)
+	memberRoles, evacuatedMembers, err := getClusterMemberRolesAndEvacuatedMembers(r.Context(), s)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles)
+	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles, evacuatedMembers)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1215,13 +1215,13 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 
 // Check if there's a dqlite node whose role should be changed, and post a
 // change role request if so.
-func rebalanceMemberRoles(ctx context.Context, s *state.State, gateway *cluster.Gateway, unavailableMembers []string, memberRoles map[string][]db.ClusterRole) error {
+func rebalanceMemberRoles(ctx context.Context, s *state.State, gateway *cluster.Gateway, unavailableMembers []string, memberRoles map[string][]db.ClusterRole, evacuatedMembers []string) error {
 	if s.ShutdownCtx.Err() != nil {
 		return nil
 	}
 
 	for {
-		address, nodes, connectivity, err := cluster.GetNextRoleChange(s, gateway, unavailableMembers, memberRoles, nil)
+		address, nodes, connectivity, err := cluster.GetNextRoleChange(s, gateway, unavailableMembers, memberRoles, evacuatedMembers)
 		if err != nil {
 			return err
 		}
@@ -1332,7 +1332,7 @@ func handoverMemberRole(s *state.State, gateway *cluster.Gateway) error {
 	logCtx := logger.Ctx{"address": localClusterAddress}
 
 	// Use context.Background() because s.ShutdownCtx may already be cancelled at this point in the shutdown sequence, but the handover must complete.
-	memberRoles, err := getClusterMemberRoles(context.Background(), s)
+	memberRoles, evacuatedMembers, err := getClusterMemberRolesAndEvacuatedMembers(context.Background(), s)
 	if err != nil {
 		return err
 	}
@@ -1346,7 +1346,7 @@ findLeader:
 
 	if leaderInfo.Leader {
 		logger.Info("Transferring leadership", logCtx)
-		err := gateway.TransferLeadership(memberRoles, nil)
+		err := gateway.TransferLeadership(memberRoles, evacuatedMembers...)
 		if err != nil {
 			return fmt.Errorf("Failed transferring leadership: %w", err)
 		}
@@ -1601,12 +1601,12 @@ func internalClusterRaftNodeDelete(d *Daemon, r *http.Request) response.Response
 		return response.SmartError(err)
 	}
 
-	memberRoles, err := getClusterMemberRoles(r.Context(), s)
+	memberRoles, evacuatedMembers, err := getClusterMemberRolesAndEvacuatedMembers(r.Context(), s)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles)
+	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles, evacuatedMembers)
 	if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
 		logger.Warn("Could not rebalance cluster member roles after raft member removal", logger.Ctx{"err": err})
 	}
@@ -1614,24 +1614,32 @@ func internalClusterRaftNodeDelete(d *Daemon, r *http.Request) response.Response
 	return response.SyncResponse(true, nil)
 }
 
-// getClusterMemberRoles returns cluster member roles keyed by member address.
-func getClusterMemberRoles(ctx context.Context, s *state.State) (map[string][]db.ClusterRole, error) {
+// getClusterMemberRolesAndEvacuatedMembers returns cluster member roles keyed by member address and a slice of evacuated member addresses.
+func getClusterMemberRolesAndEvacuatedMembers(ctx context.Context, s *state.State) (map[string][]db.ClusterRole, []string, error) {
 	var memberRoles map[string][]db.ClusterRole
+	var evacuatedMembers []string
 
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
-		memberRoles, err = cluster.GetMemberRoles(ctx, tx)
+		members, err := tx.GetNodes(ctx)
 		if err != nil {
-			return fmt.Errorf("Failed loading cluster member roles: %w", err)
+			return fmt.Errorf("Failed getting cluster members: %w", err)
+		}
+
+		memberRoles = make(map[string][]db.ClusterRole, len(members))
+		for _, member := range members {
+			memberRoles[member.Address] = member.Roles
+			if member.State == db.ClusterMemberStateEvacuated {
+				evacuatedMembers = append(evacuatedMembers, member.Address)
+			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return memberRoles, nil
+	return memberRoles, evacuatedMembers, nil
 }
 
 func autoHealClusterTask(stateFunc func() *state.State, gateway *cluster.Gateway) (task.Func, task.Schedule) {

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -2224,6 +2224,12 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 		}
 
 		revert.Success()
+
+		err = triggerClusterRebalance(ctx, s)
+		if err != nil {
+			logger.Warn("Could not rebalance cluster member roles after restore", logger.Ctx{"err": err, "member": originName})
+		}
+
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterMemberRestored.Event(originName, op.EventLifecycleRequestor(), nil))
 		return nil
 	}

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1197,12 +1197,12 @@ func clusterMemberDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed removing member from database: %w", err))
 	}
 
-	memberRoles, err := getClusterMemberRoles(r.Context(), s)
+	memberRoles, evacuatedMembers, err := getClusterMemberRolesAndEvacuatedMembers(r.Context(), s)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles)
+	err = rebalanceMemberRoles(r.Context(), s, d.gateway, nil, memberRoles, evacuatedMembers)
 	if err != nil {
 		logger.Warnf("Failed rebalancing dqlite nodes: %v", err)
 	}

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1322,12 +1322,12 @@ func clusterMemberStateGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
-	name := r.PathValue("name")
+	memberName := r.PathValue("name")
 	var err error
 	s := d.State()
 
 	// Forward request
-	resp := forwardedResponseToNode(r.Context(), s, name)
+	resp := forwardedResponseToNode(r.Context(), s, memberName)
 	if resp != nil {
 		return resp
 	}
@@ -1348,14 +1348,14 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	switch req.Action {
-	case "evacuate":
-		err = validateEvacuateRequest(r.Context(), s, name)
+	case api.ClusterMemberActionEvacuate:
+		err = validateEvacuateRequest(r.Context(), s, memberName)
 		if err != nil {
 			return response.BadRequest(err)
 		}
 
 		if !req.Force {
-			err = validateClusterMemberEvacuation(r.Context(), s, name)
+			err = validateClusterMemberEvacuation(r.Context(), s, memberName)
 			if err != nil {
 				return response.BadRequest(err)
 			}
@@ -1431,7 +1431,7 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		run := func(ctx context.Context, op *operations.Operation) error {
-			return evacuateClusterMember(ctx, s, d.gateway, op, name, req.Mode, stopFunc, migrateFunc)
+			return evacuateClusterMember(ctx, s, d.gateway, op, memberName, req.Mode, req.Force, stopFunc, migrateFunc)
 		}
 
 		args := operations.OperationArgs{
@@ -1449,15 +1449,15 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		return operations.OperationResponse(op)
-	case "restore":
+	case api.ClusterMemberActionRestore:
 		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberEvacuate, true)
 		if err != nil {
 			return response.SmartError(err)
 		}
 
 		for _, op := range ops {
-			if op.Location == name && !op.StatusCode.IsFinal() {
-				return response.BadRequest(fmt.Errorf("Cannot restore %q while an evacuate operation is in progress", name))
+			if op.Location == memberName && !op.StatusCode.IsFinal() {
+				return response.BadRequest(fmt.Errorf("Cannot restore %q while an evacuate operation is in progress", memberName))
 			}
 		}
 
@@ -1675,7 +1675,59 @@ func checkEvacuationQuorum(targetMember db.NodeInfo, raftNodes []db.RaftNode, co
 	return nil
 }
 
-func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster.Gateway, op *operations.Operation, name string, mode string, stopInstance evacuateStopFunc, migrateInstance evacuateMigrateFunc) error {
+// ensureEvacuationLeadershipHandover transfers raft leadership away from the
+// member being evacuated before evacuation proceeds, if that member is the
+// current raft leader.
+func ensureEvacuationLeadershipHandover(ctx context.Context, s *state.State, gateway *cluster.Gateway, name string) error {
+	leaderInfo, err := s.LeaderInfo()
+	if err != nil {
+		return err
+	}
+
+	if !leaderInfo.Clustered {
+		return nil
+	}
+
+	// Look up the address of the member being evacuated to determine whether
+	// it is the raft leader. This check is done by name rather than by
+	// assuming the local member is the evacuated one, so the function is
+	// correct regardless of which cluster member the API handler runs on.
+	var memberAddress string
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		member, err := tx.GetNodeByName(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		memberAddress = member.Address
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if memberAddress != leaderInfo.Address {
+		return nil
+	}
+
+	memberRoles, evacuatedMembers, err := getClusterMemberRolesAndEvacuatedMembers(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Transferring leadership before cluster member evacuation", logger.Ctx{"member": name})
+	err = gateway.TransferLeadership(memberRoles, evacuatedMembers...)
+	if err != nil {
+		return fmt.Errorf("Failed transferring leadership before evacuation: %w", err)
+	}
+
+	return nil
+}
+
+// evacuateClusterMember marks the member evacuated, rebalances raft roles, and
+// then migrates or stops workloads before evacuating networks.
+// When force is true, the pre-evacuation quorum check is skipped.
+func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster.Gateway, op *operations.Operation, name string, mode string, force bool, stopInstance evacuateStopFunc, migrateInstance evacuateMigrateFunc) error {
 	// The instances are retrieved in a separate transaction, after the node is in EVACUATED state.
 	var dbInstances []dbCluster.Instance
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
@@ -1706,6 +1758,18 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 	// Setup a reverter.
 	revert := revert.New()
 	defer revert.Fail()
+
+	skipRoleRebalance := mode == api.ClusterEvacuateModeHeal
+	if !skipRoleRebalance {
+		err = ensureEvacuationLeadershipHandover(ctx, s, gateway, name)
+		if err != nil {
+			if !force {
+				return err
+			}
+
+			logger.Warn("Leadership handover failed during forced evacuation; rebalance will promote a non-evacuated standby or spare to voter to take over from the evacuated leader", logger.Ctx{"err": err, "member": name})
+		}
+	}
 
 	// Set node status to EVACUATED.
 	err = evacuateClusterSetState(s, name, db.ClusterMemberStateEvacuated)

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1349,15 +1349,9 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Action {
 	case "evacuate":
-		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberRestore, true)
+		err = validateEvacuateRequest(r.Context(), s, name)
 		if err != nil {
-			return response.SmartError(err)
-		}
-
-		for _, op := range ops {
-			if op.Location == name && !op.StatusCode.IsFinal() {
-				return response.BadRequest(fmt.Errorf("Cannot evacuate %q while a restore operation is in progress", name))
-			}
+			return response.BadRequest(err)
 		}
 
 		stopFunc := func(ctx context.Context, inst instance.Instance) error {
@@ -1511,6 +1505,37 @@ func evacuateClusterSetState(s *state.State, name string, state int) error {
 
 // evacuateHostShutdownDefaultTimeout default timeout (in seconds) for waiting for clean shutdown to complete.
 const evacuateHostShutdownDefaultTimeout = 30
+
+// validateEvacuateRequest checks that no conflicting operation is already running before
+// allowing an evacuation to proceed. It rejects the request if a restore is in progress
+// for the target member, or if any cluster-wide evacuation is already running.
+// Note: the ConflictReference on the operation provides a race-safe fallback, but checking
+// here gives a clear error message before the quorum check runs.
+func validateEvacuateRequest(ctx context.Context, s *state.State, memberName string) error {
+	ops, err := operationsGetByType(ctx, s, "", operationtype.ClusterMemberRestore, true)
+	if err != nil {
+		return err
+	}
+
+	for _, op := range ops {
+		if op.Location == memberName && !op.StatusCode.IsFinal() {
+			return fmt.Errorf("Cannot evacuate %q while a restore operation is in progress", memberName)
+		}
+	}
+
+	evacOps, err := operationsGetByType(ctx, s, "", operationtype.ClusterMemberEvacuate, true)
+	if err != nil {
+		return err
+	}
+
+	for _, op := range evacOps {
+		if !op.StatusCode.IsFinal() {
+			return fmt.Errorf("Cannot evacuate %q while another cluster member evacuation is in progress", memberName)
+		}
+	}
+
+	return nil
+}
 
 // checkEvacuationQuorum determines whether evacuating targetMember would break
 // raft quorum. It returns an error if evacuation should be rejected.

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1755,10 +1755,6 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 		instances = append(instances, inst)
 	}
 
-	// Setup a reverter.
-	revert := revert.New()
-	defer revert.Fail()
-
 	skipRoleRebalance := mode == api.ClusterEvacuateModeHeal
 	if !skipRoleRebalance {
 		err = ensureEvacuationLeadershipHandover(ctx, s, gateway, name)
@@ -1782,10 +1778,6 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 	evacuationCommittedError := func(err error) error {
 		return fmt.Errorf("%w (cluster member remains evacuated)", err)
 	}
-	// Ensure node is put into its previous state if anything fails.
-	revert.Add(func() {
-		_ = evacuateClusterSetState(s, name, db.ClusterMemberStateCreated)
-	})
 
 	if !skipRoleRebalance {
 		// Trigger a raft rebalance now that the member is marked EVACUATED, before
@@ -1798,7 +1790,7 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 		err = triggerClusterRebalance(ctx, s)
 		if err != nil {
 			if !force {
-				return err
+				return evacuationCommittedError(err)
 			}
 
 			logger.Warn("Proceeding with forced evacuation after role rebalance failure", logger.Ctx{"err": err, "member": name})
@@ -1833,15 +1825,13 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 
 	err = evacuateInstances(context.Background(), opts)
 	if err != nil {
-		return err
+		return evacuationCommittedError(err)
 	}
 
 	// Evacuate networks too, but not during healing.
 	if mode != api.ClusterEvacuateModeHeal {
 		networkStop(s, true)
 	}
-
-	revert.Success()
 
 	if mode != api.ClusterEvacuateModeHeal {
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterMemberEvacuated.Event(name, op.EventLifecycleRequestor(), nil))

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1354,6 +1354,13 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
+		if !req.Force {
+			err = validateClusterMemberEvacuation(r.Context(), s, name)
+			if err != nil {
+				return response.BadRequest(err)
+			}
+		}
+
 		stopFunc := func(ctx context.Context, inst instance.Instance) error {
 			l := logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 
@@ -1535,6 +1542,58 @@ func validateEvacuateRequest(ctx context.Context, s *state.State, memberName str
 	}
 
 	return nil
+}
+
+// validateClusterMemberEvacuation rejects evacuating an online raft voter when
+// doing so would leave too few online voters to preserve raft quorum, even
+// after accounting for the narrow case where rebalance can first promote an
+// online standby/spare to replace the evacuated voter.
+func validateClusterMemberEvacuation(ctx context.Context, s *state.State, memberName string) error {
+	var member db.NodeInfo
+	var members []db.NodeInfo
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		members, err = tx.GetNodes(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed getting cluster members: %w", err)
+		}
+
+		for _, m := range members {
+			if m.Name == memberName {
+				member = m
+				return nil
+			}
+		}
+
+		return api.StatusErrorf(http.StatusNotFound, "Cluster member %q not found", memberName)
+	})
+	if err != nil {
+		return err
+	}
+
+	memberRoles := make(map[string][]db.ClusterRole, len(members))
+	connectivity := make(map[string]bool, len(members))
+	var evacuatedMembers []string
+	offlineThreshold := s.GlobalConfig.OfflineThreshold()
+	for _, m := range members {
+		memberRoles[m.Address] = m.Roles
+		connectivity[m.Address] = !m.IsOffline(offlineThreshold)
+		if m.State == db.ClusterMemberStateEvacuated {
+			evacuatedMembers = append(evacuatedMembers, m.Address)
+		}
+	}
+
+	var raftNodes []db.RaftNode
+	err = s.DB.Node.Transaction(ctx, func(ctx context.Context, tx *db.NodeTx) error {
+		var err error
+		raftNodes, err = tx.GetRaftNodes(ctx)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("Failed getting raft nodes: %w", err)
+	}
+
+	return checkEvacuationQuorum(member, raftNodes, connectivity, evacuatedMembers, memberRoles, offlineThreshold)
 }
 
 // checkEvacuationQuorum determines whether evacuating targetMember would break

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1512,6 +1512,85 @@ func evacuateClusterSetState(s *state.State, name string, state int) error {
 // evacuateHostShutdownDefaultTimeout default timeout (in seconds) for waiting for clean shutdown to complete.
 const evacuateHostShutdownDefaultTimeout = 30
 
+// checkEvacuationQuorum determines whether evacuating targetMember would break
+// raft quorum. It returns an error if evacuation should be rejected.
+//
+// Evacuation is allowed when:
+//   - the target is not currently a raft voter, or
+//   - the target is offline (already not contributing to quorum), or
+//   - enough online voters remain after removal to meet the required majority, or
+//   - an online standby or spare exists that can be promoted first, and the
+//     cluster currently has enough voters to make that promotion decision.
+func checkEvacuationQuorum(targetMember db.NodeInfo, raftNodes []db.RaftNode, connectivity map[string]bool, evacuatedMembers []string, memberRoles map[string][]db.ClusterRole, offlineThreshold time.Duration) error {
+	totalVoters := 0
+	onlineVoters := 0
+	onlineReplacementCandidates := 0
+	targetRole := db.RaftSpare
+
+	// Evaluate control-plane mode as if the target were already removed so that
+	// the pre-flight replacement-candidate filter matches the post-evacuation
+	// reality. If the target is one of exactly 3 CP members, including it would
+	// incorrectly keep CP mode active and exclude non-CP standbys that would
+	// legitimately be eligible after evacuation.
+	memberRolesWithoutTarget := make(map[string][]db.ClusterRole, len(memberRoles))
+	for addr, roles := range memberRoles {
+		if addr != targetMember.Address {
+			memberRolesWithoutTarget[addr] = roles
+		}
+	}
+
+	controlPlaneActive := cluster.IsControlPlaneActive(memberRolesWithoutTarget)
+
+	for _, raftNode := range raftNodes {
+		switch raftNode.Role {
+		case db.RaftVoter:
+			totalVoters++
+			if connectivity[raftNode.Address] && !slices.Contains(evacuatedMembers, raftNode.Address) {
+				onlineVoters++
+			}
+
+			if raftNode.Address == targetMember.Address {
+				targetRole = raftNode.Role
+			}
+
+		case db.RaftStandBy, db.RaftSpare:
+			if !connectivity[raftNode.Address] || slices.Contains(evacuatedMembers, raftNode.Address) {
+				continue
+			}
+
+			if controlPlaneActive && !slices.Contains(memberRoles[raftNode.Address], db.ClusterRoleControlPlane) {
+				continue
+			}
+
+			onlineReplacementCandidates++
+		}
+	}
+
+	// If the target is already evacuated in the DB its voter raft role is a stale
+	// artifact (not yet demoted by rebalance). It is not contributing to quorum,
+	// so the check is not applicable.
+	if targetRole != db.RaftVoter || targetMember.IsOffline(offlineThreshold) || slices.Contains(evacuatedMembers, targetMember.Address) {
+		return nil
+	}
+
+	requiredMajority := (totalVoters-1)/2 + 1
+	remainingOnlineVoters := onlineVoters - 1
+	if remainingOnlineVoters >= requiredMajority {
+		return nil
+	}
+
+	currentMajority := totalVoters/2 + 1
+	canPromoteReplacement := onlineVoters >= currentMajority &&
+		remainingOnlineVoters+1 >= requiredMajority &&
+		onlineReplacementCandidates > 0 &&
+		onlineVoters > 1
+	if !canPromoteReplacement {
+		return errors.New("Insufficient online voters to maintain quorum")
+	}
+
+	return nil
+}
+
 func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster.Gateway, op *operations.Operation, name string, mode string, stopInstance evacuateStopFunc, migrateInstance evacuateMigrateFunc) error {
 	// The instances are retrieved in a separate transaction, after the node is in EVACUATED state.
 	var dbInstances []dbCluster.Instance

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1777,10 +1777,48 @@ func evacuateClusterMember(ctx context.Context, s *state.State, gateway *cluster
 		return err
 	}
 
+	// Once the member is marked EVACUATED we don't roll it back on later failure,
+	// because raft role changes may already have committed on the leader.
+	evacuationCommittedError := func(err error) error {
+		return fmt.Errorf("%w (cluster member remains evacuated)", err)
+	}
 	// Ensure node is put into its previous state if anything fails.
 	revert.Add(func() {
 		_ = evacuateClusterSetState(s, name, db.ClusterMemberStateCreated)
 	})
+
+	if !skipRoleRebalance {
+		// Trigger a raft rebalance now that the member is marked EVACUATED, before
+		// migrating workloads. The rebalance demotes the evacuated member's voter or
+		// standby role and promotes a replacement. It must run after the member is
+		// marked EVACUATED: rolesAdjust reads the member state and only excludes
+		// evacuated members from promotion candidacy (and prioritizes demoting them)
+		// once the state is committed. If we rebalanced first, the member could be
+		// re-selected as a voter/standby.
+		err = triggerClusterRebalance(ctx, s)
+		if err != nil {
+			if !force {
+				return err
+			}
+
+			logger.Warn("Proceeding with forced evacuation after role rebalance failure", logger.Ctx{"err": err, "member": name})
+		}
+
+		// If leadership was transferred during the rebalance (e.g. this node was
+		// the leader and got evacuated), trigger a second rebalance on the new
+		// leader so it can demote this node before the API returns.
+		leaderInfo, leaderInfoErr := s.LeaderInfo()
+		if leaderInfoErr == nil && leaderInfo.Clustered && !leaderInfo.Leader {
+			err = triggerClusterRebalance(ctx, s)
+			if err != nil {
+				if !force {
+					return evacuationCommittedError(err)
+				}
+
+				logger.Warn("Proceeding with forced evacuation after follow-up rebalance failure", logger.Ctx{"err": err, "member": name})
+			}
+		}
+	}
 
 	opts := evacuateOpts{
 		s:               s,

--- a/lxd/api_cluster_member_test.go
+++ b/lxd/api_cluster_member_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/canonical/go-dqlite/v3/client"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/canonical/lxd/lxd/db"
+)
+
+func TestCheckEvacuationQuorum(t *testing.T) {
+	t.Parallel()
+
+	// threshold is large enough that only nodes with a zero-value Heartbeat
+	// are considered offline by IsOffline.
+	const threshold = time.Minute
+
+	recentHeartbeat := time.Now()
+
+	// addr returns a synthetic cluster member address for node index i.
+	addr := func(i int) string { return fmt.Sprintf("10.0.0.%d:8443", i) }
+
+	// node builds a db.RaftNode with the given index, address, and role.
+	node := func(i int, role db.RaftRole) db.RaftNode {
+		return db.RaftNode{NodeInfo: client.NodeInfo{ID: uint64(i), Address: addr(i), Role: role}}
+	}
+
+	tests := []struct {
+		name             string
+		targetMember     db.NodeInfo
+		raftNodes        []db.RaftNode
+		connectivity     map[string]bool
+		evacuatedMembers []string
+		memberRoles      map[string][]db.ClusterRole
+		wantErrContains  string // empty means no error expected
+	}{
+		{
+			name:             "Target is standby; allow",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftStandBy), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): true, addr(4): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			name:             "Target is spare; allow",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftSpare), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): true, addr(4): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			name: "Target is offline voter; allow",
+			// Zero-value Heartbeat makes IsOffline return true.
+			targetMember:     db.NodeInfo{Address: addr(1)},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): false, addr(2): true, addr(3): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			name:             "3-voter cluster fully online; allow (2 remain >= majority-of-2)",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			name:             "3 voters 2 online no standby; deny",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+			wantErrContains:  "Insufficient online voters",
+		},
+		{
+			name:             "3 voters 2 online with online standby; allow (replacement can be promoted)",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftStandBy)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false, addr(4): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			name:             "3 voters 2 online standby is evacuated; deny",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftStandBy)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false, addr(4): true},
+			evacuatedMembers: []string{addr(4)},
+			memberRoles:      map[string][]db.ClusterRole{},
+			wantErrContains:  "Insufficient online voters",
+		},
+		{
+			// 5 voters, only 2 online. Current majority = 3, so the cluster cannot
+			// make the promotion decision even though a standby is available.
+			name:             "Cluster below current majority; deny even with standby",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftVoter), node(5, db.RaftVoter), node(6, db.RaftStandBy)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false, addr(4): false, addr(5): false, addr(6): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+			wantErrContains:  "Insufficient online voters",
+		},
+		{
+			// Single voter means onlineVoters == 1 after evacuation, triggering the
+			// onlineVoters > 1 guard that prevents a degenerate promotion.
+			name:             "Single voter with standby; deny",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftStandBy)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true},
+			evacuatedMembers: []string{},
+			memberRoles:      map[string][]db.ClusterRole{},
+			wantErrContains:  "Insufficient online voters",
+		},
+		{
+			// 5 CP voters; addr(3) and addr(5) are offline. Removing the target
+			// (addr(1)) leaves 4 CP members — CP mode stays active (≥3). The
+			// non-CP standby (addr(4)) is ineligible as a replacement, and the
+			// remaining online voters (addr(2), addr(6)) do not meet the
+			// required majority of 3 for a 4-voter post-evacuation cluster.
+			name:         "Control plane active; standby lacks role; deny",
+			targetMember: db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes: []db.RaftNode{
+				node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter),
+				node(4, db.RaftStandBy), node(5, db.RaftVoter), node(6, db.RaftVoter),
+			},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false, addr(4): true, addr(5): false, addr(6): true},
+			evacuatedMembers: []string{},
+			memberRoles: map[string][]db.ClusterRole{
+				addr(1): {db.ClusterRoleControlPlane},
+				addr(2): {db.ClusterRoleControlPlane},
+				addr(3): {db.ClusterRoleControlPlane},
+				addr(5): {db.ClusterRoleControlPlane},
+				addr(6): {db.ClusterRoleControlPlane},
+			},
+			wantErrContains: "Insufficient online voters",
+		},
+		{
+			// Target is already EVACUATED in the DB (it appears in evacuatedMembers)
+			// but still holds a voter raft role that rebalance has not yet demoted.
+			// Its heartbeat is still fresh. The quorum check must allow the request
+			// rather than double-counting the target's absence and returning
+			// "Insufficient online voters".
+			name:             "Target is already evacuated voter; allow",
+			targetMember:     db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes:        []db.RaftNode{node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter)},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): true},
+			evacuatedMembers: []string{addr(1)},
+			memberRoles:      map[string][]db.ClusterRole{},
+		},
+		{
+			// Target is one of exactly 3 CP members, so without the fix
+			// IsControlPlaneActive would return true and exclude the non-CP standby.
+			// After removing the target from the roles map, only 2 CP members remain,
+			// CP mode becomes inactive, and the CP standby (addr(4)) is eligible.
+			name:         "Control plane active; target is CP voter; standby has CP role; allow",
+			targetMember: db.NodeInfo{Address: addr(1), Heartbeat: recentHeartbeat},
+			raftNodes: []db.RaftNode{
+				node(1, db.RaftVoter), node(2, db.RaftVoter), node(3, db.RaftVoter), node(4, db.RaftStandBy),
+			},
+			connectivity:     map[string]bool{addr(1): true, addr(2): true, addr(3): false, addr(4): true},
+			evacuatedMembers: []string{},
+			memberRoles: map[string][]db.ClusterRole{
+				addr(1): {db.ClusterRoleControlPlane},
+				addr(2): {db.ClusterRoleControlPlane},
+				addr(3): {db.ClusterRoleControlPlane},
+				addr(4): {db.ClusterRoleControlPlane},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkEvacuationQuorum(
+				tc.targetMember,
+				tc.raftNodes,
+				tc.connectivity,
+				tc.evacuatedMembers,
+				tc.memberRoles,
+				threshold,
+			)
+			if tc.wantErrContains != "" {
+				assert.ErrorContains(t, err, tc.wantErrContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -482,8 +482,8 @@ func (g *Gateway) Kill() {
 
 // TransferLeadership attempts to transfer leadership to another online voter.
 // When memberRoles is provided and control-plane mode is active, only control-plane
-// voters are eligible targets.
-func (g *Gateway) TransferLeadership(memberRoles map[string][]db.ClusterRole) error {
+// voters are eligible targets. Members in excludedMembers are never eligible.
+func (g *Gateway) TransferLeadership(memberRoles map[string][]db.ClusterRole, excludedMembers ...string) error {
 	client, err := g.getClient()
 	if err != nil {
 		return err
@@ -509,6 +509,10 @@ func (g *Gateway) TransferLeadership(memberRoles map[string][]db.ClusterRole) er
 		address, err := g.nodeAddress(server.Address)
 		if err != nil {
 			return err
+		}
+
+		if slices.Contains(excludedMembers, address) {
+			continue
 		}
 
 		if cpActive && !slices.Contains(memberRoles[address], db.ClusterRoleControlPlane) {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -48,6 +48,7 @@ type APIHeartbeatMember struct {
 	LastHeartbeat time.Time        `json:"LastHeartbeat"` // Last time we received a successful response from node.
 	Online        bool             `json:"Online"`        // Calculated from offline threshold and LastHeatbeat time.
 	Roles         []db.ClusterRole `json:"Roles"`         // Supplementary non-database roles the member has.
+	State         int              `json:"State"`         // Cluster member state from the nodes table.
 	updated       bool             // Has node been updated during this heartbeat run. Not sent to nodes.
 }
 
@@ -105,6 +106,7 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 			LastHeartbeat: node.Heartbeat,
 			Online:        !node.IsOffline(offlineThreshold),
 			Roles:         node.Roles,
+			State:         node.State,
 		}
 
 		raftNode, exists := raftNodeMap[member.Address]

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -806,6 +806,59 @@ func filterPromotionCandidates(candidates []client.NodeInfo, memberRoles map[str
 	return eligible
 }
 
+// isLeaderEvacuated reports whether the current raft leader is in the evacuated set.
+func isLeaderEvacuated(roles *app.RolesChanges, leaderID uint64, evacuatedMembers []string) bool {
+	for node := range roles.State {
+		if node.ID == leaderID && slices.Contains(evacuatedMembers, node.Address) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// rolesAdjustSmallCluster determines the next role change when the cluster has
+// fewer members than [app.MinVoters]. In this scenario we keep exactly one
+// voter (the leader). If the leader itself is evacuated we first promote a
+// replacement so that leadership can be transferred before the evacuated leader
+// is demoted.
+func rolesAdjustBelowQuorum(roles *app.RolesChanges, leaderID uint64, memberRoles map[string][]db.ClusterRole, evacuatedMembers []string) (role client.NodeRole, candidates []client.NodeInfo, leaderNeedsTransfer bool) {
+	if !isLeaderEvacuated(roles, leaderID, evacuatedMembers) {
+		// Normal case: keep exactly one voter (the leader) by demoting any others.
+		for node := range roles.State {
+			if node.ID == leaderID || node.Role != client.Voter {
+				continue
+			}
+
+			return client.Spare, []client.NodeInfo{node}, false
+		}
+
+		return -1, nil, false
+	}
+
+	// Leader is evacuated. Promote a non-evacuated standby or spare to voter
+	// so that leadership can be transferred to it.
+	candidates = roles.List(client.StandBy, true, nil)
+	candidates = append(candidates, roles.List(client.Spare, true, nil)...)
+	candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
+	if len(candidates) > 0 {
+		return client.Voter, candidates, false
+	}
+
+	// A replacement was already promoted in a previous cycle. Signal a
+	// leadership transfer so that the new voter can take over and the
+	// evacuated leader can be demoted in the next rebalance cycle.
+	for node := range roles.State {
+		if node.ID == leaderID || node.Role != client.Voter || slices.Contains(evacuatedMembers, node.Address) {
+			continue
+		}
+
+		return -1, nil, true
+	}
+
+	return -1, nil, false
+}
+
 // rolesAdjust determines the next role change using the same generic roles algorithm as [app.RolesChanges.Adjust], while applying LXD-specific control-plane restrictions.
 // memberRoles reflects the current LXD cluster role assignments and defines the target raft topology:
 // when control-plane mode is active, only members with the control-plane role are eligible for
@@ -1040,6 +1093,37 @@ func prioritizeNonControlPlane(candidates []client.NodeInfo, memberRoles map[str
 	}
 
 	return append(nonControlPlane, controlPlane...)
+}
+
+// prioritizeEvacuated returns candidates with evacuated members ordered first.
+func prioritizeEvacuated(candidates []client.NodeInfo, evacuatedMembers []string) []client.NodeInfo {
+	evacuated := make([]client.NodeInfo, 0, len(candidates))
+	others := make([]client.NodeInfo, 0, len(candidates))
+
+	for _, candidate := range candidates {
+		if slices.Contains(evacuatedMembers, candidate.Address) {
+			evacuated = append(evacuated, candidate)
+		} else {
+			others = append(others, candidate)
+		}
+	}
+
+	return append(evacuated, others...)
+}
+
+// evacuatedMembersByState returns the subset of online nodes that are evacuated,
+// grouped by their raft role. Only roles passed in the onlineByRole map are included.
+func evacuatedMembersByState(onlineByRole map[client.NodeRole][]client.NodeInfo, evacuatedMembers []string) map[client.NodeRole][]client.NodeInfo {
+	result := make(map[client.NodeRole][]client.NodeInfo, len(onlineByRole))
+	for role, nodes := range onlineByRole {
+		for _, node := range nodes {
+			if slices.Contains(evacuatedMembers, node.Address) {
+				result[role] = append(result[role], node)
+			}
+		}
+	}
+
+	return result
 }
 
 // GetNextRoleChange determines the next raft cluster member role change needed for rebalancing.

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -784,7 +784,7 @@ func filterPromotionCandidates(candidates []client.NodeInfo, memberRoles map[str
 	eligible := make([]client.NodeInfo, 0, len(candidates))
 	controlPlaneActive := IsControlPlaneActive(memberRoles)
 	for _, candidate := range candidates {
-		if evacuatedMembers[candidate.Address] {
+		if slices.Contains(excludedMembers, candidate.Address) {
 			continue
 		}
 
@@ -864,33 +864,60 @@ func rolesAdjustBelowQuorum(roles *app.RolesChanges, leaderID uint64, memberRole
 // when control-plane mode is active, only members with the control-plane role are eligible for
 // voter/standby positions, and non-control-plane members holding those positions are demoted.
 func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, connectivity map[string]bool, memberRoles map[string][]db.ClusterRole, evacuatedMembers []string) (role client.NodeRole, candidates []client.NodeInfo, leaderNeedsTransfer bool) {
+	// Single-node cluster: no role changes are ever needed.
 	if roles.Size() == 1 {
 		return -1, nil, false
 	}
 
 	// If the cluster is too small, keep exactly one voter (the leader).
 	if roles.Size() < app.MinVoters {
-		for node := range roles.State {
-			if node.ID == leaderID || node.Role != client.Voter {
-				continue
-			}
-
-			return client.Spare, []client.NodeInfo{node}, false
-		}
-
-		return -1, nil, false
+		return rolesAdjustBelowQuorum(roles, leaderID, memberRoles, evacuatedMembers)
 	}
 
 	onlineVoters := roles.List(client.Voter, true, nil)
 	onlineStandBys := roles.List(client.StandBy, true, nil)
 	offlineVoters := roles.List(client.Voter, false, nil)
 	offlineStandBys := roles.List(client.StandBy, false, nil)
+	evacuated := evacuatedMembersByState(map[client.NodeRole][]client.NodeInfo{
+		client.Voter:   onlineVoters,
+		client.StandBy: onlineStandBys,
+	}, evacuatedMembers)
 
 	domainsWithVoters := roles.FailureDomains(onlineVoters)
 	allDomains := roles.AllFailureDomains()
 	controlPlaneActive := IsControlPlaneActive(memberRoles)
 
-	// Try to spread voters across all failure domains first.
+	remainingOnlineVotersAfterEvacuation := len(onlineVoters) - len(evacuated[client.Voter])
+	remainingOnlineStandBysAfterEvacuation := len(onlineStandBys) - len(evacuated[client.StandBy])
+
+	// Phase 1: Pre-emptively promote a replacement voter when evacuated voters would leave us
+	// below the target voter count. Acting early ensures quorum is maintained before the
+	// evacuated members are demoted in a later cycle.
+	if len(evacuated[client.Voter]) > 0 && remainingOnlineVotersAfterEvacuation < roles.Config.Voters {
+		candidates := roles.List(client.StandBy, true, nil)
+		candidates = append(candidates, roles.List(client.Spare, true, nil)...)
+		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
+		if len(candidates) > 0 {
+			domains := roles.FailureDomains(onlineVoters)
+			roles.SortCandidates(candidates, domains)
+			return client.Voter, candidates, false
+		}
+	}
+
+	// Phase 2: Pre-emptively promote a replacement standby when evacuated standbys would leave
+	// us below the target standby count.
+	if len(evacuated[client.StandBy]) > 0 && remainingOnlineStandBysAfterEvacuation < roles.Config.StandBys {
+		candidates := roles.List(client.Spare, true, nil)
+		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
+		if len(candidates) > 0 {
+			domains := roles.FailureDomains(onlineStandBys)
+			roles.SortCandidates(candidates, domains)
+			return client.StandBy, candidates, false
+		}
+	}
+
+	// Phase 3: Spread voters across failure domains to improve fault tolerance before applying
+	// count-based promotions or demotions.
 	if len(domainsWithVoters) < len(allDomains) && len(domainsWithVoters) < len(onlineVoters) {
 		domainsWithoutVoters := roles.DomainsSubtract(allDomains, domainsWithVoters)
 		candidates := roles.List(client.StandBy, true, domainsWithoutVoters)
@@ -905,30 +932,43 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 	}
 
 	// If we have exactly the desired number of voters and stand-bys, and they are all
-	// online, we're good unless control-plane mode still requires demotions.
-	if len(offlineVoters) == 0 && len(onlineVoters) == roles.Config.Voters && len(offlineStandBys) == 0 && len(onlineStandBys) == roles.Config.StandBys {
+	// online, we're good unless evacuation or control-plane mode still requires demotions.
+	if len(offlineVoters) == 0 && len(onlineVoters) == roles.Config.Voters && len(offlineStandBys) == 0 && len(onlineStandBys) == roles.Config.StandBys && len(evacuated[client.Voter]) == 0 && len(evacuated[client.StandBy]) == 0 {
 		if !controlPlaneActive {
 			return -1, nil, false
 		}
 	}
 
-	// Promote voters if we're below target.
+	// Phase 4: Promote to voter if we are below the target voter count. If no non-evacuated
+	// candidates are available and an evacuated non-leader voter holds the role, demote it to
+	// spare so a future cycle can promote a replacement.
 	nOnlineVoters := len(onlineVoters)
 	if nOnlineVoters < roles.Config.Voters {
 		candidates := roles.List(client.StandBy, true, nil)
 		candidates = append(candidates, roles.List(client.Spare, true, nil)...)
 		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
 
-		if len(candidates) == 0 {
-			return -1, nil, false
+		if len(candidates) > 0 {
+			domains := roles.FailureDomains(onlineVoters)
+			roles.SortCandidates(candidates, domains)
+			return client.Voter, candidates, false
 		}
 
-		domains := roles.FailureDomains(onlineVoters)
-		roles.SortCandidates(candidates, domains)
-		return client.Voter, candidates, false
+		// No non-evacuated promotion candidates exist. Demote an evacuated non-leader voter
+		// to spare to free up the slot, allowing a replacement to be promoted in the next cycle.
+		if len(evacuated[client.Voter]) > 0 {
+			for _, node := range evacuated[client.Voter] {
+				if node.ID == leaderID {
+					continue
+				}
+
+				return db.RaftSpare, []client.NodeInfo{node}, false
+			}
+		}
 	}
 
-	// Demote extra online voters.
+	// Phase 5: Demote excess online voters, prioritizing evacuated members so they are removed
+	// from quorum first.
 	nOnlineVoters = len(onlineVoters)
 	if nOnlineVoters > roles.Config.Voters {
 		candidates := make([]client.NodeInfo, 0, len(onlineVoters))
@@ -945,10 +985,12 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 			candidates = prioritizeNonControlPlane(candidates, memberRoles)
 		}
 
+		candidates = prioritizeEvacuated(candidates, evacuatedMembers)
+
 		return client.Spare, candidates, false
 	}
 
-	// Demote offline voters.
+	// Phase 6: Demote offline voters.
 	nOfflineVoters := len(offlineVoters)
 	if nOfflineVoters > 0 {
 		candidates := offlineVoters
@@ -959,7 +1001,9 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 		return client.Spare, candidates, false
 	}
 
-	// Promote standbys if we're below target.
+	// Phase 7: Promote to standby if we are below the target standby count. If no non-evacuated
+	// candidates are available and an evacuated standby holds the role, demote it so a future
+	// cycle can promote a replacement.
 	nOnlineStandBys := len(onlineStandBys)
 	if nOnlineStandBys < roles.Config.StandBys {
 		candidates := roles.List(client.Spare, true, nil)
@@ -971,7 +1015,15 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 			return client.StandBy, candidates, false
 		}
 
-		if !controlPlaneActive {
+		// No non-evacuated promotion candidates exist. Demote an evacuated standby to spare
+		// to free up the slot, allowing a replacement to be promoted in the next cycle.
+		if len(evacuated[client.StandBy]) > 0 {
+			return db.RaftSpare, evacuated[client.StandBy], false
+		}
+
+		// No evacuation-driven work remains and control-plane mode is not enforcing demotions,
+		// so no further changes are needed this cycle.
+		if !controlPlaneActive && len(evacuated[client.Voter]) == 0 {
 			return -1, nil, false
 		}
 
@@ -980,7 +1032,7 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 		// should not hold database roles.
 	}
 
-	// Demote extra online standbys.
+	// Phase 8: Demote excess online standbys, prioritizing evacuated members.
 	nOnlineStandBys = len(onlineStandBys)
 	if nOnlineStandBys > roles.Config.StandBys {
 		candidates := make([]client.NodeInfo, 0, len(onlineStandBys))
@@ -996,10 +1048,12 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 			candidates = prioritizeNonControlPlane(candidates, memberRoles)
 		}
 
+		candidates = prioritizeEvacuated(candidates, evacuatedMembers)
+
 		return client.Spare, candidates, false
 	}
 
-	// Demote offline standbys.
+	// Phase 9: Demote offline standbys.
 	nOfflineStandBys := len(offlineStandBys)
 	if nOfflineStandBys > 0 {
 		candidates := offlineStandBys
@@ -1010,6 +1064,31 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 		return client.Spare, candidates, false
 	}
 
+	// Phase 10: All counts are at target. Demote any remaining online evacuated voters or
+	// standbys that did not need replacing. For an evacuated voter that is also the leader,
+	// signal a leadership transfer first so it can be demoted in the next rebalance cycle.
+	for _, node := range evacuated[client.Voter] {
+		if node.ID == leaderID {
+			continue
+		}
+
+		return db.RaftSpare, []client.NodeInfo{node}, false
+	}
+
+	if len(evacuated[client.StandBy]) > 0 {
+		return db.RaftSpare, evacuated[client.StandBy], false
+	}
+
+	for _, node := range evacuated[client.Voter] {
+		if node.ID == leaderID {
+			return -1, nil, true
+		}
+	}
+
+	// All evacuation-driven and count-based changes are complete. If control-plane mode is
+	// active, enforce that only control-plane members hold voter/standby roles. Guard against
+	// unnecessary demotions by only proceeding if an eligible control-plane promotion candidate
+	// exists, so we never drop below the target voter count without a ready replacement.
 	// No generic changes needed.
 	if controlPlaneActive {
 		hasNonControlPlaneVoter := false

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -777,15 +777,22 @@ func IsControlPlaneActive(memberRoles map[string][]db.ClusterRole) bool {
 }
 
 // filterPromotionCandidates returns the subset of candidates that are eligible for
-// promotion based on control plane mode and member roles. When controlPlaneActive
-// is true, only candidates with the control-plane role are eligible.
-func filterPromotionCandidates(candidates []client.NodeInfo, memberRoles map[string][]db.ClusterRole) []client.NodeInfo {
-	if !IsControlPlaneActive(memberRoles) {
-		return candidates
-	}
-
+// promotion based on control plane mode, member roles, and evacuation state.
+// Evacuated members are never eligible for promotion. When control-plane mode
+// is active, only candidates with the control-plane role are eligible.
+func filterPromotionCandidates(candidates []client.NodeInfo, memberRoles map[string][]db.ClusterRole, excludedMembers []string) []client.NodeInfo {
 	eligible := make([]client.NodeInfo, 0, len(candidates))
+	controlPlaneActive := IsControlPlaneActive(memberRoles)
 	for _, candidate := range candidates {
+		if evacuatedMembers[candidate.Address] {
+			continue
+		}
+
+		if !controlPlaneActive {
+			eligible = append(eligible, candidate)
+			continue
+		}
+
 		roles, ok := memberRoles[candidate.Address]
 		if !ok {
 			continue
@@ -803,7 +810,7 @@ func filterPromotionCandidates(candidates []client.NodeInfo, memberRoles map[str
 // memberRoles reflects the current LXD cluster role assignments and defines the target raft topology:
 // when control-plane mode is active, only members with the control-plane role are eligible for
 // voter/standby positions, and non-control-plane members holding those positions are demoted.
-func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, connectivity map[string]bool, memberRoles map[string][]db.ClusterRole) (role client.NodeRole, candidates []client.NodeInfo, leaderNeedsTransfer bool) {
+func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, connectivity map[string]bool, memberRoles map[string][]db.ClusterRole, evacuatedMembers []string) (role client.NodeRole, candidates []client.NodeInfo, leaderNeedsTransfer bool) {
 	if roles.Size() == 1 {
 		return -1, nil, false
 	}
@@ -836,9 +843,7 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 		candidates := roles.List(client.StandBy, true, domainsWithoutVoters)
 		candidates = append(candidates, roles.List(client.Spare, true, domainsWithoutVoters)...)
 
-		if controlPlaneActive {
-			candidates = filterPromotionCandidates(candidates, memberRoles)
-		}
+		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
 
 		if len(candidates) > 0 {
 			roles.SortCandidates(candidates, domainsWithoutVoters)
@@ -859,10 +864,7 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 	if nOnlineVoters < roles.Config.Voters {
 		candidates := roles.List(client.StandBy, true, nil)
 		candidates = append(candidates, roles.List(client.Spare, true, nil)...)
-
-		if controlPlaneActive {
-			candidates = filterPromotionCandidates(candidates, memberRoles)
-		}
+		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
 
 		if len(candidates) == 0 {
 			return -1, nil, false
@@ -908,9 +910,7 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 	nOnlineStandBys := len(onlineStandBys)
 	if nOnlineStandBys < roles.Config.StandBys {
 		candidates := roles.List(client.Spare, true, nil)
-		if controlPlaneActive {
-			candidates = filterPromotionCandidates(candidates, memberRoles)
-		}
+		candidates = filterPromotionCandidates(candidates, memberRoles, evacuatedMembers)
 
 		if len(candidates) > 0 {
 			domains := roles.FailureDomains(onlineStandBys)
@@ -1049,7 +1049,7 @@ func prioritizeNonControlPlane(candidates []client.NodeInfo, memberRoles map[str
 // If a role change is needed, returns the address of the candidate node, the updated list of raft nodes,
 // and a connectivity map keyed by member address.
 // If no changes are needed, returns an empty address.
-func GetNextRoleChange(state *state.State, gateway *Gateway, unavailableMembers []string, memberRoles map[string][]db.ClusterRole) (string, []db.RaftNode, map[string]bool, error) {
+func GetNextRoleChange(state *state.State, gateway *Gateway, unavailableMembers []string, memberRoles map[string][]db.ClusterRole, evacuatedMembers []string) (string, []db.RaftNode, map[string]bool, error) {
 	// If we're a standalone node, do nothing.
 	if gateway.memoryDial != nil {
 		return "", nil, nil, nil
@@ -1065,7 +1065,7 @@ func GetNextRoleChange(state *state.State, gateway *Gateway, unavailableMembers 
 		return "", nil, nil, err
 	}
 
-	role, candidates, needsLeaderTransfer := rolesAdjust(roles, gateway.info.ID, nodes, connectivity, memberRoles)
+	role, candidates, needsLeaderTransfer := rolesAdjust(roles, gateway.info.ID, nodes, connectivity, memberRoles, evacuatedMembers)
 
 	if role == -1 || len(candidates) == 0 {
 		if needsLeaderTransfer {
@@ -1075,7 +1075,7 @@ func GetNextRoleChange(state *state.State, gateway *Gateway, unavailableMembers 
 			}
 
 			if leaderInfo.Clustered && leaderInfo.Leader {
-				err = gateway.TransferLeadership(memberRoles)
+				err = gateway.TransferLeadership(memberRoles, evacuatedMembers...)
 				if err != nil {
 					return "", nil, nil, err
 				}

--- a/lxd/cluster/membership_adjust_test.go
+++ b/lxd/cluster/membership_adjust_test.go
@@ -272,6 +272,378 @@ func TestAdjustRoles_InactiveAllowsNonControlPlanePromotion(t *testing.T) {
 	assert.Equal(t, []uint64{3}, testNodeIDs(candidates))
 }
 
+// TestAdjustRoles_EvacuatedMemberIsNeverPromoted verifies that evacuated members
+// are excluded from voter promotion even when they are otherwise eligible.
+func TestAdjustRoles_EvacuatedMemberIsNeverPromoted(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftSpare}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.3:8443",
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftVoter, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_EvacuatedVoterPromotionFirst verifies that evacuation first
+// promotes a replacement voter and then demotes the evacuated member.
+func TestAdjustRoles_EvacuatedVoterPromotionFirst(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.2:8443",
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftVoter, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+
+	nodes[3].Role = db.RaftVoter
+	roles = testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ = rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.NotEmpty(t, candidates)
+	assert.Equal(t, uint64(2), candidates[0].ID)
+}
+
+// TestAdjustRoles_EvacuatedVoterDemotedWithoutReplacement verifies that an
+// evacuated voter is still demoted when no replacement candidate exists.
+func TestAdjustRoles_EvacuatedVoterDemotedWithoutReplacement(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.2:8443",
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 2, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_EvacuatedVoterDemotedWithStandbyTarget verifies that an
+// evacuated voter is demoted even when the standby target is unsatisfied.
+// This covers the case where all nodes are voters (no spares to promote to
+// standby) and the standby promotion check must not prevent the evacuated
+// voter from being demoted.
+func TestAdjustRoles_EvacuatedVoterDemotedWithStandbyTarget(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.2:8443",
+	}
+
+	// 3 voters with max_voters=3 and max_standby=2 (the default).
+	// The standby target is unmet (0 standbys vs 2 target) but there are
+	// no spares to promote. The evacuated voter must still be demoted.
+	roles := testRolesChanges(nodes, connectivity, 3, 2)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_EvacuatedStandbyDemotedWithoutReplacement verifies that an
+// evacuated standby is still demoted when no replacement candidate exists.
+func TestAdjustRoles_EvacuatedStandbyDemotedWithoutReplacement(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftStandBy}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.3:8443",
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 2, 1)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.Equal(t, []uint64{3}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_EvacuatedStandbyReplacedWhenSpareAvailable verifies that
+// when an evacuated standby can be replaced by a spare, the spare is promoted
+// first before the evacuated standby is demoted.
+func TestAdjustRoles_EvacuatedStandbyReplacedWhenSpareAvailable(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftStandBy}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.3:8443",
+	}
+
+	// Step 1: promote spare to standby (replacement for evacuated standby).
+	roles := testRolesChanges(nodes, connectivity, 2, 1)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftStandBy, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+
+	// Step 2: after promotion, we have 2 standbys vs target of 1, and the
+	// evacuated standby (node3) is prioritized first for demotion.
+	nodes[3].Role = db.RaftStandBy
+	roles = testRolesChanges(nodes, connectivity, 2, 1)
+	role, candidates, _ = rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, client.Spare, role)
+	assert.NotEmpty(t, candidates)
+	assert.Equal(t, uint64(3), candidates[0].ID)
+}
+
+// TestAdjustRoles_EvacuatedStandbyNotBlockedByVoterPromotion verifies that
+// an evacuated standby is demoted even when the voter count is below target
+// and cannot be filled. The voter promotion check must not prevent subsequent
+// standby demotion.
+func TestAdjustRoles_EvacuatedStandbyNotBlockedByVoterPromotion(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftStandBy}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.3:8443",
+	}
+
+	// max_voters=3 but only 2 actual voters and no spares to promote.
+	// The evacuated standby must still be demoted despite the voter deficit.
+	roles := testRolesChanges(nodes, connectivity, 3, 1)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.Equal(t, []uint64{3}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_ExtraVotersDemoteEvacuatedFirst verifies that when the
+// cluster has more voters than the target, the evacuated voter is prioritized
+// for demotion.
+func TestAdjustRoles_ExtraVotersDemoteEvacuatedFirst(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.3:8443",
+	}
+
+	// 4 voters with max_voters=3. The evacuated voter (node3) should be
+	// prioritized for demotion over non-evacuated voters.
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, client.Spare, role)
+	assert.NotEmpty(t, candidates)
+	assert.Equal(t, uint64(3), candidates[0].ID)
+}
+
+// TestAdjustRoles_OfflineVoterDemoted verifies that an offline voter is
+// demoted to spare when no standby or spare is available for promotion.
+func TestAdjustRoles_OfflineVoterDemoted(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": false,
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, nil)
+
+	assert.Equal(t, client.Spare, role)
+	assert.Equal(t, []uint64{3}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_StandbyPromoted verifies that a spare is promoted to standby
+// when the cluster is below the standby target.
+func TestAdjustRoles_StandbyPromoted(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	roles := testRolesChanges(nodes, connectivity, 3, 1)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, nil, nil)
+
+	assert.Equal(t, client.StandBy, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+}
+
+// TestAdjustRoles_EvacuatedVoterWithControlPlaneActive verifies that an
+// evacuated voter with the control-plane role is still demoted when
+// control-plane mode is active.
+func TestAdjustRoles_EvacuatedVoterWithControlPlaneActive(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+	}
+
+	memberRoles := map[string][]db.ClusterRole{
+		"10.0.0.1:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.2:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.3:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.4:8443": {db.ClusterRoleControlPlane},
+	}
+
+	evacuatedMembers := []string{
+		"10.0.0.2:8443",
+	}
+
+	// Step 1: promote spare (node4) to replace evacuated voter (node2).
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, evacuatedMembers)
+
+	assert.Equal(t, db.RaftVoter, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+
+	// Step 2: after promotion, evacuated voter is demoted.
+	nodes[3].Role = db.RaftVoter
+	roles = testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, _ = rolesAdjust(roles, 1, nodes, connectivity, memberRoles, evacuatedMembers)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.NotEmpty(t, candidates)
+	assert.Equal(t, uint64(2), candidates[0].ID)
+}
+
+// TestAdjustRoles_EvacuatedLeaderSignalsTransfer verifies that when the only
+// remaining evacuated voter is the raft leader, rolesAdjust signals a leadership
+// transfer (leaderNeedsTransfer=true) so the leader can hand off before being
+// demoted in a subsequent rebalance cycle.
+func TestAdjustRoles_EvacuatedLeaderSignalsTransfer(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+	}
+
+	// Node 1 is the leader and is evacuated.
+	evacuatedMembers := []string{
+		"10.0.0.1:8443",
+	}
+
+	// Leader ID is 1. Node 1 is evacuated but is the leader and cannot be
+	// demoted directly; rolesAdjust must signal a leadership transfer.
+	roles := testRolesChanges(nodes, connectivity, 3, 0)
+	role, candidates, leaderNeedsTransfer := rolesAdjust(roles, 1, nodes, connectivity, nil, evacuatedMembers)
+
+	assert.Equal(t, client.NodeRole(-1), role)
+	assert.Empty(t, candidates)
+	assert.True(t, leaderNeedsTransfer)
+}
+
 // testRolesChanges creates a RolesChanges test fixture using raft nodes and connectivity.
 func testRolesChanges(nodes []db.RaftNode, connectivity map[string]bool, voters int, standbys int) *app.RolesChanges {
 	state := make(map[client.NodeInfo]*client.NodeMetadata, len(nodes))

--- a/lxd/cluster/membership_adjust_test.go
+++ b/lxd/cluster/membership_adjust_test.go
@@ -306,3 +306,242 @@ func testNodeIDs(nodes []client.NodeInfo) []uint64 {
 
 	return ids
 }
+
+func TestPrioritizeEvacuated(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+		{ID: 3, Address: "10.0.0.3:8443"},
+		{ID: 4, Address: "10.0.0.4:8443"},
+	}
+
+	evacuated := []string{"10.0.0.2:8443", "10.0.0.4:8443"}
+
+	result := prioritizeEvacuated(nodes, evacuated)
+	assert.Equal(t, []uint64{2, 4, 1, 3}, testNodeIDs(result), "evacuated members should be ordered first")
+}
+
+func TestPrioritizeEvacuated_NoEvacuated(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	result := prioritizeEvacuated(nodes, nil)
+	assert.Equal(t, []uint64{1, 2}, testNodeIDs(result), "order should be unchanged when no members are evacuated")
+}
+
+func TestPrioritizeEvacuated_AllEvacuated(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	evacuated := []string{"10.0.0.1:8443", "10.0.0.2:8443"}
+
+	result := prioritizeEvacuated(nodes, evacuated)
+	assert.Equal(t, []uint64{1, 2}, testNodeIDs(result), "order should be unchanged when all members are evacuated")
+}
+
+func TestPrioritizeNonControlPlane(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+		{ID: 3, Address: "10.0.0.3:8443"},
+		{ID: 4, Address: "10.0.0.4:8443"},
+	}
+
+	memberRoles := map[string][]db.ClusterRole{
+		"10.0.0.1:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.3:8443": {db.ClusterRoleControlPlane},
+	}
+
+	result := prioritizeNonControlPlane(nodes, memberRoles)
+	assert.Equal(t, []uint64{2, 4, 1, 3}, testNodeIDs(result), "non-control-plane members should be ordered first")
+}
+
+func TestPrioritizeNonControlPlane_NoControlPlane(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	result := prioritizeNonControlPlane(nodes, map[string][]db.ClusterRole{})
+	assert.Equal(t, []uint64{1, 2}, testNodeIDs(result), "order should be unchanged when no members have control-plane role")
+}
+
+func TestPrioritizeNonControlPlane_AllControlPlane(t *testing.T) {
+	nodes := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	memberRoles := map[string][]db.ClusterRole{
+		"10.0.0.1:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.2:8443": {db.ClusterRoleControlPlane},
+	}
+
+	result := prioritizeNonControlPlane(nodes, memberRoles)
+	assert.Equal(t, []uint64{1, 2}, testNodeIDs(result), "order should be unchanged when all members have control-plane role")
+}
+
+func TestIsLeaderEvacuated_LeaderEvacuated(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	assert.True(t, isLeaderEvacuated(roles, 1, []string{"10.0.0.1:8443"}), "should detect evacuated leader")
+}
+
+func TestIsLeaderEvacuated_NonLeaderEvacuated(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	assert.False(t, isLeaderEvacuated(roles, 1, []string{"10.0.0.2:8443"}), "should return false when only a non-leader is evacuated")
+}
+
+func TestIsLeaderEvacuated_NoEvacuatedMembers(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	assert.False(t, isLeaderEvacuated(roles, 1, nil), "should return false when no members are evacuated")
+}
+
+// TestRolesAdjustBelowQuorum_DemoteExcessVoter verifies that when the leader is not
+// evacuated and a second voter exists, that voter is demoted to spare.
+func TestRolesAdjustBelowQuorum_DemoteExcessVoter(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	role, candidates, leaderNeedsTransfer := rolesAdjustBelowQuorum(roles, 1, nil, nil)
+
+	assert.Equal(t, client.Spare, role)
+	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
+	assert.False(t, leaderNeedsTransfer)
+}
+
+// TestRolesAdjustBelowQuorum_NoChangesNeeded verifies that when the leader is the only
+// voter, no role change is needed.
+func TestRolesAdjustBelowQuorum_NoChangesNeeded(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	role, candidates, leaderNeedsTransfer := rolesAdjustBelowQuorum(roles, 1, nil, nil)
+
+	assert.Equal(t, client.NodeRole(-1), role)
+	assert.Empty(t, candidates)
+	assert.False(t, leaderNeedsTransfer)
+}
+
+// TestRolesAdjustBelowQuorum_EvacuatedLeader_PromoteSpare verifies that when the leader
+// is evacuated and a spare is available, the spare is promoted to voter so leadership
+// can be transferred to it.
+func TestRolesAdjustBelowQuorum_EvacuatedLeader_PromoteSpare(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	evacuated := []string{"10.0.0.1:8443"}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	role, candidates, leaderNeedsTransfer := rolesAdjustBelowQuorum(roles, 1, nil, evacuated)
+
+	assert.Equal(t, client.Voter, role)
+	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
+	assert.False(t, leaderNeedsTransfer)
+}
+
+// TestRolesAdjustBelowQuorum_EvacuatedLeader_ReplacementExists verifies that when the
+// leader is evacuated and a non-evacuated replacement voter already exists, a leadership
+// transfer is signaled so the evacuated leader can be demoted in the next rebalance cycle.
+func TestRolesAdjustBelowQuorum_EvacuatedLeader_ReplacementExists(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+	}
+
+	connectivity := map[string]bool{"10.0.0.1:8443": true, "10.0.0.2:8443": true}
+	evacuated := []string{"10.0.0.1:8443"}
+	roles := testRolesChanges(nodes, connectivity, 1, 0)
+
+	role, candidates, leaderNeedsTransfer := rolesAdjustBelowQuorum(roles, 1, nil, evacuated)
+
+	assert.Equal(t, client.NodeRole(-1), role)
+	assert.Empty(t, candidates)
+	assert.True(t, leaderNeedsTransfer)
+}
+
+func TestEvacuatedMembersByState(t *testing.T) {
+	voters := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	standbys := []client.NodeInfo{
+		{ID: 3, Address: "10.0.0.3:8443"},
+		{ID: 4, Address: "10.0.0.4:8443"},
+	}
+
+	evacuated := []string{"10.0.0.1:8443", "10.0.0.3:8443"}
+
+	result := evacuatedMembersByState(map[client.NodeRole][]client.NodeInfo{
+		client.Voter:   voters,
+		client.StandBy: standbys,
+	}, evacuated)
+
+	assert.Equal(t, []uint64{1}, testNodeIDs(result[client.Voter]), "only evacuated voters should be returned")
+	assert.Equal(t, []uint64{3}, testNodeIDs(result[client.StandBy]), "only evacuated standbys should be returned")
+}
+
+func TestEvacuatedMembersByState_NoEvacuated(t *testing.T) {
+	voters := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	result := evacuatedMembersByState(map[client.NodeRole][]client.NodeInfo{
+		client.Voter: voters,
+	}, nil)
+
+	assert.Empty(t, result[client.Voter], "no evacuated members should yield empty result")
+}
+
+func TestEvacuatedMembersByState_AllEvacuated(t *testing.T) {
+	voters := []client.NodeInfo{
+		{ID: 1, Address: "10.0.0.1:8443"},
+		{ID: 2, Address: "10.0.0.2:8443"},
+	}
+
+	evacuated := []string{"10.0.0.1:8443", "10.0.0.2:8443"}
+
+	result := evacuatedMembersByState(map[client.NodeRole][]client.NodeInfo{
+		client.Voter: voters,
+	}, evacuated)
+
+	assert.Equal(t, []uint64{1, 2}, testNodeIDs(result[client.Voter]), "all members should appear when all are evacuated")
+}

--- a/lxd/cluster/membership_adjust_test.go
+++ b/lxd/cluster/membership_adjust_test.go
@@ -34,7 +34,7 @@ func TestAdjustRoles_InactiveMatchesGeneric(t *testing.T) {
 	expectedRole, expectedCandidates := expectedRoles.Adjust(1)
 
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, expectedRole, role)
 	assert.Equal(t, testNodeIDs(expectedCandidates), testNodeIDs(candidates))
@@ -62,7 +62,7 @@ func TestAdjustRoles_ActiveSkipsNonControlPlanePromotion(t *testing.T) {
 	}
 
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, client.NodeRole(-1), role)
 	assert.Empty(t, candidates)
@@ -93,7 +93,7 @@ func TestAdjustRoles_ActiveDemotesNonControlPlaneVoterWhenReplacementExists(t *t
 	}
 
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, db.RaftStandBy, role)
 	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
@@ -124,7 +124,7 @@ func TestAdjustRoles_ActiveSkipsVoterDemotionWithoutControlPlaneReplacement(t *t
 	}
 
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, client.NodeRole(-1), role)
 	assert.Empty(t, candidates)
@@ -154,7 +154,7 @@ func TestAdjustRoles_ActiveDemotesNonControlPlaneStandby(t *testing.T) {
 	}
 
 	roles := testRolesChanges(nodes, connectivity, 3, 1)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, db.RaftSpare, role)
 	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
@@ -194,7 +194,7 @@ func TestAdjustRoles_ActiveDemotesNonControlPlaneStandbyBelowTarget(t *testing.T
 	// Target is 2 standbys but only 1 exists (non-control-plane). Because no eligible
 	// control-plane spare can fill the gap, the non-control-plane standby must still be demoted.
 	roles := testRolesChanges(nodes, connectivity, 3, 2)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, db.RaftSpare, role)
 	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
@@ -228,14 +228,14 @@ func TestAdjustRoles_ActiveInterleavesDemotionsAndPromotions(t *testing.T) {
 
 	// Step 1: demote non-control-plane voter.
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 	assert.Equal(t, db.RaftStandBy, role)
 	assert.Equal(t, []uint64{2}, testNodeIDs(candidates))
 
 	// Apply change and evaluate next step.
 	nodes[1].Role = db.RaftStandBy
 	roles = testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ = rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ = rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	// Step 2: promote an eligible control-plane spare to refill voters.
 	assert.Equal(t, db.RaftVoter, role)
@@ -266,7 +266,7 @@ func TestAdjustRoles_InactiveAllowsNonControlPlanePromotion(t *testing.T) {
 	}
 
 	roles := testRolesChanges(nodes, connectivity, 3, 0)
-	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles, nil)
 
 	assert.Equal(t, db.RaftVoter, role)
 	assert.Equal(t, []uint64{3}, testNodeIDs(candidates))

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2760,8 +2760,12 @@ func (d *Daemon) handleHeartbeatClusterRoleChanges(heartbeatData *cluster.APIHea
 
 	// Build member roles map from heartbeat data.
 	memberRoles := make(map[string][]db.ClusterRole, len(heartbeatData.Members))
+	var evacuatedMembers []string
 	for _, member := range heartbeatData.Members {
 		memberRoles[member.Address] = member.Roles
+		if member.State == db.ClusterMemberStateEvacuated {
+			evacuatedMembers = append(evacuatedMembers, member.Address)
+		}
 	}
 
 	controlPlaneActive := cluster.IsControlPlaneActive(memberRoles)
@@ -2807,7 +2811,7 @@ func (d *Daemon) handleHeartbeatClusterRoleChanges(heartbeatData *cluster.APIHea
 	// If there are offline members that have voter or stand-by database roles, let's see if we can replace them with spare ones.
 	if needsRebalance {
 		logger.Debug("Rebalancing member roles in heartbeat", logger.Ctx{"local": localClusterAddress})
-		err := rebalanceMemberRoles(context.Background(), s, d.gateway, unavailableMembers, memberRoles)
+		err := rebalanceMemberRoles(context.Background(), s, d.gateway, unavailableMembers, memberRoles, evacuatedMembers)
 		if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
 			logger.Warn("Could not rebalance cluster member roles", logger.Ctx{"err": err, "local": localClusterAddress})
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2754,6 +2754,7 @@ func (d *Daemon) handleHeartbeatClusterRoleChanges(heartbeatData *cluster.APIHea
 	isDegraded := false
 	hasNodesNotPartOfRaft := false
 	hasNonControlPlaneMemberWithDatabaseRole := false
+	hasEvacuatedMemberWithDatabaseRole := false
 	onlineVoters := int64(0)
 	onlineStandbys := int64(0)
 	offlineMemberIDs = make([]int64, 0, len(heartbeatData.Members))
@@ -2789,6 +2790,11 @@ func (d *Daemon) handleHeartbeatClusterRoleChanges(heartbeatData *cluster.APIHea
 				hasNonControlPlaneMemberWithDatabaseRole = true
 				logger.Info("Detected non-control-plane member with database role", logger.Ctx{"address": node.Address, "role": role, "local": localClusterAddress})
 			}
+
+			if node.State == db.ClusterMemberStateEvacuated && role != db.RaftSpare {
+				hasEvacuatedMemberWithDatabaseRole = true
+				logger.Info("Detected evacuated member with database role", logger.Ctx{"address": node.Address, "role": role, "local": localClusterAddress})
+			}
 		} else {
 			offlineMemberIDs = append(offlineMemberIDs, id)
 			if role != db.RaftSpare {
@@ -2799,7 +2805,7 @@ func (d *Daemon) handleHeartbeatClusterRoleChanges(heartbeatData *cluster.APIHea
 
 	maxVoters := s.GlobalConfig.MaxVoters()
 	maxStandBy := s.GlobalConfig.MaxStandBy()
-	needsRebalance := isDegraded || onlineVoters != maxVoters || onlineStandbys != maxStandBy || hasNonControlPlaneMemberWithDatabaseRole
+	needsRebalance := isDegraded || onlineVoters != maxVoters || onlineStandbys != maxStandBy || hasNonControlPlaneMemberWithDatabaseRole || hasEvacuatedMemberWithDatabaseRole
 
 	if !needsRebalance && !hasNodesNotPartOfRaft {
 		return offlineMemberIDs

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -316,6 +316,12 @@ type ClusterMemberStatePost struct {
 	//
 	// API extension: clustering_evacuation_mode
 	Mode string `json:"mode" yaml:"mode"`
+
+	// Permit evacuation even if it would drop the cluster below the required voter majority.
+	// Example: false
+	//
+	// API extension: clustering_evacuation_force
+	Force bool `json:"force" yaml:"force"`
 }
 
 // ClusterGroupsPost represents the fields available for a new cluster group.

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -297,6 +297,12 @@ const (
 
 	// ClusterRestoreModeSkip indicates that cluster member status should be restored without starting local instances or migrating back evacuated instances.
 	ClusterRestoreModeSkip = "skip"
+
+	// ClusterMemberActionEvacuate indicates the member should be evacuated.
+	ClusterMemberActionEvacuate = "evacuate"
+
+	// ClusterMemberActionRestore indicates the member should be restored.
+	ClusterMemberActionRestore = "restore"
 )
 
 // ClusterMemberStatePost represents the fields required to evacuate a cluster member.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -495,6 +495,7 @@ var APIExtensions = []string{
 	"project_replica_mode",
 	"cluster_links_used_by",
 	"network_load_balancer_pool",
+	"clustering_evacuation_force",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -32,6 +32,7 @@ readonly test_group_cluster=(
     "clustering_roles"
     "clustering_failure_domains"
     "clustering_evacuation"
+    "clustering_evacuation_quorum_force"
     "clustering_evacuation_restore_operations"
     "clustering_move"
     "clustering_remove_members"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3794,6 +3794,47 @@ test_clustering_evacuation() {
   LXD_NETNS=
 }
 
+test_clustering_evacuation_quorum_force() {
+  # Create a 2-node cluster. The second member joins as a standby, leaving
+  # node1 as the only raft voter. The quorum pre-check computes:
+  # requiredMajority=(totalVoters-1)/2+1 and remainingOnlineVoters=onlineVoters-1.
+  # Here that becomes requiredMajority=(1-1)/2+1=1 and
+  # remainingOnlineVoters=1-1=0, so evacuation without --force must fail (0 < 1).
+  spawn_lxd_and_bootstrap_cluster
+
+  local cert
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Spawn a second node.
+  spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}"
+
+  # Verify the 2-node case above is rejected without --force.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes 2>&1)" = 'Error: Failed updating cluster member state: Insufficient online voters to maintain quorum' ]
+
+  # Verify --force overrides the quorum safety check.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes --force
+
+  # Verify the evacuation completed successfully and the raft role was demoted.
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node1 | grep -xF "status: Evacuated"
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node1 | grep -xF "database: false"
+
+  echo "Clean up"
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+
+  # shellcheck disable=SC2034
+  LXD_NETNS=
+}
+
 test_clustering_evacuation_restore_operations() {
   echo "Create cluster with 2 nodes"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3493,11 +3493,21 @@ test_clustering_evacuation() {
   # For debugging
   LXD_DIR="${LXD_TWO_DIR}" lxc list -c nsL
 
+  local cluster_list
+  echo "Verify node1 starts as the database leader"
+  cluster_list="$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster list -f json)"
+  jq --exit-status '[.[] | select(any(.roles[]; . == "database-leader")) | .server_name] == ["node1"]' <<< "${cluster_list}"
+
   echo "Evacuate first node"
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node1 --yes
 
   echo "Ensure the node is evacuated"
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node1 | grep -F "status: Evacuated"
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node1 | grep -xF "database: false"
+
+  echo "Verify leadership moved away from the evacuated member"
+  cluster_list="$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster list -f json)"
+  jq --exit-status '[.[] | select(any(.roles[]; . == "database-leader")) | .server_name] | length == 1 and .[0] != "node1"' <<< "${cluster_list}"
 
   # For debugging
   LXD_DIR="${LXD_TWO_DIR}" lxc list -c nsL
@@ -3554,7 +3564,7 @@ test_clustering_evacuation() {
 
   # Now test a full restore for comparison
   echo 'Evacuate node1 again'
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node1 --yes
 
   echo 'Ensure instances cannot be created on the evacuated node'
   ! LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c8 --target=node1 || false
@@ -3616,7 +3626,7 @@ test_clustering_evacuation() {
   LXD_DIR="${LXD_ONE_DIR}" lxc init testimage evac-c3 -c placement.group=pg-evac-compact-permissive -c cluster.evacuate=migrate --target node1
 
   echo "Evacuating..."
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes
 
   echo "Verify all instances moved off node1"
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L evac-c1)" != "node1" ]
@@ -3651,7 +3661,7 @@ test_clustering_evacuation() {
   wait_for_evacuation_op "${LXD_ONE_DIR}"
 
   echo "Evacuating..."
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes
 
   echo "Verify all instances moved off node1"
   LXD_DIR="${LXD_ONE_DIR}" lxc list
@@ -3683,7 +3693,7 @@ test_clustering_evacuation() {
   wait_for_evacuation_op "${LXD_ONE_DIR}"
 
   echo "Evacuating..."
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes
 
   echo "Verify all instances have moved off node1"
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L evac-c1)" != "node1" ]
@@ -3718,7 +3728,7 @@ test_clustering_evacuation() {
   wait_for_evacuation_op "${LXD_ONE_DIR}"
 
   echo "Evacuating..."
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes
 
   echo "Verify all instances have moved off node1"
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L evac-c1)" != "node1" ]
@@ -3745,7 +3755,7 @@ test_clustering_evacuation() {
   wait_for_evacuation_op "${LXD_ONE_DIR}"
 
   echo "Evacuating..."
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes
   LXD_DIR="${LXD_ONE_DIR}" lxc list # For debugging
 
   echo "Verify instances evacuated (with fallback behavior during evacuation)"
@@ -3858,12 +3868,13 @@ test_clustering_evacuation_restore_operations() {
   for c in c{1..3}; do LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage "${c}" --target node1; done
 
   echo "Start node1 evacuation in background"
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --quiet --force &
+  # In a 2-node cluster node1 is the only raft voter, so bypass the pre-evacuation quorum guard.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --quiet --yes --force &
   evac_pid=$!
   sleep 0.5 # Wait a bit for the operation to register
 
   echo "Check evacuation fails while another evacuation is in progress"
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node2 --force 2>&1)" = 'Error: Failed updating cluster member state: Failed creating "Evacuating cluster member" operation record: An operation with this conflict reference is already running' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_TWO_DIR}" lxc cluster evacuate node2 --yes 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node2" while another cluster member evacuation is in progress' ]
 
   echo "Check restore fails while evacuation operation in progress"
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore node1 --force 2>&1)" = 'Error: Failed updating cluster member state: Cannot restore "node1" while an evacuate operation is in progress' ]
@@ -3882,7 +3893,7 @@ test_clustering_evacuation_restore_operations() {
   sleep 0.5 # Wait a bit for the operation to register
 
   echo "Check evacuation fails while restore operation in progress"
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --force 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" while a restore operation is in progress' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node1 --yes 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" while a restore operation is in progress' ]
 
   echo "Wait for all containers to be restored to node1"
   wait "${restore_pid}"
@@ -6452,7 +6463,7 @@ test_clustering_replicator_evacuated_member() {
   LXD_DIR="${LXD_ONE_DIR}" lxc config set c2 cluster.evacuate=migrate --project replicator-project
 
   # Evacuate node2; c1 should migrate to node1 or node3.
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node2 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node2 --yes
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -F "status: Evacuated"
 
   # c1 must no longer be on node2.

--- a/test/suites/clustering_waitready.sh
+++ b/test/suites/clustering_waitready.sh
@@ -65,7 +65,7 @@ test_clustering_waitready() {
   # We should be able to use the waitready command until all resources are successfully started again.
   # In the last step we can then safely run "lxc cluster restore" to bring the member back online.
   # If this member had any instance relying on those resources, they can now safely be moved back.
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --yes
 
   echo "==> Corrupt the network by setting an invalid external interface"
   ns1_pid="$(< "${TEST_DIR}/ns/${ns1}/PID")"
@@ -149,7 +149,7 @@ test_clustering_waitready() {
   LXD_NETNS="${ns1}" respawn_lxd "${LXD_ONE_DIR}" true
 
   # The cluster member cannot be evacuated as long as its networks and storage pools have not started.
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --force 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" because some networks have not started yet' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --yes 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" because some networks have not started yet' ]
 
   echo "==> Restore the network by unsetting the external interface"
   LXD_DIR="${LXD_ONE_DIR}" lxc network unset br1 bridge.external_interfaces --target "node1"
@@ -161,7 +161,7 @@ test_clustering_waitready() {
   LXD_NETNS="${ns1}" respawn_lxd "${LXD_ONE_DIR}" true
 
   # The cluster member cannot be evacuated as long as its storage pools have not started.
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --force 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" because some storage pools have not started yet' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --yes 2>&1)" = 'Error: Failed updating cluster member state: Cannot evacuate "node1" because some storage pools have not started yet' ]
 
   echo "==> Restore the storage pool directory"
   rm "${LXD_ONE_DIR}/storage-pools/pool1"
@@ -171,7 +171,7 @@ test_clustering_waitready() {
   LXD_NETNS="${ns1}" respawn_lxd "${LXD_ONE_DIR}" true
 
   # The cluster member can now be evacuated.
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --yes
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore "node1" --force
 
   # Cleanup.


### PR DESCRIPTION
This adds pre-evacuation quorum validation with a force API override, repurposes `lxc cluster evacuate --force` to bypass that server-side safety check, and adds `--yes` as the confirmation bypass flag. During evacuation, LXD now transfers leadership first when needed, marks the member evacuated, triggers an immediate raft rebalance so evacuated members are demoted and excluded from promotion candidacy, and only then migrates workloads. Restore continues to prioritize networks and instances first, with raft rebalancing triggered afterward.

This also updates the client/API surface, docs, unit coverage for `rolesAdjust`, and cluster integration tests for quorum rejection, forced evacuation, leadership handover, and the new CLI semantics.

Closes https://github.com/canonical/lxd/issues/15223.

https://warthogs.atlassian.net/browse/LXD-3790
