### PR TITLE
Standardise operation metadata entity URL

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -843,14 +843,9 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 
 		opAPI := op.Get()
 
-		targetSecrets := map[string]string{}
-		for k, v := range opAPI.Metadata {
-			vStr, ok := v.(string)
-			if !ok {
-				continue
-			}
-
-			targetSecrets[k] = vStr
+		targetSecrets, err := opAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Prepare the source request
@@ -876,14 +871,9 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 
 	opAPI := op.Get()
 
-	sourceSecrets := map[string]string{}
-	for k, v := range opAPI.Metadata {
-		vStr, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		sourceSecrets[k] = vStr
+	sourceSecrets, err := opAPI.WebsocketSecrets()
+	if err != nil {
+		return nil, err
 	}
 
 	// Relay mode migration
@@ -901,14 +891,9 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 		targetOpAPI := targetOp.Get()
 
 		// Extract the websockets
-		targetSecrets := map[string]string{}
-		for k, v := range targetOpAPI.Metadata {
-			vStr, ok := v.(string)
-			if !ok {
-				continue
-			}
-
-			targetSecrets[k] = vStr
+		targetSecrets, err := targetOpAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Launch the relay
@@ -1961,14 +1946,9 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 
 		opAPI := op.Get()
 
-		targetSecrets := map[string]string{}
-		for k, v := range opAPI.Metadata {
-			vStr, ok := v.(string)
-			if !ok {
-				continue
-			}
-
-			targetSecrets[k] = vStr
+		targetSecrets, err := opAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Prepare the source request
@@ -1994,14 +1974,9 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 
 	opAPI := op.Get()
 
-	sourceSecrets := map[string]string{}
-	for k, v := range opAPI.Metadata {
-		vStr, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		sourceSecrets[k] = vStr
+	sourceSecrets, err := opAPI.WebsocketSecrets()
+	if err != nil {
+		return nil, err
 	}
 
 	// Relay mode migration
@@ -2019,14 +1994,9 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 		targetOpAPI := targetOp.Get()
 
 		// Extract the websockets
-		targetSecrets := map[string]string{}
-		for k, v := range targetOpAPI.Metadata {
-			vStr, ok := v.(string)
-			if !ok {
-				continue
-			}
-
-			targetSecrets[k] = vStr
+		targetSecrets, err := targetOpAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Launch the relay

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -681,12 +681,9 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 
 		opAPI := op.Get()
 
-		targetSecrets := map[string]string{}
-		for k, v := range opAPI.Metadata {
-			value, ok := v.(string)
-			if ok {
-				targetSecrets[k] = value
-			}
+		targetSecrets, err := opAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Prepare the source request
@@ -714,12 +711,9 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 	opAPI := op.Get()
 
 	// Prepare source server secrets for remote
-	sourceSecrets := map[string]string{}
-	for k, v := range opAPI.Metadata {
-		value, ok := v.(string)
-		if ok {
-			sourceSecrets[k] = value
-		}
+	sourceSecrets, err := opAPI.WebsocketSecrets()
+	if err != nil {
+		return nil, err
 	}
 
 	// Relay mode migration
@@ -740,12 +734,9 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		targetOpAPI := targetOp.Get()
 
 		// Extract the websockets
-		targetSecrets := map[string]string{}
-		for k, v := range targetOpAPI.Metadata {
-			value, ok := v.(string)
-			if ok {
-				targetSecrets[k] = value
-			}
+		targetSecrets, err := targetOpAPI.WebsocketSecrets()
+		if err != nil {
+			return nil, err
 		}
 
 		// Launch the relay

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1051,11 +1051,16 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 
 	// This operation does not happen "inside" a project and
 	// therefore does not have a project set.
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "projects", name)
 	args := operations.OperationArgs{
-		EntityURL: api.NewURL().Path(version.APIVersion, "projects", name),
+		EntityURL: originalEntityURL,
 		Type:      operationtype.ProjectRename,
 		Class:     operations.OperationClassTask,
 		RunHook:   run,
+		Metadata: map[string]any{
+			api.MetadataOriginalEntityURL: originalEntityURL.String(),
+			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "projects", req.Name).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -367,15 +367,16 @@ func (t Type) EntityType() entity.Type {
 		ImagesSynchronize, RemoveExpiredOIDCSessions, RemoveExpiredTokens, RemoveOrphanedOperations,
 		WarningsPruneResolved, ClusterMemberEvacuate, ClusterMemberRestore, LogsExpire, InstanceTypesUpdate,
 		BackupsExpire, SnapshotsExpire, ClusterJoinToken, CertificateAddToken, RenewServerCertificate,
-		ClusterHeal, ImagesUpdate, VolumeSnapshotsCreateScheduled, SnapshotsCreateScheduled, PruneExpiredOperations, RefreshClusterLinkVolatileAddresses:
+		ClusterHeal, ImagesUpdate, VolumeSnapshotsCreateScheduled, SnapshotsCreateScheduled,
+		PruneExpiredOperations, RefreshClusterLinkVolatileAddresses,
+		StoragePoolCreate:
 		return entity.TypeServer
 
 	// Project level operations.
 	// If creating a resource, then the parent project is the primary entity
 	// (the entity being created is not yet referenceable).
 	case VolumeCreate, ProjectRename, InstanceCreate, ImageDownload, ImageUploadToken, CustomVolumeBackupRestore,
-		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, StoragePoolCreate, NetworkCreate, NetworkACLCreate,
-		StorageBucketCreate:
+		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, NetworkCreate, NetworkACLCreate, StorageBucketCreate:
 		return entity.TypeProject
 
 	// Storage bucket operations.

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -375,7 +375,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	metadata := map[string]any{
-		operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(inst.Project().Name).String(),
+		api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(inst.Project().Name).String(),
 	}
 
 	args := operations.OperationArgs{

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -574,12 +574,19 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(projectName)
+	metadata := map[string]any{
+		api.MetadataOriginalEntityURL: originalEntityURL.String(),
+		api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "instances", name, "backups", newBackupName).Project(projectName).String(),
+	}
+
 	args := operations.OperationArgs{
 		ProjectName: projectName,
 		Type:        operationtype.BackupRename,
-		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName).Project(projectName),
+		EntityURL:   originalEntityURL,
 		Class:       operations.OperationClassTask,
 		RunHook:     rename,
+		Metadata:    metadata,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -527,12 +527,19 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return inst.Rename(req.Name, true)
 	}
 
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)
+	metadata := map[string]any{
+		api.MetadataOriginalEntityURL: originalEntityURL.String(),
+		api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
+	}
+
 	args := operations.OperationArgs{
 		ProjectName: projectName,
-		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName),
+		EntityURL:   originalEntityURL,
 		Type:        operationtype.InstanceRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
+		Metadata:    metadata,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -357,7 +357,7 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 		Class:       operations.OperationClassTask,
 		RunHook:     snapshot,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "snapshots", req.Name).Project(projectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", name, "snapshots", req.Name).Project(projectName).String(),
 		},
 	}
 

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -778,12 +778,19 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 		return snapInst.Rename(fullName, false)
 	}
 
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name)
+	metadata := map[string]any{
+		api.MetadataOriginalEntityURL: originalEntityURL.String(),
+		api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", newName).Project(snapInst.Project().Name).String(),
+	}
+
 	args := operations.OperationArgs{
 		ProjectName: snapInst.Project().Name,
-		EntityURL:   api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name),
+		EntityURL:   originalEntityURL,
 		Type:        operationtype.SnapshotRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     rename,
+		Metadata:    metadata,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1788,14 +1788,9 @@ func clusterCopyContainerInternal(r *http.Request, s *state.State, source instan
 		opAPI = op.Get()
 	}
 
-	websockets := map[string]string{}
-	for k, v := range opAPI.Metadata {
-		ws, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		websockets[k] = ws
+	websockets, err := opAPI.WebsocketSecrets()
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Reset the source for a migration

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -152,7 +152,7 @@ func createFromImage(r *http.Request, s *state.State, p api.Project, profiles []
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(p.Name).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(p.Name).String(),
 		},
 	}
 
@@ -213,7 +213,7 @@ func createFromNone(r *http.Request, s *state.State, projectName string, profile
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
 		},
 	}
 
@@ -398,7 +398,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		Type:        operationtype.InstanceCreate,
 		RunHook:     run,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
 		},
 	}
 
@@ -510,7 +510,7 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 	}
 
 	metadata := sink.Metadata()
