### PR TITLE
Fix creating instances using a local image from another project

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -498,8 +498,15 @@ func (r *ProtocolLXD) getSourceImageConnectionInfo(source ImageServer, image api
 	// Set the minimal source fields
 	instSrc.Type = api.SourceTypeImage
 
-	// Optimization for the local image case
-	if r.isSameServer(source) {
+	sameServer, err := r.isSameServer(source)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optimization for the local image case.
+	// The source image can be on the same server but in a different project compared to instance.
+	// Hence, we only compare the server identity here and allow different projects.
+	if sameServer {
 		// Always use fingerprints for local case
 		instSrc.Fingerprint = image.Fingerprint
 		instSrc.Alias = ""

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -127,6 +127,40 @@ func (r *ProtocolLXD) isSameServer(server Server) (bool, error) {
 	return sameServer, nil
 }
 
+// isSameProject compares the calling ProtocolLXD object with the provided server object to check if they are both using the same project.
+func (r *ProtocolLXD) isSameProject(server Server) (bool, error) {
+	// Short path checking if the two structs are identical.
+	if r == server {
+		return true, nil
+	}
+
+	// Short path if either of the structs are nil.
+	if r == nil || server == nil {
+		return false, nil
+	}
+
+	// When dealing with uninitialized servers, we can't safely compare.
+	if r.server == nil {
+		return false, nil
+	}
+
+	// Get the connection info from both servers.
+	srcInfo, err := r.GetConnectionInfo()
+	if err != nil {
+		return false, err
+	}
+
+	dstInfo, err := server.GetConnectionInfo()
+	if err != nil {
+		return false, err
+	}
+
+	// Check whether the two servers are using the same project.
+	sameProject := srcInfo.Project == dstInfo.Project
+
+	return sameProject, nil
+}
+
 // GetHTTPClient returns the http client used for the connection. This can be used to set custom http options.
 func (r *ProtocolLXD) GetHTTPClient() (*http.Client, error) {
 	if r.http == nil {

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -93,37 +93,38 @@ func (r *ProtocolLXD) GetConnectionInfo() (*ConnectionInfo, error) {
 }
 
 // isSameServer compares the calling ProtocolLXD object with the provided server object to check if they are the same server.
-// It verifies the equality based on their connection information (Protocol, Certificate, Project, and Target).
-func (r *ProtocolLXD) isSameServer(server Server) bool {
+// It verifies the equality based on their connection information (Protocol, Certificate, and Target).
+func (r *ProtocolLXD) isSameServer(server Server) (bool, error) {
 	// Short path checking if the two structs are identical.
 	if r == server {
-		return true
+		return true, nil
 	}
 
 	// Short path if either of the structs are nil.
 	if r == nil || server == nil {
-		return false
+		return false, nil
 	}
 
 	// When dealing with uninitialized servers, we can't safely compare.
 	if r.server == nil {
-		return false
+		return false, nil
 	}
 
 	// Get the connection info from both servers.
 	srcInfo, err := r.GetConnectionInfo()
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	dstInfo, err := server.GetConnectionInfo()
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	// Check whether we're dealing with the same server.
-	return srcInfo.Protocol == dstInfo.Protocol && srcInfo.Certificate == dstInfo.Certificate &&
-		srcInfo.Project == dstInfo.Project && srcInfo.Target == dstInfo.Target
+	sameServer := srcInfo.Protocol == dstInfo.Protocol && srcInfo.Certificate == dstInfo.Certificate && srcInfo.Target == dstInfo.Target
+
+	return sameServer, nil
 }
 
 // GetHTTPClient returns the http client used for the connection. This can be used to set custom http options.

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -722,8 +722,18 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 // CopyImage copies an image from a remote server. Additional options can be passed using ImageCopyArgs.
 func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *ImageCopyArgs) (RemoteOperation, error) {
 	// Quick checks.
-	if r.isSameServer(source) {
-		return nil, errors.New("The source and target servers must be different")
+	sameServer, err := r.isSameServer(source)
+	if err != nil {
+		return nil, err
+	}
+
+	sameProject, err := r.isSameProject(source)
+	if err != nil {
+		return nil, err
+	}
+
+	if sameServer && sameProject {
+		return nil, errors.New("Cannot copy an image within the same server and project")
 	}
 
 	// Handle profile list overrides.

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -352,7 +352,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 		}
 
 		// Fetch image info from the given remote.
-		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, &req.Source)
+		imgRemote, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -144,7 +144,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 		}
 
 		iremote, image := guessImage(conf, d, remote, iremote, image)
-		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, &req.Source)
+		imgRemote, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
 		if err != nil {
 			return err
 		}

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -378,21 +378,18 @@ func guessImage(conf *config.Config, d lxd.InstanceServer, instRemote string, im
 	return fields[0], fields[1]
 }
 
-// getImgInfo returns an image server and image info for the given image name (given by a user)
-// an image remote and an instance remote.
-func getImgInfo(d lxd.InstanceServer, conf *config.Config, imgRemote string, instRemote string, imageRef string, source *api.InstanceSource) (lxd.ImageServer, *api.Image, error) {
+// getImgInfo returns an image server and image info for the given image name, image remote, and image project.
+// It also populates the passed in InstanceSource struct with the information about the image.
+// If imageProject is provided and the remote is a LXD server, it will be used to locate the image.
+func getImgInfo(conf *config.Config, imgRemote string, imageRef string, imageProject string, source *api.InstanceSource) (lxd.ImageServer, *api.Image, error) {
 	var imgRemoteServer lxd.ImageServer
 	var imgInfo *api.Image
 	var err error
 
-	// Connect to the image server
-	if imgRemote == instRemote {
-		imgRemoteServer = d
-	} else {
-		imgRemoteServer, err = conf.GetImageServer(imgRemote)
-		if err != nil {
-			return nil, nil, err
-		}
+	// Connect to the image server.
+	imgRemoteServer, err = conf.GetImageServer(imgRemote)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Optimisation for simplestreams
@@ -402,6 +399,21 @@ func getImgInfo(d lxd.InstanceServer, conf *config.Config, imgRemote string, ins
 		imgInfo.Public = true
 		source.Alias = imageRef
 	} else {
+		server, ok := imgRemoteServer.(lxd.InstanceServer)
+		if ok && imageProject != "" {
+			// Use the given project for the image source.
+			imgRemoteServer = server.UseProject(imageProject)
+		}
+
+		// Get the connection info to fetch the currently used project.
+		connInfo, err := imgRemoteServer.GetConnectionInfo()
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed getting connection information for remote %q: %w", imgRemote, err)
+		}
+
+		// Set the currently used project for the instance source struct.
+		source.Project = connInfo.Project
+
 		// Attempt to resolve an image alias
 		alias, _, err := imgRemoteServer.GetImageAlias(imageRef)
 		if err == nil {

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -381,54 +381,54 @@ func guessImage(conf *config.Config, d lxd.InstanceServer, instRemote string, im
 // getImgInfo returns an image server and image info for the given image name, image remote, and image project.
 // It also populates the passed in InstanceSource struct with the information about the image.
 // If imageProject is provided and the remote is a LXD server, it will be used to locate the image.
-func getImgInfo(conf *config.Config, imgRemote string, imageRef string, imageProject string, source *api.InstanceSource) (lxd.ImageServer, *api.Image, error) {
-	var imgRemoteServer lxd.ImageServer
-	var imgInfo *api.Image
+func getImgInfo(conf *config.Config, imageRemote string, imageRef string, imageProject string, source *api.InstanceSource) (lxd.ImageServer, *api.Image, error) {
+	var imageRemoteServer lxd.ImageServer
+	var imageInfo *api.Image
 	var err error
 
 	// Connect to the image server.
-	imgRemoteServer, err = conf.GetImageServer(imgRemote)
+	imageRemoteServer, err = conf.GetImageServer(imageRemote)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Optimisation for simplestreams
-	if conf.Remotes[imgRemote].Protocol == "simplestreams" {
-		imgInfo = &api.Image{}
-		imgInfo.Fingerprint = imageRef
-		imgInfo.Public = true
+	if conf.Remotes[imageRemote].Protocol == "simplestreams" {
+		imageInfo = &api.Image{}
+		imageInfo.Fingerprint = imageRef
+		imageInfo.Public = true
 		source.Alias = imageRef
 	} else {
-		server, ok := imgRemoteServer.(lxd.InstanceServer)
+		server, ok := imageRemoteServer.(lxd.InstanceServer)
 		if ok && imageProject != "" {
 			// Use the given project for the image source.
-			imgRemoteServer = server.UseProject(imageProject)
+			imageRemoteServer = server.UseProject(imageProject)
 		}
 
 		// Get the connection info to fetch the currently used project.
-		connInfo, err := imgRemoteServer.GetConnectionInfo()
+		connInfo, err := imageRemoteServer.GetConnectionInfo()
 		if err != nil {
-			return nil, nil, fmt.Errorf("Failed getting connection information for remote %q: %w", imgRemote, err)
+			return nil, nil, fmt.Errorf("Failed getting connection information for remote %q: %w", imageRemote, err)
 		}
 
 		// Set the currently used project for the instance source struct.
 		source.Project = connInfo.Project
 
 		// Attempt to resolve an image alias
-		alias, _, err := imgRemoteServer.GetImageAlias(imageRef)
+		alias, _, err := imageRemoteServer.GetImageAlias(imageRef)
 		if err == nil {
 			source.Alias = imageRef
 			imageRef = alias.Target
 		}
 
 		// Get the image info
-		imgInfo, _, err = imgRemoteServer.GetImage(imageRef)
+		imageInfo, _, err = imageRemoteServer.GetImage(imageRef)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Failed finding image %q on remote %q", imageRef, imgRemote)
+			return nil, nil, fmt.Errorf("Failed finding image %q on remote %q", imageRef, imageRemote)
 		}
 	}
 
-	return imgRemoteServer, imgInfo, nil
+	return imageRemoteServer, imageInfo, nil
 }
 
 // getExportVersion returns the version sent to the server when exporting instances and custom storage volumes.

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
@@ -20,11 +21,13 @@ import (
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/project/limits"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
 	storagePools "github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/lxd/task"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
@@ -751,6 +754,44 @@ func pruneExpiredAndAutoCreateInstanceSnapshots(ctx context.Context, s *state.St
 	}
 
 	return nil
+}
+
+// resolveSourceImageFromCache searches the image to use for an instance source in the local cache and performs authorization checks.
+// This can be used to find either a cached copy of a remote image when a remote image is specified, or to find a local image when a local source image is specified.
+// If an image is not found locally, this function returns `nil` instead of an image and no error.
+func resolveSourceImageFromCache(r *http.Request, s *state.State, tx *db.ClusterTx, targetProjectName string, source api.InstanceSource, imageRef *string, instType string) (*api.Image, error) {
+	// Resolve the project used for local cache lookup to find the image.
+	localLookupProject := targetProjectName
+	if source.Server == "" && source.Project != "" {
+		// For local images, if a source project is explicitly provided, use it to locate the image.
+		localLookupProject = source.Project
+	}
+
+	// Check if the image has an entry in the database but fail only if the error
+	// is different than the image not being found.
+	sourceImage, err := getSourceImageFromInstanceSource(r.Context(), s, tx, localLookupProject, source, imageRef, instType)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return nil, err
+	}
+
+	// If the image is locally available, private, and from a different project, check if the caller can view it.
+	if sourceImage != nil && localLookupProject != targetProjectName && !sourceImage.Public {
+		// Get the effective image project based on the "features.images" value.
+		effectiveImageProject, err := project.ImageProject(r.Context(), tx.Tx(), localLookupProject)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create a child context and set effective project name to check the access permission.
+		ctx := context.WithValue(r.Context(), request.CtxEffectiveProjectName, effectiveImageProject)
+
+		err = s.Authorizer.CheckPermission(ctx, entity.ImageURL(localLookupProject, sourceImage.Fingerprint), auth.EntitlementCanView)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sourceImage, nil
 }
 
 // getSourceImageFromInstanceSource returns the image to use for an instance source.

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -115,8 +115,11 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if req.Source.Type != api.SourceTypeNone {
-			sourceImage, err = getSourceImageFromInstanceSource(ctx, s, tx, targetProject.Name, req.Source, &sourceImageRef, dbInst.Type.String())
-			if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			// Try to resolve the source image from cache and perform authorization checks.
+			// This is needed to verify the caller has access to the image if it's from a different project,
+			// and to retrieve the image's metadata.
+			sourceImage, err = resolveSourceImageFromCache(r, s, tx, targetProject.Name, req.Source, &sourceImageRef, dbInst.Type.String())
+			if err != nil {
 				return err
 			}
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1392,10 +1392,11 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 		case api.SourceTypeImage:
-			// Check if the image has an entry in the database but fail only if the error
-			// is different than the image not being found.
-			sourceImage, err = getSourceImageFromInstanceSource(ctx, s, tx, targetProject.Name, req.Source, &sourceImageRef, string(req.Type))
-			if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			// Try to resolve the source image from cache and perform authorization checks.
+			// This is needed to verify the caller has access to the image if it's from a different project,
+			// and to retrieve the image's metadata (such as profiles) so they can be applied to the instance.
+			sourceImage, err = resolveSourceImageFromCache(r, s, tx, targetProject.Name, req.Source, &sourceImageRef, string(req.Type))
+			if err != nil {
 				return err
 			}
 

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -97,6 +97,7 @@ readonly test_group_image=(
     "images_public"
     "projects_images"
     "projects_images_default"
+    "projects_instance_creation"
 )
 
 readonly test_group_network=(

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -546,6 +546,81 @@ test_projects_images_default() {
   lxc project delete foo
 }
 
+# Test creating and rebuilding an instance from a local image located in a different project.
+test_projects_instance_creation() {
+  # Create projects for images and instances.
+  lxc project create img-proj
+  lxc project create inst-proj
+
+  # Import an image into the image project.
+  ensure_import_testimage img-proj
+
+  # Add a root device to the default profile of the instance project.
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")" --project inst-proj
+
+  # Test lxc init.
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}" --project img-proj --target-project inst-proj
+
+  # Verify the container was created in inst-proj.
+  lxc list --project inst-proj -c n -f csv | grep -wF "c1"
+
+  # Test lxc launch.
+  lxc launch testimage c2 -d "${SMALL_ROOT_DISK}" --project img-proj --target-project inst-proj
+
+  # Verify the container was created and is running in inst-proj.
+  lxc list --project inst-proj -c ns -f csv | grep -wF "c2,RUNNING"
+
+  # Test lxc rebuild. Rebuild the stopped container.
+  lxc rebuild testimage c1 --project img-proj --target-project inst-proj
+
+  # Clean up instances from the first phase.
+  lxc delete -f c1 c2 --project inst-proj
+
+  # Test relying only on the "--target-project" flag while being in the image project.
+  lxc project switch img-proj
+
+  # Test lxc init.
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}" --target-project inst-proj
+  lxc list --project inst-proj -c n -f csv | grep -wF "c1"
+
+  # Test lxc launch.
+  lxc launch testimage c2 -d "${SMALL_ROOT_DISK}" --target-project inst-proj
+  lxc list --project inst-proj -c ns -f csv | grep -wF "c2,RUNNING"
+
+  # Test lxc rebuild.
+  lxc rebuild testimage c1 --target-project inst-proj
+
+  # Switch back to default project.
+  lxc project switch default
+
+  # Clean up instances.
+  lxc delete -f c1 c2 --project inst-proj
+
+  # Test relying only on the "--project" flag. In this case, it should specify both the image project and the instance project.
+
+  # Add a root device to the default profile of the image project since we will create an instance there.
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")" --project img-proj
+
+  # Test lxc init.
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}" --project img-proj
+  lxc list --project img-proj -c n -f csv | grep -wF "c1"
+
+  # Test lxc launch.
+  lxc launch testimage c2 -d "${SMALL_ROOT_DISK}" --project img-proj
+  lxc list --project img-proj -c ns -f csv | grep -wF "c2,RUNNING"
+
+  # Test lxc rebuild.
+  lxc rebuild testimage c1 --project img-proj
+
+  # Clean up instances from the final phase.
+  lxc delete -f c1 c2 --project img-proj
+
+  # Clean up image and projects.
+  lxc image delete testimage --project img-proj
+  lxc project delete inst-proj
+  lxc project delete img-proj
+}
+
 # Interaction between projects and storage pools.
 test_projects_storage() {
   pool="lxdtest-$(basename "${LXD_DIR}")"


### PR DESCRIPTION
This PR fixes the behaviour of `--project` and `--target-project` flags for `lxc init`, `lxc rebuild`, and `lxc launch` commands, specifically when using local images.

It ensures that the `--project` flag overrides the image's source project, whereas the `--target-project` allows specifying target project for the new instance if it is different from the image.

The PR also fixes the `POST /1.0/instances` and `POST /1.0/instances/{name}/rebuild` API endpoints to correctly resolve source image project when creating an instance from a local image.

Fixes https://github.com/canonical/lxd/issues/17905.