### PR TITLE
chore: add optional version pinning to install-trivy action

### DIFF
--- a/.github/actions/install-trivy/action.yml
+++ b/.github/actions/install-trivy/action.yml
@@ -1,6 +1,12 @@
 name: Install Trivy
 description: Installs Trivy from deb package
 
+inputs:
+  trivy-version:
+    description: "Trivy version to install (e.g. 0.69.3). If empty, installs the latest available version."
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -15,4 +21,8 @@ runs:
         wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
         sudo apt-get update
-        sudo apt-get install trivy
+        if [ -n "${{ inputs.trivy-version }}" ]; then
+          sudo apt-get install -y "trivy=${{ inputs.trivy-version }}"
+        else
+          sudo apt-get install -y trivy
+        fi


### PR DESCRIPTION
## Description

The `install-trivy` composite action currently runs `sudo apt-get install trivy` without pinning a version. This adds an optional `trivy-version` input parameter so callers can pin to a specific version if desired.

### Changes
- Add optional `trivy-version` input (default: empty = latest)
- When set, installs `trivy=<version>` instead of unpinned `trivy`
- Add `-y` flag to `apt-get install` for non-interactive use

### Context
Supply-chain hygiene improvement prompted by [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23). While this repo was not affected by that specific compromise, pinning allows consumers to avoid silently picking up compromised versions in future incidents.

### Backward compatibility
Fully backward compatible — existing callers that don't pass `trivy-version` continue to get the latest version.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.