### PR TITLE
doc/howto/instances_console: make it explicit that `--console=vga` is for VM only

### DIFF
--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -23,7 +23,7 @@ To show new log messages (only for containers), pass the `--show-log` flag:
 You can also immediately attach to the console when you start your instance:
 
     lxc start <instance_name> --console
-    lxc start <instance_name> --console=vga
+    lxc start <instance_name> --console=vga # VM only
 
 ```{tip}
 To exit the console, enter {kbd}`Ctrl`+{kbd}`a` {kbd}`q`.


### PR DESCRIPTION
Suggested by @setuid on MM