### PR TITLE
doc: prevent indexing older versions

### DIFF
--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -1,0 +1,9 @@
+{% extends "!base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing for older RTD versions defined in conf.py (noindex_versions). #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -446,3 +446,14 @@ with open(".sphinx/latex_elements_template.txt", "rt") as file:
     latex_config = file.read()
 
 latex_elements = ast.literal_eval(latex_config.replace("$PROJECT", project))
+
+
+###########################################
+### Prevent indexing of older docs versions
+###########################################
+
+# Add RTD docs version slugs for versions that should not be indexed by search engines
+noindex_versions = {"stable-5.0", "stable-4.0"}
+
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+html_context["seo_noindex"] = rtd_version in noindex_versions


### PR DESCRIPTION
This sets up code for preventing search engines from indexing certain versions (tracked in `doc/conf.py` in the `noindex-versions` set) by inserting `<meta name="robots" content="noindex">` into the `<head>`s of those versions' pages. See [google documentation](https://developers.google.com/search/docs/crawling-indexing/block-indexing).

The intent is to prevent the `stable-5.0` and `stable-4.0` docs from appearing in search results; currently they tend to appear higher in search results than the `latest` or `stable-5.21` docs. Users will still be able to access those docs sets from the RTD flyout menu at the bottom right corner of the docs (or existing links/bookmarks), but we don't want them to accidentally go to the old docs from search results.

I am pushing this change into `main` for consistency and future-proofing; however, for this to work, this must be backported into the branches corresponding to the docs versions to be noindexed (`stable-5.0` and `stable-4.0` - with slight modifications due to different docs structures in those versions) and those docs must be rebuilt afterward. 