### PR TITLE
Network: Idempotent load balancer edits

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/canonical/lxd/lxd/linux"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/dnsutil"
+	"github.com/canonical/lxd/shared/logger"
 )
 
 // OVNRouter OVN router name.
@@ -1942,55 +1944,150 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 		return ip.String()
 	}
 
-	// Build up the commands to add VIPs to the load balancer.
-	for _, r := range vips {
-		if r.ListenAddress == nil {
-			return errors.New("Missing VIP listen address")
-		}
-
-		if len(r.Targets) == 0 {
-			return errors.New("Missing VIP target(s)")
-		}
-
+	// deleteLBArgs returns the args for load balancer deletion.
+	deleteLBArgs := func(args []string, lbUUID string) []string {
 		if len(args) > 0 {
 			args = append(args, "--")
 		}
 
-		if r.Protocol == "udp" {
-			args = append(args, "lb-add", lbUDPName)
-		} else {
-			args = append(args, "lb-add", lbTCPName)
+		return append(args, "--if-exists", "destroy", "load_balancer", lbUUID)
+	}
+
+	allVIPsForProtocol := map[string][]string{}
+
+	// Get a view of all load balancers matching the given name.
+	lbUUIDs, err := o.loadBalancerUUIDs(loadBalancerName)
+	if err != nil {
+		return fmt.Errorf("Failed getting UUIDs for load balancer %q: %w", loadBalancerName, err)
+	}
+
+	// When initializing the size assume there are no duplicates (which should be the normal case).
+	args := make([]string, 0)
+
+	// Account for https://github.com/canonical/lxd/issues/13462.
+	// If there is more than one load balancer with the same name, drop it.
+	// This ensures consistency and allows all of the following operations to operate on a single load balancer.
+	for _, protocol := range []string{"tcp", "udp"} {
+		if len(lbUUIDs[protocol]) > 1 {
+			// Delete all duplicate load balancers except the first one.
+			for _, lbUUID := range lbUUIDs[protocol][1:] {
+				logger.Warn("Cleaning up duplicate load balancer", logger.Ctx{"name": loadBalancerName, "protocol": protocol, "uuid": lbUUID})
+
+				args = deleteLBArgs(args, lbUUID)
+			}
+		}
+	}
+
+	// Remove the duplicates right away to have a clean set of load balancers to continue.
+	if len(args) > 0 {
+		_, err := o.nbctl(args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	// When initializing the size assume the best case without any VIP or load balancer removal.
+	args = make([]string, 0, len(vips)*7)
+
+	// Build up the commands for the load balancer changes.
+	for _, vip := range vips {
+		// Validate the VIP.
+		if vip.ListenAddress == nil {
+			return errors.New("Missing VIP listen address")
 		}
 
-		targetArgs := make([]string, 0, len(r.Targets))
+		if len(vip.Targets) == 0 {
+			return errors.New("Missing VIP target(s)")
+		}
 
-		for _, target := range r.Targets {
-			if (r.ListenPort > 0 && target.Port <= 0) || (target.Port > 0 && r.ListenPort <= 0) {
+		targetArgs := make([]string, 0, len(vip.Targets))
+
+		// Generate a list of load balancer targets.
+		for _, target := range vip.Targets {
+			if (vip.ListenPort > 0 && target.Port <= 0) || (target.Port > 0 && vip.ListenPort <= 0) {
 				return errors.New("The listen and target ports must be specified together")
 			}
 
-			if r.ListenPort > 0 {
+			if vip.ListenPort > 0 {
 				targetArgs = append(targetArgs, ipToString(target.Address)+":"+strconv.FormatUint(target.Port, 10))
 			} else {
 				targetArgs = append(targetArgs, ipToString(target.Address))
 			}
 		}
 
-		if r.ListenPort > 0 {
-			args = append(args,
-				ipToString(r.ListenAddress)+":"+strconv.FormatUint(r.ListenPort, 10),
-				strings.Join(targetArgs, ","),
-				r.Protocol,
-			)
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+
+		// In case no protocol is set, default to TCP as OVN does.
+		if vip.Protocol == "" {
+			vip.Protocol = "tcp"
+		}
+
+		// Append all requested targets to the load balancer VIP.
+		lbName := string(loadBalancerName) + "-" + vip.Protocol
+		args = append(args, "--may-exist", "lb-add", lbName)
+
+		vipStr := ipToString(vip.ListenAddress)
+		joinedTargets := strings.Join(targetArgs, ",")
+
+		if vip.ListenPort > 0 {
+			vipStr = ipToString(vip.ListenAddress) + ":" + strconv.FormatUint(vip.ListenPort, 10)
+			args = append(args, vipStr, joinedTargets, vip.Protocol)
 		} else {
-			args = append(args,
-				ipToString(r.ListenAddress),
-				strings.Join(targetArgs, ","),
-			)
+			args = append(args, vipStr, joinedTargets)
+		}
+
+		// Record the VIP for this protocol.
+		if allVIPsForProtocol[vip.Protocol] == nil {
+			allVIPsForProtocol[vip.Protocol] = []string{}
+		}
+
+		allVIPsForProtocol[vip.Protocol] = append(allVIPsForProtocol[vip.Protocol], vipStr)
+	}
+
+	// Check if the current load balancer has any obsolete VIPs that require removal.
+	// We can only retrieve the VIPs in case the load balancer already exists.
+	for _, protocol := range []string{"tcp", "udp"} {
+		// If there are no VIPs for the current protocol there is no need to remove VIPs
+		// as the parent load balancer will be removed anyway if it exists.
+		if allVIPsForProtocol[protocol] == nil {
+			continue
+		}
+
+		lbName := string(loadBalancerName) + "-" + protocol
+
+		currentVIPs, err := o.loadBalancerVIPs(loadBalancerName, protocol)
+		if err == nil {
+			for _, currentVIP := range currentVIPs {
+				if !slices.Contains(allVIPsForProtocol[protocol], currentVIP) {
+					if len(args) > 0 {
+						args = append(args, "--")
+					}
+
+					args = append(args, "--if-exists", "lb-del", lbName, currentVIP)
+				}
+			}
 		}
 	}
 
+	// When initializing the size account for all load balancers.
+	toBeDeletedLBs := make([]string, 0, len(lbUUIDs["tcp"])+len(lbUUIDs["udp"]))
+
+	// If there are no VIPs for an existing TCP or UDP load balancer, mark it for deletion.
+	for _, protocol := range []string{"tcp", "udp"} {
+		if allVIPsForProtocol[protocol] == nil && len(lbUUIDs[protocol]) > 0 {
+			// If there is more than one load balancer matching the name, it already got removed.
+			toBeDeletedLBs = append(toBeDeletedLBs, lbUUIDs[protocol][:1]...)
+		}
+	}
+
+	for _, lbUUID := range toBeDeletedLBs {
+		args = deleteLBArgs(args, lbUUID)
+	}
+
 	// Apply the load balancer changes.
+	// This will add new and remove obsolete load balancers together with their VIPs and targets.
 	if len(args) > 0 {
 		_, err := o.nbctl(args...)
 		if err != nil {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1902,6 +1902,34 @@ func (o *OVN) loadBalancerUUIDs(loadBalancerName OVNLoadBalancer) (map[string][]
 	return lbUUIDs, nil
 }
 
+// loadBalancerVIPs returns a slice of VIPs currently configured on the given load balancer.
+func (o *OVN) loadBalancerVIPs(loadBalancerName OVNLoadBalancer, protocol string) ([]string, error) {
+	lbName := string(loadBalancerName) + "-" + protocol
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=vips", "list", "load_balancer", lbName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed listing the VIPs of load balancer %q: %w", lbName, err)
+	}
+
+	output, err = unquote(strings.TrimSpace(output))
+	if err != nil {
+		return nil, fmt.Errorf("Failed unquoting VIPs output %q of load balancer %q: %w", output, lbName, err)
+	}
+
+	vipTargets := strings.Fields(output)
+	vips := make([]string, 0, len(vipTargets))
+
+	for _, vipTarget := range vipTargets {
+		before, _, found := strings.Cut(vipTarget, "=")
+		if !found {
+			return nil, fmt.Errorf("Invalid line %q in VIPs output of load balancer %q", vipTarget, lbName)
+		}
+
+		vips = append(vips, before)
+	}
+
+	return vips, nil
+}
+
 // LoadBalancerApply creates a new load balancer (if doesn't exist) on the specified routers and switches.
 // Providing an empty set of vips will delete the load balancer.
 func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNRouter, switches []OVNSwitch, vips ...OVNLoadBalancerVIP) error {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -2095,40 +2095,41 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 		}
 	}
 
-	// If there are some VIP rules then associate the load balancer to the requested routers and switches.
-	if len(vips) > 0 {
-		args := make([]string, 0, 6*len(lbUUIDs))
+	// If there are new load balancers, associate them to the requested routers and switches.
+	// It's a noop in case the load balancer is already associated to the router/switch.
+	// Start by getting a fresh list of load balancer UUIDs.
+	lbUUIDs, err = o.loadBalancerUUIDs(loadBalancerName)
+	if err != nil {
+		return fmt.Errorf("Failed getting UUIDs: %w", err)
+	}
 
-		// Get fresh list of load balancer UUIDs.
-		lbUUIDs, err := o.loadBalancerUUIDs(loadBalancerName)
-		if err != nil {
-			return fmt.Errorf("Failed getting UUIDs: %w", err)
-		}
+	args = make([]string, 0, (len(lbUUIDs["tcp"])+len(lbUUIDs["udp"]))*(len(routers)+len(switches))*5)
 
-		for _, lbUUID := range lbUUIDs {
-			if len(args) > 0 {
-				args = append(args, "--")
-			}
-
+	for _, lbUUIDsForProtocol := range lbUUIDs {
+		for _, lbUUID := range lbUUIDsForProtocol {
 			for _, r := range routers {
-				args = append(args, "add", "logical_router", string(r), "load_balancer", lbUUID)
-			}
-		}
-
-		if len(args) > 0 {
-			_, err = o.nbctl(args...)
-			if err != nil {
-				return err
-			}
-		}
-
-		for _, lbUUID := range lbUUIDs {
-			for _, s := range switches {
-				_, err = o.nbctl("ls-lb-add", string(s), lbUUID)
-				if err != nil {
-					return err
+				if len(args) > 0 {
+					args = append(args, "--")
 				}
+
+				args = append(args, "--may-exist", "lr-lb-add", string(r), lbUUID)
 			}
+
+			for _, s := range switches {
+				if len(args) > 0 {
+					args = append(args, "--")
+				}
+
+				args = append(args, "--may-exist", "ls-lb-add", string(s), lbUUID)
+			}
+		}
+	}
+
+	// Apply both router and switch associations together.
+	if len(args) > 0 {
+		_, err = o.nbctl(args...)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1876,21 +1876,27 @@ func (o *OVN) PortGroupPortClearACLRules(portGroupName OVNPortGroup, portName OV
 	return nil
 }
 
-// loadBalancerUUIDs returns list of UUID records for named load balancer.
-func (o *OVN) loadBalancerUUIDs(loadBalancerName OVNLoadBalancer) ([]string, error) {
-	lbTCPName := string(loadBalancerName) + "-tcp"
-	lbUDPName := string(loadBalancerName) + "-udp"
-
-	var lbUUIDs []string //nolint:prealloc
+// loadBalancerUUIDs returns a map of UUID records for the named load balancer.
+// All load balancers for all protocols matching the given name are returned.
+// The returned map is keyed by protocol which helps differentiating the UUIDs.
+func (o *OVN) loadBalancerUUIDs(loadBalancerName OVNLoadBalancer) (map[string][]string, error) {
+	protocols := []string{"tcp", "udp"}
+	lbUUIDs := make(map[string][]string, len(protocols))
 
 	// Use find command in order to workaround OVN bug where duplicate records of same name can exist.
-	for _, lbName := range []string{lbTCPName, lbUDPName} {
-		output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=_uuid", "find", "load_balancer", `name="`+lbName+`"`)
+	for _, protocol := range protocols {
+		output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=_uuid", "find", "load_balancer", `name="`+string(loadBalancerName)+"-"+protocol+`"`)
 		if err != nil {
 			return nil, err
 		}
 
-		lbUUIDs = append(lbUUIDs, shared.SplitNTrimSpace(strings.TrimSpace(output), "\n", -1, true)...)
+		uuids := shared.SplitNTrimSpace(strings.TrimSpace(output), "\n", -1, true)
+
+		if lbUUIDs[protocol] == nil {
+			lbUUIDs[protocol] = make([]string, 0, len(uuids))
+		}
+
+		lbUUIDs[protocol] = append(lbUUIDs[protocol], uuids...)
 	}
 
 	return lbUUIDs, nil

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -2040,12 +2040,14 @@ func (o *OVN) LoadBalancerDelete(loadBalancerNames ...OVNLoadBalancer) error {
 		}
 
 		// Remove load balancers if they exist.
-		for _, lbUUID := range lbUUIDs {
-			if len(args) > 0 {
-				args = append(args, "--")
-			}
+		for _, lbUUIDsForProtocol := range lbUUIDs {
+			for _, lbUUID := range lbUUIDsForProtocol {
+				if len(args) > 0 {
+					args = append(args, "--")
+				}
 
-			args = append(args, "--if-exists", "destroy", "load_balancer", lbUUID)
+				args = append(args, "--if-exists", "destroy", "load_balancer", lbUUID)
+			}
 		}
 	}
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1933,25 +1933,6 @@ func (o *OVN) loadBalancerVIPs(loadBalancerName OVNLoadBalancer, protocol string
 // LoadBalancerApply creates a new load balancer (if doesn't exist) on the specified routers and switches.
 // Providing an empty set of vips will delete the load balancer.
 func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNRouter, switches []OVNSwitch, vips ...OVNLoadBalancerVIP) error {
-	lbTCPName := string(loadBalancerName) + "-tcp"
-	lbUDPName := string(loadBalancerName) + "-udp"
-
-	// Remove load balancers if they exist.
-	lbUUIDs, err := o.loadBalancerUUIDs(loadBalancerName)
-	if err != nil {
-		return fmt.Errorf("Failed getting UUIDs: %w", err)
-	}
-
-	args := make([]string, 0, 5*len(lbUUIDs))
-
-	for _, lbUUID := range lbUUIDs {
-		if len(args) > 0 {
-			args = append(args, "--")
-		}
-
-		args = append(args, "--if-exists", "destroy", "load_balancer", lbUUID)
-	}
-
 	// ipToString wraps IPv6 addresses in square brackets.
 	ipToString := func(ip net.IP) string {
 		if ip.To4() == nil {

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -577,6 +577,24 @@ test_network_ovn() {
   # 7. Enable the ipv4.address back.
   lxc network set "${ovn_network}" ipv4.address=10.24.140.1/24 ipv4.nat=true
 
+  sub_test "Check that editing a load balancer doesn't replace it with a new one."
+  # 1. Create a load balancer.
+  lxc network load-balancer create "${ovn_network}" 2001:db8:1:2::1
+  # 2. Create a dummy backend.
+  lxc network load-balancer backend add "${ovn_network}" 2001:db8:1:2::1 c1 fd42:bd85:5f89:5293::10
+  # 3. Setup a port pointing to the backend.
+  lxc network load-balancer port add "${ovn_network}" 2001:db8:1:2::1 tcp 80 c1
+  # 4. Get the load balancer's internal UUID.
+  load_balancer_name="${chassis_group_name}-lb-2001:db8:1:2::1-tcp"
+  load_balancer_uuid="$(ovn-nbctl get load_balancer "${load_balancer_name}" _uuid)"
+  # 5. Edit the load balancer by setting another listen port.
+  lxc network load-balancer show "${ovn_network}" 2001:db8:1:2::1 | yq '.ports.[].listen_port = "8080"' | lxc network load-balancer edit "${ovn_network}" 2001:db8:1:2::1
+  # 6. Check the load balancer's UUID is still identical.
+  [ "$(lxc network load-balancer show "${ovn_network}" 2001:db8:1:2::1 | yq -r '.ports.[].listen_port')" = "8080" ]
+  [ "$(ovn-nbctl get load_balancer "${load_balancer_name}" _uuid)" = "${load_balancer_uuid}" ]
+  # 7. Cleanup load balancer.
+  lxc network load-balancer delete "${ovn_network}" 2001:db8:1:2::1
+
   echo "Check that instance NIC passthrough with ipv4.routes.external does not allow using volatile.network.ipv4.address."
   ! lxc launch testimage c1 -n "${ovn_network}" -d eth0,ipv4.routes.external="${volatile_ip4}/32" || false
 


### PR DESCRIPTION
When editing a load balancer, don't remove and re-create it. 
Instead modify it's properties in place. 

This ensures no interruption for new ingress requests as well as making sure that future entities like load balancer health checks (which depend on the load balancer) won't get removed when updating the load balancer (cascade).

Due to https://github.com/canonical/lxd/pull/13493 special care is required if there are accidental duplicate LBs.
