### PR TITLE
API: Include additional metadata fields for images fetched from SimpleStreams sources

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3038,3 +3038,10 @@ Clients should check for this extension and handle the asynchronous response by 
 ## `gpu_cdi_hotplug`
 
 Adds support for hotplugging GPU devices into containers when using {ref}`gpu-physical-cdi`.
+
+(extension-image-extended-metadata)=
+## `image_extended_metadata`
+
+Adds `release_codename` and `release_title` fields to the `api.Image` struct. These fields are optional and are populated from the SimpleStreams index when available.
+
+Also updates the generated image description for SimpleStreams images to include variant if available. The image creation date and architecture are no longer used for image description.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1141,6 +1141,16 @@ definitions:
                 example: false
                 type: boolean
                 x-go-name: Public
+            release_codename:
+                description: OS release codename
+                example: jammy
+                type: string
+                x-go-name: ReleaseCodename
+            release_title:
+                description: OS release title
+                example: 22.04 LTS
+                type: string
+                x-go-name: ReleaseTitle
             size:
                 description: Size of the image in bytes
                 example: 272237676

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -209,6 +209,18 @@ type Image struct {
 	//
 	// API extension: images_all_projects
 	Project string `json:"project" yaml:"project"`
+
+	// OS release codename
+	// Example: jammy
+	//
+	// API extension: image_extended_metadata
+	ReleaseCodename string `json:"release_codename,omitempty" yaml:"release_codename,omitempty"`
+
+	// OS release title
+	// Example: 22.04 LTS
+	//
+	// API extension: image_extended_metadata
+	ReleaseTitle string `json:"release_title,omitempty" yaml:"release_title,omitempty"`
 }
 
 // Writable converts a full Image struct into a ImagePut struct (filters read-only fields).

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -164,6 +164,11 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 					description += " (" + version.Label + ")"
 				}
 
+				// If variant is specified, append it to the image description.
+				if product.Variant != "" {
+					description += " (" + product.Variant + ")"
+				}
+
 				image := api.Image{}
 				image.Architecture = architectureName
 				image.Public = true

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -159,7 +159,7 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 				filename := fields[len(fields)-1]
 
 				// Generate the actual image entry
-				description := product.OperatingSystem + " " + product.ReleaseTitle + " " + product.Architecture
+				description := product.OperatingSystem + " " + product.ReleaseTitle
 				if version.Label != "" {
 					description += " (" + version.Label + ")"
 				}

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -164,8 +164,6 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 					description += " (" + version.Label + ")"
 				}
 
-				description += " (" + name + ")"
-
 				image := api.Image{}
 				image.Architecture = architectureName
 				image.Public = true

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -200,6 +200,9 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 
 				image.Type = "container"
 
+				image.ReleaseCodename = product.ReleaseCodename
+				image.ReleaseTitle = product.ReleaseTitle
+
 				if root != nil {
 					image.Properties["type"] = root.FileType
 					if root.FileType == "disk1.img" || root.FileType == "disk-kvm.img" || root.FileType == "uefi1.img" {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -485,6 +485,7 @@ var APIExtensions = []string{
 	"storage_zfs_promote",
 	"storage_and_network_operations",
 	"gpu_cdi_hotplug",
+	"image_extended_metadata",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR extends the `api.Image` struct to include additional metadata fields (`ReleaseCodename` and `ReleaseTitle`). These fields are optional and are populated from the SimpleStreams index when available.

This change will be helpful for LXD UI once image registries https://github.com/canonical/lxd/pull/17680 are introduced, since the UI relies on [these fields](https://github.com/canonical/lxd-ui/blob/main/src/types/image.d.ts#L40-L68).

This change also updates the generated image description for SimpleStreams images to include `variant` if available (e.g. `cloud`). The image creation date and architecture are no longer used for image description.

Closes https://github.com/canonical/lxd/issues/13952.

