### PR TITLE
Adjust ZFS promote tests to better represent our use case

### DIFF
--- a/test/suites/storage_volume_initial_config.sh
+++ b/test/suites/storage_volume_initial_config.sh
@@ -138,79 +138,163 @@ test_storage_volume_initial_config() {
     lxc launch "${image}" c --no-profiles --storage "${pool}"
     [ "$(! "${_LXC}" config device set c root initial.zfs.promote=true 2>&1 1>/dev/null)" = 'Error: Device "root" initial configuration "initial.zfs.promote" cannot be added once the instance is created' ]
 
+    imagesnap="${pool}/images/$(lxc config get c volatile.base_image)@readonly"
+    has_origin() {
+      if [ "$2" = image ]; then
+        expected="^${imagesnap}\$"
+      else
+        expected="^${pool}/containers/$2@copy-"
+      fi
+      zfs get origin "${pool}/containers/$1" -H -o value | grep "$expected"
+    }
+
     # > Check that container's origin is the base image snapshot.
-    [ "$(zfs get origin "${pool}/containers/c" -H -o value)" = "${pool}/images/$(lxc config get c volatile.base_image)@readonly" ]
-
-    # > Create a clone of the container as a backup for restore later. Ensure a new volatile.uuid is generated.
-    lxc copy c c-backup --refresh -c "volatile.uuid=$(uuidgen)" -d root,initial.zfs.promote=true
-    [ "$(lxc config get c volatile.uuid)" != "$(lxc config get c-backup volatile.uuid)" ]
-
-    # > Check that the c container has a ZFS origin of c-backup copy snapshot prefix.
-    zfs get origin "${pool}/containers/c" -H -o value | grep "^${pool}/containers/c-backup@copy-"
+    has_origin c image
 
     # > Create a snapshot of the container to check that after promotion is not allowed with snapshots present.
     lxc snapshot c snap0
     # > Check that a container with snapshots cannot be promoted.
-    [ "$(! "${_LXC}" copy c c-save1 --refresh -c "volatile.uuid=$(uuidgen)" -d root,initial.zfs.promote=true 2>&1 1>/dev/null)" = 'Error: Create instance from copy: Cannot promote volume when source volume has snapshots or is a snapshot' ]
+    [ "$(! "${_LXC}" copy c c-save1 -d root,initial.zfs.promote=true 2>&1 1>/dev/null)" = 'Error: Create instance from copy: Cannot promote volume when source volume has snapshots or is a snapshot' ]
     lxc delete c/snap0
 
-    # > Add some data to the container and create a ZFS promoted saved point with a new volatile.uuid.
+    # > Add some data to the container and create a ZFS promoted saved point.
     lxc exec c -- touch /root/testfile1
-    lxc copy c c-save1 --refresh -c "volatile.uuid=$(uuidgen)" -d root,initial.zfs.promote=true
-    [ "$(lxc config get c volatile.uuid)" != "$(lxc config get c-save1 volatile.uuid)" ]
+    lxc copy c c-save1 -d root,initial.zfs.promote=true
 
-    # > Check that the c container has a ZFS origin of c-save1 copy snapshot prefix.
-    zfs get origin "${pool}/containers/c" -H -o value | grep "^${pool}/containers/c-save1@copy-"
+    # > Check that the c container has a ZFS origin of c-save1, which takes c's place.
+    has_origin c c-save1
+    has_origin c-save1 image
 
-    # > Add some more data to the container and create a 2nd ZFS promoted saved point with a new volatile.uuid.
+    # > Add some more data to the container and create a 2nd ZFS promoted saved point.
     lxc exec c -- touch /root/testfile2
-    lxc copy c c-save2 --refresh -c "volatile.uuid=$(uuidgen)" -d root,initial.zfs.promote=true
-    [ "$(lxc config get c volatile.uuid)" != "$(lxc config get c-save2 volatile.uuid)" ]
+    lxc copy c c-save2 -d root,initial.zfs.promote=true
 
-    # > Check that the c container has a ZFS origin of c-save2 copy snapshot prefix.
-    zfs get origin "${pool}/containers/c" -H -o value | grep "^${pool}/containers/c-save2@copy-"
+    # > Check that the c container has a ZFS origin of c-save2, which takes c's place.
+    has_origin c c-save2
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
 
     # > Now create new container from the save points and check their data is present.
     lxc copy c-save1 c-restore1
-    zfs get origin "${pool}/containers/c-restore1" -H -o value | grep "^${pool}/containers/c-save1@copy-"
-    [ "$(lxc config get c-save1  volatile.uuid)" != "$(lxc config get c-restore1 volatile.uuid)" ]
-    lxc start c-restore1
-    lxc exec c-restore1 -- test -f /root/testfile1
-    ! lxc exec c-restore1 -- test -f /root/testfile2 || false
-    lxc delete -f c-restore1
+    has_origin c-restore1 c-save1
+    has_origin c c-save2
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+    lxc file delete c-restore1/root/testfile1
+    ! lxc file delete c-restore1/root/testfile2 || false
 
     lxc copy c-save2 c-restore2
-    zfs get origin "${pool}/containers/c-restore2" -H -o value | grep "^${pool}/containers/c-save2@copy-"
-    [ "$(lxc config get c-save2  volatile.uuid)" != "$(lxc config get c-restore2 volatile.uuid)" ]
-    lxc start c-restore2
-    lxc exec c-restore2 -- test -f /root/testfile1
-    lxc exec c-restore2 -- test -f /root/testfile2
-    lxc delete -f c-restore2
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c c-save2
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+    lxc file delete c-restore2/root/testfile1
+    lxc file delete c-restore2/root/testfile2
 
-    # > Let's imagine something went wrong creating the 3rd save point and we need to restore from the backup (keeping the current volatile.uuid).
-    lxc stop -f c
+    # > Create a clone of the c container as a backup for restore later.
+    lxc stop --force c
+    lxc copy c c-backup -d root,initial.zfs.promote=true
+
+    # > Check that the c container has a ZFS origin of c-backup, which takes c's place.
+    has_origin c c-backup
+    has_origin c-backup c-save2
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+
+    # > Now restore the container from a save point and check its data is present.
     cUUID=$(lxc config get c volatile.uuid)
-    lxc rebuild "${image}" c
+    lxc copy --refresh -c "volatile.uuid=${cUUID}" c-save1 c
+    [ "$(lxc config get c volatile.uuid)" = "${cUUID}" ]
+    has_origin c c-save1
+    has_origin c-backup c-save2
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+    lxc start c
+    lxc exec c -- test -f /root/testfile1
+    lxc exec c -- test ! -f /root/testfile2
 
     # > Create a 3rd ZFS promoted saved point from the rebuilt container.
-    lxc copy c c-save3 --refresh -c "volatile.uuid=$(uuidgen)" -d root,initial.zfs.promote=true
-    [ "$(lxc config get c volatile.uuid)" != "$(lxc config get c-save3 volatile.uuid)" ]
+    lxc copy c c-save3 -d root,initial.zfs.promote=true
+    # > Check that the c container has a ZFS origin of c-save3, which takes c's place.
+    has_origin c c-save3
+    has_origin c-save3 c-save1
+    has_origin c-backup c-save2
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
 
-    # > Check that the c container has a ZFS origin of c-save3 copy snapshot prefix.
-    zfs get origin "${pool}/containers/c" -H -o value | grep "^${pool}/containers/c-save3@copy-"
-
-    # > Now restore from backup.
-    lxc copy c-backup c --refresh -c "volatile.uuid=${cUUID}" -d root,initial.zfs.promote=true
+    # > Let's imagine something went wrong creating the 4th save point and we need to restore from the backup.
+    lxc stop --force c
+    lxc copy --refresh -c "volatile.uuid=${cUUID}" -d root,initial.zfs.promote=true c-backup c
+    [ "$(lxc config get c volatile.uuid)" = "${cUUID}" ]
+    has_origin c c-save2
+    has_origin c-save3 c-save1
+    has_origin c-backup c
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+    lxc start c
+    lxc exec c -- test -f /root/testfile1
+    lxc exec c -- test -f /root/testfile2
     lxc delete c-backup
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
 
-    # > Check that container's origin is the base image snapshot.
-    [ "$(zfs get origin "${pool}/containers/c" -H -o value)" = "${pool}/images/$(lxc config get c volatile.base_image)@readonly" ]
+    # > Try again from scratch.
+    lxc stop --force c
+    lxc copy c c-backup -d root,initial.zfs.promote=true
+    lxc rebuild "${image}" c
+    [ "$(lxc config get c volatile.uuid)" = "${cUUID}" ]
+    has_origin c image
+    has_origin c-backup c-save2
+    has_origin c-save3 c-save1
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+    lxc start c
+    lxc exec c -- test ! -f /root/testfile1
+    lxc exec c -- test ! -f /root/testfile2
 
-    # > Cleanup created containers.
-    lxc delete -f c c-save1 c-save2 c-save3
+    # > Create a new version of the c-save1 saved point from the rebuilt container.
+    lxc copy c c-save1b -d root,initial.zfs.promote=true
+    has_origin c c-save1b
+    has_origin c-save1b image
+    has_origin c-backup c-save2
+    has_origin c-save3 c-save1
+    has_origin c-restore2 c-save2
+    has_origin c-restore1 c-save1
+    has_origin c-save2 c-save1
+    has_origin c-save1 image
+
+    # > Assuming everything went well, we can remove the backup.
+    lxc delete c-backup
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
+
+    # > At some point we can remove the cloned containers.
+    lxc delete c-restore1 c-restore2
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
+
+    # > At some later stage we'll remove unused save points.
+    lxc delete c-save1 c-save2 c-save3
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
+
+    # > Eventually we remove the container.
+    lxc delete -f c
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
+
+    # > Then remove the last save point.
+    lxc delete c-save1b
+    [ "$(zfs list -H -r -t all -o name "${pool}/deleted/containers" | wc -l)" -eq 1 ]
 
     # > Check only the pool level ZFS datasets and snapshots remain after deleting containers.
-    [ "$(zfs list -H -t all -o name | grep -c "^${pool}")" = "12" ]
+    [ "$(zfs list -H -r -t all -o name "${pool}" | wc -l)" -eq 12 ]
   fi
 
   # Cleanup


### PR DESCRIPTION
@tomponline Here is how I think the tests should work, let me know what you think. With some luck it might work as-is but I haven't tried it yet.

Main changes:
- Only use `--refresh` if the target instance exists. We have our own tests to ensure we merge the configs correctly, so it doesn't matter too much what these tests do. Our merge strategy is closer to `lxc copy` than `lxc copy --refresh`.
- Create the backup later on. Not much point backing up a freshly created container.
- Test all origins after making a new copy. Probably not needed but might as well.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.