### PR TITLE
lxd: Remove operation resources

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -5206,12 +5206,10 @@ func createImageTokenResponse(s *state.State, r *http.Request, projectName strin
 
 	// If downloading an image, the image is the primary entity.
 	// If uploading an image, the project is the primary entity.
-	resources := make(map[entity.Type][]api.URL)
 	var entityURL *api.URL
 	switch tokenType {
 	case operationtype.ImageUploadToken:
 		entityURL = api.NewURL().Path(version.APIVersion, "projects", projectName)
-		resources[entity.TypeProject] = []api.URL{*entityURL}
 	case operationtype.ImageDownloadToken:
 		effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 		if err != nil {
@@ -5219,7 +5217,6 @@ func createImageTokenResponse(s *state.State, r *http.Request, projectName strin
 		}
 
 		entityURL = api.NewURL().Path(version.APIVersion, "images", fingerprint).Project(effectiveProjectName)
-		resources[entity.TypeImage] = []api.URL{*entityURL}
 	default:
 		return response.SmartError(errors.New("Not an image token operation type"))
 	}
@@ -5229,7 +5226,6 @@ func createImageTokenResponse(s *state.State, r *http.Request, projectName strin
 		EntityURL:   entityURL,
 		Type:        tokenType,
 		Class:       operations.OperationClassToken,
-		Resources:   resources,
 		Metadata:    meta,
 	}
 

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -374,10 +374,6 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-	}
-
 	metadata := map[string]any{
 		operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(inst.Project().Name).String(),
 	}
@@ -387,7 +383,6 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 		Type:        operationtype.BackupCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     backup,
 		Metadata:    metadata,
 	}
@@ -579,17 +574,11 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance:       {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-		entity.TypeInstanceBackup: {*api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		Type:        operationtype.BackupRename,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(projectName),
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     rename,
 	}
 
@@ -675,16 +664,11 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(projectName),
 		Type:        operationtype.BackupRemove,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     remove,
 	}
 

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -31,7 +31,6 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
 	"github.com/canonical/lxd/shared/ws"
@@ -555,9 +554,6 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 		Metadata:    ws.Metadata(),
 		RunHook:     ws.Do,
 		ConnectHook: ws.Connect,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeInstance: {*instanceURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -33,7 +33,6 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
 	"github.com/canonical/lxd/shared/ws"
@@ -706,9 +705,6 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			Metadata:    ws.Metadata(),
 			RunHook:     ws.Do,
 			ConnectHook: ws.Connect,
-			Resources: map[entity.Type][]api.URL{
-				entity.TypeInstance: {*instanceURL},
-			},
 		}
 
 		op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -787,9 +783,6 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		Type:        operationtype.CommandExec,
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeInstance: {*instanceURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -433,16 +433,11 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			instanceURL := api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)
-			resources := map[entity.Type][]api.URL{
-				entity.TypeInstance: {*instanceURL},
-			}
-
 			args := operations.OperationArgs{
 				ProjectName: projectName,
 				EntityURL:   instanceURL,
 				Type:        operationtype.InstanceMigrate,
 				Class:       operations.OperationClassTask,
-				Resources:   resources,
 				RunHook:     run,
 			}
 
@@ -459,10 +454,6 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, "", req.Target)
 		if err != nil {
 			return response.InternalError(err)
-		}
-
-		resources := map[entity.Type][]api.URL{
-			entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
 		}
 
 		run := func(ctx context.Context, op *operations.Operation) error {
@@ -490,7 +481,6 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 				Type:        operationtype.InstanceMigrate,
 				Class:       operations.OperationClassTask,
-				Resources:   resources,
 				RunHook:     run,
 			}
 
@@ -508,7 +498,6 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 			Type:        operationtype.InstanceMigrate,
 			Class:       operations.OperationClassWebsocket,
-			Resources:   resources,
 			Metadata:    ws.Metadata(),
 			RunHook:     run,
 			ConnectHook: ws.Connect,
