### PR TITLE
test/suites/devlxd: renaming the NIC during boot can take some time

### DIFF
--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -756,6 +756,13 @@ test_devlxd_vm() {
   waitInstanceReady v1
 
   echo "==> Confirm agent.nic_config applied the NIC configuration"
+  # Wait for lxd-agent to finish renaming the NIC; the agent initializes
+  # asynchronously after the guest kernel starts, so waitInstanceReady is not
+  # sufficient on its own.
+  for _ in $(seq 30); do
+    lxc exec v1 -- ip link show a-nic && break
+    sleep 1
+  done
   lxc exec v1 -- ip link show a-nic | grep -wF "mtu 1400"
 
   echo "==> Remove the NIC"


### PR DESCRIPTION
It doesn't really matters if it's slow as we just want to ascertain that once done, the MTU also matches the expected value.