### PR TITLE
Docs: [WD-34769] Make network exposure command IPv4/6 compatible

### DIFF
--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -112,10 +112,10 @@ If you prefer to use the LXD UI, expand and follow the steps below.
 By default, LXD is exposed through a Unix socket only and is not accessible over HTTPS. To access and manage LXD through a web browser using HTTPS, we must set the {config:option}`server-core:core.https_address` server configuration option. We will use the local network by configuring this to the IPv6 loopback address `[::1]` and port 8443. Run:
 
 ```bash
-lxc config set core.https_address 127.0.0.1:8443
+lxc config set core.https_address :8443
 ```
 
-Confirm that the `core.https_address` is set to `127.0.0.1:8443`:
+Confirm that the `core.https_address` is set to `:8443`:
 
 ```bash
 lxc config get core.https_address


### PR DESCRIPTION
## Checklist

Amended http://127.0.0.1:8000/tutorial/first_steps/ to make the config address IPv4/6 compatible.

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
