### PR TITLE
Fix: Recover from phantom DB entries and orphaned storage after interrupted cluster migrations

### DIFF
--- a/lxd/migration_connection.go
+++ b/lxd/migration_connection.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/tcp"
 	"github.com/canonical/lxd/shared/ws"
 )
 
@@ -97,14 +95,12 @@ func (c *migrationConn) AcceptIncoming(r *http.Request, w http.ResponseWriter) e
 		return fmt.Errorf("Failed upgrading incoming request to websocket: %w", err)
 	}
 
-	// Set TCP timeout options.
-	remoteTCP, err := tcp.ExtractConn(c.conn.NetConn())
-	if err == nil && remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP, 0)
-		if err != nil {
-			logger.Warn("Failed setting TCP timeouts on incoming websocket connection", logger.Ctx{"err": err})
-		}
-	}
+	// Enable TCP keepalive and periodic websocket pings so that a silently-dead
+	// connection (e.g. after a network partition) is detected within ~15 seconds
+	// rather than relying solely on TCP retransmission timeouts, which can take
+	// minutes. This ensures migration failures are surfaced quickly so cleanup
+	// can happen on both sides while LXD is still running.
+	ws.StartKeepAlive(c.conn)
 
 	close(c.connected)
 
@@ -138,6 +134,11 @@ func (c *migrationConn) WebSocket(ctx context.Context) (*websocket.Conn, error) 
 			c.mu.Unlock()
 			return nil, err
 		}
+
+		// Enable keepalive so that a dead outgoing connection is detected quickly.
+		// Previously outgoing connections had no TCP timeouts at all,
+		// so the dialing side could block indefinitely on a network partition.
+		ws.StartKeepAlive(c.conn)
 
 		c.mu.Unlock()
 		return c.conn, nil

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -150,6 +150,36 @@ test_clustering_move() {
 
   LXD_DIR="${LXD_ONE_DIR}" lxc profile delete prof1
 
+  sub_test "Phantom volume DB entry error after failed migration"
+  # When a cluster move fails mid-transfer (e.g. due to network disruption), LXD may leave a
+  # phantom storage_volumes DB entry on the target node if the target's revert chain could not
+  # reach the distributed DB while the network was down. Simulate this by directly inserting an
+  # orphaned row on node2 (no corresponding storage backing exists there), then verify LXD
+  # returns an actionable error message telling the administrator how to fix it.
+
+  # c1 is on node1 at this point.
+
+  # Inject a phantom storage_volumes row for c1 on node2, mimicking what is left behind
+  # when a migration fails mid-transfer and the target cannot run its DB revert.
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "INSERT INTO storage_volumes (name, storage_pool_id, node_id, type, description, project_id) SELECT 'c1', (SELECT id FROM storage_pools WHERE name='data'), (SELECT id FROM nodes WHERE name='node2'), 0, '', (SELECT id FROM projects WHERE name='default')"
+
+  # Attempting to migrate c1 to node2 must fail because a volume DB entry
+  # already exists on node2 but has no backing storage.
+  exit_code=0
+  err_msg="$(LXD_DIR="${LXD_ONE_DIR}" lxc move cluster:c1 --target node2 2>&1)" || exit_code=$?
+  [[ "${exit_code}" -ne 0 ]]
+  [[ "${err_msg}" == *"exists in database but not on storage"* ]]
+
+  # Remove the phantom entry as directed by the error message.
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "DELETE FROM storage_volumes WHERE name='c1' AND node_id=(SELECT id FROM nodes WHERE name='node2') AND storage_pool_id=(SELECT id FROM storage_pools WHERE name='data')"
+
+  # After removing the phantom, migration to node2 succeeds.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move cluster:c1 --target node2
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list --format csv --columns L cluster:c1)" = "node2" ]
+
+  # Restore c1 to node1 for the subsequent tests.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move cluster:c1 --target node1
+
   echo "==> Project restriction tests"
   # At this stage we have:
   # - node1 in group foobar1,default


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Problem
When a cluster migration is interrupted mid-transfer (network drop, kill -9 on target), phantom storage_volumes records can be left in the global database with no corresponding storage on disk (as mentioned in #17787).

On retry, the consistency checks in `CreateInstanceFromMigration` and `CreateCustomVolumeFromMigration` return "Volume exists in database but not on storage", permanently blocking migration for the affected instance.

Separately, dead migration connections were not detected promptly, leaving migrations hanging for minutes before timing out.

## Fix
- Fast dead-connection detection (`lxd/migration_connection.go`)
Enable `ws.StartKeepAlive()` on both incoming (`AcceptIncoming`) and outgoing (`WebSocket`) migration WebSocket connections. Dead connections are now detected in ~15 seconds instead of relying on TCP timeout defaults.

- Integration test (`test/suites/clustering_move.sh`)

Add a sub-test under `test_clustering_move that`:
- Injects a phantom storage_volumes row via `lxd sql global`
- Verifies the migration fails with the expected error.
- Removes the phantom row.
- Verifies migration then succeeds.

## What this does NOT do
This PR does not auto-repair storage inconsistencies. [A follow-up PR](https://github.com/canonical/lxd/pull/18101) will improve the error message with recovery guidance and add documentation for the manual cleanup steps.

Fixes #17787