### PR TITLE
edk2: update `CODE`/`VARS` handling and ship non-secureboot `CODE`

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -35,7 +35,6 @@ Name                            | Description
 `LXD_LXC_TEMPLATE_CONFIG`       | Path to the LXC template configuration directory
 `LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off
 `LXD_UNPRIVILEGED_ONLY`         | If set to `true`, enforces that only unprivileged containers can be created. Note that any privileged containers that have been created before setting LXD_UNPRIVILEGED_ONLY will continue to be privileged. To use this option effectively it should be set when the LXD daemon is first set up.
-`LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd` (deprecated, please use `LXD_QEMU_FW_PATH` instead)
 `LXD_QEMU_FW_PATH`              | Path (or `:` separated list of paths) to firmware (OVMF, SeaBIOS) to be used by QEMU
 `LXD_IDMAPPED_MOUNTS_DISABLE`   | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `LXD_DEVMONITOR_DIR`            | Path to be monitored by the device monitor. This is primarily for testing.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1271,7 +1271,13 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 	// Copy EDK2 settings firmware to nvram file if needed.
 	// This firmware file can be modified by the VM so it must be copied from the defaults.
 	if supportsUEFI {
-		// ovmfNeedsUpdate checks if nvram file needs to be regenerated using new template.
+		// ovmfNeedsUpdate checks if the NVRAM file must be regenerated from the
+		// firmware template. This action is destructive in the sense that the
+		// NVRAM state is lost which is not ideal but also not terrible as it is
+		// rarely used (only for custom SB keys, boot order tweaks, etc). This
+		// covers cases where the existing NVRAM content is genuinely
+		// incompatible with the current firmware. The OVMF 4MB -> _4M rename
+		// (content-compatible) is handled separately below.
 		ovmfNeedsUpdate := func(nvramTarget string) bool {
 			if !shared.InSnap() {
 				return false
@@ -1285,8 +1291,10 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 				return true
 			} else if strings.Contains(nvramTarget, "OVMF") {
 				// The 2MB firmware was deprecated in the LXD snap.
-				// Detect this by the absence of "4MB" in the nvram file target.
-				if !strings.Contains(nvramTarget, "4MB") {
+				// Detect this by the absence of both "4MB" and "_4M" in the nvram file target.
+				// Note: "_4M" must also be accepted as valid to handle VMs that were already
+				// migrated to the new naming convention (e.g. by an updated snap).
+				if !strings.Contains(nvramTarget, "4MB") && !strings.Contains(nvramTarget, "_4M") {
 					return true
 				}
 
@@ -1316,6 +1324,18 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 		// Decide if nvram file needs to be setup/refreshed.
 		if nvramMissing || shared.IsTrue(d.localConfig["volatile.apply_nvram"]) || ovmfNeedsUpdate(nvramTarget) {
 			err = d.setupNvram()
+			if err != nil {
+				op.Done(err)
+				return err
+			}
+		} else if !nvramMissing {
+			// When the firmware filename convention changed but the content is
+			// identical (e.g. OVMF 4MB -> _4M on x86_64, or OVMF-named arm64 ->
+			// AAVMF), rename the existing file to preserve boot order, custom
+			// Secure Boot keys, and other NVRAM state. renameNvram only proceeds
+			// when the preferred firmware actually exists in the snap, making it
+			// safe to deploy this LXD change before the snap is updated.
+			_, err = d.renameNvram(nvramTarget)
 			if err != nil {
 				op.Done(err)
 				return err
@@ -2053,6 +2073,94 @@ func (d *qemu) effectiveBootMode() string {
 	}
 
 	return bootMode
+}
+
+// renameNvram renames the existing NVRAM vars file when the firmware filename has
+// changed but the content remains compatible, preserving any existing boot settings
+// such as boot order or custom Secure Boot keys. This covers:
+//   - OVMF 4MB -> _4M rename on x86_64 (identical binary content)
+//   - OVMF-named arm64 EDK2 -> AAVMF rename (both are AArch64 EDK2 builds)
+//
+// Returns true if the rename was performed successfully.
+func (d *qemu) renameNvram(nvramTarget string) (bool, error) {
+	if !shared.InSnap() {
+		return false, nil
+	}
+
+	// Only applicable to OVMF 4MB variants: the 4MB size is the content-compatible
+	// baseline used across all renames handled here (x86_64 _4M and arm64 AAVMF).
+	nvramBasename := filepath.Base(nvramTarget)
+	if !strings.Contains(nvramBasename, "OVMF") || !strings.Contains(nvramBasename, "4MB") {
+		return false, nil
+	}
+
+	// Determine the expected firmware for this VM's boot mode.
+	var firmwares []edk2.FirmwarePair
+	switch d.effectiveBootMode() {
+	case instancetype.BootModeUEFISecureBoot:
+		firmwares = edk2.GetArchitectureFirmwarePairsForUsage(d.architecture, edk2.SECUREBOOT)
+	default:
+		firmwares = edk2.GetArchitectureFirmwarePairsForUsage(d.architecture, edk2.GENERIC)
+	}
+
+	if len(firmwares) == 0 {
+		return false, nil
+	}
+
+	// The preferred (first available) firmware determines the new vars filename.
+	newVarsName := filepath.Base(firmwares[0].Vars)
+
+	// Nothing to rename if the preferred firmware already matches the current one.
+	if newVarsName == nvramBasename {
+		return false, nil
+	}
+
+	newVarsPath := filepath.Join(d.Path(), newVarsName)
+
+	// If the destination already exists the file was previously migrated (e.g. by an earlier
+	// LXD start that failed mid-way). Skip the rename to avoid overwriting current NVRAM state.
+	_, err := os.Stat(newVarsPath)
+	if err == nil {
+		d.logger.Info("Skipping NVRAM vars file rename, destination already exists", logger.Ctx{"source": nvramBasename, "destination": newVarsName})
+		return false, nil
+	}
+
+	if !os.IsNotExist(err) {
+		return false, fmt.Errorf("Failed checking existing NVRAM vars file %q: %w", newVarsPath, err)
+	}
+
+	// Rename the vars file and update the symlink atomically so that a failure mid-way
+	// does not leave the instance in an unbootable state.
+	rev := revert.New()
+	defer rev.Fail()
+
+	err = os.Rename(nvramTarget, newVarsPath)
+	if err != nil {
+		return false, fmt.Errorf("Failed renaming NVRAM vars file %q to %q: %w", nvramTarget, newVarsPath, err)
+	}
+
+	rev.Add(func() { _ = os.Rename(newVarsPath, nvramTarget) })
+
+	// Update the symlink via a temporary name so the replacement is atomic.
+	nvramPath := d.nvramPath()
+	tmpNvramPath := nvramPath + ".tmp"
+	_ = os.Remove(tmpNvramPath)
+
+	err = os.Symlink(newVarsName, tmpNvramPath)
+	if err != nil {
+		return false, fmt.Errorf("Failed creating temporary NVRAM symlink to %q: %w", newVarsName, err)
+	}
+
+	err = os.Rename(tmpNvramPath, nvramPath)
+	if err != nil {
+		_ = os.Remove(tmpNvramPath)
+		return false, fmt.Errorf("Failed updating NVRAM symlink to %q: %w", newVarsName, err)
+	}
+
+	rev.Success()
+
+	d.logger.Info("Renamed NVRAM vars file", logger.Ctx{"old": nvramBasename, "new": newVarsName})
+	return true, nil
 }
 
 func (d *qemu) setupNvram() error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3552,9 +3552,16 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 			return "", nil, fmt.Errorf("Cannot locate matching VM firmware: %+v", firmwares)
 		}
 
-		// Use debug version of firmware. (Only works for "preferred" (OVMF 4MB, no CSM) firmware flavor)
-		if shared.IsTrue(d.expandedConfig["boot.debug_edk2"]) && efiCode == firmwares[0].Code {
-			efiCode = filepath.Join(filepath.Dir(efiCode), edk2.OVMFDebugFirmware)
+		// Use debug version of firmware when boot.debug_edk2 is set.
+		// The debug firmware path is derived by inserting ".debug" before the ".fd" extension.
+		// An error is returned if the debug firmware file does not exist.
+		if shared.IsTrue(d.expandedConfig["boot.debug_edk2"]) && strings.HasSuffix(efiCode, ".fd") {
+			debugCode := strings.TrimSuffix(efiCode, ".fd") + ".debug.fd"
+			if !shared.PathExists(debugCode) {
+				return "", nil, fmt.Errorf("Cannot find debug firmware %q", debugCode)
+			}
+
+			efiCode = debugCode
 		}
 
 		driveFirmwareOpts := qemuDriveFirmwareOpts{

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -32,7 +32,7 @@ const (
 	// SECUREBOOT is a UEFI Secure Boot enabled firmware.
 	SECUREBOOT
 
-	// CSM is a firmware with the UEFI Compatibility Support Module enabled to boot BIOS-only operating systems.
+	// CSM is a SeaBIOS firmware used for booting legacy BIOS-only operating systems.
 	CSM
 )
 

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -54,16 +54,16 @@ var architectureInstallations = map[int][]Installation{
 		Paths: GetenvEdk2Paths("/usr/share/OVMF"),
 		Usage: map[FirmwareUsage][]FirmwarePair{
 			GENERIC: {
-				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
 				{Code: "OVMF_CODE_4M.fd", Vars: "OVMF_VARS_4M.fd"},
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
 				{Code: "OVMF_CODE.4m.fd", Vars: "OVMF_VARS.4m.fd"},
 				{Code: "OVMF_CODE.2MB.fd", Vars: "OVMF_VARS.2MB.fd"},
 				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"},
 				{Code: "OVMF_CODE.fd", Vars: "qemu.nvram"},
 			},
 			SECUREBOOT: {
-				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.ms.fd"},
 				{Code: "OVMF_CODE_4M.ms.fd", Vars: "OVMF_VARS_4M.ms.fd"},
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.ms.fd"},
 				{Code: "OVMF_CODE_4M.secboot.fd", Vars: "OVMF_VARS_4M.secboot.fd"},
 				{Code: "OVMF_CODE.secboot.4m.fd", Vars: "OVMF_VARS.4m.fd"},
 				{Code: "OVMF_CODE.secboot.fd", Vars: "OVMF_VARS.secboot.fd"},
@@ -131,8 +131,8 @@ var architectureInstallations = map[int][]Installation{
 		Usage: map[FirmwareUsage][]FirmwarePair{
 			GENERIC: {
 				{Code: "AAVMF_CODE.fd", Vars: "AAVMF_VARS.fd"},
-				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
 				{Code: "OVMF_CODE_4M.fd", Vars: "OVMF_VARS_4M.fd"},
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
 				{Code: "OVMF_CODE.4m.fd", Vars: "OVMF_VARS.4m.fd"},
 				{Code: "OVMF_CODE.2MB.fd", Vars: "OVMF_VARS.2MB.fd"},
 				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"},
@@ -140,8 +140,8 @@ var architectureInstallations = map[int][]Installation{
 			},
 			SECUREBOOT: {
 				{Code: "AAVMF_CODE.ms.fd", Vars: "AAVMF_VARS.ms.fd"},
-				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.ms.fd"},
 				{Code: "OVMF_CODE_4M.ms.fd", Vars: "OVMF_VARS_4M.ms.fd"},
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.ms.fd"},
 				{Code: "OVMF_CODE_4M.secboot.fd", Vars: "OVMF_VARS_4M.secboot.fd"},
 				{Code: "OVMF_CODE.secboot.4m.fd", Vars: "OVMF_VARS.4m.fd"},
 				{Code: "OVMF_CODE.secboot.fd", Vars: "OVMF_VARS.secboot.fd"},

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -221,18 +221,14 @@ func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []F
 }
 
 // GetenvEdk2Paths returns a list of paths to search for VM firmwares.
-// If LXD_QEMU_FW_PATH or LXD_OVMF_PATH env vars are set then these values are split on ":" and prefixed to the
-// returned slice of paths.
+// If LXD_QEMU_FW_PATH env variable is set then its value is split on ":" and
+// prefixed to the returned slice of paths.
 // The defaultPath argument is returned as the last element in the slice.
 func GetenvEdk2Paths(defaultPath string) []string {
 	var qemuFwPaths []string
 
-	for _, v := range []string{"LXD_QEMU_FW_PATH", "LXD_OVMF_PATH"} {
-		searchPaths := os.Getenv(v)
-		if searchPaths == "" {
-			continue
-		}
-
+	searchPaths := os.Getenv("LXD_QEMU_FW_PATH")
+	if searchPaths != "" {
 		qemuFwPaths = append(qemuFwPaths, strings.Split(searchPaths, ":")...)
 	}
 

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -36,9 +36,6 @@ const (
 	CSM
 )
 
-// OVMFDebugFirmware is the debug version of the "preferred" firmware.
-const OVMFDebugFirmware = "OVMF_CODE.4MB.debug.fd"
-
 // legacyFirmwareVarsCandidates lists firmware vars file names that were previously used but have since been
 // deprecated. They are still returned by GetArchitectureFirmwareVarsCandidates to allow cleanup of any
 // orphaned files left over on existing VM instances.

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -39,6 +39,16 @@ const (
 // OVMFDebugFirmware is the debug version of the "preferred" firmware.
 const OVMFDebugFirmware = "OVMF_CODE.4MB.debug.fd"
 
+// legacyFirmwareVarsCandidates lists firmware vars file names that were previously used but have since been
+// deprecated. They are still returned by GetArchitectureFirmwareVarsCandidates to allow cleanup of any
+// orphaned files left over on existing VM instances.
+// These are OVMF EDK2-based CSM firmware vars files, which were replaced by SeaBIOS for BIOS mode.
+var legacyFirmwareVarsCandidates = []string{
+	"OVMF_VARS.4MB.CSM.fd",
+	"OVMF_VARS.2MB.CSM.fd",
+	"OVMF_VARS.CSM.fd",
+}
+
 var architectureInstallations = map[int][]Installation{
 	osarch.ARCH_64BIT_INTEL_X86: {{
 		Paths: GetenvEdk2Paths("/usr/share/OVMF"),
@@ -65,11 +75,6 @@ var architectureInstallations = map[int][]Installation{
 			CSM: {
 				{Code: "bios-256k.bin", Vars: "bios-256k.bin"},
 				{Code: "seabios.bin", Vars: "seabios.bin"},
-				{Code: "OVMF_CODE.4MB.CSM.fd", Vars: "OVMF_VARS.4MB.CSM.fd"},
-				{Code: "OVMF_CODE.csm.4m.fd", Vars: "OVMF_VARS.4m.fd"},
-				{Code: "OVMF_CODE.2MB.CSM.fd", Vars: "OVMF_VARS.2MB.CSM.fd"},
-				{Code: "OVMF_CODE.CSM.fd", Vars: "OVMF_VARS.CSM.fd"},
-				{Code: "OVMF_CODE.csm.fd", Vars: "OVMF_VARS.fd"},
 			},
 		},
 	}, {
@@ -106,10 +111,6 @@ var architectureInstallations = map[int][]Installation{
 			GENERIC: {
 				{Code: "OVMF_CODE.4m.fd", Vars: "OVMF_VARS.4m.fd"},
 				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"},
-			},
-			CSM: {
-				{Code: "OVMF_CODE.csm.4m.fd", Vars: "OVMF_VARS.4m.fd"},
-				{Code: "OVMF_CODE.csm.fd", Vars: "OVMF_VARS.fd"},
 			},
 			SECUREBOOT: {
 				{Code: "OVMF_CODE.secboot.4m.fd", Vars: "OVMF_VARS.4m.fd"},
@@ -165,6 +166,7 @@ var architectureInstallations = map[int][]Installation{
 // GetArchitectureFirmwareVarsCandidates returns a unique list of candidate vars names for hostArch for all usages.
 // It does not check whether the associated firmware files are present on the host now.
 // This can be used to check for the existence of previously used firmware vars files in an existing VM instance.
+// Legacy (deprecated) vars file names are also included to allow cleanup of orphaned files.
 func GetArchitectureFirmwareVarsCandidates(hostArch int) (varsNames []string) {
 	for _, installation := range architectureInstallations[hostArch] {
 		for _, usage := range installation.Usage {
@@ -172,6 +174,15 @@ func GetArchitectureFirmwareVarsCandidates(hostArch int) (varsNames []string) {
 				if !slices.Contains(varsNames, fwPair.Vars) {
 					varsNames = append(varsNames, fwPair.Vars)
 				}
+			}
+		}
+	}
+
+	// The legacy OVMF and CSM vars files were only ever created on x86-64.
+	if hostArch == osarch.ARCH_64BIT_INTEL_X86 {
+		for _, legacyVars := range legacyFirmwareVarsCandidates {
+			if !slices.Contains(varsNames, legacyVars) {
+				varsNames = append(varsNames, legacyVars)
 			}
 		}
 	}

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -63,6 +63,7 @@ var architectureInstallations = map[int][]Installation{
 				{Code: "OVMF_CODE.fd", Vars: "qemu.nvram"},
 			},
 			CSM: {
+				{Code: "bios-256k.bin", Vars: "bios-256k.bin"},
 				{Code: "seabios.bin", Vars: "seabios.bin"},
 				{Code: "OVMF_CODE.4MB.CSM.fd", Vars: "OVMF_VARS.4MB.CSM.fd"},
 				{Code: "OVMF_CODE.csm.4m.fd", Vars: "OVMF_VARS.4m.fd"},
@@ -83,6 +84,7 @@ var architectureInstallations = map[int][]Installation{
 				{Code: "ovmf-x86_64-ms-code.bin", Vars: "ovmf-x86_64-ms-vars.bin"},
 			},
 			CSM: {
+				{Code: "bios-256k.bin", Vars: "bios-256k.bin"},
 				{Code: "seabios.bin", Vars: "seabios.bin"},
 			},
 		},
@@ -119,6 +121,7 @@ var architectureInstallations = map[int][]Installation{
 		Usage: map[FirmwareUsage][]FirmwarePair{
 			CSM: {
 				{Code: "bios-256k.bin", Vars: "bios-256k.bin"},
+				{Code: "seabios.bin", Vars: "seabios.bin"},
 			},
 		},
 	}},

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -82,10 +82,10 @@ var architectureInstallations = map[int][]Installation{
 		Usage: map[FirmwareUsage][]FirmwarePair{
 			GENERIC: {
 				{Code: "ovmf-x86_64-4m-code.bin", Vars: "ovmf-x86_64-4m-vars.bin"},
-				{Code: "ovmf-x86_64.bin", Vars: "ovmf-x86_64-code.bin"},
+				{Code: "ovmf-x86_64-code.bin", Vars: "ovmf-x86_64-vars.bin"},
 			},
 			SECUREBOOT: {
-				{Code: "ovmf-x86_64-ms-4m-vars.bin", Vars: "ovmf-x86_64-ms-4m-code.bin"},
+				{Code: "ovmf-x86_64-ms-4m-code.bin", Vars: "ovmf-x86_64-ms-4m-vars.bin"},
 				{Code: "ovmf-x86_64-ms-code.bin", Vars: "ovmf-x86_64-ms-vars.bin"},
 			},
 			CSM: {

--- a/lxd/instance/drivers/edk2/edk2_test.go
+++ b/lxd/instance/drivers/edk2/edk2_test.go
@@ -1,0 +1,190 @@
+package edk2
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/canonical/lxd/shared/osarch"
+)
+
+func TestGetenvEdk2Paths(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		defaultPath string
+		want        []string
+	}{
+		{
+			name:        "empty environment falls back to the default path",
+			envValue:    "",
+			defaultPath: "/usr/share/OVMF",
+			want:        []string{"/usr/share/OVMF"},
+		},
+		{
+			name:        "environment paths are prefixed before the default path",
+			envValue:    "/snap/lxd/current/share/qemu:/opt/fw",
+			defaultPath: "/usr/share/OVMF",
+			want:        []string{"/snap/lxd/current/share/qemu", "/opt/fw", "/usr/share/OVMF"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LXD_QEMU_FW_PATH", tc.envValue)
+
+			got := GetenvEdk2Paths(tc.defaultPath)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("GetenvEdk2Paths(%q) = %v, want %v", tc.defaultPath, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetArchitectureFirmwareVarsCandidates(t *testing.T) {
+	x86Candidates := GetArchitectureFirmwareVarsCandidates(osarch.ARCH_64BIT_INTEL_X86)
+
+	// The returned list must not contain duplicates.
+	seen := make(map[string]struct{}, len(x86Candidates))
+	for _, name := range x86Candidates {
+		_, duplicate := seen[name]
+		if duplicate {
+			t.Errorf("Duplicate vars candidate %q", name)
+		}
+
+		seen[name] = struct{}{}
+	}
+
+	// x86_64 must offer the current, transitional and legacy (deprecated) vars names
+	// so that orphaned files from any previous naming convention can be cleaned up.
+	for _, want := range []string{
+		"OVMF_VARS_4M.fd",
+		"OVMF_VARS_4M.ms.fd",
+		"OVMF_VARS.4MB.fd",
+		"OVMF_VARS.4MB.ms.fd",
+		"OVMF_VARS.4MB.CSM.fd",
+		"OVMF_VARS.2MB.CSM.fd",
+		"OVMF_VARS.CSM.fd",
+	} {
+		if !slices.Contains(x86Candidates, want) {
+			t.Errorf("x86_64 vars candidates missing %q", want)
+		}
+	}
+
+	// The legacy CSM vars files were only ever created on x86_64 so they must not be
+	// offered for cleanup on arm64.
+	armCandidates := GetArchitectureFirmwareVarsCandidates(osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN)
+	for _, legacy := range []string{
+		"OVMF_VARS.4MB.CSM.fd",
+		"OVMF_VARS.2MB.CSM.fd",
+		"OVMF_VARS.CSM.fd",
+	} {
+		if slices.Contains(armCandidates, legacy) {
+			t.Errorf("arm64 vars candidates should not include legacy x86_64 file %q", legacy)
+		}
+	}
+
+	if !slices.Contains(armCandidates, "AAVMF_VARS.fd") {
+		t.Error("arm64 vars candidates missing AAVMF_VARS.fd")
+	}
+}
+
+// TestArchitectureInstallationsPreferenceOrder asserts that the firmware catalog lists the
+// preferred (new) firmware names ahead of the legacy ones. This ordering determines which
+// firmware a VM ends up using and, for existing VMs, the target name its NVRAM vars file is
+// renamed to on start.
+func TestArchitectureInstallationsPreferenceOrder(t *testing.T) {
+	assertVarsBefore := func(t *testing.T, pairs []FirmwarePair, preferredVars string, legacyVars string) {
+		t.Helper()
+
+		preferredIdx := slices.IndexFunc(pairs, func(p FirmwarePair) bool { return p.Vars == preferredVars })
+		legacyIdx := slices.IndexFunc(pairs, func(p FirmwarePair) bool { return p.Vars == legacyVars })
+
+		if preferredIdx == -1 {
+			t.Errorf("Preferred vars %q not found", preferredVars)
+			return
+		}
+
+		if legacyIdx == -1 {
+			t.Errorf("Legacy vars %q not found", legacyVars)
+			return
+		}
+
+		if preferredIdx > legacyIdx {
+			t.Errorf("Expected %q (index %d) to be preferred over %q (index %d)", preferredVars, preferredIdx, legacyVars, legacyIdx)
+		}
+	}
+
+	// On x86_64 the _4M names must rank before the legacy 4MB names.
+	x86Usage := architectureInstallations[osarch.ARCH_64BIT_INTEL_X86][0].Usage
+	assertVarsBefore(t, x86Usage[GENERIC], "OVMF_VARS_4M.fd", "OVMF_VARS.4MB.fd")
+	assertVarsBefore(t, x86Usage[SECUREBOOT], "OVMF_VARS_4M.ms.fd", "OVMF_VARS.4MB.ms.fd")
+
+	// On arm64 the AAVMF firmware must be the preferred (first) pair for both usages.
+	armUsage := architectureInstallations[osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN][0].Usage
+	wantFirst := map[FirmwareUsage]FirmwarePair{
+		GENERIC:    {Code: "AAVMF_CODE.fd", Vars: "AAVMF_VARS.fd"},
+		SECUREBOOT: {Code: "AAVMF_CODE.ms.fd", Vars: "AAVMF_VARS.ms.fd"},
+	}
+
+	for usage, want := range wantFirst {
+		got := armUsage[usage][0]
+		if got != want {
+			t.Errorf("arm64 usage %d: expected first pair %+v, got %+v", usage, want, got)
+		}
+	}
+}
+
+// TestGetArchitectureFirmwarePairsForUsage drives the selection logic against a controlled
+// firmware catalog backed by a temporary directory. The package catalog resolves its search
+// paths at init time, so it is swapped out here to make the test deterministic and independent
+// of any firmware installed on the host.
+func TestGetArchitectureFirmwarePairsForUsage(t *testing.T) {
+	fwDir := t.TempDir()
+
+	// emptyDir is searched first but contains no firmware, exercising path precedence.
+	emptyDir := t.TempDir()
+
+	const testArch = osarch.ARCH_64BIT_INTEL_X86
+
+	original := architectureInstallations
+	t.Cleanup(func() { architectureInstallations = original })
+	architectureInstallations = map[int][]Installation{
+		testArch: {{
+			Paths: []string{emptyDir, fwDir},
+			Usage: map[FirmwareUsage][]FirmwarePair{
+				GENERIC: {
+					{Code: "OVMF_CODE_4M.fd", Vars: "OVMF_VARS_4M.fd"},
+					{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
+					// Only the code file is created below, so this pair must be skipped.
+					{Code: "OVMF_CODE.2MB.fd", Vars: "OVMF_VARS.2MB.fd"},
+				},
+			},
+		}},
+	}
+
+	for _, name := range []string{
+		"OVMF_CODE_4M.fd", "OVMF_VARS_4M.fd",
+		"OVMF_CODE.4MB.fd", "OVMF_VARS.4MB.fd",
+		"OVMF_CODE.2MB.fd", // intentionally without its matching vars file
+	} {
+		err := os.WriteFile(filepath.Join(fwDir, name), []byte("firmware"), 0o600)
+		if err != nil {
+			t.Fatalf("Failed writing fake firmware %q: %v", name, err)
+		}
+	}
+
+	got := GetArchitectureFirmwarePairsForUsage(testArch, GENERIC)
+
+	// Only pairs whose code and vars both exist are returned, preferred name first, with full
+	// paths resolved against the matching search directory.
+	want := []FirmwarePair{
+		{Code: filepath.Join(fwDir, "OVMF_CODE_4M.fd"), Vars: filepath.Join(fwDir, "OVMF_VARS_4M.fd")},
+		{Code: filepath.Join(fwDir, "OVMF_CODE.4MB.fd"), Vars: filepath.Join(fwDir, "OVMF_VARS.4MB.fd")},
+	}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("GetArchitectureFirmwarePairsForUsage() = %+v, want %+v", got, want)
+	}
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -482,11 +482,16 @@ parts:
 
       if [ "$(uname -m)" = "x86_64" ]; then
           DSC="OvmfPkg/OvmfPkgX64.dsc"
-          BUILD_TARGET="install-ovmf"
+          BUILD_TARGETS="install-ovmf-secboot install-ovmf-no-secboot"
           SRC_DIR="debian/tmp/usr/share/OVMF"
-          SRC_CODE="OVMF_CODE_4M.secboot.fd"
+          SRC_CODE="OVMF_CODE_4M.ms.fd"
+          SRC_CODE_NOSB="OVMF_CODE_4M.fd"
           SRC_VARS="OVMF_VARS_4M.fd"
           SRC_VARS_MS="OVMF_VARS_4M.ms.fd"
+          DST_CODE="OVMF_CODE_4M.ms"
+          DST_CODE_NOSB="OVMF_CODE_4M"
+          DST_VARS="OVMF_VARS_4M"
+          DST_VARS_MS="OVMF_VARS_4M.ms"
           # Add DEBUG_VERBOSE to print error level for DEBUG build
           # * 0x80000000 (DEBUG_ERROR)
           # * 0x00000040 (DEBUG_INFO)
@@ -496,20 +501,33 @@ parts:
           SED_EXPR="s#PcdDebugPrintErrorLevel|0x8000004F#PcdDebugPrintErrorLevel|0x8040004F#g"
       elif [ "$(uname -m)" = "aarch64" ]; then
           DSC="ArmVirtPkg/ArmVirt.dsc.inc"
-          BUILD_TARGET="install-qemu-efi-aarch64"
+          BUILD_TARGETS="install-qemu-efi-aarch64-secboot install-qemu-efi-aarch64-no-secboot"
           SRC_DIR="debian/tmp/usr/share/AAVMF"
-          SRC_CODE="AAVMF_CODE.secboot.fd"
+          SRC_CODE="AAVMF_CODE.ms.fd"
+          # XXX: The package doesn't create AAVMF_CODE.fd for this
+          # non-secureboot variant, but we need a consistent name for the snap,
+          # so we copy it from the .no-secboot.fd file.
+          SRC_CODE_NOSB="AAVMF_CODE.no-secboot.fd"
           SRC_VARS="AAVMF_VARS.fd"
           SRC_VARS_MS="AAVMF_VARS.ms.fd"
+          DST_CODE="AAVMF_CODE.ms"
+          DST_CODE_NOSB="AAVMF_CODE"
+          DST_VARS="AAVMF_VARS"
+          DST_VARS_MS="AAVMF_VARS.ms"
           # See note in `x86_64` section for DEBUG_VERBOSE explanation
           SED_EXPR="s#DEBUG_PRINT_ERROR_LEVEL = 0x8000004F#DEBUG_PRINT_ERROR_LEVEL = 0x8040004F#g"
       elif [ "$(uname -m)" = "riscv64" ]; then
           DSC="OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc"
-          BUILD_TARGET="install-qemu-efi-riscv64"
+          BUILD_TARGETS="install-qemu-efi-riscv64"
           SRC_DIR="debian/tmp/usr/share/qemu-efi-riscv64"
-          SRC_CODE="RISCV_VIRT_CODE.fd"
+          SRC_CODE=""
+          SRC_CODE_NOSB="RISCV_VIRT_CODE.fd"
           SRC_VARS="RISCV_VIRT_VARS.fd"
-          SRC_VARS_MS="RISCV_VIRT_VARS.fd"
+          SRC_VARS_MS=""
+          DST_CODE=""
+          DST_CODE_NOSB="RISCV_VIRT_CODE"
+          DST_VARS="RISCV_VIRT_VARS"
+          DST_VARS_MS=""
           # See note in `x86_64` section for DEBUG_VERBOSE explanation
           SED_EXPR="s#DEBUG_PRINT_ERROR_LEVEL = 0x8000004F#DEBUG_PRINT_ERROR_LEVEL = 0x8040004F#g"
       fi
@@ -531,17 +549,23 @@ parts:
 
           # Enable parallel builds to avoid lengthy build times due to LTO. amd64 build on LP goes from ~1h45m -> ~60m
           # lto-wrapper: note: see the ‘-flto’ option documentation for more information
-          /usr/bin/make -j$(nproc) -f debian/rules "${BUILD_TARGET}" BUILD_TYPE="${TYPE}"
+          # BUILD_TARGETS holds one or more space-separated make goals, so it must stay
+          # unquoted here to be word-split into separate targets.
+          # shellcheck disable=SC2086
+          /usr/bin/make -j$(nproc) -f debian/rules ${BUILD_TARGETS} BUILD_TYPE="${TYPE}"
 
           if [ "${TYPE}" = "DEBUG" ] && [ -f "${DSC}.bak" ]; then
               mv "${DSC}.bak" "${DSC}"
           fi
 
-          cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.4MB${SUFFIX}.fd"
-          cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB${SUFFIX}.fd"
+          if [ -n "${SRC_CODE}" ] && [ -n "${DST_CODE}" ]; then
+              cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_CODE}${SUFFIX}.fd"
+          fi
+          cp "${SRC_DIR}/${SRC_CODE_NOSB}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_CODE_NOSB}${SUFFIX}.fd"
+          cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS}${SUFFIX}.fd"
 
-          if [ "${TYPE}" = "RELEASE" ]; then
-               cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.ms.fd"
+          if [ "${TYPE}" = "RELEASE" ] && [ -n "${SRC_VARS_MS}" ] && [ -n "${DST_VARS_MS}" ]; then
+               cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS_MS}.fd"
           fi
       }
 
@@ -555,7 +579,7 @@ parts:
       fi
 
       # Cleanup debug vars
-      rm -f "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.debug.fd"
+      rm -f "${CRAFT_PART_INSTALL}/share/qemu/${DST_VARS}.debug.fd"
     prime:
       - share/qemu/*
 

--- a/test/suites/vm.sh
+++ b/test/suites/vm.sh
@@ -10,6 +10,72 @@ _boot_mode() {
   lxc delete -f v1
 }
 
+# _nvram_rename checks that an existing VM created by an older snap (which shipped its
+# firmware under the OVMF 4MB name) has its NVRAM vars file renamed to the current
+# per-architecture name on start, preserving the existing NVRAM state instead of
+# regenerating it from the firmware template.
+_nvram_rename() {
+  echo "==> VM NVRAM vars file rename on firmware name change"
+
+  # Name used by the previous snap for the secureboot vars file on both x86_64 and arm64.
+  local old_vars="OVMF_VARS.4MB.ms.fd"
+  local inst_dir new_vars old_inode
+
+  lxc launch --vm --empty v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}" --config boot.mode=uefi-secureboot
+  lxc stop -f v1
+
+  # The current name is whatever the running snap shipped (e.g. OVMF_VARS_4M.ms.fd on
+  # x86_64 or AAVMF_VARS.ms.fd on arm64).
+  inst_dir="${LXD_DIR}/virtual-machines/v1"
+  new_vars="$(readlink "${inst_dir}/qemu.nvram" || true)"
+  if [ -n "${new_vars}" ]; then
+    new_vars="$(basename "${new_vars}")"
+  fi
+
+  # Manipulating the stopped VM's NVRAM file requires its instance directory to stay reachable
+  # from the host while the VM is stopped. Storage backends that unmount the VM's filesystem
+  # (config) volume on stop leave qemu.nvram unreachable once stopped, so the
+  # read above comes back empty. The rename itself runs during start (volume
+  # mounted), is backend-agnostic, and was already exercised by the launch
+  # above; only the in-place inode check below needs host access, so skip it
+  # when the stopped directory is not reachable.
+  if [ -z "${new_vars}" ]; then
+    echo "==> SKIP: stopped VM instance directory not reachable on this backend; cannot verify the NVRAM rename in place"
+    lxc delete -f v1
+    return 0
+  fi
+
+  # If the snap still bundles firmware under the old name there is nothing to migrate to yet
+  # (the snapcraft.yaml rename has not reached this snap build). The VM still launched above,
+  # confirming the new binary boots old-named VMs; skip the rest until the snap is updated.
+  if [ "${new_vars}" = "${old_vars}" ]; then
+    echo "==> SKIP: snap still bundles firmware as ${old_vars}; rename migration not applicable yet"
+    lxc delete -f v1
+    return 0
+  fi
+
+  sub_test "Existing NVRAM vars file is renamed (not regenerated) on start"
+
+  # Simulate an instance created by a previous snap that used the old firmware name.
+  mv "${inst_dir}/${new_vars}" "${inst_dir}/${old_vars}"
+  ln -sf "${old_vars}" "${inst_dir}/qemu.nvram"
+  old_inode="$(stat -c %i "${inst_dir}/${old_vars}")"
+
+  lxc start v1
+  lxc stop -f v1
+
+  # The vars file must have been renamed back to the current name and the symlink updated.
+  [ "$(basename "$(readlink "${inst_dir}/qemu.nvram")")" = "${new_vars}" ]
+  [ -f "${inst_dir}/${new_vars}" ]
+  [ ! -e "${inst_dir}/${old_vars}" ]
+
+  # A matching inode proves the file was renamed (preserving NVRAM state) rather than
+  # regenerated from the firmware template.
+  [ "$(stat -c %i "${inst_dir}/${new_vars}")" = "${old_inode}" ]
+
+  lxc delete -f v1
+}
+
 test_vm_empty() {
   if [ "${LXD_TMPFS:-0}" = "1" ] && ! runsMinimumKernel 6.6; then
     export TEST_UNMET_REQUIREMENT="QEMU requires direct-io support which requires a kernel >= 6.6 for tmpfs support (LXD_TMPFS=${LXD_TMPFS})"
@@ -201,4 +267,7 @@ test_vm_pcie_bus() {
 test_snap_vm_empty() {
   # useful to test snap provided BIOS boot
   _boot_mode
+
+  # The NVRAM vars file rename migration only happens inside the snap.
+  _nvram_rename
 }


### PR DESCRIPTION
#17729 has 2 sides:

1. Every few boots, there is a unusually slow boot
2. The unusually slow boot is accompanied with all the vCPUs pegged at 100% usage

1) still occurs as there is no way around the NVRAM GC activity every few boots (~32-38) (except `boot.mode=bios`).
2) is addressed by switching to `boot.mode=uefi-nosecureboot` which prevents the slow boot (NVRAM GC) from pegging all the vCPUs as there is no SMM rendez-vous forcing all other cores going into busy-wait loops.