### PR TITLE
lxd/apparmor/network_dnsmasq: allow `dnsmasq` to communicate with LXD

### DIFF
--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -29,6 +29,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Network access
   network inet raw,
   network inet6 raw,
+  unix (send, receive, accept) type=stream addr=@** peer=(label=unconfined),
 
   # Network-specific paths
   {{ .varPath }}/networks/{{ .networkName }}/dnsmasq.hosts/{,*} r,


### PR DESCRIPTION
This should avoid this noise:

```
Mar 30 18:43:56 kernel: audit: type=1400 audit(1774896236.134:782): apparmor="DENIED" operation="connect" class="net" namespace="root//lxd-m1_<var-snap-lxd-common-lxd>" profile="lxd_dnsmasq-lxdbr0_</var/snap/lxd/common/lxd>" pid=13302 comm="lxd" family="unix" sock_type="stream" protocol=0 requested="send receive accept" denied="send accept" addr="@abf50" peer_addr=none peer="unconfined"
Mar 30 18:43:57 kernel: audit: type=1400 audit(1774896237.728:783): apparmor="DENIED" operation="connect" class="net" namespace="root//lxd-m1_<var-snap-lxd-common-lxd>" profile="lxd_dnsmasq-lxdbr0_</var/snap/lxd/common/lxd>" pid=13302 comm="lxd" family="unix" sock_type="stream" protocol=0 requested="send receive accept" denied="send accept" addr="@abf50" peer_addr=none peer="unconfined"
```

This was noticed in the `lxd-ci` `tests/cluster`.
