### PR TITLE
Images: Restrict public images to the default project

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -153,6 +153,24 @@ func validateImagePublicSetting(requestedPublic bool, imageProject string) error
 	return nil
 }
 
+// isImageUploadPublic resolves the requested public flag for image uploads from HTTP header and token metadata.
+// Metadata field "public" takes precedence over "X-LXD-public" HTTP header, and is type-checked when present.
+func isImageUploadPublic(r *http.Request, metadata map[string]any) (bool, error) {
+	public := shared.IsTrue(r.Header.Get("X-LXD-public"))
+
+	publicValue, ok := metadata["public"]
+	if ok {
+		publicBool, ok := publicValue.(bool)
+		if !ok {
+			return false, errors.New(`Invalid type for key "public"`)
+		}
+
+		public = publicBool
+	}
+
+	return public, nil
+}
+
 const ctxImageDetails request.CtxKey = "image-details"
 
 // imageDetails contains fields that are determined prior to the access check. This is set in the request context when

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3384,7 +3384,12 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 	trusted := requestor.IsTrusted()
 	secret := r.FormValue("secret")
 
-	// Unauthenticated clients that do not provide a secret may only view public images.
+	// Untrusted callers may only retrieve images from the default project unless they provide a valid secret.
+	if !trusted && secret == "" && projectName != api.ProjectDefaultName {
+		return response.NotFound(nil)
+	}
+
+	// Untrusted callers that do not provide a secret may only view public images.
 	publicOnly := !trusted && secret == ""
 
 	// Get the image. We need to do this before the permission check because the URL in the permission check will not
