### PR TITLE
lxd/cluster: Handle certificate conflict errors when gaining trust

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -144,12 +144,79 @@ func SetupTrust(serverCert *shared.CertInfo, clusterPut api.ClusterPut) error {
 		TrustToken:  clusterPut.ClusterToken,
 	}
 
-	err = target.CreateCertificate(post)
-	if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
-		return fmt.Errorf("Failed adding server cert to cluster: %w", err)
+	createCertificateError := target.CreateCertificate(post)
+	if createCertificateError != nil {
+		// If there was a conflict, it could be because either a) there is already a certificate with the same fingerprint,
+		// or b) there is a certificate with the same name.
+		if api.StatusErrorCheck(createCertificateError, http.StatusConflict) {
+			// If there is already a certificate with the same fingerprint then we are already trusted, but the certificate type may not be correct.
+			// Get the server info to check if we're trusted.
+			server, _, err := target.GetServer()
+			if err != nil {
+				return fmt.Errorf("Failed getting server information: %w", err)
+			}
+
+			// If trusted, check that the certificate is identical to the one we are trying to create.
+			// This could be from a previous failed cluster join.
+			if server.Auth == api.AuthTrusted {
+				// Regardless of privilege, we can always view our own certificate.
+				existingCert, _, err := target.GetCertificate(cert.Fingerprint)
+				if err != nil {
+					return fmt.Errorf("Failed validating existing certificate: %w", err)
+				}
+
+				// If the existing certificate is identical, then we're done.
+				if certificatesAreEqual(*existingCert, *cert) {
+					return nil
+				}
+			}
+		}
+
+		// If there was a conflict error on identity name, or the certificate was not identical, return original error.
+		return fmt.Errorf("Failed adding server cert to cluster: %w", createCertificateError)
 	}
 
 	return nil