@@ -538,16 +527,11 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return inst.Rename(req.Name, true)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 		Type:        operationtype.InstanceRename,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 
@@ -908,16 +892,11 @@ func instancePostClusteringMigrate(s *state.State, srcPool storagePools.Pool, sr
 		}
 
 		instanceURL := api.NewURL().Path(version.APIVersion, "instances", srcInstName).Project(srcInst.Project().Name)
-		resources := map[entity.Type][]api.URL{
-			entity.TypeInstance: {*instanceURL},
-		}
-
 		args := operations.OperationArgs{
 			ProjectName: targetProject,
 			EntityURL:   instanceURL,
 			Type:        operationtype.InstanceMigrate,
 			Class:       operations.OperationClassWebsocket,
-			Resources:   resources,
 			Metadata:    srcMigration.Metadata(),
 			RunHook:     run,
 			ConnectHook: srcMigration.Connect,

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -23,7 +23,6 @@ import (
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/version"
@@ -198,16 +197,11 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		opType = operationtype.SnapshotRestore
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 		Type:        opType,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     do,
 	}
 

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -19,7 +19,6 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -158,16 +157,11 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 		return instanceRebuildFromImage(ctx, s, inst, sourceImage, op)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(inst.Project().Name)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: targetProject.Name,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(inst.Project().Name),
 		Type:        operationtype.InstanceRebuild,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -350,16 +350,11 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	instanceURL := api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*instanceURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   instanceURL,
 		Type:        operationtype.SnapshotCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     snapshot,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "snapshots", req.Name).Project(projectName).String(),
@@ -712,10 +707,6 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 			return response.SmartError(err)
 		}
 
-		resources := map[entity.Type][]api.URL{
-			entity.TypeInstanceSnapshot: {*api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name)},
-		}
-
 		run := func(ctx context.Context, op *operations.Operation) error {
 			return ws.Do(s, op)
 		}
@@ -727,7 +718,6 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 				EntityURL:   api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name),
 				Type:        operationtype.SnapshotTransfer,
 				Class:       operations.OperationClassTask,
-				Resources:   resources,
 				RunHook:     run,
 			}
 
@@ -745,7 +735,6 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 			EntityURL:   api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name),
 			Type:        operationtype.SnapshotTransfer,
 			Class:       operations.OperationClassWebsocket,
-			Resources:   resources,
 			Metadata:    ws.Metadata(),
 			RunHook:     run,
 			ConnectHook: ws.Connect,
@@ -789,16 +778,11 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 		return snapInst.Rename(fullName, false)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstanceSnapshot: {*api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: snapInst.Project().Name,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name),
 		Type:        operationtype.SnapshotRename,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     rename,
 	}
 

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -20,7 +20,6 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -205,10 +204,6 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 		return doInstanceStatePut(inst, req)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeInstance: {*api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)},
-	}
-
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
 		return response.BadRequest(err)
@@ -235,7 +230,6 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
 		Type:        opType,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     do,
 	}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -145,16 +145,11 @@ func createFromImage(r *http.Request, s *state.State, p api.Project, profiles []
 		return instanceCreateFinish(s, req, args, nil)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", p.Name)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: p.Name,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", p.Name),
 		Type:        operationtype.InstanceCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(p.Name).String(),
