### PR TITLE
Reject setting sensitive keys to `"true"` or `"false"` (stable-5.21)

### DIFF
--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -55,6 +55,21 @@ func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 			change = m.GetRaw(name)
 		}
 
+		// Reject the strings "true" and "false" as values for hidden keys.
+		// Hidden keys display as "true" when set; passing these strings back
+		// as a value would result in a weak secret being stored rather than
+		// the user's intent of keeping the existing value.
+		if ok && key.Hidden {
+			changeStr, isStr := change.(string)
+			if isStr {
+				switch strings.ToLower(changeStr) {
+				case "true", "false":
+					errors.add(name, changeStr, `hidden config keys display as "true" when set; provide the actual secret value`)
+					continue
+				}
+			}
+		}
+
 		// A nil object means the empty string.
 		if change == nil {
 			change = ""

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -227,6 +227,7 @@ func TestMap_ChangeError(t *testing.T) {
 	schema := config.Schema{
 		"foo": {Type: config.Bool},
 		"egg": {Setter: failingSetter},
+		"xyz": {Hidden: true},
 	}
 
 	var cases = []struct {
@@ -253,6 +254,16 @@ func TestMap_ChangeError(t *testing.T) {
 			`non string value`,
 			map[string]any{"egg": 123},
 			`Cannot set "egg": Invalid type: "int"`,
+		},
+		{
+			`hidden key cannot be set to string "true"`,
+			map[string]any{"xyz": "true"},
+			`Cannot set "xyz" to "true": hidden config keys display as "true" when set; provide the actual secret value`,
+		},
+		{
+			`hidden key cannot be set to string "false"`,
+			map[string]any{"xyz": "false"},
+			`Cannot set "xyz" to "false": hidden config keys display as "true" when set; provide the actual secret value`,
 		},
 	}
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -645,7 +645,7 @@ fine_grained_authorization() {
 
   # Check we can view the server's config.
   # As the core.trust_password is stored as scrypt value together with its hash, we cannot easily compare it against the original value.
-  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."core.trust_password" = "true"'
+  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."core.trust_password" == true'
   lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."loki.auth.password" == true'
 
   # Check we can modify the server's config.

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -17,6 +17,13 @@ _server_config_password() {
   lxc config unset core.trust_password
   ! lxc config show | grep -F "trust_password" || false
 
+  # Verify that setting core.trust_password to the obfuscated display value is rejected
+  # The config show output displays hidden keys as "true", which a user might
+  # try to copy back as an lxc config set argument. Verify this is rejected to
+  # prevent accidentally storing a weak password.
+  ! lxc config set core.trust_password true || false
+  ! lxc config set core.trust_password false || false
+
   # PATCH
   my_curl -X PATCH "https://${LXD_ADDR}/1.0" -d '{"config":{"core.https_address":"'"${LXD_ADDR}"'"}}' | jq -e '.status == "Success" and .status_code == 200'
 }

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -11,11 +11,11 @@ _server_config_password() {
   lxc config set core.trust_password 123456
 
   config=$(lxc config show)
-  echo "${config}" | grep -q "trust_password"
-  echo "${config}" | grep -q -v "123456"
+  echo "${config}" | grep -F "trust_password"
+  ! echo "${config}" | grep -F "123456" || false
 
   lxc config unset core.trust_password
-  lxc config show | grep -Fv "trust_password"
+  ! lxc config show | grep -F "trust_password" || false
 
   # PATCH
   my_curl -X PATCH "https://${LXD_ADDR}/1.0" -d '{"config":{"core.https_address":"'"${LXD_ADDR}"'"}}' | jq -e '.status == "Success" and .status_code == 200'

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -24,6 +24,19 @@ _server_config_password() {
   ! lxc config set core.trust_password true || false
   ! lxc config set core.trust_password false || false
 
+  # Verify that setting loki.auth.password to the obfuscated display value is rejected
+  lxc config set loki.auth.password secret123
+
+  config=$(lxc config show)
+  echo "${config}" | grep -F "loki.auth.password"
+  ! echo "${config}" | grep -F "secret123" || false
+
+  lxc config unset loki.auth.password
+  ! lxc config show | grep -F "loki.auth.password" || false
+
+  ! lxc config set loki.auth.password true || false
+  ! lxc config set loki.auth.password false || false
+
   # PATCH
   my_curl -X PATCH "https://${LXD_ADDR}/1.0" -d '{"config":{"core.https_address":"'"${LXD_ADDR}"'"}}' | jq -e '.status == "Success" and .status_code == 200'
 }


### PR DESCRIPTION
This PR came to be after seeing a set of configuration instructions:

```
lxc config set core.metrics_address :8444
lxc config set core.metrics_authentication false
lxc config set core.trust_password true
...
lxc config set oidc.groups.claim groups
...
```

The `core.trust_password` value it probably attributable to the obfuscated output from `lxc config get core.trust_password`.

If there are clusters out there depending on such weak passwords, they won't be affected by the changes unless they try to make a new config change to those 2 denied strings.