### PR TITLE
Stop asking for lxc info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,11 +10,10 @@ Feel free to remove anything which doesn't apply to you and add more information
  * Distribution:
  * Distribution version:
  * The output of "snap list --all lxd core20 core22 core24 snapd":
- * The output of "lxc info" or if that fails:
-   * Kernel version:
-   * LXC version:
-   * LXD version:
-   * Storage backend in use:
+ * Kernel version:
+ * LXC version:
+ * LXD version:
+ * Storage backend in use:
 
 # Issue description
 


### PR DESCRIPTION
Stop asking for `lxc info` in bug template to mitigate information leak:

- https://github.com/canonical/lxd/issues/17586
- https://github.com/canonical/lxd/issues/17552

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
