### PR TITLE
Makefile: exclude .git from lxd-metadata scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ check-api: update-api
 update-metadata: lxd-metadata
 	@echo "Generating golang documentation metadata"
 	$(shell [ -n "$(GOCOVERDIR)" ] && mkdir -p "$(GOCOVERDIR)" && chmod 0777 "$(GOCOVERDIR)")
-	$(GOPATH)/bin/lxd-metadata . --json ./lxd/metadata/configuration.json --txt ./doc/metadata.txt --substitution-db ./doc/substitutions.yaml
+	$(GOPATH)/bin/lxd-metadata . --json ./lxd/metadata/configuration.json --txt ./doc/metadata.txt --substitution-db ./doc/substitutions.yaml --exclude .git
 
 .PHONY: check-metadata
 check-metadata: update-metadata


### PR DESCRIPTION
The branch ai-findings-autofix/lxd-storage-drivers-load.go ends with .go, causing git to create a reflog file at .git/logs/refs/remotes/origin/ai-findings-autofix/lxd-storage-drivers-load.go. The lxd-metadata tool walks from . without excluding .git/, so it picks up this reflog file as a Go source file and fails to parse it, breaking CI for all PRs.
