### PR TITLE
doc: prevent indexing older versions (stable-5.0)

### DIFF
--- a/doc/.sphinx/_templates/base.html
+++ b/doc/.sphinx/_templates/base.html
@@ -1,0 +1,9 @@
+{% extends "!base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing for older RTD versions defined in conf.py (noindex_versions). #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -416,3 +416,15 @@ else:
 
 
 sys.path.append(os.path.abspath('.sphinx/_extensions/'))
+
+
+
+###########################################
+### Prevent indexing of older docs versions
+###########################################
+
+# Add RTD docs version slugs for versions that should not be indexed by search engines
+noindex_versions = {"stable-5.0", "stable-4.0", "v4", "v5"}
+
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+html_context["seo_noindex"] = rtd_version in noindex_versions


### PR DESCRIPTION
Manual cherry pick due to filepath changes between main and stable-5.0. Paths adapted:
- doc/_templates/base.html -> doc/.sphinx/_templates/base.html
- doc/conf.py -> doc/custom_conf.py

(cherry picked from commit 5c3d7e86c36d881e332d2f4db65f0ad1fdc901b1)

Prevents stable-5.0 docs from being indexed by search engines, as introduced in https://github.com/canonical/lxd/pull/17984.