### PR TITLE
doc: remove diataxis tags from operations index (stable-5.21)

### DIFF
--- a/doc/operation.md
+++ b/doc/operation.md
@@ -6,12 +6,12 @@ The following how-to guides cover common operations related to the LXD server:
 ```{toctree}
 :titlesonly:
 
-:diataxis:Expose LXD to the network </howto/server_expose>
-:diataxis:Configure the LXD server </howto/server_configure>
-:diataxis:Configure OIDC authentication with Auth0 </howto/oidc_auth0>
-:diataxis:Configure OIDC authentication with Ory Hydra </howto/oidc_ory>
-:diataxis:Configure OIDC authentication with Keycloak </howto/oidc_keycloak>
-:diataxis:Configure OIDC authentication with Microsoft Entra ID </howto/oidc_entra_id>
+Expose LXD to the network </howto/server_expose>
+Configure the LXD server </howto/server_configure>
+Configure OIDC authentication with Auth0 </howto/oidc_auth0>
+Configure OIDC authentication with Ory Hydra </howto/oidc_ory>
+Configure OIDC authentication with Keycloak </howto/oidc_keycloak>
+Configure OIDC authentication with Microsoft Entra ID </howto/oidc_entra_id>
 ```
 
 The following how-to guides cover common operations related to the LXD client (`lxc`):


### PR DESCRIPTION
I removed diataxis/topical tags from all other pages in recent backports but missed the `operations.md` index page (which has a different structure in `main`).