### PR TITLE
Dell PowerStore storage driver (part 2)

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6412,6 +6412,220 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```
 
 <!-- config group storage-powerflex-volume-conf end -->
+<!-- config group storage-powerstore-pool-conf start -->
+```{config:option} powerstore.discovery storage-powerstore-pool-conf
+:defaultdesc: "the list of discovery addresses"
+:shortdesc: "List of discovery addresses."
+:type: "string"
+A comma-separated list of NVMe or iSCSI discovery addresses.
+```
+
+```{config:option} powerstore.gateway storage-powerstore-pool-conf
+:scope: "global"
+:shortdesc: "Address of the PowerStore Gateway"
+:type: "string"
+
+```
+
+```{config:option} powerstore.gateway.verify storage-powerstore-pool-conf
+:defaultdesc: "`true`"
+:scope: "global"
+:shortdesc: "Whether to verify the PowerStore Gateway's certificate"
+:type: "bool"
+
+```
+
+```{config:option} powerstore.mode storage-powerstore-pool-conf
+:defaultdesc: "the discovered mode"
+:scope: "global"
+:shortdesc: "How volumes are mapped to the local server"
+:type: "string"
+The mode gets discovered automatically if the system provides the necessary kernel modules.
+Supported values are `iscsi` and `nvme`.
+```
+
+```{config:option} powerstore.target storage-powerstore-pool-conf
+:defaultdesc: "the list of target addresses"
+:shortdesc: "List of target addresses."
+:type: "string"
+A comma-separated list of NVMe or iSCSI target addresses. When empty targets are discovered via discovery endpoints.
+```
+
+```{config:option} powerstore.transport storage-powerstore-pool-conf
+:defaultdesc: "the discovered transport"
+:scope: "global"
+:shortdesc: "Transport layer used when transferring volumes data to the local server."
+:type: "string"
+The transport gets discovered automatically if the system provides the necessary kernel modules.
+Supported values are `tcp`.
+```
+
+```{config:option} powerstore.user.name storage-powerstore-pool-conf
+:defaultdesc: "`admin`"
+:scope: "global"
+:shortdesc: "User for PowerStore Gateway authentication"
+:type: "string"
+
+```
+
+```{config:option} powerstore.user.password storage-powerstore-pool-conf
+:scope: "global"
+:shortdesc: "Password for PowerStore Gateway authentication"
+:type: "string"
+
+```
+
+```{config:option} rsync.bwlimit storage-powerstore-pool-conf
+:defaultdesc: "`0` (no limit)"
+:scope: "global"
+:shortdesc: "Upper limit on the socket I/O for `rsync`"
+:type: "string"
+When `rsync` must be used to transfer storage entities, this option specifies the upper limit
+to be placed on the socket I/O.
+```
+
+```{config:option} rsync.compression storage-powerstore-pool-conf
+:defaultdesc: "`true`"
+:scope: "global"
+:shortdesc: "Whether to use compression while migrating storage pools"
+:type: "bool"
+
+```
+
+```{config:option} volume.size storage-powerstore-pool-conf
+:defaultdesc: "`10GiB`"
+:scope: "global"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+```
+
+<!-- config group storage-powerstore-pool-conf end -->
+<!-- config group storage-powerstore-volume-conf start -->
+```{config:option} block.filesystem storage-powerstore-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
+:shortdesc: "File system of the storage volume"
+:type: "string"
+Valid options are: `btrfs`, `ext4`, `xfs`
+If not set, `ext4` is assumed.
+```
+
+```{config:option} block.mount_options storage-powerstore-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
+:shortdesc: "Mount options for block-backed file system volumes"
+:type: "string"
+
+```
+
+```{config:option} security.shared storage-powerstore-volume-conf
+:condition: "virtual-machine or custom block volume"
+:defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
+:shortdesc: "Enable volume sharing"
+:type: "bool"
+Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
+
+```
+
+```{config:option} security.shifted storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-powerstore-volume-conf
+:defaultdesc: "same as `volume.size`"
+:scope: "global"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+```
+
+```{config:option} snapshots.expiry storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
+```
+
+```{config:option} snapshots.schedule storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+```{config:option} volatile.devlxd.owner storage-powerstore-volume-conf
+:defaultdesc: "DevLXD owner identity ID"
+:scope: "global"
+:shortdesc: "The ID of the DevLXD identity which owns the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.idmap.last storage-powerstore-volume-conf
+:condition: "filesystem"
+:shortdesc: "JSON-serialized UID/GID map that has been applied to the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.idmap.next storage-powerstore-volume-conf
+:condition: "filesystem"
+:shortdesc: "JSON-serialized UID/GID map that has been applied to the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.uuid storage-powerstore-volume-conf
+:defaultdesc: "random UUID"
+:scope: "global"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
+```
+
+<!-- config group storage-powerstore-volume-conf end -->
 <!-- config group storage-pure-pool-conf start -->
 ```{config:option} pure.api.token storage-pure-pool-conf
 :shortdesc: "API authorization token for Pure Storage gateway"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7064,6 +7064,234 @@
 				]
 			}
 		},
+		"storage-powerstore": {
+			"pool-conf": {
+				"keys": [
+					{
+						"powerstore.discovery": {
+							"defaultdesc": "the list of discovery addresses",
+							"longdesc": "A comma-separated list of NVMe or iSCSI discovery addresses.",
+							"shortdesc": "List of discovery addresses.",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.gateway": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Address of the PowerStore Gateway",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.gateway.verify": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Whether to verify the PowerStore Gateway's certificate",
+							"type": "bool"
+						}
+					},
+					{
+						"powerstore.mode": {
+							"defaultdesc": "the discovered mode",
+							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nSupported values are `iscsi` and `nvme`.",
+							"scope": "global",
+							"shortdesc": "How volumes are mapped to the local server",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.target": {
+							"defaultdesc": "the list of target addresses",
+							"longdesc": "A comma-separated list of NVMe or iSCSI target addresses. When empty targets are discovered via discovery endpoints.",
+							"shortdesc": "List of target addresses.",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.transport": {
+							"defaultdesc": "the discovered transport",
+							"longdesc": "The transport gets discovered automatically if the system provides the necessary kernel modules.\nSupported values are `tcp`.",
+							"scope": "global",
+							"shortdesc": "Transport layer used when transferring volumes data to the local server.",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.user.name": {
+							"defaultdesc": "`admin`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "User for PowerStore Gateway authentication",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.user.password": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Password for PowerStore Gateway authentication",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.bwlimit": {
+							"defaultdesc": "`0` (no limit)",
+							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"scope": "global",
+							"shortdesc": "Upper limit on the socket I/O for `rsync`",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.compression": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Whether to use compression while migrating storage pools",
+							"type": "bool"
+						}
+					},
+					{
+						"volume.size": {
+							"defaultdesc": "`10GiB`",
+							"longdesc": "The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.",
+							"scope": "global",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"block.filesystem": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.filesystem`",
+							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
+							"shortdesc": "File system of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"block.mount_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.mount_options`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Mount options for block-backed file system volumes",
+							"type": "string"
+						}
+					},
+					{
+						"security.shared": {
+							"condition": "virtual-machine or custom block volume",
+							"defaultdesc": "same as `volume.security.shared` or `false`",
+							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
+							"shortdesc": "Enable volume sharing",
+							"type": "bool"
+						}
+					},
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.",
+							"scope": "global",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.devlxd.owner": {
+							"defaultdesc": "DevLXD owner identity ID",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "The ID of the DevLXD identity which owns the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.idmap.last": {
+							"condition": "filesystem",
+							"longdesc": "",
+							"shortdesc": "JSON-serialized UID/GID map that has been applied to the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.idmap.next": {
+							"condition": "filesystem",
+							"longdesc": "",
+							"shortdesc": "JSON-serialized UID/GID map that has been applied to the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "The volume's UUID",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"storage-pure": {
 			"pool-conf": {
 				"keys": [

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -33,6 +34,11 @@ const (
 // iscsiDiskDevicePrefix is the prefix of the iSCSI disk device name in /dev/disk/by-id/.
 const iscsiDiskDevicePrefix = "scsi-"
 
+const (
+	// ISCSIDefaultPort is the default port number for iSCSI targets.
+	ISCSIDefaultPort = "3260"
+)
+
 var _ Connector = &connectorISCSI{}
 
 type connectorISCSI struct {
@@ -43,7 +49,9 @@ type connectorISCSI struct {
 
 // ISCSIDiscoveryLogRecord represents an ISCSI discovery entry.
 type ISCSIDiscoveryLogRecord struct {
-	IQN string
+	Address        string
+	PortalGroupTag string
+	IQN            string
 }
 
 // Type returns the type of the connector.
@@ -112,6 +120,7 @@ func (c *connectorISCSI) Connect(ctx context.Context, targetQN string, targetAdd
 	// Connects to the provided target address. If the connection is already established,
 	// the session is rescanned to detect new volumes.
 	connectFunc := func(ctx context.Context, s *session, targetAddr string) error {
+		targetAddr = shared.EnsurePort(targetAddr, ISCSIDefaultPort)
 		if s != nil && slices.Contains(s.addresses, targetAddr) {
 			// If connection with the target address is already established,
 			// rescan the session to ensure new volumes are detected.
@@ -261,7 +270,15 @@ func (c *connectorISCSI) findSession(targetQN string) (*session, error) {
 			continue
 		}
 
-		addr := strings.TrimSpace(string(addrBytes))
+		// Get port of an active iSCSI connection.
+		portPath := filepath.Join(connBasePath, conn.Name(), "port")
+		portBytes, err := os.ReadFile(portPath)
+		if err != nil {
+			// In case of an error when reading the port, use default port.
+			portBytes = []byte(ISCSIDefaultPort)
+		}
+
+		addr := net.JoinHostPort(strings.TrimSpace(string(addrBytes)), strings.TrimSpace(string(portBytes)))
 		session.addresses = append(session.addresses, addr)
 	}
 
@@ -280,6 +297,7 @@ func (c *connectorISCSI) Discover(ctx context.Context, targetAddresses ...string
 
 	result := make([]any, 0)
 	for _, targetAddr := range targetAddresses {
+		targetAddr = shared.EnsurePort(targetAddr, ISCSIDefaultPort)
 		stdout, err := shared.RunCommand(ctx, "iscsiadm", "--mode", "discovery", "--type", "sendtargets", "--portal", targetAddr)
 		if err != nil {
 			logger.Warn("Failed connecting to discovery target", logger.Ctx{"target_address": targetAddr, "err": err})
@@ -290,18 +308,30 @@ func (c *connectorISCSI) Discover(ctx context.Context, targetAddresses ...string
 
 		for scanner.Scan() {
 			// each string looks like "192.168.168.1:3260,41 iqn.2023-24.com.org:cz2e123asd"
-			fields := strings.Fields(scanner.Text())
 
-			if len(fields) != 2 {
+			// Skip invalid entrees.
+			addrAndTag, iqn, ok := strings.Cut(scanner.Text(), " ")
+			if !ok {
 				continue
 			}
 
-			if !strings.HasPrefix(fields[0], targetAddr) {
+			// Skip invalid entrees.
+			addr, tag, ok := strings.Cut(addrAndTag, ",")
+			if !ok {
+				continue
+			}
+
+			// Make sure addr have a port number for stable output.
+			addr = shared.EnsurePort(addr, ISCSIDefaultPort)
+
+			if addr != targetAddr {
 				continue
 			}
 
 			result = append(result, ISCSIDiscoveryLogRecord{
-				IQN: fields[1],
+				Address:        addr,
+				PortalGroupTag: tag,
+				IQN:            iqn,
 			})
 		}
 

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -24,21 +25,98 @@ var _ Connector = &connectorNVMe{}
 // nvmeDiskDevicePrefix is the prefix of the NVMe disk device name in /dev/disk/by-id/.
 const nvmeDiskDevicePrefix = "nvme-eui."
 
-// SubtypeNVMESubsys defines an NVMe subsystem type (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L99).
-const SubtypeNVMESubsys = "nvme subsystem"
-
 type connectorNVMe struct {
 	common
 }
 
 // NVMeDiscoveryLogRecord represents an NVMe discovery entry.
 type NVMeDiscoveryLogRecord struct {
-	SubType string `json:"subtype"`
-	SubNQN  string `json:"subnqn"`
+	TransportType              string `json:"trtype"`
+	AddressFamily              string `json:"adrfam"`
+	TransportAddress           string `json:"traddr"`
+	TransportServiceIdentifier string `json:"trsvcid"`
+	SubType                    string `json:"subtype"`
+	SubNQN                     string `json:"subnqn"`
 }
+
+const (
+	// NVMeDefaultDiscoveryPort is the default port number for NVMe/TCP discovery
+	// controller.
+	NVMeDefaultDiscoveryPort = "8009"
+
+	// NVMeDefaultTransportPort is the default port number for NVMe/TCP I/O
+	// controller.
+	NVMeDefaultTransportPort = "4420"
+)
+
+// Transport type definitions (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L73).
+const (
+	nvmeTransportTypeFC  = "fc"
+	nvmeTransportTypeTCP = "tcp"
+)
+
+// Address family definitions (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L85).
+const (
+	nvmeAddressFamilyIPv4         = "ipv4"
+	nvmeAddressFamilyIPv6         = "ipv6"
+	nvmeAddressFamilyFibreChannel = "fibre-channel"
+)
+
+// SubtypeNVMESubsys defines an NVMe subsystem type (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L99).
+const SubtypeNVMESubsys = "nvme subsystem"
 
 type nvmeDiscoveryLog struct {
 	Records []NVMeDiscoveryLogRecord `json:"records"`
+}
+
+// nvmeFilterDiscoveryLog filters out entries from the provided discovery log
+// that do not describe proper NVMe over TCP targets.
+func nvmeFilterDiscoveryLog(log *nvmeDiscoveryLog) {
+	if len(log.Records) == 0 {
+		return
+	}
+
+	filteredRecords := make([]NVMeDiscoveryLogRecord, 0, len(log.Records))
+	for _, record := range log.Records {
+		if record.SubType != SubtypeNVMESubsys {
+			continue
+		}
+
+		if record.TransportType != nvmeTransportTypeTCP {
+			continue
+		}
+
+		if record.AddressFamily != nvmeAddressFamilyIPv4 && record.AddressFamily != nvmeAddressFamilyIPv6 {
+			continue
+		}
+
+		filteredRecords = append(filteredRecords, record)
+	}
+
+	log.Records = filteredRecords
+}
+
+// nvmeAddMissingServiceIDToDiscoveryLog ensure all port numbers (transport
+// service identifiers) are set. For non specified ports function uses
+// the discovery controller port if present, otherwise uses the default
+// transport port number.
+func nvmeAddMissingServiceIDToDiscoveryLog(log *nvmeDiscoveryLog, discoveryAddress string) {
+	if len(log.Records) == 0 {
+		return
+	}
+
+	_, transportServiceID, err := net.SplitHostPort(discoveryAddress)
+	if err != nil {
+		transportServiceID = NVMeDefaultTransportPort
+	}
+
+	for i := range log.Records {
+		if log.Records[i].TransportServiceIdentifier != "" {
+			continue
+		}
+
+		log.Records[i].TransportServiceIdentifier = transportServiceID
+	}
 }
 
 // Type returns the type of the connector.
@@ -84,6 +162,7 @@ func (c *connectorNVMe) QualifiedName() (string, error) {
 func (c *connectorNVMe) Connect(ctx context.Context, targetQN string, targetAddresses ...string) (revert.Hook, error) {
 	// Connects to the provided target address, if the connection is not yet established.
 	connectFunc := func(ctx context.Context, session *session, targetAddr string) error {
+		targetAddr = shared.EnsurePort(targetAddr, NVMeDefaultTransportPort)
 		if session != nil && slices.Contains(session.addresses, targetAddr) {
 			// Already connected.
 			return nil
@@ -94,7 +173,12 @@ func (c *connectorNVMe) Connect(ctx context.Context, targetQN string, targetAddr
 			return err
 		}
 
-		_, err = shared.RunCommand(ctx, "nvme", "connect", "--transport", "tcp", "--traddr", targetAddr, "--nqn", targetQN, "--hostnqn", hostNQN, "--hostid", c.serverUUID)
+		transportAddr, transportServiceID, err := net.SplitHostPort(targetAddr)
+		if err != nil {
+			return fmt.Errorf("Bad transport address %q: %w", targetAddr, err)
+		}
+
+		_, err = shared.RunCommand(ctx, "nvme", "connect", "--transport", "tcp", "--traddr", transportAddr, "--trsvcid", transportServiceID, "--nqn", targetQN, "--hostnqn", hostNQN, "--hostid", c.serverUUID)
 		if err != nil {
 			return fmt.Errorf("Failed connecting to target %q on %q via NVMe: %w", targetQN, targetAddr, err)
 		}
@@ -227,14 +311,27 @@ func (c *connectorNVMe) findSession(targetQN string) (*session, error) {
 		// The "address" file contains one line per connection,
 		// each in format "traddr=<ip>,trsvcid=<port>,...".
 		for line := range strings.SplitSeq(string(fileBytes), "\n") {
-			parts := strings.SplitSeq(strings.TrimSpace(line), ",")
-			for part := range parts {
+			parts := strings.Split(strings.TrimSpace(line), ",")
+
+			transportAddr := ""
+			for _, part := range parts {
 				addr, ok := strings.CutPrefix(part, "traddr=")
 				if ok {
-					session.addresses = append(session.addresses, addr)
+					transportAddr = addr
 					break
 				}
 			}
+
+			transportServiceID := NVMeDefaultTransportPort
+			for _, part := range parts {
+				port, ok := strings.CutPrefix(part, "trsvcid=")
+				if ok {
+					transportServiceID = port
+					break
+				}
+			}
+
+			session.addresses = append(session.addresses, net.JoinHostPort(transportAddr, transportServiceID))
 		}
 	}
 
@@ -258,7 +355,13 @@ func (c *connectorNVMe) Discover(ctx context.Context, targetAddresses ...string)
 
 	var discoveryLog nvmeDiscoveryLog
 	for _, targetAddr := range targetAddresses {
-		stdout, err := shared.RunCommand(ctx, "nvme", "discover", "--transport", "tcp", "--traddr", targetAddr, "--hostnqn", hostNQN, "--hostid", c.serverUUID, "--output-format", "json")
+		discoveryAddr, discoveryServiceID, err := net.SplitHostPort(shared.EnsurePort(targetAddr, NVMeDefaultDiscoveryPort))
+		if err != nil {
+			logger.Warn("Bad discovery address", logger.Ctx{"target_address": targetAddr, "err": err})
+			continue
+		}
+
+		stdout, err := shared.RunCommand(ctx, "nvme", "discover", "--transport", "tcp", "--traddr", discoveryAddr, "--trsvcid", discoveryServiceID, "--hostnqn", hostNQN, "--hostid", c.serverUUID, "--output-format", "json")
 		if err != nil {
 			// Exit code 110 is returned if the target address cannot be reached.
 			logger.Warn("Failed connecting to discovery target", logger.Ctx{"target_address": targetAddr, "err": err})
@@ -279,7 +382,10 @@ func (c *connectorNVMe) Discover(ctx context.Context, targetAddresses ...string)
 			return nil, fmt.Errorf("Failed unmarshaling the returned discovery log entries from %q: %w", targetAddr, err)
 		}
 
-		// Unmarshalling the response from the discovery succeeded, break the loop.
+		nvmeAddMissingServiceIDToDiscoveryLog(&discoveryLog, targetAddr)
+		nvmeFilterDiscoveryLog(&discoveryLog)
+
+		// Unmarshaling the response from the discovery succeeded, break the loop.
 		break
 	}
 

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/connectors"
+	"github.com/canonical/lxd/lxd/storage/drivers/powerstoreclient"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/validate"
 )
@@ -64,6 +65,10 @@ var powerStoreVersion string
 
 type powerstore struct {
 	common
+
+	// Holds the low level client for the PowerStore API.
+	// Use powerstore.client() to retrieve the initialized client struct.
+	apiClient *powerstoreclient.Client
 
 	// Holds the low level connector for the PowerStore driver.
 	// Use powerstore.connector() to retrieve the initialized connector.

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -1,0 +1,356 @@
+package drivers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/storage/connectors"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/validate"
+)
+
+// powerStoreDefaultUser represents the default PowerStore user name.
+const powerStoreDefaultUser = "admin"
+
+// powerStoreMinVolumeSizeBytes represents the minimal PowerStore volume size
+// in bytes.
+const powerStoreMinVolumeSizeBytes = 1 * 1024 * 1024 // 1MiB
+
+// powerStoreMinVolumeSizeUnit represents the minimal PowerStore volume size
+// expressed as unit string.
+const powerStoreMinVolumeSizeUnit = "1MiB"
+
+// powerStoreMaxVolumeSizeBytes represents the maximum PowerStore volume size
+// in bytes.
+const powerStoreMaxVolumeSizeBytes = 256 * 1024 * 1024 * 1024 * 1024 // 256TiB
+
+// powerStoreMaxVolumeSizeUnit represents the maximum PowerStore volume size
+// expressed as unit string.
+const powerStoreMaxVolumeSizeUnit = "256TiB"
+
+// powerStoreMinVolumeSizeAlignmentUnit represents the alignment unit for
+// the PowerStore volume size (each volume size needs to be multiplicate of
+// this value).
+const powerStoreMinVolumeSizeAlignmentUnit = "1MiB"
+
+const (
+	powerStoreModeNVME  string = "nvme"
+	powerStoreModeISCSI string = "iscsi"
+)
+
+const (
+	powerStoreTransportTCP string = "tcp"
+)
+
+// powerStoreSupportedConnectorTypes list all connector types supported by
+// the PowerStore driver.
+var powerStoreSupportedModesAndTransports = driverModesAndTransports{
+	{
+		Mode:          powerStoreModeNVME,
+		Transport:     powerStoreTransportTCP,
+		ConnectorType: connectors.TypeNVME,
+	},
+	{
+		Mode:          powerStoreModeISCSI,
+		Transport:     powerStoreTransportTCP,
+		ConnectorType: connectors.TypeISCSI,
+	},
+}
+
+var powerStoreLoaded bool
+var powerStoreVersion string
+
+type powerstore struct {
+	common
+
+	// Holds the low level connector for the PowerStore driver.
+	// Use powerstore.connector() to retrieve the initialized connector.
+	storageConnector connectors.Connector
+}
+
+// load is used to run one-time action per-driver rather than per-pool.
+func (d *powerstore) load() error {
+	// Done if previously loaded.
+	if powerStoreLoaded {
+		return nil
+	}
+
+	versions := connectors.GetSupportedVersions(powerStoreSupportedModesAndTransports.ConnectorTypes())
+	powerStoreVersion = strings.Join(versions, " / ")
+	powerStoreLoaded = true
+
+	// Load the kernel modules of the respective connector, ignoring those that cannot be loaded.
+	// Support for a specific connector is checked during pool creation. However, this
+	// ensures that the kernel modules are loaded, even if the host has been rebooted.
+	connector, err := d.connector()
+	if err == nil {
+		_ = connector.LoadModules()
+	}
+
+	return nil
+}
+
+// isRemote returns true indicating this driver uses remote storage.
+func (d *powerstore) isRemote() bool {
+	return true
+}
+
+// Info returns info about the driver and its environment.
+func (d *powerstore) Info() Info {
+	return Info{
+		Name:                         "powerstore",
+		Version:                      powerStoreVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
+		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
+		OptimizedImages:              false,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeVM, VolumeTypeContainer, VolumeTypeImage},
+		BlockBacking:                 true,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  false,
+		PopulateParentVolumeUUID:     false,
+		UUIDVolumeNames:              true,
+	}
+}
+
+// SourceIdentifier returns a combined string consisting of the gateway address and pool name.
+func (d *powerstore) SourceIdentifier() (string, error) {
+	gateway := d.config["powerstore.gateway"]
+	if gateway == "" {
+		return "", errors.New("Cannot derive identifier from empty gateway address")
+	}
+
+	return "", ErrNotSupported
+}
+
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *powerstore) FillConfig() error {
+	if d.config["powerstore.user.name"] == "" {
+		d.config["powerstore.user.name"] = powerStoreDefaultUser
+	}
+
+	// Try to discover the PowerStore operation mode and transport.
+	if d.config["powerstore.mode"] == "" || d.config["powerstore.transport"] == "" {
+		discovered, err := discoverModeAndTransport(powerStoreSupportedModesAndTransports, d.config["powerstore.mode"], d.config["powerstore.transport"])
+		if err != nil {
+			return err
+		}
+
+		d.config["powerstore.mode"] = discovered.Mode
+		d.config["powerstore.transport"] = discovered.Transport
+	}
+
+	// Set default volume size if not provided.
+	if d.config["volume.size"] == "" {
+		d.config["volume.size"] = d.defaultBlockVolumeSize()
+	}
+
+	return nil
+}
+
+// Create is called during pool creation and is effectively using an empty driver struct.
+// WARNING: The Create() function cannot rely on any of the struct attributes being set.
+func (d *powerstore) Create() error {
+	return ErrNotSupported
+}
+
+// Mount mounts the storage pool.
+func (d *powerstore) Mount() (bool, error) {
+	return false, ErrNotSupported
+}
+
+// Unmount unmounts the storage pool.
+func (d *powerstore) Unmount() (bool, error) {
+	return false, ErrNotSupported
+}
+
+// Delete removes the storage pool from the storage device.
+func (d *powerstore) Delete(op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// GetResources returns the pool resource usage information.
+func (d *powerstore) GetResources() (*api.ResourcesStoragePool, error) {
+	return nil, ErrNotSupported
+}
+
+// commonVolumeRules returns validation rules which are common for pool and
+// volume.
+func (d *powerstore) commonVolumeRules() map[string]func(value string) error {
+	return map[string]func(value string) error{
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=block.filesystem)
+		// Valid options are: `btrfs`, `ext4`, `xfs`
+		// If not set, `ext4` is assumed.
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.filesystem`
+		//  shortdesc: File system of the storage volume
+		//  scope: global
+		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=block.mount_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.mount_options`
+		//  shortdesc: Mount options for block-backed file system volumes
+		//  scope: global
+		"block.mount_options": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=size)
+		// The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+		// ---
+		//  type: string
+		//  defaultdesc: same as `volume.size`
+		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
+		"size": validate.Optional(
+			validate.IsNoLessThanUnit(powerStoreMinVolumeSizeUnit),
+			validate.IsNoGreaterThanUnit(powerStoreMaxVolumeSizeUnit),
+			validate.IsMultipleOfUnit(powerStoreMinVolumeSizeAlignmentUnit),
+		),
+	}
+}
+
+// Validate checks that all provided keys are supported and that no conflicting or missing configuration is present.
+func (d *powerstore) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.user.name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `admin`
+		//  shortdesc: User for PowerStore Gateway authentication
+		//  scope: global
+		"powerstore.user.name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.user.password)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Password for PowerStore Gateway authentication
+		//  scope: global
+		"powerstore.user.password": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.gateway)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Address of the PowerStore Gateway
+		//  scope: global
+		"powerstore.gateway": validate.Optional(validate.IsRequestURL),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.gateway.verify)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Whether to verify the PowerStore Gateway's certificate
+		//  scope: global
+		"powerstore.gateway.verify": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.discovery)
+		// A comma-separated list of NVMe or iSCSI discovery addresses.
+		// ---
+		//  type: string
+		//  defaultdesc: the list of discovery addresses
+		//  shortdesc: List of discovery addresses.
+		"powerstore.discovery": validate.Optional(validate.IsListOf(validate.IsNetworkAddressWithOptionalPort)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.target)
+		// A comma-separated list of NVMe or iSCSI target addresses. When empty targets are discovered via discovery endpoints.
+		// ---
+		//  type: string
+		//  defaultdesc: the list of target addresses
+		//  shortdesc: List of target addresses.
+		"powerstore.target": validate.Optional(validate.IsListOf(validate.IsNetworkAddressWithOptionalPort)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.mode)
+		// The mode gets discovered automatically if the system provides the necessary kernel modules.
+		// Supported values are `iscsi` and `nvme`.
+		// ---
+		//  type: string
+		//  defaultdesc: the discovered mode
+		//  shortdesc: How volumes are mapped to the local server
+		//  scope: global
+		"powerstore.mode": validate.Optional(validate.IsOneOf(powerStoreSupportedModesAndTransports.Modes()...)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.transport)
+		// The transport gets discovered automatically if the system provides the necessary kernel modules.
+		// Supported values are `tcp`.
+		// ---
+		//  type: string
+		//  defaultdesc: the discovered transport
+		//  shortdesc: Transport layer used when transferring volumes data to the local server.
+		//  scope: global
+		"powerstore.transport": validate.Optional(validate.IsOneOf(powerStoreSupportedModesAndTransports.Transports()...)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=volume.size)
+		// The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+		// ---
+		//  type: string
+		//  defaultdesc: `10GiB`
+		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
+		"volume.size": validate.Optional(
+			validate.IsNoLessThanUnit(powerStoreMinVolumeSizeUnit),
+			validate.IsNoGreaterThanUnit(powerStoreMaxVolumeSizeUnit),
+			validate.IsMultipleOfUnit(powerStoreMinVolumeSizeAlignmentUnit),
+		),
+	}
+
+	err := d.validatePool(config, rules, d.commonVolumeRules())
+	if err != nil {
+		return err
+	}
+
+	// Ensure powerstore.mode cannot be changed to avoid leaving volume mappings
+	// and to prevent disturbing running instances.
+	newMode, oldMode := config["powerstore.mode"], d.config["powerstore.mode"]
+	if oldMode != "" && oldMode != newMode {
+		return errors.New("PowerStore mode cannot be changed")
+	}
+
+	// Ensure powerstore.transport cannot be changed to avoid leaving volume
+	// mappings and to prevent disturbing running instances.
+	newTransport, oldTransport := config["powerstore.transport"], d.config["powerstore.transport"]
+	if oldTransport != "" && oldTransport != newTransport {
+		return errors.New("PowerStore transport cannot be changed")
+	}
+
+	// Check if the selected PowerStore mode and transport is supported on this
+	// node. Also when forming the storage pool on a LXD cluster, the mode
+	// that got discovered on the creating machine needs to be validated
+	// on the other cluster members too. This can be done here since Validate
+	// gets executed on every cluster member when receiving the cluster
+	// notification to finally create the pool.
+	if newMode != "" && newTransport != "" {
+		mt, err := powerStoreSupportedModesAndTransports.Find(newMode, newTransport)
+		if err != nil {
+			return err
+		}
+
+		connector, err := connectors.NewConnector(mt.ConnectorType, "")
+		if err != nil {
+			return fmt.Errorf("PowerStore mode %q with transport %q is not supported: %w", newMode, newTransport, err)
+		}
+
+		err = connector.LoadModules()
+		if err != nil {
+			return fmt.Errorf("PowerStore mode %q with transport %q is not supported due to missing kernel modules: %w", newMode, newTransport, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateSource checks whether the required config keys are set to access the remote source.
+func (d *powerstore) ValidateSource() error {
+	if d.config["powerstore.gateway"] == "" {
+		return errors.New("The powerstore.gateway cannot be empty")
+	}
+
+	return nil
+}
+
+// Update applies any driver changes required from a configuration change.
+func (d *powerstore) Update(changedConfig map[string]string) error {
+	return ErrNotSupported
+}

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/powerstoreclient"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/validate"
 )
@@ -130,7 +131,7 @@ func (d *powerstore) SourceIdentifier() (string, error) {
 		return "", errors.New("Cannot derive identifier from empty gateway address")
 	}
 
-	return "", ErrNotSupported
+	return fmt.Sprintf("%s-%s", gateway, d.Name()), nil
 }
 
 // FillConfig populates the storage pool's configuration file with the default values.
@@ -161,22 +162,28 @@ func (d *powerstore) FillConfig() error {
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
 func (d *powerstore) Create() error {
-	return ErrNotSupported
+	return nil
 }
 
 // Mount mounts the storage pool.
 func (d *powerstore) Mount() (bool, error) {
-	return false, ErrNotSupported
+	return true, nil
 }
 
 // Unmount unmounts the storage pool.
 func (d *powerstore) Unmount() (bool, error) {
-	return false, ErrNotSupported
+	return true, nil
 }
 
 // Delete removes the storage pool from the storage device.
 func (d *powerstore) Delete(op *operations.Operation) error {
-	return ErrNotSupported
+	// If the user completely destroyed it, call it done.
+	if !shared.PathExists(GetPoolMountPath(d.name)) {
+		return nil
+	}
+
+	// On delete, wipe everything in the directory.
+	return wipeDirectory(GetPoolMountPath(d.name))
 }
 
 // GetResources returns the pool resource usage information.
@@ -357,5 +364,5 @@ func (d *powerstore) ValidateSource() error {
 
 // Update applies any driver changes required from a configuration change.
 func (d *powerstore) Update(changedConfig map[string]string) error {
-	return ErrNotSupported
+	return nil
 }

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -196,7 +196,19 @@ func (d *powerstore) Delete(op *operations.Operation) error {
 
 // GetResources returns the pool resource usage information.
 func (d *powerstore) GetResources() (*api.ResourcesStoragePool, error) {
-	return nil, ErrNotSupported
+	metrics, err := d.client().GetApplianceMetrics(d.state.ShutdownCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &api.ResourcesStoragePool{}
+
+	for _, m := range metrics {
+		res.Space.Total += uint64(m.LastPhysicalTotalSpace)
+		res.Space.Used += uint64(m.LastPhysicalUsedSpace)
+	}
+
+	return res, nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -74,6 +74,14 @@ type powerstore struct {
 	// Holds the low level connector for the PowerStore driver.
 	// Use powerstore.connector() to retrieve the initialized connector.
 	storageConnector connectors.Connector
+
+	// Derived initiator resource associated with current host, mode and transport
+	// Use powerstore.initiator() to retrieve the initialized initiator resource.
+	initiatorResource *powerstoreclient.HostInitiatorResource
+
+	// List of discovered targets ant theirs QNs (qualified names)
+	// Use powerstore.targets() to retrieve the discovered PowerStore targets.
+	discoveredTargets []powerStoreTarget
 }
 
 // load is used to run one-time action per-driver rather than per-pool.

--- a/lxd/storage/drivers/driver_powerstore_utils.go
+++ b/lxd/storage/drivers/driver_powerstore_utils.go
@@ -2,7 +2,35 @@ package drivers
 
 import (
 	"github.com/canonical/lxd/lxd/storage/connectors"
+	"github.com/canonical/lxd/lxd/storage/drivers/powerstoreclient"
+	"github.com/canonical/lxd/lxd/storage/drivers/tokencache"
+	"github.com/canonical/lxd/shared"
 )
+
+// powerStoreTokenCache stores shared PowerStore login sessions.
+var powerStoreTokenCache = tokencache.New[powerstoreclient.LoginSession]("powerstore")
+
+// newPowerStoreClient creates a new instance of the PowerStore HTTP API
+// client.
+func newPowerStoreClient(driver *powerstore) *powerstoreclient.Client {
+	return &powerstoreclient.Client{
+		Gateway:              driver.config["powerstore.gateway"],
+		GatewaySkipTLSVerify: shared.IsFalse(driver.config["powerstore.gateway.verify"]),
+		Username:             driver.config["powerstore.user.name"],
+		Password:             driver.config["powerstore.user.password"],
+		TokenCache:           powerStoreTokenCache,
+	}
+}
+
+// client returns the PowerStore API client.
+// A new client gets created if one does not exists.
+func (d *powerstore) client() *powerstoreclient.Client {
+	if d.apiClient == nil {
+		d.apiClient = newPowerStoreClient(d)
+	}
+
+	return d.apiClient
+}
 
 // connector retrieves an initialized storage connector based on the configured
 // PowerStore mode. The connector is cached in the driver struct.

--- a/lxd/storage/drivers/driver_powerstore_utils.go
+++ b/lxd/storage/drivers/driver_powerstore_utils.go
@@ -250,6 +250,9 @@ var powerStoreVolContentTypeSuffixesRev = map[string]ContentType{
 // powerStorePoolAndVolSep separates pool name and volume data in encoded volume names.
 const powerStorePoolAndVolSep = "-"
 
+// powerStoreVolSnapSuffix volume snapshot name suffix
+const powerStoreVolSnapSuffix = "-snap"
+
 // volumeResourceNamePrefix returns the prefix used by all volume resource
 // names in PowerStore associated with the current storage pool.
 func (d *powerstore) volumeResourceNamePrefix() string {
@@ -328,6 +331,16 @@ func (d *powerstore) extractDataFromVolumeResourceName(name string) (poolHash st
 func (d *powerstore) volumeWWN(volResource *powerstoreclient.VolumeResource) string {
 	_, wwn, _ := strings.Cut(volResource.WWN, ".")
 	return wwn
+}
+
+// volumeSnapshotResourceName derives the name of a volume snapshot resource
+// in PowerStore from the provided volume snapshot.
+func (d *powerstore) volumeSnapshotResourceName(snapVol Volume) (string, error) {
+	name, err := d.volumeResourceName(snapVol)
+	if err != nil {
+		return "", err
+	}
+	return name + powerStoreVolSnapSuffix, nil
 }
 
 // hostResourceName derives the name of a host resource in PowerStore
@@ -783,4 +796,103 @@ func (d *powerstore) deleteHostAndInitiatorResource(hostResource *powerstoreclie
 	}
 
 	return d.client().DeleteHostByID(d.state.ShutdownCtx, hostResource.ID)
+}
+
+// getVolumeResourceSnapshotByVolumeSnapshot retrieves volume resource associated with
+// the provided volume.
+func (d *powerstore) getVolumeResourceSnapshotByVolumeSnapshot(snapVol Volume) (*powerstoreclient.VolumeResource, error) {
+	volSnapResourceName, err := d.volumeSnapshotResourceName(snapVol)
+	if err != nil {
+		return nil, err
+	}
+
+	volSnapResource, err := d.client().GetVolumeSnapshotByName(d.state.ShutdownCtx, volSnapResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource snapshot %q associated with volume snapshot %q: %w", volSnapResourceName, snapVol.name, err)
+	}
+
+	return volSnapResource, nil
+}
+
+// getExistingVolumeResourceSnapshotByVolumeSnapshot retrieves volume resource
+// snapshot associated with the provided volume snapshot, just like
+// getVolumeResourceSnapshotByVolumeSnapshot function, but returns error if
+// the volume resource snapshot does not exists.
+func (d *powerstore) getExistingVolumeResourceSnapshotByVolumeSnapshot(snapVol Volume) (*powerstoreclient.VolumeResource, error) {
+	volSnapResourceName, err := d.volumeSnapshotResourceName(snapVol)
+	if err != nil {
+		return nil, err
+	}
+
+	volSnapResource, err := d.client().GetVolumeSnapshotByName(d.state.ShutdownCtx, volSnapResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource snapshot %q associated with volume snapshot %q: %w", volSnapResourceName, snapVol.name, err)
+	}
+
+	if volSnapResource == nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource snapshot %q associated with volume snapshot %q: resource not found", volSnapResourceName, snapVol.name)
+	}
+
+	return volSnapResource, nil
+}
+
+// createVolumeResourceSnapshot creates a new snapshot of volume resources in
+// PowerStore.
+func (d *powerstore) createVolumeResourceSnapshot(snapVol Volume) (*powerstoreclient.VolumeResource, error) {
+	parentVolResource, err := d.getExistingVolumeResourceByVolume(snapVol.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	volSnapResourceName, err := d.volumeSnapshotResourceName(snapVol)
+	if err != nil {
+		return nil, err
+	}
+
+	desc := limitString("LXD Name: "+snapVol.name, 128) // maximum allowed value length for volume snapshot description field is 128
+
+	return d.client().CreateVolumeSnapshot(d.state.ShutdownCtx, parentVolResource.ID, volSnapResourceName, desc)
+}
+
+// deleteVolumeResourceSnapshot deletes snapshot of volume resources in
+// PowerStore.
+func (d *powerstore) deleteVolumeResourceSnapshot(volSnapResource *powerstoreclient.VolumeResource) error {
+	return d.deleteVolumeResource(volSnapResource)
+}
+
+// copyVolumeResourceSnapshotToVolume clones the provided volume resource
+// snapshot, if the volume resource associated with the target volume do not
+// exists. Otherwise it restores the volume resource associated with the target
+// volume from the provided volume resource snapshot.
+func (d *powerstore) copyVolumeResourceSnapshotToVolume(srcVolSnapResource *powerstoreclient.VolumeResource, dstVol Volume) (*powerstoreclient.VolumeResource, error) {
+	dstVolResourceName, err := d.volumeResourceName(dstVol)
+	if err != nil {
+		return nil, err
+	}
+
+	dstVolResource, err := d.getVolumeResourceByVolume(dstVol)
+	if err != nil {
+		return nil, err
+	}
+
+	if dstVolResource == nil {
+		// Destination volume do not exists yet - use clone to create it.
+		dstDesc := limitString("LXD Name: "+dstVol.name, 128) // maximum allowed value length for volume description field is 128
+
+		dstVolResource, err := d.client().CloneVolume(d.state.ShutdownCtx, srcVolSnapResource.ID, dstVolResourceName, dstDesc)
+		if err != nil {
+			return nil, err
+		}
+
+		return dstVolResource, nil
+	}
+
+	// Destination volume already exists - use refresh to update it.
+	// TODO: Use restore when available instead.
+	err = d.client().RefreshVolume(d.state.ShutdownCtx, srcVolSnapResource.ID, dstVolResource.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return dstVolResource, nil
 }

--- a/lxd/storage/drivers/driver_powerstore_utils.go
+++ b/lxd/storage/drivers/driver_powerstore_utils.go
@@ -1,0 +1,25 @@
+package drivers
+
+import (
+	"github.com/canonical/lxd/lxd/storage/connectors"
+)
+
+// connector retrieves an initialized storage connector based on the configured
+// PowerStore mode. The connector is cached in the driver struct.
+func (d *powerstore) connector() (connectors.Connector, error) {
+	if d.storageConnector == nil {
+		mt, err := powerStoreSupportedModesAndTransports.Find(d.config["powerstore.mode"], d.config["powerstore.transport"])
+		if err != nil {
+			return nil, err
+		}
+
+		connector, err := connectors.NewConnector(mt.ConnectorType, d.state.OS.ServerUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		d.storageConnector = connector
+	}
+
+	return d.storageConnector, nil
+}

--- a/lxd/storage/drivers/driver_powerstore_utils.go
+++ b/lxd/storage/drivers/driver_powerstore_utils.go
@@ -19,6 +19,8 @@ func newPowerStoreClient(driver *powerstore) *powerstoreclient.Client {
 		Username:             driver.config["powerstore.user.name"],
 		Password:             driver.config["powerstore.user.password"],
 		TokenCache:           powerStoreTokenCache,
+		VolumeNamePrefix:     powerStoreResourceNamePrefix,
+		HostNamePrefix:       powerStoreResourceNamePrefix,
 	}
 }
 
@@ -51,3 +53,6 @@ func (d *powerstore) connector() (connectors.Connector, error) {
 
 	return d.storageConnector, nil
 }
+
+// powerStoreResourceNamePrefix common prefix for all resource names in PowerStore.
+const powerStoreResourceNamePrefix = "lxd:"

--- a/lxd/storage/drivers/driver_powerstore_utils.go
+++ b/lxd/storage/drivers/driver_powerstore_utils.go
@@ -1,10 +1,25 @@
 package drivers
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/powerstoreclient"
 	"github.com/canonical/lxd/lxd/storage/drivers/tokencache"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/units"
 )
 
 // powerStoreTokenCache stores shared PowerStore login sessions.
@@ -19,9 +34,31 @@ func newPowerStoreClient(driver *powerstore) *powerstoreclient.Client {
 		Username:             driver.config["powerstore.user.name"],
 		Password:             driver.config["powerstore.user.password"],
 		TokenCache:           powerStoreTokenCache,
-		VolumeNamePrefix:     powerStoreResourceNamePrefix,
+		VolumeNamePrefix:     driver.volumeResourceNamePrefix(),
 		HostNamePrefix:       powerStoreResourceNamePrefix,
 	}
+}
+
+// powerStoreTarget represent a PowerStore connection target.
+type powerStoreTarget struct {
+	Address       string
+	QualifiedName string
+}
+
+// powerStoreGroupTargetsAddressesByQualifiedName combines target addresses
+// from targets with the same qualified names together into a single map key.
+func powerStoreGroupTargetsAddressesByQualifiedName(targets ...powerStoreTarget) map[string][]string {
+	grouped := map[string][]string{}
+	// Attempt to preserve order while grouping.
+	for _, target := range targets {
+		grouped[target.QualifiedName] = append(grouped[target.QualifiedName], target.Address)
+	}
+
+	for qn, addresses := range grouped {
+		grouped[qn] = shared.Unique(addresses)
+	}
+
+	return grouped
 }
 
 // client returns the PowerStore API client.
@@ -54,5 +91,696 @@ func (d *powerstore) connector() (connectors.Connector, error) {
 	return d.storageConnector, nil
 }
 
+// targets return discovered PowerStore targets (their addresses and associated
+// qualified names).
+func (d *powerstore) targets() ([]powerStoreTarget, error) {
+	if len(d.discoveredTargets) == 0 {
+		connector, err := d.connector()
+		if err != nil {
+			return nil, err
+		}
+
+		discoveryAddresses := shared.SplitNTrimSpace(d.config["powerstore.discovery"], ",", -1, true)
+		var discoveryLogRecords []any
+		for _, addr := range discoveryAddresses {
+			discovered, err := connector.Discover(d.state.ShutdownCtx, addr)
+			if err != nil {
+				// Underlying connector should log a waring.
+				continue
+			}
+
+			discoveryLogRecords = append(discoveryLogRecords, discovered...)
+		}
+
+		if len(discoveryLogRecords) == 0 {
+			return nil, errors.New("Failed fetching a discovery log record from any of the target addresses")
+		}
+
+		discoveredTargets := []powerStoreTarget{}
+		userForcedTargetAddresses := shared.SplitNTrimSpace(d.config["powerstore.target"], ",", -1, true)
+		parser := d.discoveryLogRecordParser(userForcedTargetAddresses)
+		for _, record := range discoveryLogRecords {
+			target, includeTarget, err := parser(record)
+			if err != nil {
+				return nil, err
+			}
+
+			if !includeTarget {
+				continue
+			}
+
+			discoveredTargets = append(discoveredTargets, target)
+		}
+
+		discoveredTargets = shared.Unique(discoveredTargets)
+
+		if len(discoveredTargets) == 0 {
+			return nil, errors.New("Failed fetching a discovery log record from any of the discovery addresses")
+		}
+
+		d.discoveredTargets = discoveredTargets
+	}
+
+	return d.discoveredTargets, nil
+}
+
+// discoveryLogRecordParser returns a parsing function that converts single
+// discovery log entry to target.
+func (d *powerstore) discoveryLogRecordParser(filterTargetAddresses []string) func(any) (powerStoreTarget, bool, error) {
+	mode := d.config["powerstore.mode"]
+	transport := d.config["powerstore.transport"]
+	switch {
+	case mode == powerStoreModeISCSI && transport == powerStoreTransportTCP:
+		filterTargetAddresses = slices.Clone(filterTargetAddresses)
+		for i := range filterTargetAddresses {
+			filterTargetAddresses[i] = shared.EnsurePort(filterTargetAddresses[i], connectors.ISCSIDefaultPort)
+		}
+
+		return func(record any) (powerStoreTarget, bool, error) {
+			r, ok := record.(connectors.ISCSIDiscoveryLogRecord)
+			if !ok {
+				return powerStoreTarget{}, false, fmt.Errorf("Invalid discovery log record entry type %T is not connectors.ISCSIDiscoveryLogRecord", record)
+			}
+
+			target := powerStoreTarget{
+				Address:       r.Address,
+				QualifiedName: r.IQN,
+			}
+
+			if len(filterTargetAddresses) > 0 && !slices.Contains(filterTargetAddresses, target.Address) {
+				return powerStoreTarget{}, false, nil
+			}
+
+			return target, true, nil
+		}
+
+	case mode == powerStoreModeNVME && transport == powerStoreTransportTCP:
+		filterTargetAddresses = slices.Clone(filterTargetAddresses)
+		for i := range filterTargetAddresses {
+			filterTargetAddresses[i] = shared.EnsurePort(filterTargetAddresses[i], connectors.NVMeDefaultTransportPort)
+		}
+
+		return func(record any) (powerStoreTarget, bool, error) {
+			r, ok := record.(connectors.NVMeDiscoveryLogRecord)
+			if !ok {
+				return powerStoreTarget{}, false, fmt.Errorf("Invalid discovery log record entry type %T is not connectors.NVMeDiscoveryLogRecord", record)
+			}
+
+			target := powerStoreTarget{
+				Address:       net.JoinHostPort(r.TransportAddress, r.TransportServiceIdentifier),
+				QualifiedName: r.SubNQN,
+			}
+
+			if len(filterTargetAddresses) > 0 && !slices.Contains(filterTargetAddresses, target.Address) {
+				return powerStoreTarget{}, false, nil
+			}
+
+			return target, true, nil
+		}
+	}
+
+	panic(fmt.Errorf("storage: powerstore: bad configuration (mode: %q, transport: %q); this case should never be reached", mode, transport))
+}
+
 // powerStoreResourceNamePrefix common prefix for all resource names in PowerStore.
 const powerStoreResourceNamePrefix = "lxd:"
+
+const (
+	powerStoreVolPrefixSep       = "_" // volume name prefix separator
+	powerStoreContainerVolPrefix = "c" // volume name prefix indicating container volume
+	powerStoreVMVolPrefix        = "v" // volume name prefix indicating virtual machine volume
+	powerStoreImageVolPrefix     = "i" // volume name prefix indicating image volume
+	powerStoreCustomVolPrefix    = "u" // volume name prefix indicating custom volume
+)
+
+// powerStoreVolTypePrefixes maps volume type to storage volume name prefix.
+var powerStoreVolTypePrefixes = map[VolumeType]string{
+	VolumeTypeContainer: powerStoreContainerVolPrefix,
+	VolumeTypeVM:        powerStoreVMVolPrefix,
+	VolumeTypeImage:     powerStoreImageVolPrefix,
+	VolumeTypeCustom:    powerStoreCustomVolPrefix,
+}
+
+// powerStoreVolTypePrefixesRev maps storage volume name prefix to volume type.
+var powerStoreVolTypePrefixesRev = map[string]VolumeType{
+	powerStoreContainerVolPrefix: VolumeTypeContainer,
+	powerStoreVMVolPrefix:        VolumeTypeVM,
+	powerStoreImageVolPrefix:     VolumeTypeImage,
+	powerStoreCustomVolPrefix:    VolumeTypeCustom,
+}
+
+const (
+	powerStoreVolSuffixSep   = "." // volume name suffix separator
+	powerStoreBlockVolSuffix = "b" // volume name suffix used for block content type volumes
+	powerStoreISOVolSuffix   = "i" // volume name suffix used for iso content type volumes
+)
+
+// powerStoreVolContentTypeSuffixes maps volume content type to storage volume name suffix.
+var powerStoreVolContentTypeSuffixes = map[ContentType]string{
+	ContentTypeBlock: powerStoreBlockVolSuffix,
+	ContentTypeISO:   powerStoreISOVolSuffix,
+}
+
+// powerStoreVolContentTypeSuffixesRev maps storage volume name suffix to volume content type.
+var powerStoreVolContentTypeSuffixesRev = map[string]ContentType{
+	powerStoreBlockVolSuffix: ContentTypeBlock,
+	powerStoreISOVolSuffix:   ContentTypeISO,
+}
+
+// powerStorePoolAndVolSep separates pool name and volume data in encoded volume names.
+const powerStorePoolAndVolSep = "-"
+
+// volumeResourceNamePrefix returns the prefix used by all volume resource
+// names in PowerStore associated with the current storage pool.
+func (d *powerstore) volumeResourceNamePrefix() string {
+	poolHash := sha256.Sum256([]byte(d.Name()))
+	poolName := base64.StdEncoding.EncodeToString(poolHash[:])
+	return powerStoreResourceNamePrefix + poolName + powerStorePoolAndVolSep
+}
+
+// volumeResourceName derives the name of a volume resource in PowerStore from
+// the provided volume.
+func (d *powerstore) volumeResourceName(vol Volume) (string, error) {
+	volUUID, err := uuid.Parse(vol.config["volatile.uuid"])
+	if err != nil {
+		return "", fmt.Errorf(`Failed parsing "volatile.uuid" from volume %q: %w`, vol.name, err)
+	}
+
+	volName := base64.StdEncoding.EncodeToString(volUUID[:])
+
+	// Search for the volume type prefix, and if found, prepend it to the volume
+	// name.
+	prefix := powerStoreVolTypePrefixes[vol.volType]
+	if prefix != "" {
+		volName = prefix + powerStoreVolPrefixSep + volName
+	}
+
+	// Search for the content type suffix, and if found, append it to the volume
+	// name.
+	suffix := powerStoreVolContentTypeSuffixes[vol.contentType]
+	if suffix != "" {
+		volName = volName + powerStoreVolSuffixSep + suffix
+	}
+
+	return d.volumeResourceNamePrefix() + volName, nil
+}
+
+// extractDataFromVolumeResourceName decodes the PowerStore volume resource
+// name and extracts the stored data.
+func (d *powerstore) extractDataFromVolumeResourceName(name string) (poolHash string, volType VolumeType, volUUID uuid.UUID, volContentType ContentType, err error) {
+	prefixLess, hasPrefix := strings.CutPrefix(name, powerStoreResourceNamePrefix)
+	if !hasPrefix {
+		return "", "", uuid.Nil, "", fmt.Errorf("Cannot decode volume name %q: invalid name format", name)
+	}
+
+	poolHash, volName, ok := strings.Cut(prefixLess, powerStorePoolAndVolSep)
+	if !ok || poolHash == "" || volName == "" {
+		return "", "", uuid.Nil, "", fmt.Errorf("Cannot decode volume name %q: invalid name format", name)
+	}
+
+	prefix, volNameWithoutPrefix, ok := strings.Cut(volName, powerStoreVolPrefixSep)
+	if ok {
+		volName = volNameWithoutPrefix
+		volType = powerStoreVolTypePrefixesRev[prefix]
+	}
+
+	volNameWithoutSuffix, suffix, ok := strings.Cut(volName, powerStoreVolSuffixSep)
+	if ok {
+		volName = volNameWithoutSuffix
+		volContentType = powerStoreVolContentTypeSuffixesRev[suffix]
+	}
+
+	binUUID, err := base64.StdEncoding.DecodeString(volName)
+	if err != nil {
+		return poolHash, volType, volUUID, volContentType, fmt.Errorf("Cannot decode volume name %q: %w", name, err)
+	}
+
+	volUUID, err = uuid.FromBytes(binUUID)
+	if err != nil {
+		return poolHash, volType, volUUID, volContentType, fmt.Errorf("Failed parsing UUID from decoded volume name: %w", err)
+	}
+
+	return poolHash, volType, volUUID, volContentType, nil
+}
+
+// volumeWWN derives the world wide name of a volume resource in PowerStore
+// from the provided volume resource.
+func (d *powerstore) volumeWWN(volResource *powerstoreclient.VolumeResource) string {
+	_, wwn, _ := strings.Cut(volResource.WWN, ".")
+	return wwn
+}
+
+// hostResourceName derives the name of a host resource in PowerStore
+// associated with the current node or host and mode. On success, it returns
+// name applicable to use as PowerStore host resource name along of full
+// unencoded name.
+func (d *powerstore) hostResourceName() (resource string, hostname string, err error) {
+	hostname, err = ResolveServerName(d.state.ServerName)
+	if err != nil {
+		return "", "", err
+	}
+
+	resource = fmt.Sprintf("%s%s-%s/%s", powerStoreResourceNamePrefix, hostname, d.config["powerstore.mode"], d.config["powerstore.transport"])
+	if len(resource) > 128 { // PowerStore limits host resource name to 128 characters
+		hostnameHash := sha256.Sum256([]byte(hostname))
+		resource = fmt.Sprintf("%s%s-%s/%s", powerStoreResourceNamePrefix, base64.StdEncoding.EncodeToString(hostnameHash[:]), d.config["powerstore.mode"], d.config["powerstore.transport"])
+	}
+
+	return resource, hostname, nil
+}
+
+// initiator returns PowerStore initiator resource associated the current host,
+// mode and transport.
+func (d *powerstore) initiator() (*powerstoreclient.HostInitiatorResource, error) {
+	if d.initiatorResource == nil {
+		initiatorResource := &powerstoreclient.HostInitiatorResource{}
+		connector, err := d.connector()
+		if err != nil {
+			return nil, err
+		}
+
+		initiatorResource.PortName, err = connector.QualifiedName()
+		if err != nil {
+			return nil, err
+		}
+
+		switch {
+		case d.config["powerstore.mode"] == connectors.TypeNVME:
+			// PowerStore uses the same port type for both NVMe/TCP and NVMe/FC
+			initiatorResource.PortType = powerstoreclient.InitiatorPortTypeEnumNVMe
+		case d.config["powerstore.mode"] == connectors.TypeISCSI && d.config["powerstore.transport"] == "tcp":
+			initiatorResource.PortType = powerstoreclient.InitiatorPortTypeEnumISCSI
+		case d.config["powerstore.mode"] == connectors.TypeISCSI && d.config["powerstore.transport"] == "fc":
+			initiatorResource.PortType = powerstoreclient.InitiatorPortTypeEnumFC
+		default:
+			return nil, fmt.Errorf("Cannot determine PowerStore initiator port type (mode: %q, transport: %q)", d.config["powerstore.mode"], d.config["powerstore.transport"])
+		}
+
+		d.initiatorResource = initiatorResource
+	}
+
+	return d.initiatorResource, nil
+}
+
+// getMappedDevicePathByVolumeID returns the local device path associated with
+// the given PowerStore volume WWN.
+func (d *powerstore) getMappedDevicePathByVolumeWWN(volWWN string, wait bool) (devicePath string, err error) {
+	connector, err := d.connector()
+	if err != nil {
+		return "", err
+	}
+
+	devicePathFilter := func(path string) bool {
+		return strings.Contains(path, volWWN)
+	}
+
+	if wait {
+		// Wait for the device path to appear as the volume has been just mapped to the host.
+		devicePath, err = connector.WaitDiskDevicePath(d.state.ShutdownCtx, devicePathFilter)
+	} else {
+		// Get the the device path without waiting.
+		devicePath, err = connector.GetDiskDevicePath(devicePathFilter)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return devicePath, nil
+}
+
+// mapVolumeByVolumeResource maps the volume associated with the given
+// PowerStore volume resource onto this host.
+func (d *powerstore) mapVolumeByVolumeResource(volResource *powerstoreclient.VolumeResource) (revert.Hook, error) {
+	connector, err := d.connector()
+	if err != nil {
+		return nil, err
+	}
+
+	unlock, err := remoteVolumeMapLock(connector.Type(), d.Info().Name)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unlock()
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	hostResource, err := d.getOrCreateHostWithInitiatorResource()
+	if err != nil {
+		return nil, err
+	}
+
+	reverter.Add(func() { _ = d.deleteHostAndInitiatorResource(hostResource) })
+
+	mapped := slices.ContainsFunc(volResource.MappedVolumes, func(mappingResource *powerstoreclient.HostVolumeMappingResource) bool {
+		return mappingResource.HostID == hostResource.ID
+	})
+	if !mapped {
+		err := d.client().AttachHostToVolume(d.state.ShutdownCtx, hostResource.ID, volResource.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		reverter.Add(func() { _ = d.client().DetachHostFromVolume(d.state.ShutdownCtx, hostResource.ID, volResource.ID) })
+	}
+
+	// Reverting mapping or connection outside mapVolume function
+	// could conflict with other ongoing operations as lock will
+	// already be released. Therefore, use unmapVolume instead
+	// because it ensures the lock is acquired and accounts for
+	// an existing session before unmapping a volume.
+	outerReverter := revert.New()
+	if !mapped {
+		outerReverter.Add(func() { _ = d.unmapVolumeByVolumeResource(volResource) })
+	}
+
+	targets, err := d.targets()
+	if err != nil {
+		return nil, err
+	}
+
+	for qualifiedName, addresses := range powerStoreGroupTargetsAddressesByQualifiedName(targets...) {
+		cleanup, err := connector.Connect(d.state.ShutdownCtx, qualifiedName, addresses...)
+		if err != nil {
+			return nil, err
+		}
+
+		reverter.Add(cleanup)
+		outerReverter.Add(cleanup)
+	}
+
+	reverter.Success()
+	return outerReverter.Fail, nil
+}
+
+// unmapVolumeByVolumeResource unmaps the volume associated with the given
+// PowerStore volume resource from this host.
+func (d *powerstore) unmapVolumeByVolumeResource(volResource *powerstoreclient.VolumeResource) error {
+	connector, err := d.connector()
+	if err != nil {
+		return err
+	}
+
+	unlock, err := remoteVolumeMapLock(connector.Type(), d.Info().Name)
+	if err != nil {
+		return err
+	}
+
+	defer unlock()
+
+	hostResource, _, err := d.getHostWithInitiatorResource()
+	if err != nil {
+		return err
+	}
+
+	var volumePath string
+	if volResource != nil {
+		// Get a path of a block device we want to unmap, ignoring any errors.
+		volumePath, _ := d.getMappedDevicePathByVolumeWWN(d.volumeWWN(volResource), false)
+		err = connector.RemoveDiskDevice(d.state.ShutdownCtx, volumePath)
+		if err != nil {
+			return fmt.Errorf("Cannot unmap device for PowerStore volume resource with ID %q: %w", volResource.ID, err)
+		}
+	}
+
+	if hostResource != nil && volResource != nil {
+		for _, mappingResource := range volResource.MappedVolumes {
+			if mappingResource.HostID != hostResource.ID {
+				continue
+			}
+
+			err := d.client().DetachHostFromVolume(d.state.ShutdownCtx, mappingResource.HostID, volResource.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if volumePath != "" {
+		// Wait until the volume has disappeared.
+		ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
+		defer cancel()
+
+		if !block.WaitDiskDeviceGone(ctx, volumePath) {
+			return fmt.Errorf("Timeout exceeded waiting for disk device %q related to PowerStore volume resource with ID %q to disappear", volumePath, volResource.ID)
+		}
+	}
+
+	// Disconnect connector if:
+	// - there is no associated PowerStore host resource,
+	// - there are no other volumes mapped.
+	if hostResource == nil || len(hostResource.MappedHosts) == 0 {
+		targets, err := d.targets()
+		if err != nil {
+			return err
+		}
+
+		for qualifiedName := range powerStoreGroupTargetsAddressesByQualifiedName(targets...) {
+			err = connector.Disconnect(qualifiedName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if hostResource != nil {
+		err = d.deleteHostAndInitiatorResource(hostResource)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getVolumeResourceByVolume retrieves volume resource associated with
+// the provided volume.
+func (d *powerstore) getVolumeResourceByVolume(vol Volume) (*powerstoreclient.VolumeResource, error) {
+	volResourceName, err := d.volumeResourceName(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	volResource, err := d.client().GetVolumeByName(d.state.ShutdownCtx, volResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource %q associated with volume %q: %w", volResourceName, vol.name, err)
+	}
+
+	return volResource, nil
+}
+
+// getExistingVolumeResourceByVolume retrieves volume resource associated with
+// the provided volume, just like getVolumeResourceByVolume function, but
+// returns error if the volume resource does not exists.
+func (d *powerstore) getExistingVolumeResourceByVolume(vol Volume) (*powerstoreclient.VolumeResource, error) {
+	volResourceName, err := d.volumeResourceName(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	volResource, err := d.client().GetVolumeByName(d.state.ShutdownCtx, volResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource %q associated with volume %q: %w", volResourceName, vol.name, err)
+	}
+
+	if volResource == nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume resource %q associated with volume %q: resource not found", volResourceName, vol.name)
+	}
+
+	return volResource, nil
+}
+
+// createVolumeResource creates volume resources in PowerStore associated with
+// the provided volume.
+func (d *powerstore) createVolumeResource(vol Volume) (*powerstoreclient.VolumeResource, error) {
+	sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
+	if err != nil {
+		return nil, err
+	}
+
+	if sizeBytes < powerStoreMinVolumeSizeBytes {
+		return nil, fmt.Errorf("Volume size is too small, supported minimum %s", powerStoreMinVolumeSizeUnit)
+	}
+
+	if sizeBytes > powerStoreMaxVolumeSizeBytes {
+		return nil, fmt.Errorf("Volume size is too large, supported maximum %s", powerStoreMaxVolumeSizeUnit)
+	}
+
+	volResourceName, err := d.volumeResourceName(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	typ := "lxd"
+	if vol.volType != "" {
+		typ += ":" + string(vol.volType)
+	}
+
+	if vol.contentType != "" {
+		typ += ":" + string(vol.contentType)
+	}
+
+	volResource := &powerstoreclient.VolumeResource{
+		Name:         volResourceName,
+		Description:  limitString("LXD Name: "+vol.name, 128), // maximum allowed value length for volume description field is 128
+		Size:         sizeBytes,
+		AppType:      "Other",
+		AppTypeOther: limitString(typ, 32), // maximum allowed value length for volume app_type_other field is 32,
+	}
+
+	err = d.client().CreateVolume(d.state.ShutdownCtx, volResource)
+	if err != nil {
+		return nil, err
+	}
+
+	return volResource, nil
+}
+
+// deleteVolumeResource deletes volume resources in PowerStore.
+func (d *powerstore) deleteVolumeResource(volResource *powerstoreclient.VolumeResource) error {
+	for _, mappingResource := range volResource.MappedVolumes {
+		err := d.client().DetachHostFromVolume(d.state.ShutdownCtx, mappingResource.HostID, volResource.ID)
+		if err != nil {
+			return err
+		}
+	}
+	for _, volumeGroupResource := range volResource.VolumeGroups {
+		err := d.client().RemoveMembersFromVolumeGroup(d.state.ShutdownCtx, volumeGroupResource.ID, []string{volResource.ID})
+		if err != nil {
+			return err
+		}
+	}
+	return d.client().DeleteVolumeByID(d.state.ShutdownCtx, volResource.ID)
+}
+
+// getHostWithInitiatorResource retrieves initiator and associated host
+// resources from PowerStore associated with the current host, mode and
+// transport.
+func (d *powerstore) getHostWithInitiatorResource() (*powerstoreclient.HostResource, *powerstoreclient.HostInitiatorResource, error) {
+	initiatorResource, err := d.initiator()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostResource, err := d.client().GetHostByInitiator(d.state.ShutdownCtx, initiatorResource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if hostResource != nil {
+		// host with initiator already exists
+		return hostResource, initiatorResource, nil
+	}
+
+	// no initiator found
+	hostResourceName, _, err := d.hostResourceName()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostResource, err = d.client().GetHostByName(d.state.ShutdownCtx, hostResourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if hostResource != nil {
+		// host without initiator found
+		return hostResource, nil, nil
+	}
+
+	// no host or initiator exists
+	return nil, nil, nil
+}
+
+// getOrCreateHostWithInitiatorResource retrieves (or creates if missing)
+// initiator and associated host resources in PowerStore associated with
+// the current host, mode and transport.
+func (d *powerstore) getOrCreateHostWithInitiatorResource() (*powerstoreclient.HostResource, error) {
+	hostResource, initiatorResource, err := d.getHostWithInitiatorResource()
+	if err != nil {
+		return nil, err
+	}
+
+	if hostResource == nil {
+		// no host or initiator exists
+		initiatorResource, err = d.initiator()
+		if err != nil {
+			return nil, err
+		}
+
+		hostResourceName, hostname, err := d.hostResourceName()
+		if err != nil {
+			return nil, err
+		}
+
+		hostResource = &powerstoreclient.HostResource{
+			Name:        hostResourceName,
+			Description: limitString("LXD Name: "+hostname, 256), // maximum allowed value length for host description field is 256
+			OsType:      powerstoreclient.OSTypeEnumLinux,
+			Initiators:  []*powerstoreclient.HostInitiatorResource{initiatorResource},
+		}
+
+		err = d.client().CreateHost(d.state.ShutdownCtx, hostResource)
+		if err != nil {
+			return nil, err
+		}
+
+		return hostResource, nil
+	}
+
+	if initiatorResource == nil {
+		// host exists but initiator is missing
+		initiatorResource, err = d.initiator()
+		if err != nil {
+			return nil, err
+		}
+
+		err = d.client().AddInitiatorToHostByID(d.state.ShutdownCtx, hostResource.ID, initiatorResource)
+		if err != nil {
+			return nil, err
+		}
+
+		return d.client().GetHostByID(d.state.ShutdownCtx, hostResource.ID) // refetch to refresh the data
+	}
+
+	// host with initiator already exists
+	return hostResource, nil
+}
+
+// deleteHostAndInitiatorResource deletes initiator and associated host
+// resources in PowerStore if there are no mapped (attached) volumes.
+func (d *powerstore) deleteHostAndInitiatorResource(hostResource *powerstoreclient.HostResource) error {
+	initiatorResource, err := d.initiator()
+	if err != nil {
+		return err
+	}
+
+	hostResourceName, _, err := d.hostResourceName()
+	if err != nil {
+		return err
+	}
+
+	if len(hostResource.MappedHosts) > 0 {
+		// host has some other volumes mapped
+		return nil
+	}
+
+	if len(hostResource.Initiators) > 1 {
+		// host has multiple initiators associated
+		return nil
+	}
+
+	if len(hostResource.Initiators) == 1 && (hostResource.Initiators[0].PortName != initiatorResource.PortName || hostResource.Initiators[0].PortType != initiatorResource.PortType) {
+		// associated initiator do not matches the expected one
+		return nil
+	}
+
+	if hostResource.Name != hostResourceName {
+		// host is not managed by LXD
+		return nil
+	}
+
+	return d.client().DeleteHostByID(d.state.ShutdownCtx, hostResource.ID)
+}

--- a/lxd/storage/drivers/driver_powerstore_utils_test.go
+++ b/lxd/storage/drivers/driver_powerstore_utils_test.go
@@ -1,0 +1,262 @@
+package drivers
+
+import (
+	"testing"
+)
+
+func TestPowerStoreVolumeResourceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		given   Volume
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "container-volume",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeContainer,
+				contentType: "",
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "3a628d33-a689-462b-b23e-9a10e423b02e"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-c_OmKNM6aJRiuyPpoQ5COwLg==",
+		},
+		{
+			name: "vm-volume-iso",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeVM,
+				contentType: ContentTypeISO,
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "3a628d33-a689-462b-b23e-9a10e423b02e"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-v_OmKNM6aJRiuyPpoQ5COwLg==.i",
+		},
+		{
+			name: "vm-volume-block",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeVM,
+				contentType: ContentTypeBlock,
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "3a628d33-a689-462b-b23e-9a10e423b02e"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-v_OmKNM6aJRiuyPpoQ5COwLg==.b",
+		},
+		{
+			name: "image-volume",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeImage,
+				contentType: "",
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "3a628d33-a689-462b-b23e-9a10e423b02e"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-i_OmKNM6aJRiuyPpoQ5COwLg==",
+		},
+		{
+			name: "custom-volume",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeCustom,
+				contentType: "",
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "3a628d33-a689-462b-b23e-9a10e423b02e"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-u_OmKNM6aJRiuyPpoQ5COwLg==",
+		},
+		{
+			name: "other-name-and-uuid",
+			given: Volume{
+				driver:      nil,
+				pool:        "other-pool-name",
+				volType:     "unknown-vol-type",
+				contentType: "unknown-vol-content-type",
+				name:        "other-vol-name",
+				config:      map[string]string{"volatile.uuid": "2731b28f-464b-4eac-b0cd-ec03d9effbf0"},
+				poolConfig:  map[string]string{},
+			},
+			want: "lxd:omYUlOQRvuW2uffxWqsCQCue5SfEs4+khWLni1wNmC4=-JzGyj0ZLTqywzewD2e/78A==",
+		},
+		{
+			name: "invalid-volume-volatile-uuid",
+			given: Volume{
+				driver:      nil,
+				pool:        "pool-name",
+				volType:     VolumeTypeCustom,
+				contentType: "",
+				name:        "vol-name",
+				config:      map[string]string{"volatile.uuid": "invalid-value"},
+				poolConfig:  map[string]string{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := (&powerstore{common: common{name: test.given.pool}}).volumeResourceName(test.given)
+			if err != nil && !test.wantErr {
+				t.Fatalf("unexpected error while getting PowerStore volume name: %v", err)
+			}
+
+			if err == nil && test.wantErr {
+				t.Fatalf("expected error while getting PowerStore volume name, got nil")
+			}
+
+			if test.want != got {
+				t.Errorf("unexpected result of getting PowerStore volume name (want: %q, got %q)", test.want, got)
+			}
+		})
+	}
+}
+
+func TestPowerStoreExtractDataFromVolumeResourceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                  string
+		given                 string
+		wantPoolHash          string
+		wantVolumeType        VolumeType
+		wantVolumeUUID        string
+		wantVolumeContentType ContentType
+		wantErr               bool
+	}{
+		{
+			name:                  "container-volume",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-c_OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeContainer,
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: "",
+		},
+		{
+			name:                  "vm-volume-iso",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-v_OmKNM6aJRiuyPpoQ5COwLg==.i",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeVM,
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: ContentTypeISO,
+		},
+		{
+			name:                  "vm-volume-block",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-v_OmKNM6aJRiuyPpoQ5COwLg==.b",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeVM,
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: ContentTypeBlock,
+		},
+		{
+			name:                  "image-volume",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-i_OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeImage,
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: "",
+		},
+		{
+			name:                  "custom-volume",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-u_OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeCustom,
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: "",
+		},
+		{
+			name:                  "missing-volume-type-and-content-type",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        "",
+			wantVolumeUUID:        "3a628d33-a689-462b-b23e-9a10e423b02e",
+			wantVolumeContentType: "",
+		},
+		{
+			name:                  "missing-prefix",
+			given:                 "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-u_OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "",
+			wantVolumeType:        "",
+			wantVolumeUUID:        "00000000-0000-0000-0000-000000000000",
+			wantVolumeContentType: "",
+			wantErr:               true,
+		},
+		{
+			name:                  "missing-pool-name-hash",
+			given:                 "u_OmKNM6aJRiuyPpoQ5COwLg==",
+			wantPoolHash:          "",
+			wantVolumeType:        "",
+			wantVolumeUUID:        "00000000-0000-0000-0000-000000000000",
+			wantVolumeContentType: "",
+			wantErr:               true,
+		},
+		{
+			name:                  "missing-volume-data",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantPoolHash:          "",
+			wantVolumeType:        "",
+			wantVolumeUUID:        "00000000-0000-0000-0000-000000000000",
+			wantVolumeContentType: "",
+			wantErr:               true,
+		},
+		{
+			name:                  "invalid-base64-encoded-volume-uuid",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-u_OmKNM6aJRiuyPpoQ5COwLg=",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeCustom,
+			wantVolumeUUID:        "00000000-0000-0000-0000-000000000000",
+			wantVolumeContentType: "",
+			wantErr:               true,
+		},
+		{
+			name:                  "invalid-volume-uuid",
+			given:                 "lxd:2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=-u_OmKNM6aJRiuyPpoQ5COwLgaaaa==",
+			wantPoolHash:          "2qwxIqsfgiGetqVdSVHgyhn3Kvtz65HGHeOkgAshhG8=",
+			wantVolumeType:        VolumeTypeCustom,
+			wantVolumeUUID:        "00000000-0000-0000-0000-000000000000",
+			wantVolumeContentType: "",
+			wantErr:               true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			gotPoolHash, gotVolumeType, gotVolumeUUID, gotVolumeContentType, err := (&powerstore{}).extractDataFromVolumeResourceName(test.given)
+			if err != nil && !test.wantErr {
+				t.Fatalf("unexpected error while retrieving data from PowerStore volume name: %v", err)
+			}
+
+			if err == nil && test.wantErr {
+				t.Fatalf("expected error while retrieving data from PowerStore volume name, got nil")
+			}
+
+			if test.wantPoolHash != gotPoolHash {
+				t.Errorf("wrong pool hash retrieved from PowerStore volume name (want: %q, got %q)", test.wantPoolHash, gotPoolHash)
+			}
+
+			if test.wantVolumeType != gotVolumeType {
+				t.Errorf("wrong volume type retrieved from PowerStore volume name (want: %q, got %q)", test.wantVolumeType, gotVolumeType)
+			}
+
+			if test.wantVolumeUUID != gotVolumeUUID.String() {
+				t.Errorf("wrong volume UUID retrieved from PowerStore volume name (want: %q, got %q)", test.wantVolumeUUID, gotVolumeUUID)
+			}
+
+			if test.wantVolumeContentType != gotVolumeContentType {
+				t.Errorf("wrong volume content type retrieved from PowerStore volume name (want: %q, got %q)", test.wantVolumeContentType, gotVolumeContentType)
+			}
+		})
+	}
+}

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,0 +1,155 @@
+package drivers
+
+import (
+	"strconv"
+
+	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/units"
+)
+
+// roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
+// multiple of 1 MiB, which is the minimum volume size on PowerStore.
+func (d *powerstore) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {
+	return roundAbove(powerStoreMinVolumeSizeBytes, sizeBytes)
+}
+
+// FillVolumeConfig populate volume with default config.
+func (d *powerstore) FillVolumeConfig(vol Volume) error {
+	// Copy volume.* configuration options from pool.
+	// Exclude 'block.filesystem' and 'block.mount_options'
+	// as these ones are handled below in this function and depend on the volume's type.
+	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
+	if err != nil {
+		return err
+	}
+
+	// Only validate filesystem config keys for filesystem volumes or VM block
+	// volumes (which have an associated filesystem volume).
+	if vol.ContentType() == ContentTypeFS || vol.IsVMBlock() {
+		// VM volumes will always use the default filesystem.
+		if vol.IsVMBlock() {
+			vol.config["block.filesystem"] = DefaultFilesystem
+		} else {
+			// Inherit filesystem from pool if not set.
+			if vol.config["block.filesystem"] == "" {
+				vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
+			}
+
+			// Default filesystem if neither volume nor pool specify an override.
+			if vol.config["block.filesystem"] == "" {
+				// Unchangeable volume property: Set unconditionally.
+				vol.config["block.filesystem"] = DefaultFilesystem
+			}
+		}
+
+		// Inherit filesystem mount options from pool if not set.
+		if vol.config["block.mount_options"] == "" {
+			vol.config["block.mount_options"] = d.config["volume.block.mount_options"]
+		}
+
+		// Default filesystem mount options if neither volume nor pool specify an override.
+		if vol.config["block.mount_options"] == "" {
+			// Unchangeable volume property: Set unconditionally.
+			vol.config["block.mount_options"] = "discard"
+		}
+	}
+
+	return nil
+}
+
+// ValidateVolume validates the supplied volume config.
+func (d *powerstore) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+	if vol.ContentType() == ContentTypeISO {
+		sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
+		if err != nil {
+			return err
+		}
+
+		sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+		vol.SetConfigSize(strconv.FormatInt(sizeBytes, 10))
+	}
+
+	commonRules := d.commonVolumeRules()
+
+	// Disallow block.* settings for regular custom block volumes. These settings only make sense
+	// when using custom filesystem volumes. LXD will create the filesystem
+	// for these volumes, and use the mount options. When attaching a regular block volume to a VM,
+	// these are not mounted by LXD and therefore don't need these config keys.
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
+		delete(commonRules, "block.filesystem")
+		delete(commonRules, "block.mount_options")
+	}
+
+	return d.validateVolume(vol, commonRules, removeUnknownKeys)
+}
+
+// HasVolume indicates whether a specific volume exists on the storage pool.
+func (d *powerstore) HasVolume(vol Volume) (bool, error) {
+	return false, ErrNotSupported
+}
+
+// CreateVolume creates an empty volume and can optionally fill it by executing
+// the supplied filler function.
+func (d *powerstore) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// DeleteVolume deletes a volume of the storage device.
+func (d *powerstore) DeleteVolume(vol Volume, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// RenameVolume renames a volume and its snapshots.
+func (d *powerstore) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// UpdateVolume applies config changes to the volume.
+func (d *powerstore) UpdateVolume(vol Volume, changedConfig map[string]string) error {
+	return ErrNotSupported
+}
+
+// GetVolumeUsage returns the disk space used by the volume.
+func (d *powerstore) GetVolumeUsage(vol Volume) (int64, error) {
+	return 0, ErrNotSupported
+}
+
+// SetVolumeQuota applies a size limit on volume.
+func (d *powerstore) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// GetVolumeDiskPath returns the location of a root disk block device.
+func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
+	return "", ErrNotSupported
+}
+
+// ListVolumes returns a list of LXD volumes in storage pool.
+// It returns all volumes and sets the volume's volatile.uuid extracted from
+// the name.
+func (d *powerstore) ListVolumes() ([]Volume, error) {
+	return nil, ErrNotSupported
+}
+
+// MountVolume mounts a volume and increments ref counter. Please call
+// UnmountVolume() when done with the volume.
+func (d *powerstore) MountVolume(vol Volume, op *operations.Operation) error {
+	return ErrNotSupported
+}
+
+// getMappedDevicePath returns the local device path for the given volume.
+//
+// Indicate with mapVolume if the volume should get mapped to the system if it
+// is not present.
+func (d *powerstore) getMappedDevicePath(vol Volume, mapVolume bool) (string, revert.Hook, error) {
+	return "", nil, ErrNotSupported
+}
+
+// UnmountVolume simulates unmounting a volume.
+//
+// keepBlockDev indicates if the backing block device should not be unmapped if
+// the volume is unmounted.
+func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+	return false, ErrNotSupported
+}

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,11 +1,20 @@
 package drivers
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"strconv"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
+	"github.com/canonical/lxd/shared/validate"
 )
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
@@ -86,42 +95,334 @@ func (d *powerstore) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 
 // HasVolume indicates whether a specific volume exists on the storage pool.
 func (d *powerstore) HasVolume(vol Volume) (bool, error) {
-	return false, ErrNotSupported
+	volResource, err := d.getVolumeResourceByVolume(vol)
+	if err != nil {
+		return false, err
+	}
+
+	return volResource != nil, nil
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing
 // the supplied filler function.
 func (d *powerstore) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return ErrNotSupported
+	revert := revert.New()
+	defer revert.Fail()
+
+	volResource, err := d.createVolumeResource(vol)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(func() { _ = d.deleteVolumeResource(volResource) })
+
+	if vol.contentType == ContentTypeFS {
+		cleanup, err := d.mapVolumeByVolumeResource(volResource)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(cleanup)
+
+		devPath, err := d.getMappedDevicePathByVolumeWWN(d.volumeWWN(volResource), true)
+		if err != nil {
+			return err
+		}
+
+		volumeFilesystem := vol.ConfigBlockFilesystem()
+		_, err = makeFSType(devPath, volumeFilesystem, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// For VMs, also create the filesystem volume.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.CreateVolume(fsVol, nil, op)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+	}
+
+	mountTask := func(mountPath string, op *operations.Operation) error {
+		// Run the volume filler function if supplied.
+		if filler != nil && filler.Fill != nil {
+			var err error
+			var devPath string
+
+			if IsContentBlock(vol.contentType) {
+				// Get the device path.
+				devPath, err = d.GetVolumeDiskPath(vol)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Run the filler.
+			err = d.runFiller(vol, devPath, filler, true)
+			if err != nil {
+				return err
+			}
+
+			// Move the GPT alt header to end of disk if needed.
+			if vol.IsVMBlock() {
+				err = d.moveGPTAltHeader(devPath)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if vol.contentType == ContentTypeFS {
+			// Run EnsureMountPath again after mounting and filling to ensure the mount
+			// directory has the correct permissions set.
+			err = vol.EnsureMountPath()
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	err = vol.MountTask(mountTask, op)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // DeleteVolume deletes a volume of the storage device.
 func (d *powerstore) DeleteVolume(vol Volume, op *operations.Operation) error {
-	return ErrNotSupported
+	volResource, err := d.getVolumeResourceByVolume(vol)
+	if err != nil {
+		return err
+	}
+
+	if volResource != nil {
+		err = d.deleteVolumeResource(volResource)
+		if err != nil {
+			return err
+		}
+	}
+
+	hostResource, _, err := d.getHostWithInitiatorResource()
+	if err != nil {
+		return err
+	}
+
+	if hostResource != nil {
+		err = d.deleteHostAndInitiatorResource(hostResource)
+		if err != nil {
+			return err
+		}
+	}
+
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.DeleteVolume(fsVol, op)
+		if err != nil {
+			return err
+		}
+	}
+
+	mountPath := vol.MountPath()
+	if vol.contentType == ContentTypeFS && shared.PathExists(mountPath) {
+		err := wipeDirectory(mountPath)
+		if err != nil {
+			return err
+		}
+
+		err = os.RemoveAll(mountPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Removing %q directory: %w", mountPath, err)
+		}
+	}
+
+	return nil
 }
 
 // RenameVolume renames a volume and its snapshots.
 func (d *powerstore) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
-	return ErrNotSupported
+	// Renaming a volume in PowerStore will not change the name of the associated volume resource.
+	return nil
 }
 
 // UpdateVolume applies config changes to the volume.
 func (d *powerstore) UpdateVolume(vol Volume, changedConfig map[string]string) error {
-	return ErrNotSupported
+	newSize, sizeChanged := changedConfig["size"]
+	if sizeChanged {
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GetVolumeUsage returns the disk space used by the volume.
 func (d *powerstore) GetVolumeUsage(vol Volume) (int64, error) {
-	return 0, ErrNotSupported
+	// If mounted, use the filesystem stats for pretty accurate usage information.
+	if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(vol.MountPath()) {
+		var stat unix.Statfs_t
+		err := unix.Statfs(vol.MountPath(), &stat)
+		if err != nil {
+			return -1, err
+		}
+
+		return int64(stat.Blocks-stat.Bfree) * int64(stat.Bsize), nil
+	}
+
+	volResource, err := d.getExistingVolumeResourceByVolume(vol)
+	if err != nil {
+		return -1, err
+	}
+
+	return volResource.LogicalUsed, nil
 }
 
 // SetVolumeQuota applies a size limit on volume.
 func (d *powerstore) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
-	return ErrNotSupported
+	// Convert to bytes.
+	sizeBytes, err := units.ParseByteSizeString(size)
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if size isn't specified.
+	if sizeBytes <= 0 {
+		return nil
+	}
+
+	volResource, err := d.getExistingVolumeResourceByVolume(vol)
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if volume is already specified size (+/- 512 bytes).
+	if volResource.Size+512 > sizeBytes && volResource.Size-512 < sizeBytes {
+		return nil
+	}
+
+	// PowerStore supports increasing of size only.
+	if sizeBytes < volResource.Size {
+		return errors.New("Volume capacity can only be increased")
+	}
+
+	// Validate the minimum size.
+	err = validate.IsNoLessThanUnit(powerStoreMinVolumeSizeUnit)(size)
+	if err != nil {
+		return err
+	}
+
+	// Validate the maximum size.
+	err = validate.IsNoGreaterThanUnit(powerStoreMaxVolumeSizeUnit)(size)
+	if err != nil {
+		return err
+	}
+
+	// Validate the alignment.
+	err = validate.IsMultipleOfUnit(powerStoreMinVolumeSizeAlignmentUnit)(size)
+	if err != nil {
+		return err
+	}
+
+	connector, err := d.connector()
+	if err != nil {
+		return err
+	}
+
+	// Resize filesystem if needed.
+	if vol.contentType == ContentTypeFS {
+		// Resize block device.
+		err = d.client().ResizeVolumeByID(d.state.ShutdownCtx, volResource.ID, sizeBytes)
+		if err != nil {
+			return err
+		}
+
+		devPath, cleanup, err := d.getMappedDevicePath(vol, true)
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
+
+		// Always wait for the disk to reflect the new size. In case SetVolumeQuota
+		// is called on an already mapped volume, it might take some time until
+		// the actual size of the device is reflected on the host. This is for
+		// example the case when creating a volume and the filler performs a resize
+		// in case the image exceeds the volume's size.
+		err = connector.WaitDiskDeviceResize(d.state.ShutdownCtx, devPath, sizeBytes)
+		if err != nil {
+			return fmt.Errorf("Failed waiting for volume %q to change its size: %w", vol.name, err)
+		}
+
+		// Grow the filesystem to fill block device.
+		fsType := vol.ConfigBlockFilesystem()
+		err = growFileSystem(fsType, devPath, vol)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Only perform pre-resize checks if we are not in "unsafe" mode. In unsafe
+	// mode we expect the caller to know what they are doing and understand
+	// the risks.
+	if !allowUnsafeResize && vol.MountInUse() {
+		// We don't allow online resizing of block volumes.
+		return ErrInUse
+	}
+
+	// Resize block device.
+	err = d.client().ResizeVolumeByID(d.state.ShutdownCtx, volResource.ID, sizeBytes)
+	if err != nil {
+		return err
+	}
+
+	devPath, cleanup, err := d.getMappedDevicePath(vol, true)
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+
+	// Wait for the block device to be resized before moving GPT alt header.
+	// This ensures that the GPT alt header is not moved before the actual
+	// size is reflected on a local host. Otherwise, the GPT alt header
+	// would be moved to the same location.
+	err = connector.WaitDiskDeviceResize(d.state.ShutdownCtx, devPath, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("Failed waiting for volume %q to change its size: %w", vol.name, err)
+	}
+
+	// Move the VM GPT alt header to end of disk if needed (not needed in unsafe
+	// resize mode as it is expected the caller will do all necessary post resize
+	// actions themselves).
+	if vol.IsVMBlock() && !allowUnsafeResize {
+		err = d.moveGPTAltHeader(devPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GetVolumeDiskPath returns the location of a root disk block device.
 func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
+	if vol.IsVMBlock() || (vol.volType == VolumeTypeCustom && IsContentBlock(vol.contentType)) {
+		devPath, _, err := d.getMappedDevicePath(vol, false)
+		return devPath, err
+	}
+
 	return "", ErrNotSupported
 }
 
@@ -129,13 +430,38 @@ func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
 // It returns all volumes and sets the volume's volatile.uuid extracted from
 // the name.
 func (d *powerstore) ListVolumes() ([]Volume, error) {
-	return nil, ErrNotSupported
+	volResources, err := d.client().GetVolumes(d.state.ShutdownCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	vols := make([]Volume, 0, len(volResources))
+	for _, volResource := range volResources {
+		_, volType, volUUID, volContentType, err := d.extractDataFromVolumeResourceName(volResource.Name)
+		if err != nil {
+			d.logger.Debug("Ignoring unrecognized volume", logger.Ctx{"name": volResource.Name, "err": err.Error()})
+			continue
+		}
+
+		volConfig := map[string]string{
+			"volatile.uuid": volUUID.String(),
+		}
+
+		vol := NewVolume(d, d.name, volType, volContentType, "", volConfig, d.config)
+		if volContentType == ContentTypeFS {
+			vol.SetMountFilesystemProbe(true)
+		}
+
+		vols = append(vols, vol)
+	}
+
+	return vols, nil
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call
 // UnmountVolume() when done with the volume.
 func (d *powerstore) MountVolume(vol Volume, op *operations.Operation) error {
-	return ErrNotSupported
+	return mountVolume(d, vol, d.getMappedDevicePath, op)
 }
 
 // getMappedDevicePath returns the local device path for the given volume.
@@ -143,7 +469,31 @@ func (d *powerstore) MountVolume(vol Volume, op *operations.Operation) error {
 // Indicate with mapVolume if the volume should get mapped to the system if it
 // is not present.
 func (d *powerstore) getMappedDevicePath(vol Volume, mapVolume bool) (string, revert.Hook, error) {
-	return "", nil, ErrNotSupported
+	revert := revert.New()
+	defer revert.Fail()
+
+	volResource, err := d.getExistingVolumeResourceByVolume(vol)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if mapVolume {
+		cleanup, err := d.mapVolumeByVolumeResource(volResource)
+		if err != nil {
+			return "", nil, err
+		}
+
+		revert.Add(cleanup)
+	}
+
+	devicePath, err := d.getMappedDevicePathByVolumeWWN(d.volumeWWN(volResource), mapVolume)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup := revert.Clone().Fail
+	revert.Success()
+	return devicePath, cleanup, nil
 }
 
 // UnmountVolume simulates unmounting a volume.
@@ -151,5 +501,14 @@ func (d *powerstore) getMappedDevicePath(vol Volume, mapVolume bool) (string, re
 // keepBlockDev indicates if the backing block device should not be unmapped if
 // the volume is unmounted.
 func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return false, ErrNotSupported
+	unmapVolume := func(vol Volume) error {
+		volResource, err := d.getExistingVolumeResourceByVolume(vol)
+		if err != nil {
+			return err
+		}
+
+		return d.unmapVolumeByVolumeResource(volResource)
+	}
+
+	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevicePath, unmapVolume, op)
 }

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -511,4 +512,204 @@ func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, op *operations
 	}
 
 	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevicePath, unmapVolume, op)
+}
+
+// MountVolumeSnapshot mounts a storage volume snapshot.
+func (d *powerstore) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+	revert := revert.New()
+	defer revert.Fail()
+
+	volSnapResource, err := d.getExistingVolumeResourceSnapshotByVolumeSnapshot(snapVol)
+	if err != nil {
+		return err
+	}
+
+	volResource, err := d.copyVolumeResourceSnapshotToVolume(volSnapResource, snapVol)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(func() { _ = d.deleteVolumeResource(volResource) })
+
+	// For VMs, also create the temporary filesystem volume snapshot.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+
+		volFsSnapResource, err := d.getExistingVolumeResourceSnapshotByVolumeSnapshot(snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		volFsResource, err := d.copyVolumeResourceSnapshotToVolume(volFsSnapResource, snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = d.deleteVolumeResource(volFsResource) })
+	}
+
+	err = d.MountVolume(snapVol, op)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
+}
+
+// UnmountVolume unmounts a storage volume snapshot, returns true if unmounted,
+// false if was not mounted.
+func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+	wasUnmounted, err := d.UnmountVolume(snapVol, false, op)
+	if err != nil {
+		return false, err
+	}
+
+	if !wasUnmounted {
+		return false, nil
+	}
+
+	// Cleanup temporary snapshot volume.
+
+	volResource, err := d.getVolumeResourceByVolume(snapVol)
+	if err != nil {
+		return true, err
+	}
+
+	if volResource != nil {
+		err := d.deleteVolumeResource(volResource)
+		if err != nil {
+			return true, err
+		}
+	}
+	// For VMs, also cleanup the temporary volume for a filesystem snapshot.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+
+		volFsResource, err := d.getVolumeResourceByVolume(snapFsVol)
+		if err != nil {
+			return true, err
+		}
+
+		if volFsResource != nil {
+			err := d.deleteVolumeResource(volFsResource)
+			if err != nil {
+				return true, err
+			}
+		}
+	}
+
+	return true, nil
+}
+
+// CreateVolumeSnapshot creates a snapshot of a volume.
+func (d *powerstore) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+	revert := revert.New()
+	defer revert.Fail()
+
+	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
+	sourcePath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
+
+	if filesystem.IsMountPoint(sourcePath) {
+		// Attempt to sync and freeze filesystem, but do not error if not able to freeze (as filesystem
+		// could still be busy), as we do not guarantee the consistency of a snapshot. This is costly but
+		// try to ensure that all cached data has been committed to disk. If we don't then the snapshot
+		// of the underlying filesystem can be inconsistent or, in the worst case, empty.
+		unfreezeFS, err := d.filesystemFreeze(sourcePath)
+		if err == nil {
+			defer func() { _ = unfreezeFS() }()
+		}
+	}
+
+	// Create the parent directory.
+	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	if err != nil {
+		return err
+	}
+
+	err = snapVol.EnsureMountPath()
+	if err != nil {
+		return err
+	}
+
+	_, err = d.createVolumeResourceSnapshot(snapVol)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+
+	// For VMs, create a snapshot of the filesystem volume too.
+	if snapVol.IsVMBlock() {
+		fsVol := snapVol.NewVMBlockFilesystemVolume()
+
+		// Set the parent volume's UUID.
+		fsVol.SetParentUUID(snapVol.parentUUID)
+
+		err := d.CreateVolumeSnapshot(fsVol, op)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+	}
+
+	revert.Success()
+	return nil
+}
+
+// DeleteVolumeSnapshot removes a snapshot from the storage device.
+func (d *powerstore) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+	volSnapResource, err := d.getVolumeResourceSnapshotByVolumeSnapshot(snapVol)
+	if err != nil {
+		return err
+	}
+
+	if volSnapResource != nil {
+		err = d.deleteVolumeResourceSnapshot(volSnapResource)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete temporary volume, if any.
+	_, err = d.UnmountVolumeSnapshot(snapVol, op)
+	if err != nil {
+		return err
+	}
+
+	// For VMs, delete a snapshot of the filesystem volume too.
+	if snapVol.IsVMBlock() {
+		err := d.DeleteVolumeSnapshot(snapVol.NewVMBlockFilesystemVolume(), op)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RenameVolumeSnapshot renames a volume snapshot.
+func (d *powerstore) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+	return nil
+}
+
+// VolumeSnapshots returns a list of volume snapshot names for the given volume.
+func (d *powerstore) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+	volResource, err := d.getExistingVolumeResourceByVolume(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	volSnapResources, err := d.client().GetVolumeSnapshots(d.state.ShutdownCtx, volResource.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotNames := make([]string, 0, len(volSnapResources))
+	for _, volSnapResource := range volSnapResources {
+		snapshotNames = append(snapshotNames, volSnapResource.Name)
+	}
+
+	return snapshotNames, nil
 }

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -13,6 +13,7 @@ var drivers = map[string]func() driver{
 	"dir":        func() driver { return &dir{} },
 	"lvm":        func() driver { return &lvm{} },
 	"powerflex":  func() driver { return &powerflex{} },
+	"powerstore": func() driver { return &powerstore{} },
 	"pure":       func() driver { return &pure{} },
 	"alletra":    func() driver { return &alletra{} },
 	"zfs":        func() driver { return &zfs{} },

--- a/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
+++ b/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
@@ -1,0 +1,414 @@
+package powerstoreclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	"github.com/canonical/lxd/lxd/storage/drivers/tokencache"
+	"github.com/canonical/lxd/shared/api"
+)
+
+const (
+	authorizationCookieName = "auth_cookie"
+	csrfHeaderName          = "DELL-EMC-TOKEN"
+)
+
+// LoginSession describes PowerStore login session.
+type LoginSession struct {
+	ID              string
+	IdleTimeout     time.Duration
+	LastInteraction atomic.Pointer[time.Time]
+	AuthToken       string
+	CSRFToken       string
+}
+
+func newPowerStoreLoginSession(id string, idleTimeout time.Duration, authToken, csrfToken string) *LoginSession {
+	ls := &LoginSession{
+		ID:          id,
+		IdleTimeout: idleTimeout - 30*time.Second, // subtract to add safety margin for a potential time skew
+		AuthToken:   authToken,
+		CSRFToken:   csrfToken,
+	}
+
+	ls.Interacted()
+	return ls
+}
+
+// IsValid inform if the token associated with the login session is not
+// expired.
+func (ls *LoginSession) IsValid() bool {
+	if ls == nil {
+		return false
+	}
+
+	lastInteraction := *ls.LastInteraction.Load()
+	return time.Now().Before(lastInteraction.Add(ls.IdleTimeout))
+}
+
+// Interacted informs the login session object that interaction occurred and
+// last interaction time should be updated.
+func (ls *LoginSession) Interacted() {
+	now := time.Now()
+	ls.LastInteraction.Store(&now)
+}
+
+// makeFingerprint creates a makeFingerprint of the provided strings uniquely
+// identifying them.
+func makeFingerprint(pieces ...string) string {
+	raw := bytes.Buffer{}
+	// Use base64 on the provided strings and separate pieces with ':' to make
+	// sure fingerprint is unique regardless of the strings content.
+	for i, p := range pieces {
+		_, _ = raw.WriteString(base64.StdEncoding.EncodeToString([]byte(p)))
+		if i < len(pieces)-1 {
+			raw.WriteByte(':')
+		}
+	}
+
+	// Hash the concatenated data to shorten the resulting fingerprint.
+	hash := sha256.Sum256(raw.Bytes())
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// PowerStoreError contains arbitrary error responses from PowerStore.
+type PowerStoreError struct {
+	httpStatusCode int
+	details        errorResponseResource
+	decoderErr     error
+}
+
+func newPowerStoreError(resp *http.Response) error {
+	if resp.StatusCode == http.StatusUnauthorized {
+		return api.NewStatusError(http.StatusUnauthorized, "Unauthorized request")
+	}
+
+	e := &PowerStoreError{httpStatusCode: resp.StatusCode}
+	if resp.Header.Get("Content-Type") != "application/json" || resp.Header.Get("Content-Length") == "0" {
+		return e
+	}
+
+	err := json.NewDecoder(resp.Body).Decode(&e.details)
+	if err != nil {
+		e.decoderErr = fmt.Errorf("Unmarshal HTTP error response body: %w", err)
+	}
+
+	return e
+}
+
+// Error attempts to return all kinds of errors from the PowerStore API in
+// a nicely formatted way.
+func (e *PowerStoreError) Error() string {
+	msg := "PowerStore API error"
+	if e.httpStatusCode != 0 {
+		msg = fmt.Sprintf("%s %d response", msg, e.httpStatusCode)
+	}
+
+	details, err := json.Marshal(e.details)
+	if err == nil && len(details) > 0 && !bytes.Equal(details, []byte("{}")) && !bytes.Equal(details, []byte("null")) {
+		msg = fmt.Sprintf("%s; details: %s", msg, details)
+	}
+
+	if e.decoderErr != nil {
+		msg = fmt.Sprintf("%s; response decoding error: %s", msg, e.decoderErr.Error())
+	}
+
+	return msg
+}
+
+// ErrorCode attempts to extract the PowerStore error code value. If the error
+// do not contains the PowerStore error code code function returns an empty
+// string.
+func (e *PowerStoreError) ErrorCode() string {
+	for _, em := range e.details.Messages {
+		if em != nil && em.Code != "" {
+			return em.Code
+		}
+	}
+	return ""
+}
+
+// HTTPStatusCode attempts to extract the HTTP status code value from
+// a PowerStore response. If the error is not associated with some HTTP error
+// code function returns zero.
+func (e *PowerStoreError) HTTPStatusCode() int {
+	return e.httpStatusCode
+}
+
+type errorResponseResource struct {
+	Messages []*errorMessageResource `json:"messages,omitempty"`
+}
+
+type errorMessageResource struct {
+	Severity    string                          `json:"severity"`
+	Code        string                          `json:"code"`
+	MessageL10n string                          `json:"message_l10n"`
+	Arguments   []*errorMessageArgumentResource `json:"arguments,omitempty"`
+}
+
+type errorMessageArgumentResource struct {
+	Delimiter string                   `json:"delimiter,omitempty"`
+	Messages  []*errorInstanceResource `json:"messages,omitempty"`
+}
+
+type errorInstanceResource struct {
+	Severity    string   `json:"severity"`
+	Code        string   `json:"code"`
+	MessageL10n string   `json:"message_l10n"`
+	Arguments   []string `json:"arguments,omitempty"`
+}
+
+// Client holds the PowerStore HTTP API client.
+type Client struct {
+	Gateway              string
+	GatewaySkipTLSVerify bool
+	Username             string
+	Password             string
+	TokenCache           *tokencache.TokenCache[LoginSession]
+}
+
+func (c *Client) startNewLoginSession(ctx context.Context) (*LoginSession, error) {
+	resp, info, err := c.getLoginSessionInfoWithBasicAuthorization(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Starting PowerStore session: %w", err)
+	}
+
+	if len(info) < 1 {
+		return nil, errors.New("Starting PowerStore session: Invalid session information")
+	}
+
+	sessionInfo := info[0]
+
+	if sessionInfo.IsPasswordChangeRequired {
+		return nil, errors.New("Starting PowerStore session: Password change required")
+	}
+
+	var authCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name != authorizationCookieName {
+			continue
+		}
+
+		authCookie = c
+		break
+	}
+
+	if authCookie == nil {
+		return nil, errors.New("Starting PowerStore session: Missing PowerStore authorization cookie")
+	}
+
+	csrf := resp.Header.Get(csrfHeaderName)
+	if csrf == "" {
+		return nil, errors.New("Starting PowerStore session: Missing PowerStore CSRF token")
+	}
+
+	return newPowerStoreLoginSession(sessionInfo.ID, time.Duration(sessionInfo.IdleTimeout)*time.Second, authCookie.Value, csrf), nil
+}
+
+func (c *Client) getOrCreateLoginSession(ctx context.Context, sessionKey string) (*LoginSession, error) {
+	if c.TokenCache == nil {
+		return c.startNewLoginSession(ctx)
+	}
+
+	session := c.TokenCache.Load(sessionKey)
+	if session.IsValid() {
+		return session, nil
+	}
+
+	return c.TokenCache.Replace(sessionKey, func(ls *LoginSession) (*LoginSession, error) {
+		if ls != session && ls.IsValid() {
+			return ls, nil // session was already replaced with a new valid session
+		}
+
+		return c.startNewLoginSession(ctx)
+	})
+}
+
+func (c *Client) forceLoginSessionRemoval(sessionKey string, sessionToRemove *LoginSession) {
+	if c.TokenCache == nil {
+		return
+	}
+
+	_, _ = c.TokenCache.Replace(sessionKey, func(ls *LoginSession) (*LoginSession, error) {
+		if ls != sessionToRemove {
+			return ls, nil // session was already replaced
+		}
+
+		return nil, nil // delete session
+	})
+}
+
+func (c *Client) marshalHTTPRequestBody(src any) (io.Reader, error) {
+	if src == nil {
+		return nil, nil
+	}
+
+	dst := &bytes.Buffer{}
+	err := json.NewEncoder(dst).Encode(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return dst, nil
+}
+
+func (c *Client) doUnauthenticatedHTTPRequest(ctx context.Context, method string, path string, requestData, responseData any, requestEditors ...func(*http.Request) error) (*http.Response, error) {
+	body, err := c.marshalHTTPRequestBody(requestData)
+	if err != nil {
+		return nil, fmt.Errorf("Marshal HTTP request body: %s: %w", path, err)
+	}
+
+	url := c.Gateway + path
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("Create request: %w", err)
+	}
+
+	req.Header.Add("Accept", "application/json")
+	if body != nil {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
+	for _, edit := range requestEditors {
+		err := edit(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.GatewaySkipTLSVerify,
+			},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Send request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return resp, newPowerStoreError(resp)
+	}
+
+	if responseData != nil {
+		err := json.NewDecoder(resp.Body).Decode(responseData)
+		if err != nil {
+			return resp, fmt.Errorf("Unmarshal HTTP response body: %s: %w", path, err)
+		}
+	}
+	return resp, nil
+}
+
+func (c *Client) doAuthenticatedHTTPRequest(ctx context.Context, method string, path string, requestData, responseData any, requestEditors ...func(*http.Request) error) (*http.Response, error) {
+	sessionKey := makeFingerprint(c.Gateway, c.Username, c.Password)
+
+	session, err := c.getOrCreateLoginSession(ctx, sessionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	requestEditors = append([]func(*http.Request) error{c.withLoginSession(session)}, requestEditors...)
+	resp, err := c.doUnauthenticatedHTTPRequest(ctx, method, path, requestData, responseData, requestEditors...)
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		// there is something wrong with the session token, remove it
+		c.forceLoginSessionRemoval(sessionKey, session)
+	}
+
+	return resp, err
+}
+
+func (c *Client) withBasicAuthorization(username, password string) func(req *http.Request) error {
+	return func(req *http.Request) error {
+		token := base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", username, password))
+		req.Header.Set("Authorization", "Basic "+token)
+		return nil
+	}
+}
+
+func (c *Client) withLoginSession(ls *LoginSession) func(req *http.Request) error {
+	return func(req *http.Request) error {
+		req.Header.Add("Cookie", fmt.Sprintf("%s=%s", authorizationCookieName, ls.AuthToken))
+		req.Header.Set(csrfHeaderName, ls.CSRFToken)
+		return nil
+	}
+}
+
+func (c *Client) withQuery(query query) func(req *http.Request) error {
+	return func(req *http.Request) error {
+		if len(query) == 0 {
+			req.URL.RawQuery = ""
+			return nil
+		}
+
+		req.URL.RawQuery = query.URLParameters().Encode()
+		return nil
+	}
+}
+
+// query is a container for PowerStore query request parameters.
+type query map[string]string
+
+// Clone clones the provided query. If the query is nil it returns
+// an initialized empty query.
+func (q query) Clone() query {
+	if q == nil {
+		return query{}
+	}
+
+	return maps.Clone(q)
+}
+
+// Set sets the provided value under the specified key returning the new query.
+func (q query) Set(key, val string) query {
+	q = q.Clone()
+	q[key] = val
+	return q
+}
+
+// URLParameters transforms query into URL parameters.
+func (q query) URLParameters() url.Values {
+	params := url.Values{}
+	for key, val := range q {
+		params.Set(key, val)
+	}
+
+	return params
+}
+
+type loginSessionResource struct {
+	ID                       string   `json:"id"`
+	User                     string   `json:"user"`
+	RoleIDs                  []string `json:"role_ids"`
+	IdleTimeout              int64    `json:"idle_timeout"`
+	IsPasswordChangeRequired bool     `json:"is_password_change_required"`
+	IsBuiltInUser            bool     `json:"is_built_in_user"`
+}
+
+func (c *Client) getLoginSessionInfoWithBasicAuthorization(ctx context.Context) (*http.Response, []*loginSessionResource, error) {
+	body := []*loginSessionResource{}
+	resp, err := c.doUnauthenticatedHTTPRequest(ctx, http.MethodGet, "/api/rest/login_session", nil, &body,
+		c.withBasicAuthorization(c.Username, c.Password),
+		c.withQuery(query{"select": "id,user,role_ids,idle_timeout,is_password_change_required,is_built_in_user"}),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Retrieving PowerStore login session info: %w", err)
+	}
+
+	return resp, body, nil
+}

--- a/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
+++ b/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
@@ -13,6 +13,8 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -176,6 +178,7 @@ type Client struct {
 	Username             string
 	Password             string
 	TokenCache           *tokencache.TokenCache[LoginSession]
+	VolumeNamePrefix     string
 }
 
 func (c *Client) startNewLoginSession(ctx context.Context) (*LoginSession, error) {
@@ -361,6 +364,28 @@ func (c *Client) withQuery(query query) func(req *http.Request) error {
 	}
 }
 
+// QueryResponseLimit is the maximum number of items PowerStore can return in
+// a single query response.
+const QueryResponseLimit = 2000
+
+// pagination encapsulates query request pagination data.
+type pagination struct {
+	Page         int
+	ItemsPerPage int
+}
+
+// Offset computes offset value for the provided pagination state.
+func (p pagination) Offset() int {
+	page := max(0, p.Page)
+	limit := p.Limit()
+	return page * limit
+}
+
+// Limit computes limit value for the provided pagination state.
+func (p pagination) Limit() int {
+	return min(max(0, p.ItemsPerPage), QueryResponseLimit)
+}
+
 // query is a container for PowerStore query request parameters.
 type query map[string]string
 
@@ -381,6 +406,14 @@ func (q query) Set(key, val string) query {
 	return q
 }
 
+// Paginate adds pagination parameters returning a new query.
+func (q query) Paginate(pagination pagination) query {
+	q = q.Clone()
+	q["offset"] = strconv.Itoa(pagination.Offset())
+	q["limit"] = strconv.Itoa(pagination.Limit())
+	return q
+}
+
 // URLParameters transforms query into URL parameters.
 func (q query) URLParameters() url.Values {
 	params := url.Values{}
@@ -389,6 +422,58 @@ func (q query) URLParameters() url.Values {
 	}
 
 	return params
+}
+
+// queryResponseHasMoreItems informs if there are more items available for the HTTP PowerStore query response.
+func queryResponseHasMoreItems(resp *http.Response) (bool, error) {
+	if resp == nil || resp.StatusCode != http.StatusPartialContent {
+		return false, nil
+	}
+
+	// valid Content-Range HTTP headers returned by PowerStore have a form:
+	// - firstOffset '-' lastOffset '/' totalItems
+	// - '*' '/' totalItems
+	header := resp.Header.Get("Content-Range")
+	if header == "" {
+		return false, nil
+	}
+
+	rangeStr, totalItemsStr, ok := strings.Cut(header, "/")
+	if !ok {
+		return false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	if rangeStr == "*" {
+		return false, nil
+	}
+
+	fistOffsetStr, lastOffsetStr, ok := strings.Cut(rangeStr, "-")
+	if !ok {
+		return false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	_, err := strconv.ParseUint(fistOffsetStr, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	lastOffset, err := strconv.ParseUint(lastOffsetStr, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	totalItems, err := strconv.ParseUint(totalItemsStr, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	return totalItems > lastOffset+1, nil
+}
+
+// IDResource is any resource that just contains ID. This type is often used
+// a substitute when only ID of some resource should be retrieved or used.
+type IDResource struct {
+	ID string `json:"id"`
 }
 
 type loginSessionResource struct {
@@ -411,4 +496,164 @@ func (c *Client) getLoginSessionInfoWithBasicAuthorization(ctx context.Context) 
 	}
 
 	return resp, body, nil
+}
+
+// VolumeResource describes a volume resource in PowerStore API.
+type VolumeResource struct {
+	ID            string                       `json:"id,omitempty"`
+	Name          string                       `json:"name,omitempty"`
+	Description   string                       `json:"description,omitempty"`
+	Type          string                       `json:"type,omitempty"`
+	State         string                       `json:"state,omitempty"`
+	Size          int64                        `json:"size,omitempty"`
+	LogicalUsed   int64                        `json:"logical_used,omitempty"`
+	WWN           string                       `json:"wwn,omitempty"`
+	AppType       string                       `json:"app_type,omitempty"`
+	AppTypeOther  string                       `json:"app_type_other,omitempty"`
+	VolumeGroups  []*IDResource                `json:"volume_groups,omitempty"`
+	MappedVolumes []*HostVolumeMappingResource `json:"mapped_volumes,omitempty"`
+}
+
+// HostVolumeMappingResource describes a mapping between host and volume in
+// PowerStore API.
+type HostVolumeMappingResource struct {
+	ID       string `json:"id,omitempty"`
+	HostID   string `json:"host_id,omitempty"`
+	VolumeID string `json:"volume_id,omitempty"`
+}
+
+func (c *Client) getVolumesByQuery(ctx context.Context, query query, filterOwnedByLxd bool) ([]*VolumeResource, bool, error) {
+	query = query.Set("select", "id,name,description,type,state,size,logical_used,wwn,app_type,app_type_other,volume_groups(id),mapped_volumes(id,host_id,volume_id)")
+
+	body := []*VolumeResource{}
+	resp, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodGet, "/api/rest/volume", nil, &body,
+		c.withQuery(query),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore volumes: %w", err)
+	}
+
+	hasMore, err := queryResponseHasMoreItems(resp)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore volumes: %w", err)
+	}
+
+	if !filterOwnedByLxd {
+		return body, hasMore, nil
+	}
+
+	// in most cases all items in the returned body will belong to the current storage pool and no item will be filtered out
+	filtered := make([]*VolumeResource, 0, len(body))
+	for _, v := range body {
+		if !strings.HasPrefix(v.Name, c.VolumeNamePrefix) {
+			continue
+		}
+
+		filtered = append(filtered, v)
+	}
+
+	return filtered, hasMore, nil
+}
+
+func (c *Client) getVolumeByQuery(ctx context.Context, query query, filterOwnedByLxd bool) (*VolumeResource, error) {
+	vols, _, err := c.getVolumesByQuery(ctx, query.Paginate(pagination{ItemsPerPage: 1}), filterOwnedByLxd)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vols) == 0 {
+		return nil, nil
+	}
+
+	return vols[0], nil
+}
+
+// GetVolumes retrieves list of volume associated with the storage pool.
+func (c *Client) GetVolumes(ctx context.Context) ([]*VolumeResource, error) {
+	query := query{"name": fmt.Sprintf("ilike.%s*", c.VolumeNamePrefix)}
+
+	var vols []*VolumeResource
+	for page := 0; ; page++ {
+		volsPage, hasMore, err := c.getVolumesByQuery(ctx, query.Paginate(pagination{Page: page}), true)
+		if err != nil {
+			return nil, err
+		}
+
+		vols = append(vols, volsPage...)
+		if !hasMore {
+			return vols, nil
+		}
+	}
+}
+
+// GetVolumeByID retrieves volume using its ID.
+func (c *Client) GetVolumeByID(ctx context.Context, id string) (*VolumeResource, error) {
+	return c.getVolumeByQuery(ctx, query{"id": "eq." + id}, true)
+}
+
+// GetVolumeByName retrieves volume using its name.
+func (c *Client) GetVolumeByName(ctx context.Context, name string) (*VolumeResource, error) {
+	return c.getVolumeByQuery(ctx, query{"name": "eq." + name}, true)
+}
+
+// CreateVolume creates a new volume.
+func (c *Client) CreateVolume(ctx context.Context, vol *VolumeResource) error {
+	body := &IDResource{}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume", vol, body)
+	if err != nil {
+		return fmt.Errorf("Creating PowerStore volume: %w", err)
+	}
+
+	// Fetch volume to populate all fields.
+	created, err := c.GetVolumeByID(ctx, body.ID)
+	if err != nil {
+		return fmt.Errorf("Creating PowerStore volume: %w", err)
+	}
+
+	if created == nil {
+		return errors.New("Creating PowerStore volume: No data of new volume found")
+	}
+
+	*vol = *created
+	return nil
+}
+
+// DeleteVolumeByID deletes volume using its ID.
+func (c *Client) DeleteVolumeByID(ctx context.Context, id string) error {
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodDelete, "/api/rest/volume/"+id, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Deleting PowerStore volume: %w", err)
+	}
+
+	return nil
+}
+
+type volumeModifyResource struct {
+	Size int64 `json:"size,omitempty"`
+}
+
+// ResizeVolumeByID creates a new volume.
+func (c *Client) ResizeVolumeByID(ctx context.Context, id string, newSize int64) error {
+	reqBody := &volumeModifyResource{Size: newSize}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPatch, "/api/rest/volume/"+id, reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Resizing PowerStore volume: %w", err)
+	}
+
+	return nil
+}
+
+type volumeGroupRemoveMembersResource struct {
+	VolumeIDs []string `json:"volume_ids,omitempty"`
+}
+
+// RemoveMembersFromVolumeGroup removes volumes from the volume group.
+func (c *Client) RemoveMembersFromVolumeGroup(ctx context.Context, id string, volumeIDs []string) error {
+	reqBody := &volumeGroupRemoveMembersResource{VolumeIDs: volumeIDs}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume_group/"+id+"/remove_members", reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Removing members from PowerStore volume group: %w", err)
+	}
+
+	return nil
 }

--- a/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
+++ b/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
@@ -499,6 +499,56 @@ func (c *Client) getLoginSessionInfoWithBasicAuthorization(ctx context.Context) 
 	return resp, body, nil
 }
 
+// ApplianceMetricsResource describes an appliance metric resource in
+// PowerStore API.
+type ApplianceMetricsResource struct {
+	ID                     string  `json:"id,omitempty"`
+	Name                   string  `json:"name,omitempty"`
+	AvgLatency             float64 `json:"avg_latency,omitempty"`
+	TotalIops              float64 `json:"total_iops,omitempty"`
+	TotalBandwidth         float64 `json:"total_bandwidth,omitempty"`
+	LastLogicalTotalSpace  int64   `json:"last_logical_total_space,omitempty"`
+	LastLogicalUsedSpace   int64   `json:"last_logical_used_space,omitempty"`
+	LastPhysicalTotalSpace int64   `json:"last_physical_total_space,omitempty"`
+	LastPhysicalUsedSpace  int64   `json:"last_physical_used_space,omitempty"`
+}
+
+func (c *Client) getApplianceMetricsByQuery(ctx context.Context, query query) ([]*ApplianceMetricsResource, bool, error) {
+	query = query.Set("select", "id,name,avg_latency,total_iops,total_bandwidth,last_logical_total_space,last_logical_used_space,last_physical_total_space,last_physical_used_space")
+
+	body := []*ApplianceMetricsResource{}
+	resp, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodGet, "/api/rest/appliance_list_cma_view", nil, &body,
+		c.withQuery(query),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving metrics of PowerStore appliances: %w", err)
+	}
+
+	hasMore, err := queryResponseHasMoreItems(resp)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving metrics of PowerStore appliances: %w", err)
+	}
+
+	return body, hasMore, nil
+}
+
+// GetApplianceMetrics retrieves appliance metrics.
+func (c *Client) GetApplianceMetrics(ctx context.Context) ([]*ApplianceMetricsResource, error) {
+	query := query{}
+	var metrics []*ApplianceMetricsResource
+	for page := 0; ; page++ {
+		metricsPage, hasMore, err := c.getApplianceMetricsByQuery(ctx, query.Paginate(pagination{Page: page}))
+		if err != nil {
+			return nil, err
+		}
+
+		metrics = append(metrics, metricsPage...)
+		if !hasMore {
+			return metrics, nil
+		}
+	}
+}
+
 // HostResource describes a host resource in PowerStore API.
 type HostResource struct {
 	ID               string                       `json:"id,omitempty"`

--- a/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
+++ b/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
@@ -830,7 +830,7 @@ type HostVolumeMappingResource struct {
 	VolumeID string `json:"volume_id,omitempty"`
 }
 
-func (c *Client) getVolumesByQuery(ctx context.Context, query query, filterOwnedByLxd bool) ([]*VolumeResource, bool, error) {
+func (c *Client) getVolumeInstancesByQuery(ctx context.Context, query query, filterOwnedByLxd bool) ([]*VolumeResource, bool, error) {
 	query = query.Set("select", "id,name,description,type,state,size,logical_used,wwn,app_type,app_type_other,volume_groups(id),mapped_volumes(id,host_id,volume_id)")
 
 	body := []*VolumeResource{}
@@ -861,6 +861,10 @@ func (c *Client) getVolumesByQuery(ctx context.Context, query query, filterOwned
 	}
 
 	return filtered, hasMore, nil
+}
+
+func (c *Client) getVolumesByQuery(ctx context.Context, query query, filterOwnedByLxd bool) ([]*VolumeResource, bool, error) {
+	return c.getVolumeInstancesByQuery(ctx, query.Set("or", "(type.eq.Primary,type.eq.Clone)"), filterOwnedByLxd)
 }
 
 func (c *Client) getVolumeByQuery(ctx context.Context, query query, filterOwnedByLxd bool) (*VolumeResource, error) {
@@ -961,6 +965,137 @@ func (c *Client) RemoveMembersFromVolumeGroup(ctx context.Context, id string, vo
 	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume_group/"+id+"/remove_members", reqBody, nil)
 	if err != nil {
 		return fmt.Errorf("Removing members from PowerStore volume group: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) getVolumeSnapshotsByQuery(ctx context.Context, query query) ([]*VolumeResource, bool, error) {
+	return c.getVolumeInstancesByQuery(ctx, query.Set("type", "eq.Snapshot"), true)
+}
+
+func (c *Client) getVolumeSnapshotByQuery(ctx context.Context, query query) (*VolumeResource, error) {
+	volSnaps, _, err := c.getVolumeSnapshotsByQuery(ctx, query.Paginate(pagination{ItemsPerPage: 1}))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(volSnaps) == 0 {
+		return nil, nil
+	}
+
+	return volSnaps[0], nil
+}
+
+// GetVolumeSnapshots retrieves list of volume snapshots associated with the provided volume.
+func (c *Client) GetVolumeSnapshots(ctx context.Context, parentID string) ([]*VolumeResource, error) {
+	query := query{"protection_data->>parent_id": "eq." + parentID}
+
+	var vols []*VolumeResource
+	for page := 0; ; page++ {
+		volsPage, hasMore, err := c.getVolumeSnapshotsByQuery(ctx, query.Paginate(pagination{Page: page}))
+		if err != nil {
+			return nil, err
+		}
+
+		vols = append(vols, volsPage...)
+		if !hasMore {
+			return vols, nil
+		}
+	}
+}
+
+// GetVolumeSnapshotByID retrieves volume snapshot using its ID.
+func (c *Client) GetVolumeSnapshotByID(ctx context.Context, id string) (*VolumeResource, error) {
+	return c.getVolumeSnapshotByQuery(ctx, query{"id": "eq." + id})
+}
+
+// GetVolumeSnapshotByName retrieves volume snapshot using its name.
+func (c *Client) GetVolumeSnapshotByName(ctx context.Context, name string) (*VolumeResource, error) {
+	return c.getVolumeSnapshotByQuery(ctx, query{"name": "eq." + name})
+}
+
+type createVolumeSnapshotResource struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// CreateVolumeSnapshot creates a new snapshot of a volume.
+func (c *Client) CreateVolumeSnapshot(ctx context.Context, parentID, name, description string) (*VolumeResource, error) {
+	body := &IDResource{}
+	reqBody := &createVolumeSnapshotResource{Name: name, Description: description}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume/"+parentID+"/snapshot", reqBody, body)
+	if err != nil {
+		return nil, fmt.Errorf("Creating PowerStore volume snapshot: %w", err)
+	}
+
+	// Fetch volume snapshot to populate all fields.
+	created, err := c.GetVolumeSnapshotByID(ctx, body.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Creating PowerStore volume snapshot: %w", err)
+	}
+
+	if created == nil {
+		return nil, errors.New("Creating PowerStore volume snapshot: No data of new volume snapshot found")
+	}
+
+	return created, nil
+}
+
+type cloneVolumeResource struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// CloneVolume clones the volume or the volume snapshot with the provided ID to a new volume.
+func (c *Client) CloneVolume(ctx context.Context, srcVolID, dstVolName, dstVolDescription string) (*VolumeResource, error) {
+	body := &IDResource{}
+	reqBody := &createVolumeSnapshotResource{Name: dstVolName, Description: dstVolDescription}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume/"+srcVolID+"/clone", reqBody, body)
+	if err != nil {
+		return nil, fmt.Errorf("Creating PowerStore volume clone: %w", err)
+	}
+
+	// Fetch volume to populate all fields.
+	created, err := c.GetVolumeByID(ctx, body.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Creating PowerStore volume clone: %w", err)
+	}
+
+	if created == nil {
+		return nil, errors.New("Creating PowerStore volume clone: No data of new volume found")
+	}
+
+	return created, nil
+}
+
+type restoreVolumeResource struct {
+	FromSnapID           string `json:"from_snap_id"`
+	CreateBackupSnapshot bool   `json:"create_backup_snap"`
+}
+
+// RestoreVolume restores the volume form the volume snapshot.
+func (c *Client) RestoreVolume(ctx context.Context, srcVolSnapID, dstVolID string) error {
+	reqBody := &restoreVolumeResource{FromSnapID: srcVolSnapID}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume/"+dstVolID+"/restore", reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Restoring PowerStore volume from snapshot: %w", err)
+	}
+
+	return nil
+}
+
+type refreshVolumeResource struct {
+	FromObjectID         string `json:"from_object_id"`
+	CreateBackupSnapshot bool   `json:"create_backup_snap"`
+}
+
+// RefreshVolume refreshes the volume form the volume or the volume snapshot.
+func (c *Client) RefreshVolume(ctx context.Context, srcVolID, dstVolID string) error {
+	reqBody := &refreshVolumeResource{FromObjectID: srcVolID}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/volume/"+dstVolID+"/refresh", reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Refreshing PowerStore volume: %w", err)
 	}
 
 	return nil

--- a/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
+++ b/lxd/storage/drivers/powerstoreclient/powerstoreclient.go
@@ -179,6 +179,7 @@ type Client struct {
 	Password             string
 	TokenCache           *tokencache.TokenCache[LoginSession]
 	VolumeNamePrefix     string
+	HostNamePrefix       string
 }
 
 func (c *Client) startNewLoginSession(ctx context.Context) (*LoginSession, error) {
@@ -496,6 +497,263 @@ func (c *Client) getLoginSessionInfoWithBasicAuthorization(ctx context.Context) 
 	}
 
 	return resp, body, nil
+}
+
+// HostResource describes a host resource in PowerStore API.
+type HostResource struct {
+	ID               string                       `json:"id,omitempty"`
+	Name             string                       `json:"name,omitempty"`
+	Description      string                       `json:"description,omitempty"`
+	Initiators       []*HostInitiatorResource     `json:"initiators,omitempty"`
+	OsType           OSTypeEnum                   `json:"os_type,omitempty"`
+	HostConnectivity string                       `json:"host_connectivity,omitempty"`
+	MappedHosts      []*HostVolumeMappingResource `json:"mapped_hosts,omitempty"`
+}
+
+// OSTypeEnum is an enumeration of operating system type in PowerStore API.
+type OSTypeEnum string
+
+const (
+	// OSTypeEnumLinux is an enumeration value indicating Linux operating system.
+	OSTypeEnumLinux OSTypeEnum = "Linux"
+)
+
+// HostInitiatorResource describes an initiator resource of some host in
+// PowerStore API.
+type HostInitiatorResource struct {
+	ID       string                `json:"id,omitempty"`
+	PortName string                `json:"port_name,omitempty"`
+	PortType InitiatorPortTypeEnum `json:"port_type,omitempty"`
+}
+
+// InitiatorPortTypeEnum is an enumeration of initiator port type in
+// PowerStore API.
+type InitiatorPortTypeEnum string
+
+const (
+	// InitiatorPortTypeEnumISCSI is an enumeration value indicating iSCSI
+	// initiator port type.
+	InitiatorPortTypeEnumISCSI InitiatorPortTypeEnum = "iSCSI"
+
+	// InitiatorPortTypeEnumFC is an enumeration value indicating fibre channel
+	// initiator port type.
+	InitiatorPortTypeEnumFC InitiatorPortTypeEnum = "FC"
+
+	// InitiatorPortTypeEnumNVMe is an enumeration value indicating NVMe
+	// initiator port type.
+	InitiatorPortTypeEnumNVMe InitiatorPortTypeEnum = "NVMe"
+)
+
+func (c *Client) getHostsByQuery(ctx context.Context, query query, filterOwnedByLxd bool) ([]*HostResource, bool, error) {
+	query = query.Set("select", "id,name,description,initiators(id,port_name,port_type),os_type,host_connectivity,mapped_hosts(id,host_id,volume_id)")
+
+	body := []*HostResource{}
+	resp, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodGet, "/api/rest/host", nil, &body,
+		c.withQuery(query),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore hosts: %w", err)
+	}
+
+	hasMore, err := queryResponseHasMoreItems(resp)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore hosts: %w", err)
+	}
+
+	if !filterOwnedByLxd {
+		return body, hasMore, nil
+	}
+
+	// In most cases all items in the returned body will be managed by LXD and no
+	// item will be filtered out.
+	filtered := make([]*HostResource, 0, len(body))
+	for _, h := range body {
+		if !strings.HasPrefix(h.Name, c.HostNamePrefix) {
+			continue
+		}
+
+		filtered = append(filtered, h)
+	}
+
+	return filtered, hasMore, nil
+}
+
+func (c *Client) getHostByQuery(ctx context.Context, query query, filterOwnedByLxd bool) (*HostResource, error) {
+	hosts, _, err := c.getHostsByQuery(ctx, query.Paginate(pagination{ItemsPerPage: 1}), filterOwnedByLxd)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+
+	return hosts[0], nil
+}
+
+// GetHostByID retrieves host using its ID.
+func (c *Client) GetHostByID(ctx context.Context, id string) (*HostResource, error) {
+	return c.getHostByQuery(ctx, query{"id": "eq." + id}, true)
+}
+
+// getUnfilteredHostByID retrieves host using its ID without filtration
+// (returns host even if it is not managed by lxd).
+func (c *Client) getUnfilteredHostByID(ctx context.Context, id string) (*HostResource, error) {
+	return c.getHostByQuery(ctx, query{"id": "eq." + id}, false)
+}
+
+// GetHostByName retrieves host using its name.
+func (c *Client) GetHostByName(ctx context.Context, name string) (*HostResource, error) {
+	return c.getHostByQuery(ctx, query{"name": "eq." + name}, true)
+}
+
+// CreateHost creates new host.
+func (c *Client) CreateHost(ctx context.Context, host *HostResource) error {
+	body := &IDResource{}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/host", host, body)
+	if err != nil {
+		return fmt.Errorf("Creating PowerStore host: %w", err)
+	}
+
+	// Fetch host to populate all fields.
+	created, err := c.GetHostByID(ctx, body.ID)
+	if err != nil {
+		return fmt.Errorf("Creating PowerStore host: %w", err)
+	}
+
+	if created == nil {
+		return errors.New("Creating PowerStore host: No data of new host found")
+	}
+
+	*host = *created
+	return nil
+}
+
+// DeleteHostByID deletes host using its ID.
+func (c *Client) DeleteHostByID(ctx context.Context, id string) error {
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodDelete, "/api/rest/host/"+id, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Deleting PowerStore host: %w", err)
+	}
+
+	return nil
+}
+
+type addInitiatorToHostResource struct {
+	AddInitiators []*HostInitiatorResource `json:"add_initiators,omitempty"`
+}
+
+// AddInitiatorToHostByID adds initiator to host using its ID.
+func (c *Client) AddInitiatorToHostByID(ctx context.Context, hostID string, initiator *HostInitiatorResource) error {
+	reqBody := &addInitiatorToHostResource{AddInitiators: []*HostInitiatorResource{initiator}}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPatch, "/api/rest/host/"+hostID, reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Adding initiator to PowerStore host: %w", err)
+	}
+
+	return nil
+}
+
+type removeInitiatorFromHostResource struct {
+	RemoveInitiators []string `json:"remove_initiators,omitempty"`
+}
+
+// RemoveInitiatorFromHostByID removes initiator matching port name from host using its ID.
+func (c *Client) RemoveInitiatorFromHostByID(ctx context.Context, hostID string, initiator *HostInitiatorResource) error {
+	reqBody := &removeInitiatorFromHostResource{RemoveInitiators: []string{initiator.PortName}}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPatch, "/api/rest/host/"+hostID, reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Removing initiator from PowerStore host: %w", err)
+	}
+
+	return nil
+}
+
+type hostAttachResource struct {
+	VolumeGroupID string `json:"volume_group_id,omitempty"`
+	VolumeID      string `json:"volume_id,omitempty"`
+}
+
+// AttachHostToVolume attaches (maps) host to volume.
+func (c *Client) AttachHostToVolume(ctx context.Context, hostID, volID string) error {
+	reqBody := &hostAttachResource{VolumeID: volID}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/host/"+hostID+"/attach", reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Attaching PowerStore host to a volume: %w", err)
+	}
+
+	return nil
+}
+
+type hostDetachResource struct {
+	VolumeGroupID string `json:"volume_group_id,omitempty"`
+	VolumeID      string `json:"volume_id,omitempty"`
+}
+
+// DetachHostFromVolume detaches (unmaps) host from volume.
+func (c *Client) DetachHostFromVolume(ctx context.Context, hostID, volID string) error {
+	reqBody := &hostDetachResource{VolumeID: volID}
+	_, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodPost, "/api/rest/host/"+hostID+"/detach", reqBody, nil)
+	if err != nil {
+		return fmt.Errorf("Detaching PowerStore host from a volume: %w", err)
+	}
+
+	return nil
+}
+
+// InitiatorResource describes an initiator resource in PowerStore API.
+type InitiatorResource struct {
+	ID       string `json:"id,omitempty"`
+	HostID   string `json:"host_id,omitempty"`
+	PortName string `json:"port_name,omitempty"`
+	PortType string `json:"port_type,omitempty"`
+}
+
+func (c *Client) getInitiatorsByQuery(ctx context.Context, query query) ([]*InitiatorResource, bool, error) {
+	query = query.Set("select", "id,host_id,port_name,port_type")
+
+	body := []*InitiatorResource{}
+	resp, err := c.doAuthenticatedHTTPRequest(ctx, http.MethodGet, "/api/rest/initiator", nil, &body,
+		c.withQuery(query),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore initiators: %w", err)
+	}
+
+	hasMore, err := queryResponseHasMoreItems(resp)
+	if err != nil {
+		return nil, false, fmt.Errorf("Retrieving information about PowerStore initiators: %w", err)
+	}
+
+	return body, hasMore, nil
+}
+
+func (c *Client) getInitiatorByQuery(ctx context.Context, query query) (*InitiatorResource, error) {
+	initiators, _, err := c.getInitiatorsByQuery(ctx, query.Paginate(pagination{ItemsPerPage: 1}))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(initiators) == 0 {
+		return nil, nil
+	}
+
+	return initiators[0], nil
+}
+
+// GetHostByInitiator retrieves host that have initiator matching port name and
+// type.
+func (c *Client) GetHostByInitiator(ctx context.Context, initiator *HostInitiatorResource) (*HostResource, error) {
+	hostInitiator, err := c.getInitiatorByQuery(ctx, query{"port_name": "eq." + initiator.PortName, "port_type": "eq." + string(initiator.PortType)})
+	if err != nil {
+		return nil, err
+	}
+
+	if hostInitiator == nil {
+		return nil, nil
+	}
+
+	return c.getUnfilteredHostByID(ctx, hostInitiator.HostID)
 }
 
 // VolumeResource describes a volume resource in PowerStore API.

--- a/lxd/storage/drivers/tokencache/token_cache.go
+++ b/lxd/storage/drivers/tokencache/token_cache.go
@@ -1,0 +1,85 @@
+package tokencache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/canonical/lxd/lxd/locking"
+)
+
+// TokenCache is a concurrent, per-key synchronized cache for pointer values of
+// type T.
+//
+// It allows fast, lock free value retrieval while ensuing only one replace
+// function will run at a time for a given key.
+type TokenCache[T any] struct {
+	// name of the token cache, used as part of the global lock name
+	name string
+
+	// concurrent map that holds *T items
+	items sync.Map
+}
+
+// New creates a new TokenCache with the provided name.
+func New[T any](name string) *TokenCache[T] {
+	return &TokenCache[T]{name: name}
+}
+
+// lock acquires a lock for the provided key.
+func (tc *TokenCache[T]) lock(key string) (locking.UnlockFunc, error) {
+	lockName := fmt.Sprintf("storage/tokenCache/%s/%s", tc.name, key)
+	return locking.Lock(context.Background(), lockName)
+}
+
+// Load retrieves value associated with the provided key.
+func (tc *TokenCache[T]) Load(key string) *T {
+	value, has := tc.items.Load(key)
+	if !has {
+		return nil
+	}
+
+	return value.(*T) //nolint:revive // No need to assert types as it is guaranteed that all values are of type *T.
+}
+
+// Replace perform concurrency safe replacement of a value associated with
+// the provided key. It is guaranteed that when concurrent replace operations
+// are running only one replace function will run at a time for a given key.
+//
+// If replace function returns non nil error value, it indicates that
+// the replacing operation has failed and no value should be modified.
+func (tc *TokenCache[T]) Replace(key string, replaceFunc func(*T) (*T, error)) (*T, error) {
+	unlock, err := tc.lock(key)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unlock()
+
+	value, err := replaceFunc(tc.Load(key))
+	if err != nil {
+		// Replacement failed.
+		return value, err
+	}
+
+	if value == nil {
+		// Value should be removed.
+		tc.items.Delete(key)
+		return value, nil
+	}
+
+	// Value should be replaced.
+	tc.items.Store(key, value)
+	return value, nil
+}
+
+// Range calls yield sequentially for each key, value pair in the map. If yield
+// returns false, range stops the iteration. It behaves similarly to Map.Range
+// from the "sync" package.
+func (tc *TokenCache[T]) Range(yield func(key string, value *T) bool) {
+	for key, value := range tc.items.Range {
+		if !yield(key.(string), value.(*T)) {
+			return
+		}
+	}
+}

--- a/lxd/storage/drivers/tokencache/token_cache_test.go
+++ b/lxd/storage/drivers/tokencache/token_cache_test.go
@@ -1,0 +1,152 @@
+package tokencache
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func tokenCacheReplaceFunc(t *testing.T, want, replaceWith *string, err error) func(*string) (*string, error) {
+	t.Helper()
+	return func(got *string) (*string, error) {
+		t.Helper()
+		switch {
+		case want == nil && got != nil:
+			t.Errorf("replace func got unexpected source value %q, expected nil", *got)
+		case want != nil && got == nil:
+			t.Errorf("replace func got unexpected nil source value, expected %q", *want)
+		case want != nil && got != nil && *want != *got:
+			t.Errorf("replace func got unexpected source value %q, expected %q", *got, *want)
+		}
+
+		return replaceWith, err
+	}
+}
+
+func requireTokenCacheToEqual(t *testing.T, tc *TokenCache[string], want ...string) {
+	t.Helper()
+	var got []string
+	for key, ptr := range tc.Range {
+		if ptr == nil {
+			t.Fatalf("cache reported nil value for key %q", key)
+		} else {
+			got = append(got, fmt.Sprintf("%s=%s", key, *ptr))
+		}
+	}
+	slices.Sort(got) // sort to get stable output during tests
+	if !slices.Equal(got, want) {
+		t.Fatalf("invalid cache state\n  want: %v\n  got: %v", want, got)
+	}
+}
+
+func requireTokenCacheLoadToEqual(t *testing.T, tc *TokenCache[string], key string, want *string) {
+	t.Helper()
+	got := tc.Load(key)
+	switch {
+	case want == nil && got != nil:
+		t.Fatalf("unexpected cache load value %q, expected nil", *got)
+	case want != nil && got == nil:
+		t.Fatalf("unexpected cache load nil value, expected %q", *want)
+	case want != nil && got != nil && *want != *got:
+		t.Fatalf("unexpected cache load value %q, expected %q", *got, *want)
+	}
+}
+
+func requireTokenCacheReplaceToEqual(t *testing.T, tc *TokenCache[string], key string, replaceFunc func(*string) (*string, error), wantValue *string, wantErr error) {
+	t.Helper()
+	gotValue, gotErr := tc.Replace(key, replaceFunc)
+	switch {
+	case wantErr == nil && gotErr != nil:
+		t.Fatalf("unexpected cache replace error %q, expected nil", gotErr.Error())
+	case wantErr != nil && gotErr == nil:
+		t.Fatalf("unexpected cache replace nil error, expected %q", wantErr.Error())
+	case wantErr != nil && gotErr != nil && wantErr.Error() != gotErr.Error():
+		t.Fatalf("unexpected cache replace error %q, expected %q", gotErr.Error(), wantErr.Error())
+	}
+
+	switch {
+	case wantValue == nil && gotValue != nil:
+		t.Fatalf("unexpected cache replace value %q, expected nil", *gotValue)
+	case wantValue != nil && gotValue == nil:
+		t.Fatalf("unexpected cache replace nil value, expected %q", *wantValue)
+	case wantValue != nil && gotValue != nil && *wantValue != *gotValue:
+		t.Fatalf("unexpected cache replace value %q, expected %q", *gotValue, *wantValue)
+	}
+}
+
+func TestTokenCache_SingleKey(t *testing.T) {
+	tc := &TokenCache[string]{}
+	requireTokenCacheToEqual(t, tc)
+	requireTokenCacheLoadToEqual(t, tc, "000", nil)
+
+	// add key "000" with value "AAA"
+	fromNilToAAA := tokenCacheReplaceFunc(t, nil, ptr("AAA"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromNilToAAA, ptr("AAA"), nil)
+	requireTokenCacheToEqual(t, tc, "000=AAA")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("AAA"))
+
+	// fail to replace key "000" with value "BBB"
+	fromAAAToBBBFailed := tokenCacheReplaceFunc(t, ptr("AAA"), ptr("BBB"), errors.New("replace failure"))
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromAAAToBBBFailed, ptr("BBB"), errors.New("replace failure"))
+	requireTokenCacheToEqual(t, tc, "000=AAA") // replace func returned an error - value should not change
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("AAA"))
+
+	// replace key "000" with value "CCC"
+	fromAAAToCCC := tokenCacheReplaceFunc(t, ptr("AAA"), ptr("CCC"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromAAAToCCC, ptr("CCC"), nil)
+	requireTokenCacheToEqual(t, tc, "000=CCC")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("CCC"))
+
+	// remove key "000"
+	fromCCCToNil := tokenCacheReplaceFunc(t, ptr("CCC"), nil, nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromCCCToNil, nil, nil)
+	requireTokenCacheToEqual(t, tc)
+	requireTokenCacheLoadToEqual(t, tc, "000", nil)
+}
+
+func TestTokenCache_ConfusionWithMultipleKeys(t *testing.T) {
+	tc := &TokenCache[string]{}
+	requireTokenCacheToEqual(t, tc)
+	requireTokenCacheLoadToEqual(t, tc, "000", nil)
+	requireTokenCacheLoadToEqual(t, tc, "111", nil)
+
+	// add key "000" with value "AAA"
+	fromNilToAAA := tokenCacheReplaceFunc(t, nil, ptr("AAA"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromNilToAAA, ptr("AAA"), nil)
+	requireTokenCacheToEqual(t, tc, "000=AAA")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("AAA"))
+	requireTokenCacheLoadToEqual(t, tc, "111", nil)
+
+	// add key "111" with value "BBB"
+	fromNilToBBB := tokenCacheReplaceFunc(t, nil, ptr("BBB"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "111", fromNilToBBB, ptr("BBB"), nil)
+	requireTokenCacheToEqual(t, tc, "000=AAA", "111=BBB")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("AAA"))
+	requireTokenCacheLoadToEqual(t, tc, "111", ptr("BBB"))
+
+	// replace key "000" with value "BBB"
+	fromAAAToBBB := tokenCacheReplaceFunc(t, ptr("AAA"), ptr("BBB"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromAAAToBBB, ptr("BBB"), nil)
+	requireTokenCacheToEqual(t, tc, "000=BBB", "111=BBB")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("BBB"))
+	requireTokenCacheLoadToEqual(t, tc, "111", ptr("BBB"))
+
+	// replace key "111" with value "CCC"
+	fromBBBToCCC := tokenCacheReplaceFunc(t, ptr("BBB"), ptr("CCC"), nil)
+	requireTokenCacheReplaceToEqual(t, tc, "111", fromBBBToCCC, ptr("CCC"), nil)
+	requireTokenCacheToEqual(t, tc, "000=BBB", "111=CCC")
+	requireTokenCacheLoadToEqual(t, tc, "000", ptr("BBB"))
+	requireTokenCacheLoadToEqual(t, tc, "111", ptr("CCC"))
+
+	// remove key "000"
+	fromBBBToNil := tokenCacheReplaceFunc(t, ptr("BBB"), nil, nil)
+	requireTokenCacheReplaceToEqual(t, tc, "000", fromBBBToNil, nil, nil)
+	requireTokenCacheToEqual(t, tc, "111=CCC")
+	requireTokenCacheLoadToEqual(t, tc, "000", nil)
+	requireTokenCacheLoadToEqual(t, tc, "111", ptr("CCC"))
+}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -989,4 +990,93 @@ func ValidVolumeName(volumeName string) error {
 	}
 
 	return nil
+}
+
+type driverModesAndTransports []driverModeAndTransport
+
+// driverModeAndTransport describes given mode and transport of a storage driver.
+type driverModeAndTransport struct {
+	Mode          string
+	Transport     string
+	ConnectorType string
+}
+
+// discoverModeAndTransport attempts to discover operation mode and transport
+// of a storage driver.
+func discoverModeAndTransport(supportedModesAndTransports driverModesAndTransports, currentMode, currentTransport string) (driverModeAndTransport, error) {
+	for _, toCheck := range supportedModesAndTransports {
+		if currentMode != "" && toCheck.Mode != currentMode {
+			continue
+		}
+
+		if currentTransport != "" && toCheck.Transport != currentTransport {
+			continue
+		}
+
+		connector, err := connectors.NewConnector(toCheck.ConnectorType, "")
+		if err != nil {
+			return driverModeAndTransport{}, err
+		}
+
+		if connector.LoadModules() != nil {
+			continue
+		}
+
+		return toCheck, nil
+	}
+
+	return driverModeAndTransport{}, errors.New("Failed discovering mode and transport")
+}
+
+// Find locates entity matching the provided mode and transport. If no matching
+// entity exists function returns error.
+func (list driverModesAndTransports) Find(mode, transport string) (driverModeAndTransport, error) {
+	for _, mt := range list {
+		if mt.Mode != mode || mt.Transport != transport {
+			continue
+		}
+
+		return mt, nil
+	}
+
+	return driverModeAndTransport{}, fmt.Errorf("Unsupported mode %q with transport %q", mode, transport)
+}
+
+// ConnectorTypes returns all unique connector types from the list.
+func (list driverModesAndTransports) ConnectorTypes() (res []string) {
+	for _, mt := range list {
+		if slices.Contains(res, mt.ConnectorType) {
+			continue
+		}
+
+		res = append(res, mt.ConnectorType)
+	}
+
+	return res
+}
+
+// Modes returns all unique modes from the list.
+func (list driverModesAndTransports) Modes() (res []string) {
+	for _, mt := range list {
+		if slices.Contains(res, mt.Mode) {
+			continue
+		}
+
+		res = append(res, mt.Mode)
+	}
+
+	return res
+}
+
+// Transports returns all unique transports from the list.
+func (list driverModesAndTransports) Transports() (res []string) {
+	for _, mt := range list {
+		if slices.Contains(res, mt.Transport) {
+			continue
+		}
+
+		res = append(res, mt.Transport)
+	}
+
+	return res
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -992,6 +992,11 @@ func ValidVolumeName(volumeName string) error {
 	return nil
 }
 
+// limitString trims the provided string to the specified number of characters.
+func limitString(s string, limit int) string {
+	return s[:min(len(s), limit)]
+}
+
 type driverModesAndTransports []driverModeAndTransport
 
 // driverModeAndTransport describes given mode and transport of a storage driver.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -438,7 +438,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Quota of the storage bucket
 		//  scope: local
 		"size": validate.Optional(validate.IsSize),
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.expiry)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.expiry)
 		// Specify an expression like `1M 2H 3d 4w 5m 6y`.
 		// ---
 		//  type: string
@@ -451,7 +451,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 			_, err := shared.GetExpiry(time.Time{}, value)
 			return err
 		},
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.schedule)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.schedule)
 		// Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 		// ---
 		//  type: string
@@ -460,7 +460,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Schedule for automatic volume snapshots
 		//  scope: global
 		"snapshots.schedule": validate.Optional(validate.IsCron([]string{"@hourly", "@daily", "@midnight", "@weekly", "@monthly", "@annually", "@yearly"})),
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.pattern)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.pattern)
 		// You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 		//
 		// {{snapshot_pattern_detail}}
@@ -475,7 +475,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// security.shifted and security.unmapped are only relevant for custom filesystem volumes.
 	if vol == nil || (vol.Type() == drivers.VolumeTypeCustom && vol.ContentType() == drivers.ContentTypeFS) {
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.shifted)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.shifted)
 		// Enabling this option allows attaching the volume to multiple isolated instances.
 		// ---
 		//  type: bool
@@ -484,7 +484,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Enable ID shifting overlay
 		//  scope: global
 		rules["security.shifted"] = validate.Optional(validate.IsBool)
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.unmapped)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.unmapped)
 		//
 		// ---
 		//  type: bool
@@ -497,7 +497,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// security.shared guards virtual-machine and custom block volumes.
 	if vol == nil || ((vol.Type() == drivers.VolumeTypeCustom || vol.Type() == drivers.VolumeTypeVM) && vol.ContentType() == drivers.ContentTypeBlock) {
-		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.shared)
+		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.shared)
 		// Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
 		//
 		// ---
@@ -511,7 +511,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// Those keys are only valid for volumes.
 	if vol != nil {
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.uuid)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.uuid)
 		//
 		// ---
 		//  type: string
@@ -520,7 +520,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  scope: global
 		rules["volatile.uuid"] = validate.Optional(validate.IsUUID)
 
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.devlxd.owner)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.devlxd.owner)
 		//
 		// ---
 		//  type: string
@@ -554,7 +554,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  scope: local
 		"source.recover":          validate.Optional(validate.IsBool),
 		"volatile.initial_source": validate.IsAny,
-		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-pure,storage-alletra; group=pool-conf; key=rsync.bwlimit)
+		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=pool-conf; key=rsync.bwlimit)
 		// When `rsync` must be used to transfer storage entities, this option specifies the upper limit
 		// to be placed on the socket I/O.
 		// ---
@@ -563,7 +563,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  shortdesc: Upper limit on the socket I/O for `rsync`
 		//  scope: global
 		"rsync.bwlimit": validate.Optional(validate.IsSize),
-		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-pure,storage-alletra; group=pool-conf; key=rsync.compression)
+		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=pool-conf; key=rsync.compression)
 		//
 		// ---
 		//  type: bool
@@ -621,14 +621,14 @@ func validateLocalPoolCommonRules() map[string]func(string) error {
 func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error {
 	rules := poolAndVolumeCommonRules(&vol)
 
-	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.last)
+	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.last)
 	//
 	// ---
 	//   type: string
 	//   shortdesc: JSON-serialized UID/GID map that has been applied to the volume
 	//   condition: filesystem
 
-	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.next)
+	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.next)
 	//
 	// ---
 	//   type: string

--- a/shared/util.go
+++ b/shared/util.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"io/fs"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -954,6 +955,60 @@ func RemoveDuplicatesFromString(s string, sep string) string {
 	}
 
 	return s
+}
+
+// Unique removes all duplicated values from the provided slice (in place) while
+// preserving order of unique elements.
+func Unique[S ~[]E, E comparable](s S) S {
+	seen := make(map[E]struct{})
+	end := 0
+	for _, v := range s {
+		_, exists := seen[v]
+		if exists {
+			continue
+		}
+
+		seen[v] = struct{}{}
+		s[end] = v
+		end++
+	}
+
+	// Clear the rest of elements.
+	var zero E
+	for i := end; i < len(s); i++ {
+		s[i] = zero
+	}
+
+	return s[:end]
+}
+
+// EnsurePort adds the provided port to the given address unless it already has
+// a non-zero port number.
+func EnsurePort(addr string, defaultPort string) string {
+	// Check for IP address to properly handle IPv6 addresses.
+	if net.ParseIP(addr) != nil {
+		// For valid IP address just add port number.
+		return net.JoinHostPort(addr, defaultPort)
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err == nil {
+		if port == "" || port == "0" {
+			port = defaultPort
+		}
+
+		// Rejoin host and port to ensure addresses are formatted uniformly.
+		return net.JoinHostPort(host, port)
+	}
+
+	// Attempt to naively add port to handle partially formatted IPv6 addresses.
+	host, port, err = net.SplitHostPort(fmt.Sprintf("%s:%s", addr, defaultPort))
+	if err == nil {
+		// Rejoin host and port to ensure addresses are formatted uniformly.
+		return net.JoinHostPort(host, port)
+	}
+
+	return net.JoinHostPort(addr, defaultPort)
 }
 
 // RunError is the error from the RunCommand family of functions.

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -515,3 +515,81 @@ func TestResolveSnapPath(t *testing.T) {
 		})
 	}
 }
+
+func TestUnique(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		given []string
+		want  []string
+	}{
+		{name: "nil-slice", given: nil, want: nil},
+		{name: "empty-slice", given: []string{}, want: []string{}},
+		{name: "single-item", given: []string{"aaa"}, want: []string{"aaa"}},
+		{name: "multiple-items-no-duplicates", given: []string{"aaa", "bbb", "ccc"}, want: []string{"aaa", "bbb", "ccc"}},
+		{name: "multiple-items-consecutive-duplicates", given: []string{"aaa", "aaa", "bbb", "bbb", "ccc", "ccc"}, want: []string{"aaa", "bbb", "ccc"}},
+		{name: "multiple-items-random-duplicates", given: []string{"aaa", "bbb", "ccc", "bbb", "ccc", "aaa", "ccc"}, want: []string{"aaa", "bbb", "ccc"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := Unique(test.given)
+			require.Equal(t, test.want, got, "unexpected Unique function result")
+		})
+	}
+}
+
+func TestEnsurePort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		addr string
+		port string
+		want string
+	}{
+		{name: "empty", addr: "", port: "", want: ":"},
+		{name: "empty-address", addr: "", port: "1234", want: ":1234"},
+		{name: "empty-port", addr: "host", port: "", want: "host:"},
+		{name: "host-without-port", addr: "host", port: "1234", want: "host:1234"},
+		{name: "host-with-port", addr: "host:9876", port: "1234", want: "host:9876"},
+		{name: "host-in-brackets", addr: "[host]", port: "1234", want: "host:1234"},
+		{name: "host-in-brackets-with-port", addr: "[host]:9876", port: "1234", want: "host:9876"},
+		{name: "ipv4-without-port", addr: "123.123.123.123", port: "1234", want: "123.123.123.123:1234"},
+		{name: "ipv4-with-port", addr: "123.123.123.123:9876", port: "1234", want: "123.123.123.123:9876"},
+		{name: "ipv4-in-brackets", addr: "[123.123.123.123]", port: "1234", want: "123.123.123.123:1234"},
+		{name: "ipv4-in-brackets-with-port", addr: "[123.123.123.123]:9876", port: "1234", want: "123.123.123.123:9876"},
+		{name: "ipv6-without-port", addr: "1234:567::89ab:cd:ef01", port: "1234", want: "[1234:567::89ab:cd:ef01]:1234"},
+		{name: "ipv6-with-port", addr: "1234:567::89ab:cd:ef01:9876", port: "1234", want: "[1234:567::89ab:cd:ef01:9876]:1234"},
+		{name: "ipv6-in-brackets", addr: "[1234:567::89ab:cd:ef01]", port: "1234", want: "[1234:567::89ab:cd:ef01]:1234"},
+		{name: "ipv6-in-brackets-with-port", addr: "[1234:567::89ab:cd:ef01]:9876", port: "1234", want: "[1234:567::89ab:cd:ef01]:9876"},
+		{name: "ipv6-full-without-port", addr: "1234:5678:9abc:def0:1234:5678:9abc:def0", port: "1234", want: "[1234:5678:9abc:def0:1234:5678:9abc:def0]:1234"},
+		{name: "ipv6-full-with-port", addr: "1234:5678:9abc:def0:1234:5678:9abc:def0:9876", port: "1234", want: "[1234:5678:9abc:def0:1234:5678:9abc:def0:9876]:1234"},
+		{name: "ipv6-full-in-brackets", addr: "[1234:5678:9abc:def0:1234:5678:9abc:def0]", port: "1234", want: "[1234:5678:9abc:def0:1234:5678:9abc:def0]:1234"},
+		{name: "ipv6-full-in-brackets-with-port", addr: "[1234:5678:9abc:def0:1234:5678:9abc:def0]:9876", port: "1234", want: "[1234:5678:9abc:def0:1234:5678:9abc:def0]:9876"},
+		{name: "ipv6-min-without-port", addr: "1234::5678", port: "1234", want: "[1234::5678]:1234"},
+		{name: "ipv6-min-with-port", addr: "1234::5678:9876", port: "1234", want: "[1234::5678:9876]:1234"},
+		{name: "ipv6-min-in-brackets", addr: "[1234::5678]", port: "1234", want: "[1234::5678]:1234"},
+		{name: "ipv6-min-in-brackets-with-port", addr: "[1234::5678]:9876", port: "1234", want: "[1234::5678]:9876"},
+		{name: "ipv6-loopback-without-port", addr: "::1", port: "1234", want: "[::1]:1234"},
+		{name: "ipv6-loopback-with-port", addr: "::1:9876", port: "1234", want: "[::1:9876]:1234"},
+		{name: "ipv6-loopback-in-brackets", addr: "[::1]", port: "1234", want: "[::1]:1234"},
+		{name: "ipv6-loopback-in-brackets-with-port", addr: "[::1]:9876", port: "1234", want: "[::1]:9876"},
+		{name: "colon-without-port", addr: ":", port: "1234", want: ":1234"},
+		{name: "colon-with-port", addr: "::9876", port: "1234", want: "[::9876]:1234"},
+		{name: "colon-in-brackets", addr: "[:]", port: "1234", want: "[:]:1234"},
+		{name: "colon-in-brackets-with-port", addr: "[:]:9876", port: "1234", want: "[:]:9876"},
+		{name: "colons-without-port", addr: "::", port: "1234", want: "[::]:1234"},
+		{name: "colons-with-port", addr: ":::9876", port: "1234", want: "[:::9876]:1234"},
+		{name: "colons-in-brackets", addr: "[::]", port: "1234", want: "[::]:1234"},
+		{name: "colons-in-brackets-with-port", addr: "[::]:9876", port: "1234", want: "[::]:9876"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := EnsurePort(test.addr, test.port)
+			require.Equal(t, test.want, got, "unexpected EnsurePort function result")
+		})
+	}
+}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -939,6 +939,48 @@ func IsValidCPUSet(value string) error {
 	return nil
 }
 
+// IsNoLessThanUnit checks if value is greater or equal to the provided unit.
+func IsNoLessThanUnit(unit string) func(value string) error {
+	return func(value string) error {
+		bytes, err := units.ParseByteSizeString(value)
+		if err != nil {
+			return fmt.Errorf("Invalid value: %s", value)
+		}
+
+		minBytes, err := units.ParseByteSizeString(unit)
+		if err != nil {
+			return fmt.Errorf("Invalid unit value: %s", unit)
+		}
+
+		if bytes < minBytes {
+			return fmt.Errorf("Value %s is smaller than minimum %s", value, unit)
+		}
+
+		return nil
+	}
+}
+
+// IsNoGreaterThanUnit checks if value is less or equal to the provided unit.
+func IsNoGreaterThanUnit(unit string) func(value string) error {
+	return func(value string) error {
+		bytes, err := units.ParseByteSizeString(value)
+		if err != nil {
+			return fmt.Errorf("Invalid value: %s", value)
+		}
+
+		maxBytes, err := units.ParseByteSizeString(unit)
+		if err != nil {
+			return fmt.Errorf("Invalid unit value: %s", unit)
+		}
+
+		if bytes > maxBytes {
+			return fmt.Errorf("Value %s is larger than maximum %s", value, unit)
+		}
+
+		return nil
+	}
+}
+
 // IsMultipleOfUnit checks if value is in multiples of unit.
 func IsMultipleOfUnit(unit string) func(value string) error {
 	return func(value string) error {

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/robfig/cron/v3"
 	"go.yaml.in/yaml/v2"
 
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/units"
 )
@@ -267,6 +268,33 @@ func IsNetworkAddress(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil {
 		return fmt.Errorf("Not an IP address %q", value)
+	}
+
+	return nil
+}
+
+// IsNetworkAddressWithOptionalPort validates if the provided string is
+// an IP (v4 or v6) address or an IP (v4 or v6) address with a port number.
+func IsNetworkAddressWithOptionalPort(value string) error {
+	addr, port, err := net.SplitHostPort(value)
+	if err != nil {
+		addr, port, err = net.SplitHostPort(shared.EnsurePort(value, "0"))
+
+		// If splitting host and port fails again after EnsurePort the provided
+		// value is invalid.
+		if err != nil {
+			return fmt.Errorf("Neither an IP address nor an IP address with port number %q", value)
+		}
+	}
+
+	err = IsNetworkAddress(addr)
+	if err != nil {
+		return fmt.Errorf("Not an IP address with port number %q: %w", value, err)
+	}
+
+	err = IsNetworkPort(port)
+	if err != nil {
+		return fmt.Errorf("Not an IP address with port number %q: %w", value, err)
 	}
 
 	return nil

--- a/shared/validate/validate_test.go
+++ b/shared/validate/validate_test.go
@@ -660,6 +660,39 @@ func Test_IsNetworkAddress(t *testing.T) {
 	}
 }
 
+func Test_IsNetworkAddressWithOptionalPort(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"192.0.2.1", true},
+		{"192.0.2.1:1234", true},
+		{"2001:db8::1", true},
+		{"[2001:db8::1]", true},
+		{"[2001:db8::1]:1234", true},
+		{"192.0.2.0/32", false},
+		{"192.0.2.256", false},
+		{"192.0.2.256:1234", false},
+		{"2001:db8::1/128", false},
+		{"[2001:db8::1]/128", false},
+		{"[2001:db8::1/128]", false},
+		{"2001:db8::1/128:1234", false},
+		{"[2001:db8::1]/128:1234", false},
+		{"[2001:db8::1/128]:1234", false},
+		{"2001:db8::g", false},
+		{"[2001:db8::g]", false},
+		{"2001:db8::g:1234", false},
+		{"[2001:db8::g]:1234", false},
+	}
+
+	for _, test := range tests {
+		err := validate.IsNetworkAddressWithOptionalPort(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsNetworkAddressWithOptionalPort(%q) = %v, want %v", test.value, err == nil, test.expected)
+		}
+	}
+}
+
 func Test_IsNetwork(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/shared/validate/validate_test.go
+++ b/shared/validate/validate_test.go
@@ -997,3 +997,66 @@ func TestIsHTTPSURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNoLessThanUnit(t *testing.T) {
+	tests := []struct {
+		unit     string
+		value    string
+		expected bool
+	}{
+		{"1MiB", "1MiB", true},
+		{"1MiB", "1GiB", true},
+		{"1MiB", "1KiB", false},
+		{"non-unit", "1MiB", false},
+		{"1MiB", "non-unit", false},
+	}
+
+	for _, test := range tests {
+		err := validate.IsNoLessThanUnit(test.unit)(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsNoLessThanUnit(%q)(%q) = %v, want %v; err=%v", test.unit, test.value, err == nil, test.expected, err)
+		}
+	}
+}
+
+func TestIsNoGreaterThanUnit(t *testing.T) {
+	tests := []struct {
+		unit     string
+		value    string
+		expected bool
+	}{
+		{"1MiB", "1MiB", true},
+		{"1GiB", "1MiB", true},
+		{"1KiB", "1MiB", false},
+		{"non-unit", "1MiB", false},
+		{"1MiB", "non-unit", false},
+	}
+
+	for _, test := range tests {
+		err := validate.IsNoGreaterThanUnit(test.unit)(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsNoGreaterThanUnit(%q)(%q) = %v, want %v; err=%v", test.unit, test.value, err == nil, test.expected, err)
+		}
+	}
+}
+
+func TestIsMultipleOfUnit(t *testing.T) {
+	tests := []struct {
+		unit     string
+		value    string
+		expected bool
+	}{
+		{"1MiB", "1MiB", true},
+		{"1MiB", "1GiB", true},
+		{"3KiB", "1MiB", false},
+		{"non-unit", "1MiB", false},
+		{"1MiB", "non-unit", false},
+	}
+
+	for _, test := range tests {
+		err := validate.IsMultipleOfUnit(test.unit)(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsMultipleOfUnit(%q)(%q) = %v, want %v; err=%v", test.unit, test.value, err == nil, test.expected, err)
+		}
+	}
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -484,6 +484,7 @@ var APIExtensions = []string{
 	"ovn_dynamic_northbound_connection",
 	"storage_zfs_promote",
 	"storage_and_network_operations",
+	"storage_driver_powerstore",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Continuation of phase 1 (https://github.com/canonical/lxd/pull/17281), adding full support for Dell PowerStore appliances.

## Previously missing methods from the `"github.com/canonical/lxd/storage/drivers".Driver` interface, implemented in this PR:
- Volumes
  - (TODO) CreateVolumeFromCopy
  - (TODO) RefreshVolume
  - CanDelegateVolume
  - DelegateVolume
- Snapshots
  - MountVolumeSnapshot
  - UnmountVolumeSnapshot
  - CreateVolumeSnapshot
  - DeleteVolumeSnapshot
  - RenameVolumeSnapshot
  - VolumeSnapshots
  - (TODO) CheckVolumeSnapshots
  - (TODO) RestoreVolume
- Migration
  - (TODO) MigrationTypes
  - (TODO) MigrateVolume
  - (TODO) CreateVolumeFromMigration
- Backup
  - (TODO) BackupVolume
  - (TODO) CreateVolumeFromBackup

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
