### PR TITLE
doc: add xdelta3 to required test dependencies

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -302,6 +302,7 @@ sudo apt install \
     socat \
     sqlite3 \
     swtpm \
+    xdelta3 \
     xfsprogs \
     yq
 ```


### PR DESCRIPTION
The `xdelta3` skip condition was inverted on Linux without `xdelta3`, tests
would run and fail instead of skip. Replaces duplicated skip logic across three tests with a `requireXdelta3` helper that skips when `xdelta3` is missing, but hard-fails on Linux CI (`GITHUB_ACTION` set) where it is a required dependency.