@@ -211,16 +206,11 @@ func createFromNone(r *http.Request, s *state.State, projectName string, profile
 		return instanceCreateFinish(s, req, args, nil)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	opArgs := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.InstanceCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
@@ -402,15 +392,10 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	opArgs := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.InstanceCreate,
-		Resources:   resources,
 		RunHook:     run,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
@@ -524,10 +509,6 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	metadata := sink.Metadata()
 	metadata[operations.EntityURL] = api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String()
 	opArgs := operations.OperationArgs{
@@ -535,7 +516,6 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.InstanceCreate,
 		Class:       operations.OperationClassWebsocket,
-		Resources:   resources,
 		Metadata:    metadata,
 		RunHook:     run,
 		ConnectHook: sink.Connect,
@@ -732,22 +712,16 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 		return instanceCreateFinish(s, req, args, targetClient)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	var opType operationtype.Type
 	var entityURL *api.URL
 	if shared.IsSnapshot(req.Source.Source) {
 		opType = operationtype.SnapshotCopy
 		cName, sName, _ := api.GetParentAndSnapshotName(req.Source.Source)
 		snapshotURL := api.NewURL().Path(version.APIVersion, "instances", cName, "snapshots", sName).Project(req.Source.Project)
-		resources[entity.TypeInstanceSnapshot] = []api.URL{*snapshotURL}
 		entityURL = snapshotURL
 	} else {
 		opType = operationtype.InstanceCopy
 		instanceURL := api.NewURL().Path(version.APIVersion, "instances", req.Source.Source).Project(req.Source.Project)
-		resources[entity.TypeInstance] = []api.URL{*instanceURL}
 		entityURL = instanceURL
 	}
 
@@ -756,7 +730,6 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 		EntityURL:   entityURL,
 		Type:        opType,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
@@ -1025,16 +998,11 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		return instanceCreateFinish(s, &req, db.InstanceArgs{Name: bInfo.Name, Project: bInfo.Project}, nil)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: bInfo.Project,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", bInfo.Project),
 		Type:        operationtype.BackupRestore,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", bInfo.Name).Project(bInfo.Project).String(),

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -706,16 +706,11 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	profileURL := api.NewURL().Path(version.APIVersion, "profiles", details.profileName).Project(details.effectiveProject.Name)
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProfile: {*profileURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   profileURL,
 		Type:        operationtype.ProfileUpdate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 
@@ -852,16 +847,11 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestProjectName := request.ProjectParam(r)
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProfile: {*api.NewURL().Path(version.APIVersion, "profiles", details.profileName).Project(details.effectiveProject.Name)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "profiles", details.profileName).Project(details.effectiveProject.Name),
 		Type:        operationtype.ProfileUpdate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1262,9 +1262,6 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		EntityURL:   volumeURL,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolume: {*volumeURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -1300,10 +1297,8 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 	var run func(ctx context.Context, op *operations.Operation) error
 	var opType operationtype.Type
 	var entityURL *api.URL
-	resources := make(map[entity.Type][]api.URL)
 	if req.Source.Name == "" {
 		opType = operationtype.VolumeCreate
-		resources[entity.TypeProject] = []api.URL{*projectURL}
 		entityURL = projectURL
 		run = func(ctx context.Context, op *operations.Operation) error {
 			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
@@ -1326,8 +1321,6 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 			entityURL = entity.StorageVolumeURL(srcProjectName, location, req.Source.Pool, req.Type, req.Source.Name)
 		}
 
-		resources[entity.TypeStorageVolume] = []api.URL{*entityURL}
-		resources[entity.TypeProject] = []api.URL{*projectURL}
 		run = func(ctx context.Context, op *operations.Operation) error {
 			return pool.CreateCustomVolumeFromCopy(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		}
@@ -1340,7 +1333,6 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		EntityURL:   entityURL,
-		Resources:   resources,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -2046,17 +2038,12 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 	}
 
 	volumeURL := entity.StorageVolumeURL(requestProjectName, vol.Location, vol.Pool, vol.Type, vol.Name)
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolume: {*volumeURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   volumeURL,
 		Type:        operationtype.VolumeMove,
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
-		Resources:   resources,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -2335,9 +2322,6 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		EntityURL:   volumeURL,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolume: {*volumeURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -2469,9 +2453,6 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		EntityURL:   volumeURL,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolume: {*volumeURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -2685,16 +2666,11 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.VolumeCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 
@@ -2747,15 +2723,10 @@ func createStoragePoolVolumeFromTarball(s *state.State, r *http.Request, request
 	}
 
 	projectURL := api.NewURL().Path(version.APIVersion, "projects", projectName)
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*projectURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		Type:        operationtype.VolumeCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 		EntityURL:   projectURL,
 	}
@@ -2923,16 +2894,11 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		return nil
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeProject: {*api.NewURL().Path(version.APIVersion, "projects", projectName)},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.CustomVolumeBackupRestore,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -449,9 +449,6 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		Type:        operationtype.CustomVolumeBackupCreate,
 		Class:       operations.OperationClassTask,
 		RunHook:     backup,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolume: {*volumeURL},
-		},
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName).String(),
 		},
@@ -667,9 +664,6 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		Type:        operationtype.CustomVolumeBackupRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     rename,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolumeBackup: {*backupURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -772,9 +766,6 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 		Type:        operationtype.CustomVolumeBackupRemove,
 		Class:       operations.OperationClassTask,
 		RunHook:     remove,
-		Resources: map[entity.Type][]api.URL{
-			entity.TypeStorageVolumeBackup: {*backupURL},
-		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -232,16 +232,11 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		volumeURL = volumeURL.Target(s.ServerName)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolume: {*volumeURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   volumeURL,
 		Type:        operationtype.VolumeSnapshotCreate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     snapshot,
 		Metadata: map[string]any{
 			operations.EntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(effectiveProjectName).String(),
@@ -571,16 +566,11 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 		volumeURL = volumeURL.Target(s.ServerName)
 	}
 
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolumeSnapshot: {*volumeURL},
-	}
-
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   volumeURL,
 		Type:        operationtype.VolumeSnapshotRename,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     snapshotRename,
 	}
 
@@ -814,17 +804,11 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(effectiveProjectName)
 
 	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
 	// Include the target so that the entity lookup can match by node name.
 	if s.ServerClustered && !details.pool.Driver().Info().Remote {
 		snapshotURL = snapshotURL.Target(s.ServerName)
-		volumeURL = volumeURL.Target(s.ServerName)
-	}
-
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolume: {*volumeURL},
 	}
 
 	args := operations.OperationArgs{
@@ -832,7 +816,6 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		EntityURL:   snapshotURL,
 		Type:        operationtype.VolumeSnapshotUpdate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 
@@ -959,17 +942,11 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	}
 
 	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(effectiveProjectName)
 
 	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
 	// Include the target so that the entity lookup can match by node name.
 	if s.ServerClustered && !details.pool.Driver().Info().Remote {
 		snapshotURL = snapshotURL.Target(s.ServerName)
-		volumeURL = volumeURL.Target(s.ServerName)
-	}
-
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolume: {*volumeURL},
 	}
 
 	args := operations.OperationArgs{
@@ -977,7 +954,6 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		EntityURL:   snapshotURL,
 		Type:        operationtype.VolumeSnapshotUpdate,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     run,
 	}
 
@@ -1091,17 +1067,11 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	}
 
 	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(effectiveProjectName)
 
 	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
 	// Include the target so that the entity lookup can match by node name.
 	if s.ServerClustered && !details.pool.Driver().Info().Remote {
 		snapshotURL = snapshotURL.Target(s.ServerName)
-		volumeURL = volumeURL.Target(s.ServerName)
-	}
-
-	resources := map[entity.Type][]api.URL{
-		entity.TypeStorageVolume: {*volumeURL},
 	}
 
 	args := operations.OperationArgs{
@@ -1109,7 +1079,6 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 		EntityURL:   snapshotURL,
 		Type:        operationtype.VolumeSnapshotDelete,
 		Class:       operations.OperationClassTask,
-		Resources:   resources,
 		RunHook:     snapshotDelete,
 	}
 


### PR DESCRIPTION
This map of resources is not used by LXD or any client (since the addition of entity_url to operation metadata). This commit removes usage for now until we have a more concrete usage definition (e.g. locking resources while an operation is ongoing).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