@@ -3430,6 +3435,11 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 
 	// No operation found for the secret. Perform other access checks.
 	if !userCanViewImage {
+		// Untrusted callers can only access non-default projects with a valid secret.
+		if !trusted && projectName != api.ProjectDefaultName {
+			return response.NotFound(nil)
+		}
+
 		if info.Public {
 			// If the image is public any client can view it.
 			userCanViewImage = true

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -793,7 +793,12 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 	var imageMeta *api.ImageMetadata
 	l := logger.AddContext(logger.Ctx{"function": "getImgPostInfo"})
 
-	info.Public = shared.IsTrue(r.Header.Get("X-LXD-public"))
+	public, err := isImageUploadPublic(r, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	info.Public = public
 	propHeaders := r.Header[http.CanonicalHeaderKey("X-LXD-properties")]
 	profilesHeaders := r.Header.Get("X-LXD-profiles")
 	ctype, ctypeParams, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
@@ -1053,14 +1058,6 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 			return nil, err
 		}
 	} else {
-		public, ok := metadata["public"]
-		if ok {
-			info.Public, ok = public.(bool)
-			if !ok {
-				return nil, errors.New("Invalid type for key \"public\"")
-			}
-		}
-
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Create the database entry
 			return tx.CreateImage(ctx, project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, profileIDs)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4058,6 +4058,16 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor, err := request.GetRequestor(r.Context())
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Untrusted callers may only retrieve aliases from the default project.
+	if !requestor.IsTrusted() && projectName != api.ProjectDefaultName {
+		return response.NotFound(nil)
+	}
+
 	var effectiveProjectName string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1235,6 +1235,14 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Project to associate image with.
+	imageProject := dbProject.Name
+
+	// If "features.images" is disabled for the project, associate the image with the "default" project.
+	if shared.IsFalseOrEmpty(projectConfig["features.images"]) {
+		imageProject = api.ProjectDefaultName
+	}
+
 	secret := r.Header.Get("X-LXD-secret")
 	fingerprint := r.Header.Get("X-LXD-fingerprint")
 
@@ -1324,6 +1332,28 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		imageUpload = true
 	}
 
+	if imageUpload {
+		public, err := isImageUploadPublic(r, imageMetadata)
+		if err != nil {
+			cleanup(builddir, post)
+			return response.BadRequest(err)
+		}
+
+		// Ensure that public images are only allowed in the default project.
+		err = validateImagePublicSetting(public, imageProject)
+		if err != nil {
+			cleanup(builddir, post)
+			return response.SmartError(err)
+		}
+	} else {
+		// Ensure that public images are only allowed in the default project.
+		err = validateImagePublicSetting(req.Public, imageProject)
+		if err != nil {
+			cleanup(builddir, post)
+			return response.SmartError(err)
+		}
+	}
+
 	if !imageUpload && req.Source.Mode == "push" {
 		cleanup(builddir, post)
 
@@ -1391,14 +1421,6 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			/* Processing image upload */
 			info, err = getImgPostInfo(s, r, builddir, dbProject.Name, post, imageMetadata)
 		} else {
-			// Project to associate image with.
-			imageProject := dbProject.Name
-
-			// If "features.images" is disabled for the project, associate the image with the "default" project.
-			if shared.IsFalseOrEmpty(projectConfig["features.images"]) {
-				imageProject = api.ProjectDefaultName
-			}
-
 			// Project to associate profiles with.
 			profileProject := dbProject.Name
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4516,8 +4516,12 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 
 	trusted := requestor.IsTrusted()
 
-	// Unauthenticated remote clients that do not provide a secret may only view public images.
-	// For devlxd, we allow querying for private images. We'll subsequently perform additional access checks.
+	// Untrusted callers may only retrieve images from the default project unless they provide a valid secret.
+	if !trusted && secret == "" && projectName != api.ProjectDefaultName {
+		return response.NotFound(nil)
+	}
+
+	// Without a secret, untrusted callers are restricted to public images in the default project.
 	publicOnly := !trusted && secret == ""
 
 	// Get the image. We need to do this before the permission check because the URL in the permission check will not
@@ -4563,6 +4567,11 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if !userCanViewImage {
+		// Untrusted callers can only access non-default projects with a valid secret.
+		if !trusted && projectName != api.ProjectDefaultName {
+			return response.NotFound(nil)
+		}
+
 		if imgInfo.Public {
 			// If the image is public any client can view it.
 			userCanViewImage = true

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3556,6 +3556,11 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
+	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	details, err := request.GetContextValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
@@ -3572,6 +3577,12 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.BadRequest(err)
+	}
+
+	// Ensure that public images are only allowed in the default project.
+	err = validateImagePublicSetting(req.Public, effectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Get ExpiresAt

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -58,6 +58,7 @@ import (
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/osarch"
+	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -1305,10 +1306,15 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Revert handling.
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { cleanup(builddir, post) })
+
 	_, err = io.Copy(shared.NewQuotaWriter(post, budget), r.Body)
 	if err != nil {
 		logger.Errorf("Store image POST data to disk: %v", err)
-		cleanup(builddir, post)
 		return response.InternalError(err)
 	}
 
@@ -1325,7 +1331,6 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	err = decoder.Decode(&req)
 	if err != nil {
 		if r.Header.Get("Content-Type") == "application/json" {
-			cleanup(builddir, post)
 			return response.BadRequest(err)
 		}
 
@@ -1335,28 +1340,23 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	if imageUpload {
 		public, err := isImageUploadPublic(r, imageMetadata)
 		if err != nil {
-			cleanup(builddir, post)
 			return response.BadRequest(err)
 		}
 
 		// Ensure that public images are only allowed in the default project.
 		err = validateImagePublicSetting(public, imageProject)
 		if err != nil {
-			cleanup(builddir, post)
 			return response.SmartError(err)
 		}
 	} else {
 		// Ensure that public images are only allowed in the default project.
 		err = validateImagePublicSetting(req.Public, imageProject)
 		if err != nil {
-			cleanup(builddir, post)
 			return response.SmartError(err)
 		}
 	}
 
 	if !imageUpload && req.Source.Mode == "push" {
-		cleanup(builddir, post)
-
 		metadata := map[string]any{
 			"aliases":    req.Aliases,
 			"expires_at": req.ExpiresAt,
@@ -1368,7 +1368,6 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if !imageUpload && !slices.Contains([]api.SourceType{"container", "instance", "virtual-machine", "snapshot", "image", "url"}, req.Source.Type) {
-		cleanup(builddir, post)
 		return response.InternalError(errors.New("Invalid images JSON"))
 	}
 
@@ -1391,11 +1390,11 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			r.Body = post
 			resp, err := forwardedResponseIfInstanceIsRemote(r.Context(), s, dbProject.Name, name, instanceType)
 			if err != nil {
-				cleanup(builddir, post)
 				return response.SmartError(err)
 			}
 
 			if resp != nil {
+				revert.Success()
 				cleanup(builddir, nil)
 				return resp
 			}
@@ -1546,10 +1545,10 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 	imageOp, err := operations.ScheduleUserOperationFromRequest(s, r, args)
 	if err != nil {
-		cleanup(builddir, post)
 		return response.InternalError(err)
 	}
 
+	revert.Success()
 	return operations.OperationResponse(imageOp)
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -143,6 +143,16 @@ func validateImageFingerprintPrefix(prefix string) error {
 	return nil
 }
 
+// validateImagePublicSetting checks whether an image visibility update is allowed for the effective image project.
+// Public images outside the default project are rejected.
+func validateImagePublicSetting(requestedPublic bool, imageProject string) error {
+	if requestedPublic && imageProject != api.ProjectDefaultName {
+		return api.NewStatusError(http.StatusBadRequest, "Images can only be marked public in the default project")
+	}
+
+	return nil
+}
+
 const ctxImageDetails request.CtxKey = "image-details"
 
 // imageDetails contains fields that are determined prior to the access check. This is set in the request context when

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3696,6 +3696,11 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
+	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	details, err := request.GetContextValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
@@ -3738,6 +3743,12 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	public, err := reqRaw.GetBool("public")
 	if err == nil {
 		details.image.Public = public
+	}
+
+	// Ensure that public images are only allowed in the default project.
+	err = validateImagePublicSetting(details.image.Public, effectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Get Properties

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -350,6 +350,14 @@ run_images_public() {
   lxc project create foo
   deps/import-busybox --project foo --alias foo-img
 
+  # Marking a newly imported image as public is forbidden when the image is in a non-default project.
+  if err_msg="$(deps/import-busybox --project foo --alias foo-public --public --template create 2>&1)"; then
+    echo "ERROR: Importing a public image into a non-default project unexpectedly succeeded" >&2
+    exit 1
+  fi
+
+  echo "${err_msg}" | grep -Fq "Images can only be marked public in the default project"
+
   # All callers see an empty list of images in the default project.
   query /1.0/images | jq --exit-status '(.metadata | length) == 0 and .status_code == 200'
   query /1.0/images?project=default | jq --exit-status '(.metadata | length) == 0 and .status_code == 200'
@@ -451,6 +459,32 @@ run_images_public() {
   query "/1.0/images/${fingerprint:0:12}" | jq --exit-status '.status_code == 200'
   query "/1.0/images/${fingerprint}" | jq --exit-status '.status_code == 200'
   query "/1.0/images/${fingerprint}?project=default" | jq --exit-status '.status_code == 200'
+
+  # Marking an image as public is forbidden when the image is in a non-default project. This is effectively testing the PUT request.
+  if err_msg="$(lxc image show "${fingerprint}" --project foo | sed -e "s/public: false/public: true/" | lxc image edit "${fingerprint}" --project foo 2>&1)"; then
+    echo "ERROR: Marking a non-default project image as public unexpectedly succeeded" >&2
+    exit 1
+  fi
+
+  echo "${err_msg}" | grep -Fq "Images can only be marked public in the default project"
+
+  # Ensure that PATCH request also does not allow marking an image as public when the image is in a non-default project.
+  if err_msg="$(lxc query -X PATCH "/1.0/images/${fingerprint}?project=foo" -d '{"public": true}' 2>&1)"; then
+    echo "ERROR: Marking a non-default project image as public unexpectedly succeeded" >&2
+    exit 1
+  fi
+
+  echo "${err_msg}" | grep -Fq "Images can only be marked public in the default project"
+
+  # Untrusted callers still cannot access the image in the non-default project.
+  if [ -z "${CERT_NAME:-}" ]; then
+    query "/1.0/images/aliases/foo-img?project=foo" | jq --exit-status '.error_code == 404'
+    query "/1.0/images/${fingerprint}?project=foo" | jq --exit-status '.error_code == 404'
+    query "/1.0/images/${fingerprint}/export?project=foo" | jq --exit-status '.error_code == 404'
+    # Also assert with an invalid secret to prevent bypasses where any non-empty secret skips non-default restrictions.
+    query "/1.0/images/${fingerprint}?project=foo&secret=bar" | jq --exit-status '.error_code == 404'
+    query "/1.0/images/${fingerprint}/export?project=foo&secret=bar" | jq --exit-status '.error_code == 404'
+  fi
 
   # All callers can export the public image if using a valid prefix.
   query "/1.0/images/%25/export" | jq --exit-status '.error == "Image fingerprint prefix must contain 12 characters or more" and .error_code == 400'


### PR DESCRIPTION
This PR prevents publication of an image as public in non-default projects. When creating or updating images, requests that try to mark images as public in non-default projects are rejected. 

This change also ensures that images in non-default projects cannot be viewed by untrusted callers.

This is needed for the image registries feature https://github.com/canonical/lxd/pull/17680.

**Changes:**
- `imageGet()`:  deny untrusted non-default project access without a valid secret.
- `imageExport()`: deny untrusted non-default project access without a valid secret.
- `imageAliasGet()`: deny untrusted alias retrieval in non-default projects.
- Prevent publishing images as public outside the default project using these API endpoints:
   - `POST /1.0/images` (`imagesPost`).
   - `PUT /1.0/images/{fingerprint}` (`imagePut`).
   - `PATCH /1.0/images/{fingerprint}` (`imagePatch`).