+}
+
+// certificatesAreEqual returns true if the given certificates are identical and false otherwise.
+func certificatesAreEqual(certA api.Certificate, certB api.Certificate) bool {
+	// Fingerprint must be equal.
+	if certA.Fingerprint != certB.Fingerprint {
+		return false
+	}
+
+	// Type must be equal.
+	if certA.Type != certB.Type {
+		return false
+	}
+
+	// Both must have the same restricted value.
+	if certA.Restricted != certB.Restricted {
+		return false
+	}
+
+	// Name must be equal.
+	if certA.Name != certB.Name {
+		return false
+	}
+
+	// Project slices must have the same length.
+	if len(certA.Projects) != len(certB.Projects) {
+		return false
+	}
+
+	// If there are projects, then the slices must contain the same elements.
+	if len(certA.Projects) > 0 && len(shared.RemoveElementsFromSlice(certA.Projects, certB.Projects...)) != 0 {
+		return false
+	}
+
+	// We've already checked the fingerprint, but check the certificate anyway in case it was modified.
+	if certA.Certificate != certB.Certificate {
+		return false
+	}
+
+	return true
 }
 
 // UpdateTrust ensures that the supplied certificate is stored in the target trust store with the correct name

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -13,6 +13,7 @@ readonly test_group_cluster=(
     "clustering_profiles"
     "clustering_projects_force_delete"
     "clustering_join_api"
+    "clustering_join_certificate_conflict"
     "clustering_shutdown_nodes"
     "clustering_projects"
     "clustering_metrics"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1923,6 +1923,132 @@ test_clustering_join_api() {
   kill_lxd "${LXD_ONE_DIR}"
 }
 
+test_clustering_join_certificate_conflict() {
+  local cert_json node2_cert_b64
+
+  # Sub-test 1: Pre-staged cert is identical to what join would create → join succeeds.
+  sub_test "Join succeeds when matching server cert already trusted"
+
+  spawn_lxd_and_bootstrap_cluster
+
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  # shellcheck disable=SC2154
+  ns2="${prefix}2"
+  LXD_NETNS="${ns2}" spawn_lxd "${LXD_TWO_DIR}" false
+
+  cert_json="$(cert_to_json "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Extract node2's server cert in DER base64 format, matching GenerateTrustCertificate's output.
+  node2_cert_b64="$(openssl x509 -in "${LXD_TWO_DIR}/server.crt" -outform DER | base64 | tr -d '\n')"
+
+  # Pre-stage node2's certificate on node1 as a server cert with the correct name.
+  curl --silent --unix-socket "${LXD_ONE_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X POST "lxd/1.0/certificates" \
+    -d '{"type":"server","name":"node2","certificate":"'"${node2_cert_b64}"'"}'
+
+  # Join should succeed because the pre-staged cert is identical to what SetupTrust would create.
+  token="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node2 --quiet)"
+  op="$(curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X PUT "lxd/1.0/cluster" \
+    -d '{"server_name":"node2","enabled":true,"member_config":[{"entity":"storage-pool","name":"data","key":"source","value":""}],"server_address":"100.64.1.102:8443","cluster_address":"100.64.1.101:8443","cluster_certificate":'"${cert_json}"',"cluster_token":"'"${token}"'"}' \
+    | jq --exit-status --raw-output '.operation')"
+  curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" --fail-with-body "lxd${op}/wait"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -F 'message: Fully operational'
+
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+
+  # Sub-test 2: Pre-staged cert has wrong type → join fails.
+  sub_test "Join fails when pre-staged cert has wrong type"
+
+  spawn_lxd_and_bootstrap_cluster
+
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  LXD_NETNS="${ns2}" spawn_lxd "${LXD_TWO_DIR}" false
+
+  cert_json="$(cert_to_json "${LXD_ONE_DIR}/cluster.crt")"
+  node2_cert_b64="$(openssl x509 -in "${LXD_TWO_DIR}/server.crt" -outform DER | base64 | tr -d '\n')"
+
+  # Pre-stage node2's cert as a client cert instead of a server cert.
+  curl --silent --unix-socket "${LXD_ONE_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X POST "lxd/1.0/certificates" \
+    -d '{"type":"client","name":"node2","certificate":"'"${node2_cert_b64}"'"}'
+
+  # Join should fail because the pre-staged cert type does not match the required server type.
+  token="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node2 --quiet)"
+  op="$(curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X PUT "lxd/1.0/cluster" \
+    -d '{"server_name":"node2","enabled":true,"member_config":[{"entity":"storage-pool","name":"data","key":"source","value":""}],"server_address":"100.64.1.102:8443","cluster_address":"100.64.1.101:8443","cluster_certificate":'"${cert_json}"',"cluster_token":"'"${token}"'"}' \
+    | jq --exit-status --raw-output '.operation')"
+  curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" "lxd${op}/wait" | jq --exit-status '.error_code != 0'
+
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+
+  # Sub-test 3: Different cert, same name → name collision → join fails.
+  sub_test "Join fails when a different cert is pre-staged with the same name"
+
+  spawn_lxd_and_bootstrap_cluster
+
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  LXD_NETNS="${ns2}" spawn_lxd "${LXD_TWO_DIR}" false
+
+  cert_json="$(cert_to_json "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Generate a throwaway cert with a different fingerprint.
+  gen_cert_and_key "node2-different"
+  different_cert_b64="$(openssl x509 -in "${LXD_CONF}/node2-different.crt" -outform DER | base64 | tr -d '\n')"
+
+  # Pre-stage the different cert under the name "node2" on node1.
+  curl --silent --unix-socket "${LXD_ONE_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X POST "lxd/1.0/certificates" \
+    -d '{"type":"server","name":"node2","certificate":"'"${different_cert_b64}"'"}'
+
+  # Join should fail because there is a name collision with a cert of a different fingerprint.
+  token="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node2 --quiet)"
+  op="$(curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" \
+    --fail-with-body -H 'Content-Type: application/json' -X PUT "lxd/1.0/cluster" \
+    -d '{"server_name":"node2","enabled":true,"member_config":[{"entity":"storage-pool","name":"data","key":"source","value":""}],"server_address":"100.64.1.102:8443","cluster_address":"100.64.1.101:8443","cluster_certificate":'"${cert_json}"',"cluster_token":"'"${token}"'"}' \
+    | jq --exit-status --raw-output '.operation')"
+  curl --silent --unix-socket "${LXD_TWO_DIR}/unix.socket" "lxd${op}/wait" | jq --exit-status '.error_code != 0'
+
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+}
+
 test_clustering_shutdown_nodes() {
   spawn_lxd_and_bootstrap_cluster
 


### PR DESCRIPTION
Previously conflict errors were ignored and the client assumed that if there was a conflict, then the certificate was already trusted with the correct privilege.

This is not necessarily the case, so we should check if we are trusted and enforce that if we are already trusted, then the certificate on the cluster we're joining is identical to the one we just tried to create.

I've created this as draft because I'm not exactly certain how best to test this without copying/mangling the `spawn_lxd_and_join_cluster` util, as I'll need to create a network namespace for the joining member but I need the member certificate to already be trusted and correct, trusted but incorrect, or untrusted but with a pre-existing certificate with the same name (cc @simondeziel).

PS I've created this as follow up to https://discourse.ubuntu.com/t/cannot-join-a-new-vm-to-the-cluster/79009/6

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
