### PR TITLE
lxd: Rename "manual roles" to "custom roles" for cluster member roles

### DIFF
--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -772,30 +772,30 @@ func updateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Reque
 	return response.EmptySyncResponse
 }
 
-// clusterRolesChanged checks whether manual roles have changed between oldRoles and newRoles.
+// clusterRolesChanged checks whether custom roles have changed between oldRoles and newRoles.
 func clusterRolesChanged(oldRoles []db.ClusterRole, newRoles []db.ClusterRole) bool {
-	// Get manual roles to check against.
-	manualRoles := slices.Collect(maps.Values(db.ClusterRoles[db.ClusterRoleClassManual]))
+	// Get custom roles to check against.
+	customRoles := slices.Collect(maps.Values(db.ClusterRoles[db.ClusterRoleClassCustom]))
 
-	// Filter roles to only manual (user-assignable) roles.
-	newManualRoles := make([]db.ClusterRole, 0, len(newRoles))
-	oldManualRoles := make([]db.ClusterRole, 0, len(oldRoles))
+	// Filter roles to only custom (user-assignable) roles.
+	newCustomRoles := make([]db.ClusterRole, 0, len(newRoles))
+	oldCustomRoles := make([]db.ClusterRole, 0, len(oldRoles))
 
 	for _, role := range newRoles {
-		if slices.Contains(manualRoles, role) {
-			newManualRoles = append(newManualRoles, role)
+		if slices.Contains(customRoles, role) {
+			newCustomRoles = append(newCustomRoles, role)
 		}
 	}
 
 	for _, role := range oldRoles {
-		if slices.Contains(manualRoles, role) {
-			oldManualRoles = append(oldManualRoles, role)
+		if slices.Contains(customRoles, role) {
+			oldCustomRoles = append(oldCustomRoles, role)
 		}
 	}
 
 	// Sort old and new roles for comparison.
-	sortedOld := slices.Sorted(slices.Values(oldManualRoles))
-	sortedNew := slices.Sorted(slices.Values(newManualRoles))
+	sortedOld := slices.Sorted(slices.Values(oldCustomRoles))
+	sortedNew := slices.Sorted(slices.Values(newCustomRoles))
 
 	return !slices.Equal(sortedOld, sortedNew)
 }
@@ -813,7 +813,7 @@ func validateClusterMemberRoles(currentRoles []string, requestedRoles []string) 
 		return slices.Contains(slices.Collect(maps.Values(db.ClusterRoles[db.ClusterRoleClassAutomatic])), db.ClusterRole(role))
 	}
 
-	// Used to check if a role exists in either manual or automatic roles.
+	// Used to check if a role exists in either custom or automatic roles.
 	isValidRole := func(role string) bool {
 		for _, roles := range db.ClusterRoles {
 			if slices.Contains(slices.Collect(maps.Values(roles)), db.ClusterRole(role)) {
@@ -852,7 +852,7 @@ func validateClusterMemberRoles(currentRoles []string, requestedRoles []string) 
 			return nil, fmt.Errorf("Invalid cluster role %q", role)
 		}
 
-		// Manual roles are always allowed.
+		// Custom roles are always allowed.
 		if !isAutomaticRole(role) {
 			continue
 		}

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -32,8 +32,8 @@ const (
 	// ClusterRoleClassAutomatic represents roles that are automatically assigned by LXD.
 	ClusterRoleClassAutomatic ClusterRoleClass = iota
 
-	// ClusterRoleClassManual represents roles that can be manually assigned.
-	ClusterRoleClassManual
+	// ClusterRoleClassCustom represents roles that can be custom assigned.
+	ClusterRoleClassCustom
 )
 
 // ClusterRoleDatabaseVoter represents the database voter role in a cluster.
@@ -56,7 +56,7 @@ const ClusterRoleOVNChassis = ClusterRole("ovn-chassis")
 
 // ClusterRoles maps role classes to their respective role definitions.
 // Automatic roles are managed by LXD and cannot be manually modified.
-// Manual roles can be assigned and removed by users via the API.
+// Custom roles can be assigned and removed by users via the API.
 var ClusterRoles = map[ClusterRoleClass]map[int]ClusterRole{
 	// Automatic roles are not stored in the database, so the keys are not IDs.
 	ClusterRoleClassAutomatic: {
@@ -64,8 +64,8 @@ var ClusterRoles = map[ClusterRoleClass]map[int]ClusterRole{
 		2: ClusterRoleDatabaseStandBy,
 		3: ClusterRoleDatabaseLeader,
 	},
-	// Manual cluster roles are stored in the database and are therefore keyed by their respective IDs.
-	ClusterRoleClassManual: {
+	// Custom cluster roles are stored in the database and are therefore keyed by their respective IDs.
+	ClusterRoleClassCustom: {
 		2: ClusterRoleOVNChassis,
 		3: ClusterRoleControlPlane,
 	},
@@ -450,7 +450,7 @@ func (c *ClusterTx) nodes(ctx context.Context, pending bool, where string, args 
 			nodeRoles[nodeID] = []ClusterRole{}
 		}
 
-		roleName := string(ClusterRoles[ClusterRoleClassManual][role])
+		roleName := string(ClusterRoles[ClusterRoleClassCustom][role])
 		nodeRoles[nodeID] = append(nodeRoles[nodeID], ClusterRole(roleName))
 
 		return nil
@@ -631,16 +631,16 @@ func (c *ClusterTx) UpdateNodeConfig(ctx context.Context, id int64, config map[s
 }
 
 // UpdateNodeRoles changes the list of roles on a member.
-// Only manual (user-assignable) roles are stored in the database.
+// Only custom (user-assignable) roles are stored in the database.
 // Automatic roles are managed by Raft and filtered out.
 // Callers are expected to validate roles before calling this function.
 func (c *ClusterTx) UpdateNodeRoles(id int64, roles []ClusterRole) error {
 	// Translate role names to IDs
 	roleIDs := []int{}
 	for _, role := range roles {
-		// Find the role ID for the given manual role.
-		for id, manualRole := range ClusterRoles[ClusterRoleClassManual] {
-			if role == manualRole {
+		// Find the role ID for the given custom role.
+		for id, customRole := range ClusterRoles[ClusterRoleClassCustom] {
+			if role == customRole {
 				roleIDs = append(roleIDs, id)
 				break
 			}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4489,11 +4489,11 @@ test_clustering_roles() {
   # Reject duplicate roles in request
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 control-plane,control-plane 2>&1)" = 'Error: Duplicate role "control-plane" in request' ]
 
-  # Accept valid manual role addition
+  # Accept valid custom role addition
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 control-plane
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF -- "- control-plane"
 
-  # Accept adding multiple manual roles
+  # Accept adding multiple custom roles
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 ovn-chassis
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF -- "- control-plane"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF -- "- ovn-chassis"
@@ -4501,7 +4501,7 @@ test_clustering_roles() {
   # Reject adding role member already has
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 control-plane 2>&1)" = 'Error: Member "node1" already has role "control-plane"' ]
 
-  # Accept removing manual role
+  # Accept removing custom role
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster role remove node1 control-plane
   ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF -- "- control-plane" || false
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF -- "- ovn-chassis"


### PR DESCRIPTION
Closes #17935.