-	metadata[operations.EntityURL] = api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String()
+	metadata[api.MetadataEntityURL] = api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String()
 	opArgs := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
@@ -732,7 +732,7 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
 		},
 	}
 
@@ -1005,7 +1005,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "instances", bInfo.Name).Project(bInfo.Project).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", bInfo.Name).Project(bInfo.Project).String(),
 		},
 	}
 

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -258,7 +258,20 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 			op.location = s.ServerName
 		}
 
-		op.metadata, err = validateMetadata(args.Metadata)
+		metadata := args.Metadata
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
+
+		// If the entity_url field is not already populated, populate it with the entity url of the operation.
+		// This allows the caller to override the entity URL if e.g. creating a new entity but ensures the field is populated.
+		// Skip if the entity type is "server". This doesn't give any useful information to the requestor (since the url will just be "/1.0").
+		_, ok := metadata[api.MetadataEntityURL]
+		if !ok && operationEntityType != entity.TypeServer {
+			metadata[api.MetadataEntityURL] = op.entityURL.String()
+		}
+
+		op.metadata, err = validateMetadata(metadata)
 		if err != nil {
 			return nil, fmt.Errorf("Failed validating operation metadata: %w", err)
 		}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -867,6 +867,7 @@ func (op *Operation) updateStatus(ctx context.Context, newStatus api.StatusCode)
 
 // UpdateMetadata updates the metadata of the operation. It returns an error
 // if the operation is not pending or running, or the operation is read-only.
