### PR TITLE
lxd/db/entity: Primary entity of network ACL is network

### DIFF
--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -335,7 +335,7 @@ func (t Type) EntityType() entity.Type {
 	// If creating a resource, then the parent project is the primary entity
 	// (the entity being created is not yet referenceable).
 	case VolumeCreate, ProjectRename, InstanceCreate, ImageDownload, ImageUploadToken, CustomVolumeBackupRestore,
-		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, StoragePoolCreate, NetworkCreate, NetworkACLCreate:
+		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, StoragePoolCreate, NetworkCreate:
 		return entity.TypeProject
 
 	// Volume operations.
@@ -378,7 +378,7 @@ func (t Type) EntityType() entity.Type {
 		return entity.TypeProfile
 
 	// Network operations.
-	case NetworkUpdate, NetworkDelete, NetworkRename:
+	case NetworkUpdate, NetworkDelete, NetworkRename, NetworkACLCreate:
 		return entity.TypeNetwork
 
 	// Network ACL operations.


### PR DESCRIPTION
A small fix to make the primary entity of `NetworkACLCreate` a network instead of a project.
This was introduced very recently in https://github.com/canonical/lxd/pull/17978/changes/33462fb2f2be33176f5e2a94cbc646c2073e28ec