### PR TITLE
lxd/db/dbgen: Don't allow joins on structs ending 'Row'

### DIFF
--- a/lxd/db/dbgen/main.go
+++ b/lxd/db/dbgen/main.go
@@ -233,6 +233,10 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 				for _, l := range field.Doc.List {
 					join, ok := strings.CutPrefix(l.Text, "// db:join ")
 					if ok {
+						if strings.HasSuffix(newSpec.StructName, "Row") {
+							return nil, nil, fmt.Errorf("Invalid spec for struct %q: Structs with a `Row` suffix may not include joins", newSpec.StructName)
+						}
+
 						newSpec.Joins = append(newSpec.Joins, join)
 						break
 					}


### PR DESCRIPTION
From https://github.com/canonical/lxd/pull/17850/changes/6245f44f41fe29512dfdd5e6969a4bbda5c2a389#r3020816708

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