+// The api.MetadataEntityURL field is retained unless the caller sets api.MetadataEntityURL in the input map.
 func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
 	opMetadata, err := validateMetadata(opMetadata)
 	if err != nil {
@@ -882,6 +883,16 @@ func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
 	if op.readonly {
 		op.lock.Unlock()
 		return errors.New("Read-only operations cannot be updated")
+	}
+
+	// Retain entity URL unless it is set in the input map.
+	// This is to prevent the caller inadvertently overwriting it.
+	oldEntityURL, ok := op.metadata[api.MetadataEntityURL]
+	if ok {
+		_, ok := opMetadata[api.MetadataEntityURL]
+		if !ok {
+			opMetadata[api.MetadataEntityURL] = oldEntityURL
+		}
 	}
 
 	op.updatedAt = time.Now()

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -53,14 +53,6 @@ func (t OperationClass) String() string {
 	}[t]
 }
 
-const (
-	// EntityURL is set in the operation metadata if the caller requests a resource that might have a generated name.
-	// For example, EntityURL is set on instance creation because a name is generated if one is not provided by the client.
-	// Whereas EntityURL is not set on creation of a custom storage volume, because a name must be provided.
-	// The value corresponding to EntityURL must be a string.
-	EntityURL = "entity_url"
-)
-
 // Init sets the debug value for the operations package.
 func Init(d bool) {
 	debug = d
@@ -1016,7 +1008,7 @@ func validateMetadata(metadata map[string]any) (map[string]any, error) {
 	}
 
 	// If the entity_url field is used, it must always be a string and must always be a valid URL.
-	entityURLAny, ok := metadata[EntityURL]
+	entityURLAny, ok := metadata[api.MetadataEntityURL]
 	if ok {
 		entityURL, ok := entityURLAny.(string)
 		if !ok {

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -1020,17 +1020,20 @@ func validateMetadata(metadata map[string]any) (map[string]any, error) {
 		metadata = make(map[string]any)
 	}
 
-	// If the entity_url field is used, it must always be a string and must always be a valid URL.
-	entityURLAny, ok := metadata[api.MetadataEntityURL]
-	if ok {
-		entityURL, ok := entityURLAny.(string)
-		if !ok {
-			return nil, fmt.Errorf("Operation metadata entity_url must be a string (got %T)", entityURLAny)
-		}
+	// If any url fields are used, they must always be a string and must always be a valid URL.
+	urlFields := []string{api.MetadataEntityURL, api.MetadataOriginalEntityURL}
+	for _, urlField := range urlFields {
+		urlAny, ok := metadata[urlField]
+		if ok {
+			urlString, ok := urlAny.(string)
+			if !ok {
+				return nil, fmt.Errorf("Operation metadata field %q must be a string (got %T)", urlField, urlAny)
+			}
 
-		err := validate.IsRequestURL(entityURL)
-		if err != nil {
-			return nil, fmt.Errorf("Operation metadata entity_url must be a valid request URL: %w", err)
+			err := validate.IsRequestURL(urlString)
+			if err != nil {
+				return nil, fmt.Errorf("Operation metadata field %q must be a valid request URL: %w", urlField, err)
+			}
 		}
 	}
 

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -393,10 +393,12 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		args := operations.OperationArgs{
-			Type:      operationtype.StoragePoolCreate,
-			Class:     operations.OperationClassTask,
-			RunHook:   run,
-			EntityURL: entity.ProjectURL(request.ProjectParam(r)),
+			Type:    operationtype.StoragePoolCreate,
+			Class:   operations.OperationClassTask,
+			RunHook: run,
+			Metadata: map[string]any{
+				api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", req.Name).String(),
+			},
 		}
 
 		op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -451,10 +453,12 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	args := operations.OperationArgs{
-		Type:      operationtype.StoragePoolCreate,
-		Class:     operations.OperationClassTask,
-		RunHook:   run,
-		EntityURL: entity.ProjectURL(request.ProjectParam(r)),
+		Type:    operationtype.StoragePoolCreate,
+		Class:   operations.OperationClassTask,
+		RunHook: run,
+		Metadata: map[string]any{
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", req.Name).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1167,8 +1167,6 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 }
 
 func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddress string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
-	websockets := map[string]string{}
-
 	client, err := lxdCluster.Connect(r.Context(), sourceAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 	if err != nil {
 		return response.SmartError(err)
@@ -1194,13 +1192,9 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 
 	opAPI := op.Get()
 
-	for k, v := range opAPI.Metadata {
-		ws, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		websockets[k] = ws
+	websockets, err := opAPI.WebsocketSecrets()
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Reset the source for a migration

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1143,7 +1143,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(errors.New("The source is currently offline"))
 		}
 
-		return clusterCopyCustomVolumeInternal(s, r, nodeAddress, projectName, poolName, &req)
+		return clusterCopyCustomVolumeInternal(s, r, nodeAddress, requestProjectName, projectName, poolName, &req)
 	}
 
 	switch req.Source.Type {
@@ -1167,7 +1167,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	}
 }
 
-func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddress string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddress string, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	client, err := lxdCluster.Connect(r.Context(), sourceAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 	if err != nil {
 		return response.SmartError(err)
@@ -1206,7 +1206,7 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 	req.Source.Websockets = websockets
 	req.Source.Project = ""
 
-	return doVolumeMigration(s, r, req.Source.Project, projectName, poolName, req)
+	return doVolumeMigration(s, r, requestProjectName, projectName, poolName, req)
 }
 
 func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -1287,13 +1288,15 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 
 	contentType := storagePools.VolumeDBContentTypeToContentType(volumeDBContentType)
 
-	projectURL := entity.ProjectURL(projectName)
+	requestProjectURL := entity.ProjectURL(requestProjectName)
 	var run func(ctx context.Context, op *operations.Operation) error
 	var opType operationtype.Type
 	var entityURL *api.URL
+	metadata := make(map[string]any)
 	if req.Source.Name == "" {
 		opType = operationtype.VolumeCreate
-		entityURL = projectURL
+		entityURL = requestProjectURL
+		metadata[api.MetadataEntityURL] = api.NewURL().Path(version.APIVersion, "storage-pools", pool.Name(), "volumes", cluster.StoragePoolVolumeTypeNameCustom, req.Name).Project(requestProjectName).String()
 		run = func(ctx context.Context, op *operations.Operation) error {
 			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
 		}
@@ -1327,6 +1330,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
 		EntityURL:   entityURL,
+		Metadata:    metadata,
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -1399,13 +1403,16 @@ func doVolumeMigration(s *state.State, r *http.Request, requestProjectName strin
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		RunHook:     run,
+		Type:        operationtype.VolumeCreate,
+		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", requestProjectName),
+		Metadata: map[string]any{
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", poolName, "volumes", req.Type, req.Name).Project(requestProjectName).String(),
+		},
 	}
 
-	args.Type = operationtype.VolumeCreate
-	args.EntityURL = api.NewURL().Path(version.APIVersion, "projects", projectName)
 	if push {
 		args.Class = operations.OperationClassWebsocket
-		args.Metadata = sink.Metadata()
+		maps.Copy(args.Metadata, sink.Metadata())
 		args.ConnectHook = sink.Connect
 	} else {
 		args.Class = operations.OperationClassTask
@@ -2662,10 +2669,13 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
-		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
+		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", requestProjectName),
 		Type:        operationtype.VolumeCreate,
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
+		Metadata: map[string]any{
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", pool, "volumes", cluster.StoragePoolVolumeTypeNameCustom, volName).Project(requestProjectName).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
@@ -2716,13 +2726,16 @@ func createStoragePoolVolumeFromTarball(s *state.State, r *http.Request, request
 		return nil
 	}
 
-	projectURL := api.NewURL().Path(version.APIVersion, "projects", projectName)
+	requestProjectURL := api.NewURL().Path(version.APIVersion, "projects", requestProjectName)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		Type:        operationtype.VolumeCreate,
 		Class:       operations.OperationClassTask,
 		RunHook:     run,
-		EntityURL:   projectURL,
+		EntityURL:   requestProjectURL,
+		Metadata: map[string]any{
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", poolName, "volumes", cluster.StoragePoolVolumeTypeNameCustom, volName).Project(requestProjectName).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -657,13 +657,17 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return nil
 	}
 
-	backupURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName)
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
-		EntityURL:   backupURL,
+		EntityURL:   originalEntityURL,
 		Type:        operationtype.CustomVolumeBackupRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     rename,
+		Metadata: map[string]any{
+			api.MetadataOriginalEntityURL: originalEntityURL.String(),
+			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", newBackupName).Project(requestProjectName).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -450,7 +450,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		Class:       operations.OperationClassTask,
 		RunHook:     backup,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName).String(),
 		},
 	}
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -223,7 +223,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return nil
 	}
 
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(effectiveProjectName)
+	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(requestProjectName)
 
 	// We're creating snapshot on this node.
 	// When looking up the entity for the operation, we look for the volumes located on the nodes based on the target parameter.
@@ -239,7 +239,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		Class:       operations.OperationClassTask,
 		RunHook:     snapshot,
 		Metadata: map[string]any{
-			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(effectiveProjectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(requestProjectName).String(),
 		},
 	}
 
@@ -558,20 +558,24 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 		return details.pool.RenameCustomVolumeSnapshot(effectiveProjectName, fullSnapshotName, req.Name, op)
 	}
 
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(requestProjectName)
 
 	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
 	// Include the target so that the entity lookup can match by node name.
 	if s.ServerClustered && !details.pool.Driver().Info().Remote {
-		volumeURL = volumeURL.Target(s.ServerName)
+		originalEntityURL = originalEntityURL.Target(s.ServerName)
 	}
 
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
-		EntityURL:   volumeURL,
+		EntityURL:   originalEntityURL,
 		Type:        operationtype.VolumeSnapshotRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     snapshotRename,
+		Metadata: map[string]any{
+			api.MetadataOriginalEntityURL: originalEntityURL.String(),
+			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(requestProjectName).String(),
+		},
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -239,7 +239,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		Class:       operations.OperationClassTask,
 		RunHook:     snapshot,
 		Metadata: map[string]any{
-			operations.EntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(effectiveProjectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(effectiveProjectName).String(),
 		},
 	}
 

--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -15,6 +15,17 @@ const OperationClassWebsocket = "websocket"
 // OperationClassToken represents the Token OperationClass.
 const OperationClassToken = "token"
 
+const (
+	// MetadataEntityURL is always set in operation metadata for operations whose associated entity type is not "server".
+	// It identifies the entity that the operation is acting on.
+	// The default value is the operation primary entity URL, but callers can override it to indicate the expected new URL.
+	MetadataEntityURL = "entity_url"
+
+	// MetadataOriginalEntityURL is set in operation metadata when renaming a resource.
+	// Callers are expected to set both MetadataOriginalEntityURL and MetadataEntityURL in operation metadata.
+	MetadataOriginalEntityURL = "original_entity_url"
+)
+
 // Operation represents a LXD background operation
 //
 // swagger:model

--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -219,3 +219,26 @@ func (op *Operation) parseCommonTokenFields() (secret string, fingerprint string
 
 	return secret, fingerprint, addresses, nil
 }
+
+// WebsocketSecrets extracts the secrets for websockets from the operation's metadata.
+func (op *Operation) WebsocketSecrets() (secrets map[string]string, err error) {
+	if op.Class != OperationClassWebsocket {
+		return nil, errors.New("Operation is not a websocket operation")
+	}
+
+	secrets = map[string]string{}
+	for k, v := range op.Metadata {
+		if k == MetadataEntityURL { // This field is not used as a secret.
+			continue
+		}
+
+		vStr, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		secrets[k] = vStr
+	}
+
+	return secrets, nil
+}

--- a/shared/api/operation_test.go
+++ b/shared/api/operation_test.go
@@ -334,3 +334,64 @@ func TestOperation_parseCommonTokenFields(t *testing.T) {
 		})
 	}
 }
+
+func TestOperation_WebsocketSecrets(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      Operation
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "not websocket operation",
+			op: Operation{
+				Class:    OperationClassTask,
+				Metadata: map[string]any{"0": "stdin-secret"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "websocket operation returns string secrets",
+			op: Operation{
+				Class: OperationClassWebsocket,
+				Metadata: map[string]any{
+					"0":          "stdin-secret",
+					"1":          "stdout-secret",
+					"control":    "control-secret",
+					"entity_url": "/1.0/instances/c1",
+					"pid":        100,
+					"fds":        map[string]any{"0": "nested"},
+				},
+			},
+			want: map[string]string{
+				"0":       "stdin-secret",
+				"1":       "stdout-secret",
+				"control": "control-secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "websocket operation with nil metadata",
+			op: Operation{
+				Class:    OperationClassWebsocket,
+				Metadata: nil,
+			},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.op.WebsocketSecrets()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WebsocketSecrets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WebsocketSecrets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Partially addresses #17641. This PR implements https://github.com/canonical/lxd/issues/17641#issuecomment-3996861514. It:
- Updates `ScheduleOperation` to always populate metadata `entity_url` if not already set by the caller and operation entity type is not "server".
- Adds `original_entity_url` to be used during rename operations.
- Adds the URL of the new entity to metadata when creating a resource.

Also change storage pool create operations to use the "server" entity type rather than "project".


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
