### PR TITLE
Use context for event lifecyle requestor in instance and storage drivers

### DIFF
--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -35,13 +35,14 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 	"github.com/canonical/lxd/shared/version"
 )
 
-type evacuateStopFunc func(inst instance.Instance) error
+type evacuateStopFunc func(ctx context.Context, inst instance.Instance) error
 type evacuateMigrateFunc func(ctx context.Context, s *state.State, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, op *operations.Operation) error
 
 const clusterMemberEvacuateConflictReference = "cluster-member-evacuation"
@@ -1384,7 +1385,7 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		stopFunc := func(inst instance.Instance) error {
+		stopFunc := func(ctx context.Context, inst instance.Instance) error {
 			l := logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 
 			// Get the shutdown timeout for the instance.
@@ -1395,12 +1396,12 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Start with a clean shutdown.
-			err = inst.Shutdown(time.Duration(val) * time.Second)
+			err = inst.Shutdown(ctx, time.Duration(val)*time.Second)
 			if err != nil {
 				l.Warn("Failed shutting down instance, forcing stop", logger.Ctx{"err": err})
 
 				// Fallback to forced stop.
-				err = inst.Stop(false)
+				err = inst.Stop(ctx, false)
 				if err != nil && !errors.Is(err, instanceDrivers.ErrInstanceIsStopped) {
 					return fmt.Errorf("Failed stopping instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
 				}
@@ -1439,10 +1440,7 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 
 			dest = dest.UseProject(inst.Project().Name)
 
-			if op != nil {
-				_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)})
-			}
-
+			reportEvacuationProgress(op, fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name))
 			startOp, err := dest.UpdateInstanceState(inst.Name(), api.InstanceStatePut{Action: "start"}, "")
 			if err != nil {
 				return err
@@ -1491,6 +1489,15 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	return response.BadRequest(fmt.Errorf("Unknown action %q", req.Action))
+}
+
+func reportEvacuationProgress(progressReporter ioprogress.ProgressReporter, message string) {
+	if progressReporter == nil {
+		return
+	}
+
+	handler := progressReporter.ProgressHandler("evacuation")
+	handler(ioprogress.ProgressData{Text: message})
 }
 
 func evacuateClusterSetState(s *state.State, name string, state int) error {
@@ -1638,9 +1645,9 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 		// Stop the instance if needed.
 		isRunning := inst.IsRunning()
 		if opts.stopInstance != nil && isRunning && (!migrate || !live) {
-			_ = opts.op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Stopping %q in project %q", inst.Name(), instProject.Name)})
+			reportEvacuationProgress(opts.op, fmt.Sprintf("Stopping %q in project %q", inst.Name(), instProject.Name))
 
-			err := opts.stopInstance(inst)
+			err := opts.stopInstance(ctx, inst)
 			if err != nil {
 				return err
 			}
@@ -1664,7 +1671,7 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 		}
 
 		// Start migrating the instance.
-		_ = opts.op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), instProject.Name, targetMemberInfo.Name)})
+		reportEvacuationProgress(opts.op, fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), instProject.Name, targetMemberInfo.Name))
 
 		// Set origin server (but skip if already set as that suggests more than one server being evacuated).
 		if inst.LocalConfig()["volatile.evacuate.origin"] == "" {
@@ -1855,9 +1862,9 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 				}
 
 				// Start the instance.
-				_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)})
+				reportEvacuationProgress(op, fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name))
 
-				err = inst.Start(false)
+				err = inst.Start(ctx, op, false)
 				if err != nil {
 					return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 				}
@@ -1870,7 +1877,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 				// Check if live-migratable.
 				_, live := inst.CanMigrate()
 
-				_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Migrating %q in project %q from %q", inst.Name(), inst.Project().Name, inst.Location())})
+				reportEvacuationProgress(op, fmt.Sprintf("Migrating %q in project %q from %q", inst.Name(), inst.Project().Name, inst.Location()))
 
 				err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 					sourceNode, err = tx.GetNodeByName(ctx, inst.Location())
@@ -1898,7 +1905,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 
 				isRunning := apiInst.StatusCode == api.Running
 				if isRunning && !live {
-					_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project().Name)})
+					reportEvacuationProgress(op, fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project().Name))
 
 					timeout := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
 					val, err := strconv.Atoi(timeout)
@@ -1970,7 +1977,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 					ExpiryDate:   inst.ExpiryDate(),
 				}
 
-				err = inst.Update(args, instance.UpdateActionInternal)
+				err = inst.Update(ctx, args, instance.UpdateActionInternal)
 				if err != nil {
 					return fmt.Errorf("Failed updating instance %q: %w", inst.Name(), err)
 				}
@@ -1979,9 +1986,9 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 					continue
 				}
 
-				_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)})
+				reportEvacuationProgress(op, fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name))
 
-				err = inst.Start(false)
+				err = inst.Start(ctx, op, false)
 				if err != nil {
 					return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 				}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -237,7 +237,7 @@ func internalOptimizeImage(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	err = imageCreateInPool(s, &req.Image, req.Pool, req.Project)
+	err = imageCreateInPool(r.Context(), s, &req.Image, req.Pool, req.Project)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -926,7 +926,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, bInfo *backup
 		return err
 	}
 
-	_, instOp, cleanup, err := instance.CreateInternal(s, *instDBArgs, true)
+	_, instOp, cleanup, err := instance.CreateInternal(ctx, s, *instDBArgs, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -1006,7 +1006,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, bInfo *backup
 
 		internalImportRootDevicePopulate(instancePoolName, snap.Devices, snap.ExpandedDevices, profiles)
 
-		_, snapInstOp, cleanup, err := instance.CreateInternal(s, db.InstanceArgs{
+		_, snapInstOp, cleanup, err := instance.CreateInternal(ctx, s, db.InstanceArgs{
 			Project:      projectName,
 			Architecture: arch,
 			BaseImage:    baseImage,

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -569,7 +569,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 					}
 				}
 
-				inst, cleanup, err := internalRecoverImportInstance(s, pool, projectName, poolVol, profiles)
+				inst, cleanup, err := internalRecoverImportInstance(ctx, s, pool, projectName, poolVol, profiles)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed creating instance %q record in project %q: %w", poolVol.Instance.Name, projectName, err))
 				}
@@ -587,7 +587,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 						}
 					}
 
-					cleanup, err := internalRecoverImportInstanceSnapshot(s, pool, projectName, poolVol, poolInstSnap, profiles)
+					cleanup, err := internalRecoverImportInstanceSnapshot(ctx, s, pool, projectName, poolVol, poolInstSnap, profiles)
 					if err != nil {
 						return response.SmartError(fmt.Errorf("Failed creating instance %q snapshot %q record in project %q: %w", poolVol.Instance.Name, poolInstSnap.Name, projectName, err))
 					}
@@ -622,7 +622,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 
 // internalRecoverImportInstance recreates the database records for an instance and returns the new instance.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
-func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, profiles []api.Profile) (instance.Instance, revert.Hook, error) {
+func internalRecoverImportInstance(ctx context.Context, s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, profiles []api.Profile) (instance.Instance, revert.Hook, error) {
 	if poolVol.Instance == nil {
 		return nil, nil, errors.New("Pool volume is not an instance volume")
 	}
@@ -647,7 +647,7 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 		return nil, nil, errors.New("Invalid instance type")
 	}
 
-	inst, instOp, cleanup, err := instance.CreateInternal(s, *dbInst, false)
+	inst, instOp, cleanup, err := instance.CreateInternal(ctx, s, *dbInst, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -658,7 +658,7 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 }
 
 // internalRecoverImportInstance recreates the database records for an instance snapshot.
-func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, snap *api.InstanceSnapshot, profiles []api.Profile) (revert.Hook, error) {
+func internalRecoverImportInstanceSnapshot(ctx context.Context, s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, snap *api.InstanceSnapshot, profiles []api.Profile) (revert.Hook, error) {
 	if poolVol.Instance == nil || snap == nil {
 		return nil, errors.New("Pool volume is not an instance volume")
 	}
@@ -694,7 +694,7 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 		snap.ExpiresAt = expiry
 	}
 
-	_, snapInstOp, cleanup, err := instance.CreateInternal(s, db.InstanceArgs{
+	_, snapInstOp, cleanup, err := instance.CreateInternal(ctx, s, db.InstanceArgs{
 		Project:      projectName,
 		Architecture: arch,
 		BaseImage:    snap.Config["volatile.base_image"],

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -36,7 +36,7 @@ import (
 )
 
 // Create a new backup.
-func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.Instance, version uint32, op *operations.Operation) error {
+func backupCreate(ctx context.Context, s *state.State, args db.InstanceBackup, sourceInst instance.Instance, version uint32, op *operations.Operation) error {
 	projectName := sourceInst.Project().Name
 	l := logger.AddContext(logger.Ctx{"project": projectName, "instance": sourceInst.Name(), "name": args.Name})
 	l.Debug("Instance backup started")
@@ -215,7 +215,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	revert.Success()
-	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupCreated.Event(args.Name, b.Instance(), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupCreated.Event(ctx, args.Name, b.Instance(), nil))
 
 	return nil
 }
@@ -381,7 +381,7 @@ func pruneExpiredInstanceBackups(ctx context.Context, s *state.State) error {
 		}
 
 		instBackup := backup.NewInstanceBackup(s, inst, b.ID, b.Name, b.CreationDate, b.ExpiryDate, b.InstanceOnly, b.OptimizedStorage)
-		err = instBackup.Delete()
+		err = instBackup.Delete(ctx)
 		if err != nil {
 			return fmt.Errorf("Error deleting instance backup %q: %w", b.Name, err)
 		}

--- a/lxd/backup/backup_instance.go
+++ b/lxd/backup/backup_instance.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/lifecycle"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
@@ -21,7 +20,6 @@ import (
 type Instance interface {
 	Name() string
 	Project() api.Project
-	Operation() *operations.Operation
 }
 
 // InstanceBackup represents an instance backup.
@@ -59,7 +57,7 @@ func (b *InstanceBackup) Instance() Instance {
 }
 
 // Rename renames an instance backup.
-func (b *InstanceBackup) Rename(newName string) error {
+func (b *InstanceBackup) Rename(ctx context.Context, newName string) error {
 	backupsPath := b.state.BackupsStoragePath(b.instance.Project().Name)
 	oldBackupPath := filepath.Join(backupsPath, "instances", project.Instance(b.instance.Project().Name, b.name))
 	newBackupPath := filepath.Join(backupsPath, "instances", project.Instance(b.instance.Project().Name, newName))
@@ -103,12 +101,12 @@ func (b *InstanceBackup) Rename(newName string) error {
 
 	oldName := b.name
 	b.name = newName
-	b.state.Events.SendLifecycle(b.instance.Project().Name, lifecycle.InstanceBackupRenamed.Event(b.name, b.instance, map[string]any{"old_name": oldName}))
+	b.state.Events.SendLifecycle(b.instance.Project().Name, lifecycle.InstanceBackupRenamed.Event(ctx, b.name, b.instance, map[string]any{"old_name": oldName}))
 	return nil
 }
 
 // Delete removes an instance backup.
-func (b *InstanceBackup) Delete() error {
+func (b *InstanceBackup) Delete(ctx context.Context) error {
 	backupsPathBase := b.state.BackupsStoragePath(b.instance.Project().Name)
 	backupPath := filepath.Join(backupsPathBase, "instances", project.Instance(b.instance.Project().Name, b.name))
 
@@ -136,7 +134,7 @@ func (b *InstanceBackup) Delete() error {
 		return err
 	}
 
-	b.state.Events.SendLifecycle(b.instance.Project().Name, lifecycle.InstanceBackupDeleted.Event(b.name, b.instance, nil))
+	b.state.Events.SendLifecycle(b.instance.Project().Name, lifecycle.InstanceBackupDeleted.Event(ctx, b.name, b.instance, nil))
 
 	return nil
 }

--- a/lxd/convert_instance.go
+++ b/lxd/convert_instance.go
@@ -68,7 +68,7 @@ func (s *conversionSink) Metadata() map[string]any {
 // Do performs the conversion operation on the target side (sink) for the given
 // state and instance operation. It sets up the necessary websocket connection
 // for filesystem, and then receives the conversion data.
-func (s *conversionSink) Do(state *state.State, instOp *operationlock.InstanceOperation) error {
+func (s *conversionSink) Do(state *state.State, instOp *operationlock.InstanceOperation, op *operations.Operation) error {
 	l := logger.AddContext(logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name()})
 
 	defer l.Info("Conversion channels disconnected on target")
@@ -96,7 +96,7 @@ func (s *conversionSink) Do(state *state.State, instOp *operationlock.InstanceOp
 		ConversionOptions: s.conversionOptions,
 	}
 
-	err := s.instance.ConversionReceive(args)
+	err := s.instance.ConversionReceive(args, op)
 	if err != nil {
 		l.Error("Failed conversion on target", logger.Ctx{"err": err})
 		return fmt.Errorf("Failed conversion on target: %w", err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1983,7 +1983,7 @@ func (d *Daemon) init() error {
 	d.tasks.Start(d.shutdownCtx)
 
 	// Restore instances
-	instancesStart(d.State(), instances)
+	instancesStart(d.shutdownCtx, d.State(), instances)
 
 	// Re-balance in case things changed while LXD was down
 	deviceTaskBalance(d.State())

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -320,7 +320,7 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 		// Import the image in the pool.
 		l.Debug("Image does not exist on storage pool")
 
-		err = imageCreateInPool(s, info, args.StoragePool, args.ProjectName)
+		err = imageCreateInPool(ctx, s, info, args.StoragePool, args.ProjectName)
 		if err != nil {
 			l.Debug("Failed creating image on storage pool", logger.Ctx{"err": err})
 			return nil, fmt.Errorf("Failed creating image %q on storage pool %q: %w", info.Fingerprint, args.StoragePool, err)
@@ -601,7 +601,7 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 
 	// Import into the requested storage pool
 	if args.StoragePool != "" {
-		err = imageCreateInPool(s, info, args.StoragePool, args.ProjectName)
+		err = imageCreateInPool(ctx, s, info, args.StoragePool, args.ProjectName)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/device/cdi/hooks.go
+++ b/lxd/device/cdi/hooks.go
@@ -2,6 +2,7 @@ package cdi
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -147,7 +148,7 @@ func ApplyHooksToContainer(hooksFilePath string, c instance.Container) error {
 		return err
 	}
 
-	updateLDCache(c, &sftpContainerFS{client: sftpClient})
+	updateLDCache(context.Background(), c, &sftpContainerFS{client: sftpClient})
 
 	return nil
 }
@@ -270,13 +271,13 @@ func createSymlinkInContainer(cfs containerFS, target string, link string) error
 // updateLDCache updates the linker cache inside the instance. It ignores
 // possible errors and logs them instead since this is a best effort action and
 // failure should not impact the container's start or hotplugging.
-func updateLDCache(inst instance.Instance, cfs containerFS) {
+func updateLDCache(ctx context.Context, inst instance.Instance, cfs containerFS) {
 	l := logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 
 	if inst.IsRunning() {
 		// Run ldconfig to update the linker cache, note we do not update symlinks via
 		// -X as those are handled by the CDI hooks.
-		cmd, err := inst.Exec(api.InstanceExecPost{
+		cmd, err := inst.Exec(ctx, api.InstanceExecPost{
 			Command:   []string{"/sbin/ldconfig", "-X"},
 			WaitForWS: false,
 		}, nil, nil, nil)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -205,7 +205,7 @@ func devLXDAPIPatchHandler(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if state == api.Ready {
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceReady.Event(inst, nil))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceReady.Event(r.Context(), inst, nil))
 	}
 
 	return response.DevLXDResponse(http.StatusOK, "", "raw")

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1054,7 +1054,7 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 // the image. No entry in the images database will be created. This implies that
 // imageCreateinPool() should only be called when an image already exists in the
 // database and hence has already a storage volume in at least one storage pool.
-func imageCreateInPool(s *state.State, info *api.Image, storagePool string, projectName string) error {
+func imageCreateInPool(ctx context.Context, s *state.State, info *api.Image, storagePool string, projectName string) error {
 	if storagePool == "" {
 		return errors.New("No storage pool specified")
 	}
@@ -1064,7 +1064,7 @@ func imageCreateInPool(s *state.State, info *api.Image, storagePool string, proj
 		return err
 	}
 
-	err = pool.EnsureImage(info.Fingerprint, nil, projectName)
+	err = pool.EnsureImage(ctx, info.Fingerprint, projectName, nil)
 	if err != nil {
 		return err
 	}
@@ -2617,7 +2617,7 @@ func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operati
 				continue
 			}
 
-			err = pool.DeleteImage(fingerprint, op)
+			err = pool.DeleteImage(ctx, fingerprint, op)
 			if err != nil {
 				logger.Error("Error deleting image from storage pool", logger.Ctx{"err": err, "pool": pool.Name(), "fingerprint": fingerprint})
 				continue
@@ -2983,7 +2983,7 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 				return fmt.Errorf("Error loading storage pool %q to delete image volume %q: %w", poolName, fingerprint, err)
 			}
 
-			err = pool.DeleteImage(fingerprint, op)
+			err = pool.DeleteImage(ctx, fingerprint, op)
 			if err != nil {
 				return fmt.Errorf("Error deleting image volume %q from storage pool %q: %w", fingerprint, pool.Name(), err)
 			}
@@ -3176,7 +3176,7 @@ func doImageDelete(isClusterNotification bool, opCreator operations.OperationSch
 
 			// Only perform the deletion of remote volumes on the server handling the request.
 			if !isClusterNotification || !pool.Driver().Info().Remote {
-				err = pool.DeleteImage(fingerprint, op)
+				err = pool.DeleteImage(ctx, fingerprint, op)
 				if err != nil {
 					return fmt.Errorf("Error deleting image %q from storage pool %q: %w", fingerprint, pool.Name(), err)
 				}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -35,12 +35,12 @@ import (
 // Helper functions
 
 // instanceCreateAsEmpty creates an empty instance.
-func instanceCreateAsEmpty(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
+func instanceCreateAsEmpty(ctx context.Context, s *state.State, args db.InstanceArgs, op *operations.Operation) (instance.Instance, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
 	// Create the instance record.
-	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true)
+	inst, instOp, cleanup, err := instance.CreateInternal(ctx, s, args, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -58,7 +58,7 @@ func instanceCreateAsEmpty(s *state.State, args db.InstanceArgs) (instance.Insta
 		return nil, fmt.Errorf("Failed creating instance: %w", err)
 	}
 
-	revert.Add(func() { _ = inst.Delete(true, "") })
+	revert.Add(func() { _ = inst.Delete(context.Background(), true, "", nil) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -131,7 +131,7 @@ func ensureImageIsLocallyAvailable(ctx context.Context, s *state.State, img *api
 }
 
 // instanceCreateFromImage creates an instance from a rootfs image.
-func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArgs, op *operations.Operation) error {
+func instanceCreateFromImage(ctx context.Context, s *state.State, img *api.Image, args db.InstanceArgs, op *operations.Operation) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -156,7 +156,7 @@ func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArg
 	args.BaseImage = img.Fingerprint
 
 	// Create the instance.
-	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true)
+	inst, instOp, cleanup, err := instance.CreateInternal(ctx, s, args, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -190,12 +190,12 @@ func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArg
 
 	defer unlock()
 
-	err = pool.CreateInstanceFromImage(inst, img.Fingerprint, op)
+	err = pool.CreateInstanceFromImage(ctx, inst, img.Fingerprint, op)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance from image: %w", err)
 	}
 
-	revert.Add(func() { _ = inst.Delete(true, "") })
+	revert.Add(func() { _ = inst.Delete(ctx, true, "", op) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -251,7 +251,7 @@ type instanceCreateAsCopyOpts struct {
 }
 
 // instanceCreateAsCopy create a new instance by copying from an existing instance.
-func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *operations.Operation) (instance.Instance, error) {
+func instanceCreateAsCopy(ctx context.Context, s *state.State, opts instanceCreateAsCopyOpts, op *operations.Operation) (instance.Instance, error) {
 	var inst instance.Instance
 	var instOp *operationlock.InstanceOperation
 	var err error
@@ -271,7 +271,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			opts.refresh = false // Instance doesn't exist, so switch to copy mode.
 		} else {
 			// Validate and apply refresh target config before the storage refresh.
-			err = inst.Update(opts.targetInstance, instance.UpdateActionUserRefresh)
+			err = inst.Update(ctx, opts.targetInstance, instance.UpdateActionUserRefresh)
 			if err != nil {
 				return nil, fmt.Errorf("Failed applying refresh target instance config: %w", err)
 			}
@@ -283,7 +283,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 		api.InstanceCreateConfigKeyPolicy.Apply(opts.targetInstance.Config, nil)
 
 		// Create the instance.
-		inst, instOp, cleanup, err = instance.CreateInternal(s, opts.targetInstance, true)
+		inst, instOp, cleanup, err = instance.CreateInternal(ctx, s, opts.targetInstance, true)
 		if err != nil {
 			return nil, fmt.Errorf("Failed creating instance record: %w", err)
 		}
@@ -345,7 +345,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 
 			// Delete extra snapshots first.
 			for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {
-				err := targetSnaps[deleteTargetSnapIndex].Delete(true, "")
+				err := targetSnaps[deleteTargetSnapIndex].Delete(ctx, true, "", op)
 				if err != nil {
 					return nil, err
 				}
@@ -424,7 +424,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			_, snapInstOp, cleanup, err := instance.CreateInternal(s, snapInstArgs, true)
+			_, snapInstOp, cleanup, err := instance.CreateInternal(ctx, s, snapInstArgs, true)
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", newSnapName, err)
 			}
@@ -445,17 +445,17 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	}
 
 	if opts.refresh {
-		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, opts.allowInconsistent, op)
+		err = pool.RefreshInstance(ctx, inst, opts.sourceInstance, snapshots, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, fmt.Errorf("Failed refreshing instance: %w", err)
 		}
 	} else {
-		err = pool.CreateInstanceFromCopy(inst, opts.sourceInstance, !opts.instanceOnly, opts.allowInconsistent, op)
+		err = pool.CreateInstanceFromCopy(ctx, inst, opts.sourceInstance, !opts.instanceOnly, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, fmt.Errorf("Create instance from copy: %w", err)
 		}
 
-		revert.Add(func() { _ = inst.Delete(true, "") })
+		revert.Add(func() { _ = inst.Delete(ctx, true, "", op) })
 
 		if opts.applyTemplateTrigger {
 			// Trigger the templates on next start.

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -222,7 +222,7 @@ func instanceRebuildFromImage(ctx context.Context, s *state.State, inst instance
 		return err
 	}
 
-	err = inst.Rebuild(img, op)
+	err = inst.Rebuild(ctx, img, op)
 	if err != nil {
 		return fmt.Errorf("Failed rebuilding instance from image: %w", err)
 	}
@@ -230,8 +230,8 @@ func instanceRebuildFromImage(ctx context.Context, s *state.State, inst instance
 	return nil
 }
 
-func instanceRebuildFromEmpty(inst instance.Instance, op *operations.Operation) error {
-	err := inst.Rebuild(nil, op) // Rebuild as empty.
+func instanceRebuildFromEmpty(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
+	err := inst.Rebuild(ctx, nil, op) // Rebuild as empty.
 	if err != nil {
 		return fmt.Errorf("Failed rebuilding as an empty instance: %w", err)
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -524,7 +524,8 @@ func autoCreateInstanceSnapshots(ctx context.Context, s *state.State, instances 
 			return err
 		}
 
-		err = inst.Snapshot(snapshotName, nil, false, api.DiskVolumesModeRoot)
+		// Don't track progress for automated snapshot creation
+		err = inst.Snapshot(ctx, snapshotName, nil, false, api.DiskVolumesModeRoot, nil)
 		if err != nil {
 			l.Error("Error creating snapshot", logger.Ctx{"snapshot": snapshotName, "err": err})
 			return err
@@ -549,7 +550,8 @@ func pruneExpiredInstanceSnapshots(ctx context.Context, snapshots []instance.Ins
 			continue // Deletion of this snapshot is already running, skip.
 		}
 
-		err = snapshot.Delete(true, "")
+		// Don't track progress for automated snapshot pruning.
+		err = snapshot.Delete(ctx, true, "", nil)
 		instSnapshotsPruneRunning.Delete(snapshot.ID())
 		if err != nil {
 			return fmt.Errorf("Failed deleting expired instance snapshot %q in project %q: %w", snapshot.Name(), snapshot.Project().Name, err)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -30,7 +30,6 @@ import (
 	"github.com/canonical/lxd/lxd/instance/operationlock"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/locking"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
 	storagePools "github.com/canonical/lxd/lxd/storage"
@@ -38,6 +37,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
@@ -61,7 +61,6 @@ type deviceManager interface {
 
 // common provides structure common to all instance types.
 type common struct {
-	op    *operations.Operation
 	state *state.State
 
 	architecture    int
@@ -209,11 +208,6 @@ func (d *common) IsStateful() bool {
 	return d.stateful
 }
 
-// Operation returns the instance's current operation.
-func (d *common) Operation() *operations.Operation {
-	return d.op
-}
-
 //
 // SECTION: general functions
 //
@@ -260,11 +254,6 @@ func (d *common) DeferTemplateApply(trigger instance.TemplateTrigger) error {
 	}
 
 	return nil
-}
-
-// SetOperation sets the current operation.
-func (d *common) SetOperation(op *operations.Operation) {
-	d.op = op
 }
 
 // Snapshots returns a list of snapshots.
@@ -1119,20 +1108,15 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	return nil
 }
 
-// updateProgress updates the operation metadata with a new progress string.
-func (d *common) updateProgress(progress string) {
-	if d.op == nil {
+func updateProgress(progressReporter ioprogress.ProgressReporter, progress string) {
+	if progressReporter == nil {
 		return
 	}
 
-	meta := d.op.Metadata()
-	if meta == nil {
-		meta = make(map[string]any)
-	}
-
-	if meta["container_progress"] != progress {
-		_ = d.op.ExtendMetadata(map[string]any{"container_progress": progress})
-	}
+	handler := progressReporter.ProgressHandler("container")
+	handler(ioprogress.ProgressData{
+		Text: progress,
+	})
 }
 
 // restoreCommon handles the common part of a restore.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -546,7 +546,7 @@ func (d *common) expandConfig() error {
 }
 
 // restartCommon handles the common part of instance restarts.
-func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) error {
+func (d *common) restartCommon(ctx context.Context, inst instance.Instance, timeout time.Duration, progressReporter ioprogress.ProgressReporter) error {
 	// Setup a new operation for the stop/shutdown phase.
 	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestart, true, true)
 	if err != nil {
@@ -579,7 +579,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 			Snapshot:     inst.IsSnapshot(),
 		}
 
-		err := inst.Update(args, instance.UpdateActionInternal)
+		err := inst.Update(ctx, args, instance.UpdateActionInternal)
 		if err != nil {
 			return err
 		}
@@ -587,12 +587,12 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 		// On function return, set the flag back on
 		defer func() {
 			args.Ephemeral = ephemeral
-			_ = inst.Update(args, instance.UpdateActionInternal)
+			_ = inst.Update(ctx, args, instance.UpdateActionInternal)
 		}()
 	}
 
 	if timeout == 0 {
-		err := inst.Stop(false)
+		err := inst.Stop(ctx, false)
 		if err != nil {
 			op.Done(err)
 			return err
@@ -604,7 +604,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 			return err
 		}
 
-		err := inst.Shutdown(timeout)
+		err := inst.Shutdown(ctx, timeout)
 		if err != nil {
 			op.Done(err)
 			return err
@@ -617,20 +617,20 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 		return fmt.Errorf("Create restart (for start) operation: %w", err)
 	}
 
-	err = inst.Start(false)
+	err = inst.Start(ctx, progressReporter, false)
 	if err != nil {
 		op.Done(err)
 		return err
 	}
 
 	d.logger.Info("Restarted instance", ctxMap)
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(ctx, d, nil))
 
 	return nil
 }
 
 // rebuildCommon handles the common part of instance rebuilds.
-func (d *common) rebuildCommon(inst instance.Instance, img *api.Image, op *operations.Operation) error {
+func (d *common) rebuildCommon(ctx context.Context, inst instance.Instance, img *api.Image, progressReporter ioprogress.ProgressReporter) error {
 	instLocalConfig := d.localConfig
 
 	// Reset the "image.*" keys.
@@ -658,7 +658,7 @@ func (d *common) rebuildCommon(inst instance.Instance, img *api.Image, op *opera
 		return err
 	}
 
-	err = pool.DeleteInstance(inst, op)
+	err = pool.DeleteInstance(inst, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -670,7 +670,7 @@ func (d *common) rebuildCommon(inst instance.Instance, img *api.Image, op *opera
 			return err
 		}
 	} else {
-		err = pool.CreateInstanceFromImage(inst, img.Fingerprint, op)
+		err = pool.CreateInstanceFromImage(ctx, inst, img.Fingerprint, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -701,7 +701,7 @@ func (d *common) rebuildCommon(inst instance.Instance, img *api.Image, op *opera
 
 // deleteAttachedVolumeSnapshots deletes the attached volume snapshots for a snapshot instance.
 // When diskVolumesMode is "all-exclusive", it deletes the attached volume snapshots.
-func (d *common) deleteAttachedVolumeSnapshots(snapInst instance.Instance, diskVolumesMode string) error {
+func (d *common) deleteAttachedVolumeSnapshots(ctx context.Context, snapInst instance.Instance, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	// Get attached volume snapshot UUIDs from the snapshot instance.
 	var attachedVolumeUUIDs map[string]string
 	err := json.Unmarshal([]byte(snapInst.LocalConfig()["volatile.attached_volumes"]), &attachedVolumeUUIDs)
@@ -728,7 +728,7 @@ func (d *common) deleteAttachedVolumeSnapshots(snapInst instance.Instance, diskV
 			return fmt.Errorf("Failed loading storage pool %q: %w", vol.Pool, err)
 		}
 
-		err = pool.DeleteCustomVolumeSnapshot(vol.Project, vol.Name, d.op)
+		err = pool.DeleteCustomVolumeSnapshot(ctx, vol.Project, vol.Name, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed deleting attached volume %q snapshot in storage pool %q: %w", vol.Name, vol.Pool, err)
 		}
@@ -746,7 +746,7 @@ func (d *common) deleteAttachedVolumeSnapshots(snapInst instance.Instance, diskV
 // - Calls driver-specific delete function.
 // - Attached volume snapshot deletion for snapshots (if diskVolumesMode is "all-exclusive").
 // - Parent backup file update for snapshots.
-func (d *common) deleteCommon(inst instance.Instance, force bool, diskVolumesMode string) error {
+func (d *common) deleteCommon(ctx context.Context, inst instance.Instance, force bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	isSnapshot := inst.IsSnapshot()
 
 	if isSnapshot {
@@ -783,13 +783,13 @@ func (d *common) deleteCommon(inst instance.Instance, force bool, diskVolumesMod
 
 	switch s := inst.(type) {
 	case *lxc:
-		err = s.delete(force)
+		err = s.delete(ctx, force)
 		if err != nil {
 			return err
 		}
 
 	case *qemu:
-		err = s.delete(force)
+		err = s.delete(ctx, force)
 		if err != nil {
 			return err
 		}
@@ -801,7 +801,7 @@ func (d *common) deleteCommon(inst instance.Instance, force bool, diskVolumesMod
 	if isSnapshot {
 		// Delete attached volume snapshots (if requested).
 		if diskVolumesMode == api.DiskVolumesModeAllExclusive {
-			err = d.deleteAttachedVolumeSnapshots(inst, diskVolumesMode)
+			err = d.deleteAttachedVolumeSnapshots(ctx, inst, diskVolumesMode, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Failed deleting attached volume snapshots: %w", err)
 			}
@@ -932,7 +932,7 @@ func (d *common) getAttachedVolumes(inst instance.Instance) (attachedVolumes map
 // stateful is true. When diskVolumesMode is set to [api.DiskVolumesModeAllExclusive],
 // the instance's attached exclusive volumes are included in a crash-consistent
 // snapshot.
-func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *time.Time, stateful bool, diskVolumesMode string) error {
+func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, name string, expiry *time.Time, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -977,7 +977,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	}
 
 	// Create the snapshot.
-	snap, snapInstOp, cleanup, err := instance.CreateInternal(d.state, args, true)
+	snap, snapInstOp, cleanup, err := instance.CreateInternal(ctx, d.state, args, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", name, err)
 	}
@@ -992,13 +992,13 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 
 	if pool.Driver().Info().RunningCopyFreeze && inst.IsRunning() && !inst.IsFrozen() {
 		// Freeze the processes.
-		err = inst.Freeze()
+		err = inst.Freeze(ctx)
 		if err != nil {
 			return err
 		}
 
 		defer func() {
-			err := inst.Unfreeze()
+			err := inst.Unfreeze(ctx)
 			if err != nil {
 				d.logger.Warn("Failed unfreezing instance after snapshot", logger.Ctx{"err": err})
 			}
@@ -1006,7 +1006,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	}
 
 	// Snapshot root disk.
-	err = pool.CreateInstanceSnapshot(snap, inst, d.op)
+	err = pool.CreateInstanceSnapshot(snap, inst, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance root volume snapshot: %w", err)
 	}
@@ -1014,9 +1014,9 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	revert.Add(func() {
 		switch s := snap.(type) {
 		case *lxc:
-			_ = s.delete(true)
+			_ = s.delete(context.Background(), true)
 		case *qemu:
-			_ = s.delete(true)
+			_ = s.delete(context.Background(), true)
 		default:
 			d.logger.Error("Failed deleting snapshot during revert", logger.Ctx{"snapshot": snap.Name()})
 		}
@@ -1053,7 +1053,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 			}
 
 			expiry := snap.ExpiryDate() // Attached volume snapshots inherit the expiry date of the instance snapshot.
-			snapshotUUID, err := pool.CreateCustomVolumeSnapshot(volume.Project, volume.Name, snapshotName, description, &expiry, d.op)
+			snapshotUUID, err := pool.CreateCustomVolumeSnapshot(ctx, volume.Project, volume.Name, snapshotName, description, &expiry, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Failed creating attached volume %q snapshot %q in storage pool %q: %w", volume.Name, snapshotName, volume.Pool, err)
 			}
@@ -1063,7 +1063,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 			volatileAttachedVolumes[deviceName] = snapshotUUID.String()
 
 			revert.Add(func() {
-				err := pool.DeleteCustomVolumeSnapshot(volume.Project, volume.Name+"/"+snapshotName, d.op)
+				err := pool.DeleteCustomVolumeSnapshot(ctx, volume.Project, volume.Name+"/"+snapshotName, progressReporter)
 				if err != nil {
 					d.logger.Warn("Failed deleting attached volume snapshot", logger.Ctx{"pool": volume.Pool, "volume": volume.Name, "snapshot": snapshotName, "project": volume.Project, "err": err})
 				}
@@ -1085,13 +1085,13 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	}
 
 	// Mount volume for backup.yaml writing.
-	_, err = pool.MountInstance(inst, d.op)
+	_, err = pool.MountInstance(inst, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed mounting instance root volume for backup file writing during snapshot: %w", err)
 	}
 
 	defer func() {
-		err := pool.UnmountInstance(inst, d.op)
+		err := pool.UnmountInstance(inst, progressReporter)
 		// Unmounting volumes while an instance is running is expected to return [storageDrivers.ErrInUse].
 		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			d.logger.Warn("Failed unmounting instance after snapshot", logger.Ctx{"err": err})
@@ -1133,7 +1133,7 @@ func updateProgress(progressReporter ioprogress.ProgressReporter, progress strin
 // - wasRunning: whether the instance was running before restore.
 // - op: the restore operation lock.
 // - err: error, if any.
-func (d *common) restoreCommon(inst instance.Instance, source instance.Instance, diskVolumesMode string) (wasRunning bool, op *operationlock.InstanceOperation, err error) {
+func (d *common) restoreCommon(ctx context.Context, inst instance.Instance, source instance.Instance, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) (wasRunning bool, op *operationlock.InstanceOperation, err error) {
 	// Load the storage driver.
 	pool, err := d.getStoragePool()
 	if err != nil {
@@ -1172,7 +1172,7 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance,
 				Snapshot:     d.IsSnapshot(),
 			}
 
-			err := inst.Update(args, instance.UpdateActionInternal)
+			err := inst.Update(ctx, args, instance.UpdateActionInternal)
 			if err != nil {
 				op.Done(err)
 				return false, nil, err
@@ -1181,7 +1181,7 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance,
 			// On function return, set the flag back on.
 			defer func() {
 				args.Ephemeral = ephemeral
-				err = inst.Update(args, instance.UpdateActionInternal)
+				err = inst.Update(ctx, args, instance.UpdateActionInternal)
 				if err != nil {
 					d.logger.Error("Failed restoring ephemeral flag after restore", logger.Ctx{"err": err})
 				}
@@ -1189,7 +1189,7 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance,
 		}
 
 		// This will unmount the instance storage.
-		err := inst.Stop(false)
+		err := inst.Stop(ctx, false)
 		if err != nil {
 			op.Done(err)
 			return false, nil, err
@@ -1220,14 +1220,14 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance,
 
 	// Don't pass as user-requested as there's no way to fix a bad config.
 	// This will call d.UpdateBackupFile() to ensure snapshot list is up to date.
-	err = inst.Update(args, instance.UpdateActionInternal)
+	err = inst.Update(ctx, args, instance.UpdateActionInternal)
 	if err != nil {
 		op.Done(err)
 		return false, nil, err
 	}
 
 	// Restore the rootfs.
-	err = pool.RestoreInstanceSnapshot(inst, source, nil)
+	err = pool.RestoreInstanceSnapshot(ctx, inst, source, nil)
 	if err != nil {
 		op.Done(err)
 		return false, nil, fmt.Errorf("Failed restoring snapshot rootfs: %w", err)
@@ -1246,7 +1246,7 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance,
 				return false, nil, fmt.Errorf("Failed loading storage pool %q: %w", volume.Pool, err)
 			}
 
-			err = pool.RestoreCustomVolume(volume.Project, volName, snapName, d.op)
+			err = pool.RestoreCustomVolume(ctx, volume.Project, volName, snapName, progressReporter)
 			if err != nil {
 				return false, nil, fmt.Errorf("Failed restoring volume %q snapshot %q in storage pool %q: %w", volume.Name, snapName, volume.Pool, err)
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -104,7 +104,7 @@ func lxcStatusCode(state liblxc.State) api.StatusCode {
 
 // lxcCreate creates the DB storage records and sets up instance devices.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
-func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
+func lxcCreate(ctx context.Context, s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -269,9 +269,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 	}
 
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(ctx, d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(ctx, d, map[string]any{
 			"type":         api.InstanceTypeContainer,
 			"storage-pool": d.storagePool.Name(),
 			"location":     d.Location(),
@@ -1763,7 +1763,7 @@ func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	return nil
 }
 
-func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, error) {
+func (d *lxc) handleIdmappedStorage(progressReporter ioprogress.ProgressReporter) (idmap.IdmapStorageType, *idmap.IdmapSet, error) {
 	diskIdmap, err := d.DiskIdmap()
 	if err != nil {
 		return idmap.IdmapStorageNone, nil, fmt.Errorf("Set last ID map: %w", err)
@@ -1793,7 +1793,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 	}
 
 	d.logger.Debug("Container idmap changed, remapping")
-	d.updateProgress("Remapping container filesystem")
+	updateProgress(progressReporter, "Remapping container filesystem")
 
 	storageType, err := d.getStorageType()
 	if err != nil {
@@ -1849,12 +1849,12 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 		return idmap.IdmapStorageNone, nextIdmap, fmt.Errorf("Failed setting config key %q: %w", volatileKey, err)
 	}
 
-	d.updateProgress("")
+	updateProgress(progressReporter, "")
 	return idmapType, nextIdmap, nil
 }
 
 // Start functions.
-func (d *lxc) startCommon() (revert.Hook, string, []func() error, error) {
+func (d *lxc) startCommon(ctx context.Context, progressReporter ioprogress.ProgressReporter) (revert.Hook, string, []func() error, error) {
 	postStartHooks := []func() error{}
 
 	revert := revert.New()
@@ -1916,7 +1916,7 @@ func (d *lxc) startCommon() (revert.Hook, string, []func() error, error) {
 
 	revert.Add(func() { _ = d.unmount() })
 
-	idmapType, nextIdmap, err := d.handleIdmappedStorage()
+	idmapType, nextIdmap, err := d.handleIdmappedStorage(progressReporter)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("Failed handling idmapped storage: %w", err)
 	}
@@ -2200,7 +2200,7 @@ func (d *lxc) startCommon() (revert.Hook, string, []func() error, error) {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, expiry, api.DiskVolumesModeRoot)
+		err := d.snapshot(ctx, snapName, expiry, api.DiskVolumesModeRoot, progressReporter)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("Failed taking startup snapshot: %w", err)
 		}
@@ -2246,7 +2246,7 @@ func (d *lxc) detachInterfaceRename(netns string, ifName string, hostName string
 }
 
 // Start starts the instance.
-func (d *lxc) Start(stateful bool) error {
+func (d *lxc) Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -2316,7 +2316,7 @@ func (d *lxc) Start(stateful bool) error {
 	}
 
 	// Run the shared start code.
-	cleanupInstanceDevices, configPath, postStartHooks, err := d.startCommon()
+	cleanupInstanceDevices, configPath, postStartHooks, err := d.startCommon(ctx, progressReporter)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -2388,14 +2388,14 @@ func (d *lxc) Start(stateful bool) error {
 		op.Done(err) // Must come before Stop() otherwise stop will not proceed.
 
 		// Attempt to stop container.
-		_ = d.Stop(false)
+		_ = d.Stop(ctx, false)
 
 		return err
 	}
 
 	if op.Action() == operationlock.ActionStart {
 		d.logger.Info("Started instance", ctxMap)
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(ctx, d, nil))
 	}
 
 	return nil
@@ -2411,7 +2411,7 @@ func (d *lxc) OnHook(hookName string, args map[string]string) error {
 	case instance.HookStopNS:
 		return d.onStopNS(args)
 	case instance.HookStop:
-		return d.onStop(args)
+		return d.onStop(context.Background(), args)
 	default:
 		return instance.ErrNotImplemented
 	}
@@ -2578,7 +2578,7 @@ func (d *lxc) validateStartup(statusCode api.StatusCode) error {
 }
 
 // Stop functions.
-func (d *lxc) Stop(stateful bool) error {
+func (d *lxc) Stop(ctx context.Context, stateful bool) error {
 	d.logger.Debug("Stop started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Stop finished", logger.Ctx{"stateful": stateful})
 
@@ -2661,14 +2661,14 @@ func (d *lxc) Stop(stateful bool) error {
 		// Attempt to freeze the container
 		freezer := make(chan bool, 1)
 		go func() {
-			_ = d.Freeze()
+			_ = d.Freeze(ctx)
 			freezer <- true
 		}()
 
 		select {
 		case <-freezer:
 		case <-time.After(time.Second * 5):
-			_ = d.Unfreeze()
+			_ = d.Unfreeze(ctx)
 		}
 	}
 
@@ -2700,7 +2700,7 @@ func (d *lxc) Stop(stateful bool) error {
 		return errPrefix
 	} else if op.Action() == "stop" {
 		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(ctx, d, nil))
 	}
 
 	// Now handle errors from stop sequence and return to caller if wasn't completed cleanly.
@@ -2712,7 +2712,7 @@ func (d *lxc) Stop(stateful bool) error {
 }
 
 // Shutdown stops the instance.
-func (d *lxc) Shutdown(timeout time.Duration) error {
+func (d *lxc) Shutdown(ctx context.Context, timeout time.Duration) error {
 	d.logger.Debug("Shutdown started", logger.Ctx{"timeout": timeout})
 	defer d.logger.Debug("Shutdown finished", logger.Ctx{"timeout": timeout})
 
@@ -2739,7 +2739,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 
 	// If frozen, resume so the signal can be handled.
 	if d.IsFrozen() {
-		err := d.Unfreeze()
+		err := d.Unfreeze(ctx)
 		if err != nil {
 			return err
 		}
@@ -2792,7 +2792,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 
 	d.logger.Debug("Shutdown request sent to instance")
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Wait for operation lock to be Done or context to timeout. The operation lock is normally completed by
@@ -2810,7 +2810,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 		return errPrefix
 	} else if op.Action() == "stop" {
 		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(ctx, d, nil))
 	}
 
 	// Now handle errors from shutdown sequence and return to caller if wasn't completed cleanly.
@@ -2822,13 +2822,13 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 }
 
 // Restart restart the instance.
-func (d *lxc) Restart(timeout time.Duration) error {
-	return d.restartCommon(d, timeout)
+func (d *lxc) Restart(ctx context.Context, timeout time.Duration, progressReporter ioprogress.ProgressReporter) error {
+	return d.restartCommon(ctx, d, timeout, progressReporter)
 }
 
 // Rebuild rebuilds the instance using the supplied image fingerprint as source.
-func (d *lxc) Rebuild(img *api.Image, op *operations.Operation) error {
-	return d.rebuildCommon(d, img, op)
+func (d *lxc) Rebuild(ctx context.Context, img *api.Image, op *operations.Operation) error {
+	return d.rebuildCommon(ctx, d, img, op)
 }
 
 // onStopNS is triggered by LXC's stop hook once a container is shutdown but before the container's
@@ -2857,7 +2857,7 @@ func (d *lxc) onStopNS(args map[string]string) error {
 
 // onStop is triggered by LXC's post-stop hook once a container is shutdown and after the
 // container's namespaces have been closed.
-func (d *lxc) onStop(args map[string]string) error {
+func (d *lxc) onStop(ctx context.Context, args map[string]string) error {
 	target := args["target"]
 
 	// Validate target
@@ -2885,7 +2885,7 @@ func (d *lxc) onStop(args map[string]string) error {
 		d.logger.Error("Failed recording last power state", logger.Ctx{"err": err})
 	}
 
-	go func(d *lxc, target string, op *operationlock.InstanceOperation) {
+	go func(ctx context.Context, d *lxc, target string, op *operationlock.InstanceOperation) {
 		d.fromHook = false
 		err = nil
 
@@ -2963,26 +2963,28 @@ func (d *lxc) onStop(args map[string]string) error {
 			}
 
 			d.logger.Info("Shut down instance", ctxMap)
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(ctx, d, nil))
 		}
 
 		// Reboot the container
 		if target == "reboot" {
 			// Start the container again
-			err = d.Start(false)
+			// Progress tracking here is not useful. We are in the on stop hook, which is called via lxc hook, so progress
+			// reporting would not be returned to the original client.
+			err = d.Start(ctx, nil, false)
 			if err != nil {
 				op.Done(fmt.Errorf("Failed restarting instance: %w", err))
 				return
 			}
 
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(ctx, d, nil))
 
 			return
 		}
 
 		// Destroy ephemeral containers
 		if d.ephemeral {
-			err = d.delete(true)
+			err = d.delete(ctx, true)
 			if err != nil {
 				op.Done(fmt.Errorf("Failed deleting ephemeral instance: %w", err))
 				return
@@ -2991,7 +2993,7 @@ func (d *lxc) onStop(args map[string]string) error {
 
 		// Trigger a scheduler rebalance after DB changes made.
 		cgroup.TaskSchedulerTrigger(d.dbType, d.name, "stopped")
-	}(d, target, op)
+	}(ctx, d, target, op)
 
 	return nil
 }
@@ -3031,7 +3033,7 @@ func (d *lxc) cleanupDevices(instanceRunning bool, stopHookNetnsPath string) {
 }
 
 // Freeze functions.
-func (d *lxc) Freeze() error {
+func (d *lxc) Freeze(ctx context.Context) error {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -3076,13 +3078,13 @@ func (d *lxc) Freeze() error {
 	}
 
 	d.logger.Info("Froze container", ctxMap)
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstancePaused.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstancePaused.Event(ctx, d, nil))
 
 	return err
 }
 
 // Unfreeze unfreezes the instance.
-func (d *lxc) Unfreeze() error {
+func (d *lxc) Unfreeze(ctx context.Context) error {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -3124,7 +3126,7 @@ func (d *lxc) Unfreeze() error {
 	}
 
 	d.logger.Info("Unfroze container", ctxMap)
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceResumed.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceResumed.Event(ctx, d, nil))
 
 	return err
 }
@@ -3347,15 +3349,15 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface, opts ...instance.State
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *lxc) snapshot(name string, expiry *time.Time, diskVolumesMode string) error {
+func (d *lxc) snapshot(ctx context.Context, name string, expiry *time.Time, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	// Wait for any file operations to complete to have a more consistent snapshot.
 	d.stopForkfile(false)
 
-	return d.snapshotCommon(d, name, expiry, false, diskVolumesMode)
+	return d.snapshotCommon(ctx, d, name, expiry, false, diskVolumesMode, progressReporter)
 }
 
 // Snapshot takes a new snapshot.
-func (d *lxc) Snapshot(name string, expiry *time.Time, stateful bool, diskVolumesMode string) error {
+func (d *lxc) Snapshot(ctx context.Context, name string, expiry *time.Time, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	if stateful {
 		return api.StatusErrorf(http.StatusBadRequest, "Stateful snapshots are not supported for containers")
 	}
@@ -3367,11 +3369,11 @@ func (d *lxc) Snapshot(name string, expiry *time.Time, stateful bool, diskVolume
 
 	defer unlock()
 
-	return d.snapshot(name, expiry, diskVolumesMode)
+	return d.snapshot(ctx, name, expiry, diskVolumesMode, progressReporter)
 }
 
 // Restore restores a snapshot.
-func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool, diskVolumesMode string) error {
+func (d *lxc) Restore(ctx context.Context, sourceContainer instance.Instance, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	if stateful {
 		return api.StatusErrorf(http.StatusBadRequest, "Stateful snapshot restore is not supported for containers")
 	}
@@ -3389,7 +3391,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool, diskVolu
 	// This is required so we can actually unmount the container and restore its rootfs.
 	d.stopForkfile(false)
 
-	wasRunning, op, err := d.restoreCommon(d, sourceContainer, diskVolumesMode)
+	wasRunning, op, err := d.restoreCommon(ctx, d, sourceContainer, diskVolumesMode, progressReporter)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -3398,14 +3400,14 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool, diskVolu
 	// Restart the container.
 	if wasRunning {
 		d.logger.Debug("Starting instance after snapshot restore")
-		err = d.Start(false)
+		err = d.Start(ctx, progressReporter, false)
 		if err != nil {
 			op.Done(err)
 			return err
 		}
 	}
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": sourceContainer.Name()}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestored.Event(ctx, d, map[string]any{"snapshot": sourceContainer.Name()}))
 	d.logger.Info("Restored instance", ctxMap)
 
 	return nil
@@ -3428,12 +3430,12 @@ func (d *lxc) cleanup() {
 }
 
 // Delete deletes the instance.
-func (d *lxc) Delete(force bool, diskVolumesMode string) error {
-	return d.deleteCommon(d, force, diskVolumesMode)
+func (d *lxc) Delete(ctx context.Context, force bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
+	return d.deleteCommon(ctx, d, force, diskVolumesMode, progressReporter)
 }
 
 // Delete deletes the instance without creating an operation lock.
-func (d *lxc) delete(force bool) error {
+func (d *lxc) delete(ctx context.Context, force bool) error {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -3476,7 +3478,7 @@ func (d *lxc) delete(force bool) error {
 		} else {
 			// Remove all snapshots.
 			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
-				return snapInst.(*lxc).delete(true) // Internal delete function that does not lock.
+				return snapInst.(*lxc).delete(ctx, true) // Internal delete function that does not lock.
 			})
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
@@ -3499,7 +3501,7 @@ func (d *lxc) delete(force bool) error {
 		}
 
 		for _, backup := range backups {
-			err = backup.Delete()
+			err = backup.Delete(ctx)
 			if err != nil {
 				return err
 			}
@@ -3532,16 +3534,16 @@ func (d *lxc) delete(force bool) error {
 	}
 
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(ctx, d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(ctx, d, nil))
 	}
 
 	return nil
 }
 
 // Rename renames the instance. Accepts an argument to enable applying deferred TemplateTriggerRename.
-func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
+func (d *lxc) Rename(ctx context.Context, newName string, applyTemplateTrigger bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -3672,12 +3674,12 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 		_, backupName, _ := strings.Cut(oldName, "/")
 		newName := newName + "/" + backupName
 
-		err = b.Rename(newName)
+		err = b.Rename(ctx, newName)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = b.Rename(oldName) })
+		revert.Add(func() { _ = b.Rename(context.Background(), oldName) })
 	}
 
 	// Invalidate the go-lxc cache.
@@ -3707,9 +3709,9 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 
 	d.logger.Info("Renamed instance", ctxMap)
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(ctx, d, map[string]any{"old_name": oldName}))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(ctx, d, map[string]any{"old_name": oldName}))
 	}
 
 	revert.Success()
@@ -3742,7 +3744,7 @@ func (d *lxc) CGroupSet(key string, value string) error {
 }
 
 // Update applies updated config.
-func (d *lxc) Update(args db.InstanceArgs, actionType instance.UpdateAction) error {
+func (d *lxc) Update(ctx context.Context, args db.InstanceArgs, actionType instance.UpdateAction) error {
 	reverter := revert.New()
 	defer reverter.Fail()
 
@@ -4472,9 +4474,9 @@ func (d *lxc) Update(args db.InstanceArgs, actionType instance.UpdateAction) err
 
 	if userRequested {
 		if d.isSnapshot {
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(ctx, d, nil))
 		} else {
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(ctx, d, nil))
 		}
 	}
 
@@ -4716,7 +4718,7 @@ func (d *lxc) Export(w io.Writer, properties map[string]string, expiration time.
 }
 
 // MigrateSend controls the sending side of a migration.
-func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
+func (d *lxc) MigrateSend(ctx context.Context, args instance.MigrateSendArgs, progressReporter ioprogress.ProgressReporter) (err error) {
 	d.logger.Info("Migration send starting")
 	defer d.logger.Info("Migration send stopped")
 
@@ -4788,7 +4790,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		}
 	}
 
-	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, d.op)
+	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, progressReporter)
 	if err != nil {
 		err := fmt.Errorf("Failed generating instance migration config: %w", err)
 		op.Done(err)
@@ -4923,7 +4925,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 
 		d.logger.Debug("Starting storage migration phase")
 
-		err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
+		err = pool.MigrateInstance(ctx, d, filesystemConn, volSourceArgs, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -4940,7 +4942,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 			volSourceArgs.Snapshots = nil
 			rootVol.Snapshots = nil
 
-			err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
+			err = pool.MigrateInstance(ctx, d, filesystemConn, volSourceArgs, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -4967,7 +4969,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		}
 
 		op.Done(nil)
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceMigrated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceMigrated.Event(ctx, d, nil))
 		return nil
 	}
 }
@@ -5008,7 +5010,7 @@ func (d *lxc) resetContainerDiskIdmap(srcIdmap *idmap.IdmapSet) error {
 
 // MigrateReceive receives the migration offer from the source and negotiates the migration options.
 // It establishes the necessary connections and transfers the filesystem and snapshots if required.
-func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
+func (d *lxc) MigrateReceive(ctx context.Context, args instance.MigrateReceiveArgs, progressReporter ioprogress.ProgressReporter) error {
 	d.logger.Info("Migration receive starting")
 	defer d.logger.Info("Migration receive stopped")
 
@@ -5122,7 +5124,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(true, "")
+			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(ctx, true, "", progressReporter)
 			if err != nil {
 				return err
 			}
@@ -5167,7 +5169,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 
 	// Start control connection monitor.
 	g.Go(func() error {
@@ -5306,7 +5308,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					}
 
 					// Create the snapshot instance.
-					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true)
+					_, snapInstOp, cleanup, err := instance.CreateInternal(ctx, d.state, *snapArgs, true)
 					if err != nil {
 						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 					}
@@ -5321,7 +5323,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 		}
 
-		err = pool.CreateInstanceFromMigration(d, filesystemConn, volTargetArgs, d.op)
+		err = pool.CreateInstanceFromMigration(ctx, d, filesystemConn, volTargetArgs, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed creating instance on target: %w", err)
 		}
@@ -5416,7 +5418,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 // ConversionReceive establishes the filesystem connection, transfers the filesystem / block volume,
 // and creates an instance from it.
-func (d *lxc) ConversionReceive(args instance.ConversionReceiveArgs) error {
+func (d *lxc) ConversionReceive(args instance.ConversionReceiveArgs, progressReporter ioprogress.ProgressReporter) error {
 	d.logger.Info("Conversion receive starting")
 	defer d.logger.Info("Conversion receive stopped")
 
@@ -5452,7 +5454,7 @@ func (d *lxc) ConversionReceive(args instance.ConversionReceiveArgs) error {
 		ConversionOptions: nil,                 // Containers do not support conversion options.
 	}
 
-	err = pool.CreateInstanceFromConversion(d, filesystemConn, volTargetArgs, d.op)
+	err = pool.CreateInstanceFromConversion(d, filesystemConn, volTargetArgs, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance on target: %w", err)
 	}
@@ -6017,7 +6019,7 @@ func (d *lxc) stopForkfile(force bool) {
 }
 
 // Console attaches to the instance console.
-func (d *lxc) Console(protocol string) (*os.File, chan error, error) {
+func (d *lxc) Console(ctx context.Context, protocol string) (*os.File, chan error, error) {
 	if protocol != instance.ConsoleTypeConsole {
 		return nil, nil, fmt.Errorf("Container instances do not support %q output", protocol)
 	}
@@ -6078,13 +6080,13 @@ func (d *lxc) Console(protocol string) (*os.File, chan error, error) {
 		_ = cmd.Process.Kill()
 	}()
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsole.Event(d, logger.Ctx{"type": instance.ConsoleTypeConsole}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsole.Event(ctx, d, logger.Ctx{"type": instance.ConsoleTypeConsole}))
 
 	return ptx, chDisconnect, nil
 }
 
 // ConsoleLog returns console log.
-func (d *lxc) ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error) {
+func (d *lxc) ConsoleLog(ctx context.Context, opts liblxc.ConsoleLogOptions) (string, error) {
 	cc, err := d.initLXC(false)
 	if err != nil {
 		return "", err
@@ -6096,16 +6098,16 @@ func (d *lxc) ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error) {
 	}
 
 	if opts.ClearLog {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleReset.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleReset.Event(ctx, d, nil))
 	} else if opts.ReadLog && opts.WriteToLogFile {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleRetrieved.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleRetrieved.Event(ctx, d, nil))
 	}
 
 	return string(msg), nil
 }
 
 // Exec executes a command inside the instance.
-func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (instance.Cmd, error) {
+func (d *lxc) Exec(ctx context.Context, req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (instance.Cmd, error) {
 	// Generate the LXC config if missing.
 	configPath := filepath.Join(d.LogPath(), "lxc.conf")
 	if !shared.PathExists(configPath) {
@@ -6207,7 +6209,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 
 	d.logger.Debug("Retrieved PID of executing child process", logger.Ctx{"attachedPid": attachedPid})
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceExec.Event(d, logger.Ctx{"command": req.Command}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceExec.Event(ctx, d, logger.Ctx{"command": req.Command}))
 
 	instCmd := &lxcCmd{
 		cmd:              &cmd,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -196,7 +196,7 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 
 // qemuCreate creates a new storage volume record and returns an initialised Instance.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
-func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
+func qemuCreate(ctx context.Context, s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -314,9 +314,9 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 	}
 
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(ctx, d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(ctx, d, map[string]any{
 			"type":         api.InstanceTypeVM,
 			"storage-pool": d.storagePool.Name(),
 			"location":     d.Location(),
@@ -438,7 +438,7 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 				d.logger.Debug("Instance stopped", logger.Ctx{"target": target, "reason": data["reason"]})
 			}
 
-			err = d.onStop(target)
+			err = d.onStop(context.Background(), target)
 			if err != nil {
 				d.logger.Error("Failed cleanly stopping instance", logger.Ctx{"err": err})
 				return
@@ -532,7 +532,7 @@ func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCer
 }
 
 // Freeze freezes the instance.
-func (d *qemu) Freeze() error {
+func (d *qemu) Freeze(ctx context.Context) error {
 	// Connect to the monitor.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
@@ -545,7 +545,7 @@ func (d *qemu) Freeze() error {
 		return err
 	}
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstancePaused.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstancePaused.Event(ctx, d, nil))
 	return nil
 }
 
@@ -590,7 +590,7 @@ func (d *qemu) pidWait(timeout time.Duration) bool {
 }
 
 // onStop is run when the instance stops.
-func (d *qemu) onStop(target string) error {
+func (d *qemu) onStop(ctx context.Context, target string) error {
 	d.logger.Debug("onStop hook started", logger.Ctx{"target": target})
 	defer d.logger.Debug("onStop hook finished", logger.Ctx{"target": target})
 
@@ -658,23 +658,25 @@ func (d *qemu) onStop(target string) error {
 
 	// Log and emit lifecycle if not user triggered.
 	if op.GetInstanceInitiated() {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(ctx, d, nil))
 	} else if op.Action() != operationlock.ActionMigrate {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(ctx, d, nil))
 	}
 
 	// Reboot the instance.
 	if target == "reboot" {
-		err = d.Start(false)
+		// Progress tracking here is not useful. We are in the on stop hook, which is called via lxc hook, so progress
+		// reporting would not be returned to the original client.
+		err = d.Start(ctx, nil, false)
 		if err != nil {
 			op.Done(err)
 			return err
 		}
 
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(ctx, d, nil))
 	} else if d.ephemeral {
 		// Destroy ephemeral virtual machines.
-		err = d.delete(true)
+		err = d.delete(ctx, true)
 		if err != nil {
 			op.Done(err)
 			return err
@@ -685,7 +687,7 @@ func (d *qemu) onStop(target string) error {
 }
 
 // Shutdown shuts the instance down.
-func (d *qemu) Shutdown(timeout time.Duration) error {
+func (d *qemu) Shutdown(ctx context.Context, timeout time.Duration) error {
 	d.logger.Debug("Shutdown started", logger.Ctx{"timeout": timeout})
 	defer d.logger.Debug("Shutdown finished", logger.Ctx{"timeout": timeout})
 
@@ -716,7 +718,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 
 	// If frozen, resume so the signal can be handled.
 	if d.IsFrozen() {
-		err := d.Unfreeze()
+		err := d.Unfreeze(ctx)
 		if err != nil {
 			return err
 		}
@@ -762,7 +764,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 
 	d.logger.Debug("Shutdown request sent to instance")
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Wait for operation lock to be Done or context to timeout. The operation lock is normally completed by
@@ -789,13 +791,13 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 }
 
 // Restart restart the instance.
-func (d *qemu) Restart(timeout time.Duration) error {
-	return d.restartCommon(d, timeout)
+func (d *qemu) Restart(ctx context.Context, timeout time.Duration, progressReporter ioprogress.ProgressReporter) error {
+	return d.restartCommon(ctx, d, timeout, progressReporter)
 }
 
 // Rebuild rebuilds the instance using the supplied image fingerprint as source.
-func (d *qemu) Rebuild(img *api.Image, op *operations.Operation) error {
-	return d.rebuildCommon(d, img, op)
+func (d *qemu) Rebuild(ctx context.Context, img *api.Image, op *operations.Operation) error {
+	return d.rebuildCommon(ctx, d, img, op)
 }
 
 // killQemuProcess kills specified process. Optimistically attempts to wait for the process to fully exit, but does
@@ -1091,7 +1093,7 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 }
 
 // Start starts the instance.
-func (d *qemu) Start(stateful bool) error {
+func (d *qemu) Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -1099,11 +1101,11 @@ func (d *qemu) Start(stateful bool) error {
 
 	defer unlock()
 
-	return d.start(stateful, nil)
+	return d.start(ctx, stateful, nil, progressReporter)
 }
 
 // start starts the instance and can use an existing InstanceOperation lock.
-func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
+func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.InstanceOperation, progressReporter ioprogress.ProgressReporter) error {
 	d.logger.Debug("Start started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", logger.Ctx{"stateful": stateful})
 
@@ -1485,7 +1487,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	}
 
 	if snapName != "" && expiry != nil {
-		err := d.snapshot(snapName, expiry, false, api.DiskVolumesModeRoot)
+		err := d.snapshot(ctx, snapName, expiry, false, api.DiskVolumesModeRoot, progressReporter)
 		if err != nil {
 			err = fmt.Errorf("Failed taking startup snapshot: %w", err)
 			op.Done(err)
@@ -1859,12 +1861,12 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		op.Done(err) // Must come before Stop() otherwise stop will not proceed.
 
 		// Shut down the VM if hooks fail.
-		_ = d.Stop(false)
+		_ = d.Stop(ctx, false)
 		return err
 	}
 
 	if op.Action() == "start" {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(ctx, d, nil))
 	}
 
 	// The VM started cleanly so now enable the unexpected disconnection event to ensure the onStop hook is
@@ -5262,7 +5264,7 @@ func (d *qemu) forceStop() error {
 }
 
 // Stop the VM.
-func (d *qemu) Stop(stateful bool) error {
+func (d *qemu) Stop(ctx context.Context, stateful bool) error {
 	d.logger.Debug("Stop started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Stop finished", logger.Ctx{"stateful": stateful})
 
@@ -5315,13 +5317,13 @@ func (d *qemu) Stop(stateful bool) error {
 		}
 
 		// Wait for QEMU process to exit and perform device cleanup.
-		err = d.onStop("stop")
+		err = d.onStop(ctx, "stop")
 		if err != nil {
 			op.Done(err)
 			return err
 		}
 
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(ctx, d, nil))
 
 		op.Done(nil)
 		return nil
@@ -5413,7 +5415,7 @@ func (d *qemu) Stop(stateful bool) error {
 }
 
 // Unfreeze restores the instance to running.
-func (d *qemu) Unfreeze() error {
+func (d *qemu) Unfreeze(ctx context.Context) error {
 	// Connect to the monitor.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
@@ -5426,7 +5428,7 @@ func (d *qemu) Unfreeze() error {
 		return err
 	}
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceResumed.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceResumed.Event(ctx, d, nil))
 	return nil
 }
 
@@ -5436,7 +5438,7 @@ func (d *qemu) IsPrivileged() bool {
 }
 
 // snapshot creates a snapshot of the instance.
-func (d *qemu) snapshot(name string, expiry *time.Time, stateful bool, diskVolumesMode string) error {
+func (d *qemu) snapshot(ctx context.Context, name string, expiry *time.Time, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	var err error
 	var monitor *qmp.Monitor
 
@@ -5466,7 +5468,7 @@ func (d *qemu) snapshot(name string, expiry *time.Time, stateful bool, diskVolum
 	}
 
 	// Create the snapshot.
-	err = d.snapshotCommon(d, name, expiry, stateful, diskVolumesMode)
+	err = d.snapshotCommon(ctx, d, name, expiry, stateful, diskVolumesMode, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -5489,7 +5491,7 @@ func (d *qemu) snapshot(name string, expiry *time.Time, stateful bool, diskVolum
 }
 
 // Snapshot takes a new snapshot.
-func (d *qemu) Snapshot(name string, expiry *time.Time, stateful bool, diskVolumesMode string) error {
+func (d *qemu) Snapshot(ctx context.Context, name string, expiry *time.Time, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -5497,11 +5499,11 @@ func (d *qemu) Snapshot(name string, expiry *time.Time, stateful bool, diskVolum
 
 	defer unlock()
 
-	return d.snapshot(name, expiry, stateful, diskVolumesMode)
+	return d.snapshot(ctx, name, expiry, stateful, diskVolumesMode, progressReporter)
 }
 
 // Restore restores an instance snapshot.
-func (d *qemu) Restore(source instance.Instance, stateful bool, diskVolumesMode string) error {
+func (d *qemu) Restore(ctx context.Context, source instance.Instance, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -5511,7 +5513,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool, diskVolumesMode 
 
 	d.logger.Info("Restoring instance", ctxMap)
 
-	wasRunning, op, err := d.restoreCommon(d, source, diskVolumesMode)
+	wasRunning, op, err := d.restoreCommon(ctx, d, source, diskVolumesMode, progressReporter)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -5522,20 +5524,20 @@ func (d *qemu) Restore(source instance.Instance, stateful bool, diskVolumesMode 
 	// Restart the instance.
 	if wasRunning || stateful {
 		d.logger.Debug("Starting instance after snapshot restore")
-		err := d.Start(stateful)
+		err := d.Start(ctx, progressReporter, stateful)
 		if err != nil {
 			op.Done(err)
 			return err
 		}
 	}
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": source.Name()}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestored.Event(ctx, d, map[string]any{"snapshot": source.Name()}))
 	d.logger.Info("Restored instance", ctxMap)
 	return nil
 }
 
 // Rename the instance. Accepts an argument to enable applying deferred TemplateTriggerRename.
-func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
+func (d *qemu) Rename(ctx context.Context, newName string, applyTemplateTrigger bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -5670,12 +5672,12 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 		_, backupName, _ := strings.Cut(oldName, "/")
 		newName := newName + "/" + backupName
 
-		err = b.Rename(newName)
+		err = b.Rename(ctx, newName)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = b.Rename(oldName) })
+		revert.Add(func() { _ = b.Rename(context.Background(), oldName) })
 	}
 
 	// Update lease files.
@@ -5701,9 +5703,9 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 	d.logger.Info("Renamed instance", ctxMap)
 
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(ctx, d, map[string]any{"old_name": oldName}))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(ctx, d, map[string]any{"old_name": oldName}))
 	}
 
 	revert.Success()
@@ -5750,7 +5752,7 @@ func allowRemoveSecurityProtectionStart(state *state.State, poolName string, vol
 }
 
 // Update the instance config.
-func (d *qemu) Update(args db.InstanceArgs, actionType instance.UpdateAction) error {
+func (d *qemu) Update(ctx context.Context, args db.InstanceArgs, actionType instance.UpdateAction) error {
 	userRequested := d.isUserRequested(actionType)
 
 	unlock, err := d.updateBackupFileLock(context.Background())
@@ -6216,9 +6218,9 @@ func (d *qemu) Update(args db.InstanceArgs, actionType instance.UpdateAction) er
 
 	if userRequested {
 		if d.isSnapshot {
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(ctx, d, nil))
 		} else {
-			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(ctx, d, nil))
 		}
 	}
 
@@ -6367,12 +6369,12 @@ func (d *qemu) init() error {
 }
 
 // Delete the instance.
-func (d *qemu) Delete(force bool, diskVolumesMode string) error {
-	return d.deleteCommon(d, force, diskVolumesMode)
+func (d *qemu) Delete(ctx context.Context, force bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
+	return d.deleteCommon(ctx, d, force, diskVolumesMode, progressReporter)
 }
 
 // Delete the instance without creating an operation lock.
-func (d *qemu) delete(force bool) error {
+func (d *qemu) delete(ctx context.Context, force bool) error {
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -6414,7 +6416,7 @@ func (d *qemu) delete(force bool) error {
 		} else {
 			// Remove all snapshots.
 			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
-				return snapInst.(*qemu).delete(true) // Internal delete function that does not lock.
+				return snapInst.(*qemu).delete(ctx, true) // Internal delete function that does not lock.
 			})
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
@@ -6437,7 +6439,7 @@ func (d *qemu) delete(force bool) error {
 		}
 
 		for _, backup := range backups {
-			err = backup.Delete()
+			err = backup.Delete(ctx)
 			if err != nil {
 				return err
 			}
@@ -6470,9 +6472,9 @@ func (d *qemu) delete(force bool) error {
 	}
 
 	if d.isSnapshot {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(ctx, d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(ctx, d, nil))
 	}
 
 	return nil
@@ -6757,7 +6759,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 }
 
 // MigrateSend controls the sending side of a migration.
-func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
+func (d *qemu) MigrateSend(ctx context.Context, args instance.MigrateSendArgs, progressReporter ioprogress.ProgressReporter) (err error) {
 	d.logger.Info("Migration send starting")
 	defer d.logger.Info("Migration send stopped")
 
@@ -6809,7 +6811,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 	offerHeader.IndexHeaderVersion = &indexHeaderVersion
 
 	// For VMs, send block device size hint in offer header so that target can create the volume the same size.
-	blockSize, err := storagePools.InstanceDiskBlockSize(pool, d, d.op)
+	blockSize, err := storagePools.InstanceDiskBlockSize(pool, d, progressReporter)
 	if err != nil {
 		err := fmt.Errorf("Failed getting source disk size: %w", err)
 		op.Done(err)
@@ -6819,7 +6821,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 	d.logger.Debug("Set migration offer volume size", logger.Ctx{"blockSize": blockSize})
 	offerHeader.VolumeSize = &blockSize
 
-	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, d.op)
+	srcConfig, err := pool.GenerateInstanceBackupConfig(d, args.Snapshots, nil, progressReporter)
 	if err != nil {
 		err := fmt.Errorf("Failed generating instance migration config: %w", err)
 		op.Done(err)
@@ -6917,7 +6919,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		}
 	}
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 
 	// Start control connection monitor.
 	g.Go(func() error {
@@ -6981,20 +6983,20 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 				defer instanceRefClear(d)
 			}
 
-			err = d.migrateSendLive(pool, args.ClusterMoveSourceName, blockSize, filesystemConn, stateConn, volSourceArgs)
+			err = d.migrateSendLive(ctx, pool, args.ClusterMoveSourceName, blockSize, filesystemConn, stateConn, volSourceArgs, progressReporter)
 			if err != nil {
 				return err
 			}
 		} else {
 			// Perform stateful stop if live state transfer is not supported by target.
 			if args.Live {
-				err = d.Stop(true)
+				err = d.Stop(ctx, true)
 				if err != nil {
 					return fmt.Errorf("Failed statefully stopping instance: %w", err)
 				}
 			}
 
-			err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
+			err = pool.MigrateInstance(ctx, d, filesystemConn, volSourceArgs, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -7017,13 +7019,13 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		}
 
 		op.Done(nil)
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceMigrated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceMigrated.Event(ctx, d, nil))
 		return nil
 	}
 }
 
 // migrateSendLive performs live migration send process.
-func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName string, rootDiskSize int64, filesystemConn io.ReadWriteCloser, stateConn io.ReadWriteCloser, volSourceArgs *migration.VolumeSourceArgs) error {
+func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clusterMoveSourceName string, rootDiskSize int64, filesystemConn io.ReadWriteCloser, stateConn io.ReadWriteCloser, volSourceArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
 		return err
@@ -7166,7 +7168,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 	// We enable AllowInconsistent mode as this allows for transferring the VM storage whilst it is running
 	// and the snapshot we took earlier is designed to provide consistency anyway.
 	volSourceArgs.AllowInconsistent = true
-	err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
+	err = pool.MigrateInstance(ctx, d, filesystemConn, volSourceArgs, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -7347,7 +7349,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 	if clusterMoveSourceName != "" {
 		// If doing an intra-cluster member move then we will be deleting the instance on the source,
 		// so lets just stop it after migration is completed.
-		err = d.Stop(false)
+		err = d.Stop(ctx, false)
 		if err != nil {
 			return fmt.Errorf("Failed stopping instance: %w", err)
 		}
@@ -7384,7 +7386,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 
 // MigrateReceive receives the migration offer from the source and negotiates the migration options.
 // It establishes the necessary connections and transfers the filesystem and snapshots if required.
-func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
+func (d *qemu) MigrateReceive(ctx context.Context, args instance.MigrateReceiveArgs, progressReporter ioprogress.ProgressReporter) error {
 	d.logger.Info("Migration receive starting")
 	defer d.logger.Info("Migration receive stopped")
 
@@ -7487,7 +7489,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(true, "")
+			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(ctx, true, "", progressReporter)
 			if err != nil {
 				return err
 			}
@@ -7539,7 +7541,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 
 	// Start control connection monitor.
 	g.Go(func() error {
@@ -7671,7 +7673,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					}
 
 					// Create the snapshot instance.
-					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true)
+					_, snapInstOp, cleanup, err := instance.CreateInternal(ctx, d.state, *snapArgs, true)
 					if err != nil {
 						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 					}
@@ -7686,7 +7688,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 		}
 
-		err = pool.CreateInstanceFromMigration(d, filesystemConn, volTargetArgs, d.op)
+		err = pool.CreateInstanceFromMigration(ctx, d, filesystemConn, volTargetArgs, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed creating instance on target: %w", err)
 		}
@@ -7777,7 +7779,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			// starting from the migrated state file or migration state connection.
 			d.stateful = true
 
-			err = d.start(true, args.InstanceOperation)
+			err = d.start(ctx, true, args.InstanceOperation, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -7840,7 +7842,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 // ConversionReceive establishes the filesystem connection, transfers the filesystem / block volume,
 // and creates an instance from it.
-func (d *qemu) ConversionReceive(args instance.ConversionReceiveArgs) error {
+func (d *qemu) ConversionReceive(args instance.ConversionReceiveArgs, progressReporter ioprogress.ProgressReporter) error {
 	d.logger.Info("Conversion receive starting")
 	defer d.logger.Info("Conversion receive stopped")
 
@@ -7871,7 +7873,7 @@ func (d *qemu) ConversionReceive(args instance.ConversionReceiveArgs) error {
 		ConversionOptions: args.ConversionOptions, // Non-nil options indicate image conversion.
 	}
 
-	err = pool.CreateInstanceFromConversion(d, filesystemConn, volTargetArgs, d.op)
+	err = pool.CreateInstanceFromConversion(d, filesystemConn, volTargetArgs, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance on target: %w", err)
 	}
@@ -8014,7 +8016,7 @@ func (d *qemu) FileSFTP() (*sftp.Client, error) {
 }
 
 // Console gets access to the instance's console.
-func (d *qemu) Console(protocol string) (*os.File, chan error, error) {
+func (d *qemu) Console(ctx context.Context, protocol string) (*os.File, chan error, error) {
 	var path string
 	switch protocol {
 	case instance.ConsoleTypeConsole:
@@ -8041,13 +8043,13 @@ func (d *qemu) Console(protocol string) (*os.File, chan error, error) {
 
 	_ = conn.Close()
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsole.Event(d, logger.Ctx{"type": protocol}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsole.Event(ctx, d, logger.Ctx{"type": protocol}))
 
 	return file, chDisconnect, nil
 }
 
 // Exec a command inside the instance.
-func (d *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (instance.Cmd, error) {
+func (d *qemu) Exec(ctx context.Context, req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (instance.Cmd, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -8112,7 +8114,7 @@ func (d *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, s
 		controlResCh:     controlResCh,
 	}
 
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceExec.Event(d, logger.Ctx{"command": req.Command}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceExec.Event(ctx, d, logger.Ctx{"command": req.Command}))
 
 	revert.Success()
 	return instCmd, nil

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -136,12 +137,12 @@ func validDevices(state *state.State, p api.Project, instanceType instancetype.T
 	return nil
 }
 
-func create(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
+func create(ctx context.Context, s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
 	switch args.Type {
 	case instancetype.Container:
-		return lxcCreate(s, args, p)
+		return lxcCreate(ctx, s, args, p)
 	case instancetype.VM:
-		return qemuCreate(s, args, p)
+		return qemuCreate(ctx, s, args, p)
 	}
 
 	return nil, nil, errors.New("Instance type invalid")

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -93,30 +93,30 @@ type Instance interface {
 	ConfigReader
 
 	// Instance actions.
-	Freeze() error
-	Shutdown(timeout time.Duration) error
-	Start(stateful bool) error
-	Stop(stateful bool) error
-	Restart(timeout time.Duration) error
-	Rebuild(img *api.Image, op *operations.Operation) error
-	Unfreeze() error
+	Freeze(ctx context.Context) error
+	Shutdown(ctx context.Context, timeout time.Duration) error
+	Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error
+	Stop(ctx context.Context, stateful bool) error
+	Restart(ctx context.Context, timeout time.Duration, progressReporter ioprogress.ProgressReporter) error
+	Rebuild(ctx context.Context, img *api.Image, op *operations.Operation) error
+	Unfreeze(ctx context.Context) error
 	RegisterDevices()
 
 	Info() Info
 	IsPrivileged() bool
 
 	// Snapshots & migration & backups.
-	Restore(source Instance, stateful bool, diskVolumesMode string) error
-	Snapshot(name string, expiry *time.Time, stateful bool, diskVolumesMode string) error
+	Restore(ctx context.Context, source Instance, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error
+	Snapshot(ctx context.Context, name string, expiry *time.Time, stateful bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error
 	Snapshots() ([]Instance, error)
 	Backups() ([]backup.InstanceBackup, error)
 	UpdateBackupFile() error
 
 	// Config handling.
-	Rename(newName string, applyTemplateTrigger bool) error
-	Update(newConfig db.InstanceArgs, actionType UpdateAction) error
+	Rename(ctx context.Context, newName string, applyTemplateTrigger bool) error
+	Update(ctx context.Context, newConfig db.InstanceArgs, actionType UpdateAction) error
 
-	Delete(force bool, diskVolumesMode string) error
+	Delete(ctx context.Context, force bool, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error
 	Export(w io.Writer, properties map[string]string, expiration time.Time, tracker *ioprogress.ProgressTracker) (api.ImageMetadata, error)
 
 	// Live configuration.
@@ -129,8 +129,8 @@ type Instance interface {
 	FileSFTP() (*sftp.Client, error)
 
 	// Console - Allocate and run a console tty or a spice Unix socket.
-	Console(protocol string) (*os.File, chan error, error)
-	Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (Cmd, error)
+	Console(ctx context.Context, protocol string) (*os.File, chan error, error)
+	Exec(ctx context.Context, req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (Cmd, error)
 
 	// Status
 	Render(options ...func(response any) error) (any, any, error)
@@ -177,15 +177,11 @@ type Instance interface {
 
 	// Migration.
 	CanMigrate() (bool, bool)
-	MigrateSend(args MigrateSendArgs) error
-	MigrateReceive(args MigrateReceiveArgs) error
+	MigrateSend(ctx context.Context, args MigrateSendArgs, progressReporter ioprogress.ProgressReporter) error
+	MigrateReceive(ctx context.Context, args MigrateReceiveArgs, progressReporter ioprogress.ProgressReporter) error
 
 	// Conversion.
-	ConversionReceive(args ConversionReceiveArgs) error
-
-	// Progress reporting.
-	SetOperation(op *operations.Operation)
-	Operation() *operations.Operation
+	ConversionReceive(args ConversionReceiveArgs, progressReporter ioprogress.ProgressReporter) error
 
 	DeferTemplateApply(trigger TemplateTrigger) error
 
@@ -199,7 +195,7 @@ type Container interface {
 	CurrentIdmap() (*idmap.IdmapSet, error)
 	DiskIdmap() (*idmap.IdmapSet, error)
 	NextIdmap() (*idmap.IdmapSet, error)
-	ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error)
+	ConsoleLog(ctx context.Context, opts liblxc.ConsoleLogOptions) (string, error)
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 	DevptsFd() (*os.File, error)
 	FileSFTPNoLock() (*sftp.Client, error)

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -48,7 +48,7 @@ var Load func(s *state.State, args db.InstanceArgs, p api.Project) (Instance, er
 
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
-var Create func(s *state.State, args db.InstanceArgs, p api.Project) (Instance, revert.Hook, error)
+var Create func(ctx context.Context, s *state.State, args db.InstanceArgs, p api.Project) (Instance, revert.Hook, error)
 
 // ValidConfig validates an instance's config.
 func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanceType instancetype.Type) error {
@@ -668,7 +668,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 // Returns the created instance, along with a "create" operation lock that needs to be marked as Done once the
 // instance is fully completed, and a revert fail function that can be used to undo this function if a subsequent
 // step fails.
-func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Instance, *operationlock.InstanceOperation, revert.Hook, error) {
+func CreateInternal(ctx context.Context, s *state.State, args db.InstanceArgs, clearLogDir bool) (Instance, *operationlock.InstanceOperation, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -956,7 +956,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 			return tx.DeleteInstance(ctx, dbInst.Project, dbInst.Name)
 		})
 	})
-	inst, cleanup, err := Create(s, args, *p)
+	inst, cleanup, err := Create(ctx, s, args, *p)
 	if err != nil {
 		logger.Error("Failed initialising instance", logger.Ctx{"project": args.Project, "instance": args.Name, "type": args.Type, "err": err})
 		return nil, nil, nil, fmt.Errorf("Failed initialising instance: %w", err)

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -366,7 +366,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 			CompressionAlgorithm: req.CompressionAlgorithm,
 		}
 
-		err := backupCreate(s, args, inst, req.Version, op)
+		err := backupCreate(ctx, s, args, inst, req.Version, op)
 		if err != nil {
 			return fmt.Errorf("Create backup: %w", err)
 		}
@@ -566,7 +566,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	newName := name + shared.SnapshotDelimiter + newBackupName
 
 	rename := func(ctx context.Context, op *operations.Operation) error {
-		err := backup.Rename(newName)
+		err := backup.Rename(ctx, newName)
 		if err != nil {
 			return err
 		}
@@ -663,7 +663,7 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	remove := func(ctx context.Context, op *operations.Operation) error {
-		err := backup.Delete()
+		err := backup.Delete(ctx)
 		if err != nil {
 			return err
 		}
@@ -752,7 +752,7 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 		Path: filepath.Join(d.State().BackupsStoragePath(backup.Instance().Project().Name), "instances", project.Instance(projectName, backup.Name())),
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(fullName, backup.Instance(), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(r.Context(), fullName, backup.Instance(), nil))
 
 	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -180,7 +180,7 @@ func (s *consoleWs) connectVGA(r *http.Request, w http.ResponseWriter) error {
 
 		logger.Debug("VGA dynamic websocket connected")
 
-		console, _, err := s.instance.Console("vga")
+		console, _, err := s.instance.Console(r.Context(), "vga")
 		if err != nil {
 			_ = conn.Close()
 			return err
@@ -238,7 +238,7 @@ func (s *consoleWs) doConsole(ctx context.Context) error {
 	<-s.allConnected
 
 	// Get console from instance.
-	console, consoleDisconnectCh, err := s.instance.Console(s.protocol)
+	console, consoleDisconnectCh, err := s.instance.Console(ctx, s.protocol)
 	if err != nil {
 		return err
 	}
@@ -655,7 +655,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Send a ringbuffer request to the container.
-	logContents, err := c.ConsoleLog(console)
+	logContents, err := c.ConsoleLog(r.Context(), console)
 	if err != nil {
 		errno, isErrno := shared.GetErrno(err)
 		if !isErrno {
@@ -760,7 +760,7 @@ func instanceConsoleLogDelete(d *Daemon, r *http.Request) response.Response {
 		WriteToLogFile: false,
 	}
 
-	_, err = c.ConsoleLog(console)
+	_, err = c.ConsoleLog(r.Context(), console)
 	if err != nil {
 		errno, isErrno := shared.GetErrno(err)
 		if !isErrno {

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -113,11 +113,11 @@ func doInstanceDelete(opScheduler operations.OperationScheduler, s *state.State,
 	rmct := func(ctx context.Context, op *operations.Operation) error {
 		if instRunning {
 			// Stop instance.
-			err := doInstanceStatePut(inst, api.InstanceStatePut{
+			err := doInstanceStatePut(ctx, inst, api.InstanceStatePut{
 				Action:  "stop",
 				Timeout: -1,
 				Force:   true,
-			})
+			}, op)
 			if err != nil {
 				return fmt.Errorf("Failed force stopping instance %q before deletion: %w", name, err)
 			}
@@ -128,7 +128,7 @@ func doInstanceDelete(opScheduler operations.OperationScheduler, s *state.State,
 			}
 		}
 
-		return inst.Delete(false, "")
+		return inst.Delete(ctx, false, "", op)
 	}
 
 	args := operations.OperationArgs{

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -294,7 +294,7 @@ func (s *execWs) Do(ctx context.Context, op *operations.Operation) error {
 		return cmdErr
 	}
 
-	cmd, err := s.instance.Exec(s.req, stdin, stdout, stderr)
+	cmd, err := s.instance.Exec(ctx, s.req, stdin, stdout, stderr)
 	if err != nil {
 		return finisher(-1, err)
 	}
@@ -752,7 +752,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Run the command.
-		cmd, err := inst.Exec(post, nil, stdout, stderr)
+		cmd, err := inst.Exec(ctx, post, nil, stdout, stderr)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -74,13 +75,13 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 
 	switch r.Method {
 	case "GET":
-		return instanceFileGet(s, inst, path)
+		return instanceFileGet(r.Context(), s, inst, path)
 	case "HEAD":
 		return instanceFileHead(inst, path)
 	case "POST":
-		return instanceFilePost(s, inst, path, r)
+		return instanceFilePost(r.Context(), s, inst, path, r)
 	case "DELETE":
-		return instanceFileDelete(s, inst, path)
+		return instanceFileDelete(r.Context(), s, inst, path)
 	default:
 		return response.NotFound(fmt.Errorf("Method %q not found", r.Method))
 	}
@@ -154,7 +155,7 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/NotFound"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func instanceFileGet(s *state.State, inst instance.Instance, path string) response.Response {
+func instanceFileGet(ctx context.Context, s *state.State, inst instance.Instance, path string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -215,7 +216,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string) respon
 			cleanup.Fail()
 		}
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.FileResponse(files, headers)
 	case "symlink":
 		// Find symlink target.
@@ -246,7 +247,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string) respon
 		files[0].FileModified = time.Now()
 		files[0].FileSize = int64(len(target))
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.FileResponse(files, headers)
 	case "directory":
 		dirEnts := []string{}
@@ -261,7 +262,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string) respon
 			dirEnts = append(dirEnts, entry.Name())
 		}
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.SyncResponseHeaders(true, dirEnts, headers)
 	}
 
@@ -484,7 +485,7 @@ func effectiveFileOwnership(inst instance.Instance, headers *shared.LXDFileHeade
 //	    $ref: "#/responses/NotFound"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func instanceFilePost(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
+func instanceFilePost(ctx context.Context, s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()
 	if err != nil {
@@ -562,7 +563,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			}
 		}
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	case "symlink":
 		// Figure out target.
@@ -583,7 +584,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			return response.SmartError(fmt.Errorf("Failed creating symlink %q in instance %q: %w", path, inst.Name(), err))
 		}
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	case "directory":
 		// Check if it already exists.
@@ -624,7 +625,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			}
 		}
 
-		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	}
 
@@ -662,7 +663,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 //	    $ref: "#/responses/NotFound"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func instanceFileDelete(s *state.State, inst instance.Instance, path string) response.Response {
+func instanceFileDelete(ctx context.Context, s *state.State, inst instance.Instance, path string) response.Response {
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()
 	if err != nil {
@@ -677,6 +678,6 @@ func instanceFileDelete(s *state.State, inst instance.Instance, path string) res
 		return response.SmartError(fmt.Errorf("Failed removing %q in instance %q: %w", path, inst.Name(), err))
 	}
 
-	s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileDeleted.Event(inst, logger.Ctx{"path": path}))
+	s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileDeleted.Event(ctx, inst, logger.Ctx{"path": path}))
 	return response.EmptySyncResponse
 }

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -236,7 +236,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 		Project:      projectName,
 	}
 
-	err = c.Update(args, instance.UpdateActionUser)
+	err = c.Update(r.Context(), args, instance.UpdateActionUser)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -471,7 +471,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				}
 			}()
 
-			return ws.Do(s, op)
+			return ws.Do(ctx, s, op)
 		}
 
 		if req.Target != nil {
@@ -523,8 +523,8 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return response.Conflict(fmt.Errorf("Name %q already in use", req.Name))
 	}
 
-	run := func(context.Context, *operations.Operation) error {
-		return inst.Rename(req.Name, true)
+	run := func(ctx context.Context, _ *operations.Operation) error {
+		return inst.Rename(ctx, req.Name, true)
 	}
 
 	originalEntityURL := api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)
@@ -690,7 +690,7 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 		}
 
 		statefulStart = true
-		err := inst.Stop(true)
+		err := inst.Stop(ctx, true)
 		if err != nil {
 			return err
 		}
@@ -705,7 +705,7 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 	}
 
 	// Copy instance to new target instance.
-	targetInst, err := instanceCreateAsCopy(s, instanceCreateAsCopyOpts{
+	targetInst, err := instanceCreateAsCopy(ctx, s, instanceCreateAsCopyOpts{
 		sourceInstance:           inst,
 		targetInstance:           targetArgs,
 		instanceOnly:             req.InstanceOnly,
@@ -729,21 +729,21 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 	}
 
 	// Delete original instance.
-	err = inst.Delete(true, "")
+	err = inst.Delete(ctx, true, "", op)
 	if err != nil {
 		return err
 	}
 
 	// Rename copy from temporary name to original name if needed.
 	if tempNameRequired {
-		err = targetInst.Rename(req.Name, false) // Don't apply templates when moving.
+		err = targetInst.Rename(ctx, req.Name, false) // Don't apply templates when moving.
 		if err != nil {
 			return err
 		}
 	}
 
 	if statefulStart {
-		err = targetInst.Start(true)
+		err = targetInst.Start(ctx, op, true)
 		if err != nil {
 			return err
 		}
@@ -826,7 +826,7 @@ func instancePostClusteringMigrate(s *state.State, srcPool storagePools.Pool, sr
 		// running we must forcefully stop the instance on the source before starting the migration copy
 		// so that it is as consistent as possible.
 		if !stateful && srcInstRunning {
-			err := srcInst.Stop(false)
+			err := srcInst.Stop(ctx, false)
 			if err != nil {
 				return fmt.Errorf("Failed statelessly stopping instance %q: %w", srcInstName, err)
 			}
@@ -834,7 +834,7 @@ func instancePostClusteringMigrate(s *state.State, srcPool storagePools.Pool, sr
 
 		// Rename instance if requested.
 		if newInstName != srcInstName {
-			err = srcInst.Rename(newInstName, true)
+			err = srcInst.Rename(ctx, newInstName, true)
 			if err != nil {
 				return fmt.Errorf("Failed renaming instance %q to %q: %w", srcInstName, newInstName, err)
 			}
@@ -895,7 +895,7 @@ func instancePostClusteringMigrate(s *state.State, srcPool storagePools.Pool, sr
 				}
 			}()
 
-			return srcMigration.Do(s, op)
+			return srcMigration.Do(ctx, s, op)
 		}
 
 		instanceURL := api.NewURL().Path(version.APIVersion, "instances", srcInstName).Project(srcInst.Project().Name)
@@ -1083,7 +1083,7 @@ func instancePostClusteringMigrateWithRemoteStorage(s *state.State, srcPool stor
 		}
 
 		if srcInstName != finalName {
-			err = srcInst.Rename(finalName, true)
+			err = srcInst.Rename(ctx, finalName, true)
 			if err != nil {
 				return fmt.Errorf("Failed renaming instance %q to %q: %w", srcInstName, finalName, err)
 			}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -164,7 +164,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Update container configuration
-		do = func(_ context.Context, _ *operations.Operation) error {
+		do = func(ctx context.Context, _ *operations.Operation) error {
 			defer unlock()
 
 			args := db.InstanceArgs{
@@ -177,7 +177,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 				Project:      projectName,
 			}
 
-			err = inst.Update(args, instance.UpdateActionUser)
+			err = inst.Update(ctx, args, instance.UpdateActionUser)
 			if err != nil {
 				return err
 			}
@@ -188,10 +188,10 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		opType = operationtype.InstanceUpdate
 	} else {
 		// Snapshot Restore
-		do = func(_ context.Context, _ *operations.Operation) error {
+		do = func(ctx context.Context, op *operations.Operation) error {
 			defer unlock()
 
-			return instanceSnapRestore(s, projectName, name, configRaw)
+			return instanceSnapRestore(ctx, s, projectName, name, configRaw, op)
 		}
 
 		opType = operationtype.SnapshotRestore
@@ -214,7 +214,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 	return operations.OperationResponse(op)
 }
 
-func instanceSnapRestore(s *state.State, projectName string, name string, req api.InstancePut) error {
+func instanceSnapRestore(ctx context.Context, s *state.State, projectName string, name string, req api.InstancePut, op *operations.Operation) error {
 	// normalize snapshot name
 	snap := req.Restore
 	if !shared.IsSnapshot(snap) {
@@ -263,7 +263,7 @@ func instanceSnapRestore(s *state.State, projectName string, name string, req ap
 	// Generate a new `volatile.uuid.generation` to differentiate this instance restored from a snapshot from the original instance.
 	source.LocalConfig()["volatile.uuid.generation"] = uuid.New().String()
 
-	err = inst.Restore(source, req.Stateful, req.RestoreDiskVolumesMode)
+	err = inst.Restore(ctx, source, req.Stateful, req.RestoreDiskVolumesMode, op)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -140,7 +140,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 
 	run := func(ctx context.Context, op *operations.Operation) error {
 		if req.Source.Type == api.SourceTypeNone {
-			return instanceRebuildFromEmpty(inst, op)
+			return instanceRebuildFromEmpty(ctx, inst, op)
 		}
 
 		if req.Source.Server != "" {

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -345,8 +345,7 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	snapshot := func(ctx context.Context, op *operations.Operation) error {
-		inst.SetOperation(op)
-		return inst.Snapshot(req.Name, req.ExpiresAt, req.Stateful, req.DiskVolumesMode)
+		return inst.Snapshot(ctx, req.Name, req.ExpiresAt, req.Stateful, req.DiskVolumesMode, op)
 	}
 
 	instanceURL := api.NewURL().Path(version.APIVersion, "instances", name).Project(projectName)
@@ -524,7 +523,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 		}
 
 		// Update instance configuration
-		do = func(_ context.Context, _ *operations.Operation) error {
+		do = func(ctx context.Context, _ *operations.Operation) error {
 			args := db.InstanceArgs{
 				Architecture: snapInst.Architecture(),
 				Config:       snapInst.LocalConfig(),
@@ -538,7 +537,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 				Snapshot:     snapInst.IsSnapshot(),
 			}
 
-			err = snapInst.Update(args, instance.UpdateActionInternal)
+			err = snapInst.Update(ctx, args, instance.UpdateActionInternal)
 			if err != nil {
 				return err
 			}
@@ -708,7 +707,7 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 		}
 
 		run := func(ctx context.Context, op *operations.Operation) error {
-			return ws.Do(s, op)
+			return ws.Do(ctx, s, op)
 		}
 
 		if req.Target != nil {
@@ -774,8 +773,8 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 		return response.Conflict(err)
 	}
 
-	rename := func(_ context.Context, _ *operations.Operation) error {
-		return snapInst.Rename(fullName, false)
+	rename := func(ctx context.Context, _ *operations.Operation) error {
+		return snapInst.Rename(ctx, fullName, false)
 	}
 
 	originalEntityURL := api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(snapInst.Project().Name)
@@ -838,8 +837,8 @@ func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance)
 		diskVolumesMode = api.DiskVolumesModeRoot
 	}
 
-	remove := func(_ context.Context, _ *operations.Operation) error {
-		return snapInst.Delete(false, diskVolumesMode)
+	remove := func(ctx context.Context, op *operations.Operation) error {
+		return snapInst.Delete(ctx, false, diskVolumesMode, op)
 	}
 
 	parentName, snapName, _ := api.GetParentAndSnapshotName(snapInst.Name())

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -199,9 +199,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	do := func(ctx context.Context, op *operations.Operation) error {
-		inst.SetOperation(op)
-
-		return doInstanceStatePut(inst, req)
+		return doInstanceStatePut(ctx, inst, req, op)
 	}
 
 	requestor, err := request.GetRequestor(r.Context())
@@ -290,7 +288,7 @@ func instanceActionToOptype(action string) (operationtype.Type, error) {
 	return operationtype.Unknown, fmt.Errorf("Unknown action: %q", action)
 }
 
-func doInstanceStatePut(inst instance.Instance, req api.InstanceStatePut) error {
+func doInstanceStatePut(ctx context.Context, inst instance.Instance, req api.InstanceStatePut, op *operations.Operation) error {
 	if req.Force {
 		// A zero timeout indicates to do a forced stop/restart.
 		req.Timeout = 0
@@ -305,30 +303,30 @@ func doInstanceStatePut(inst instance.Instance, req api.InstanceStatePut) error 
 	switch instancetype.InstanceAction(req.Action) {
 	case instancetype.Start:
 		if inst.IsFrozen() {
-			return inst.Unfreeze()
+			return inst.Unfreeze(ctx)
 		}
 
-		return inst.Start(req.Stateful)
+		return inst.Start(ctx, op, req.Stateful)
 	case instancetype.Stop:
 		if req.Stateful {
-			return inst.Stop(req.Stateful)
+			return inst.Stop(ctx, req.Stateful)
 		}
 
 		if req.Timeout == 0 {
-			return inst.Stop(false)
+			return inst.Stop(ctx, false)
 		}
 
 		if inst.IsFrozen() {
 			return errors.New("Cannot shutdown frozen instance (try force to stop)")
 		}
 
-		return inst.Shutdown(timeout)
+		return inst.Shutdown(ctx, timeout)
 	case instancetype.Restart:
-		return inst.Restart(timeout)
+		return inst.Restart(ctx, timeout, op)
 	case instancetype.Freeze:
-		return inst.Freeze()
+		return inst.Freeze(ctx)
 	case instancetype.Unfreeze:
-		return inst.Unfreeze()
+		return inst.Unfreeze(ctx)
 	}
 
 	return fmt.Errorf("Unknown action: %q", req.Action)

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -31,10 +31,10 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	profiles := c.Profiles()
 	suite.Len(
@@ -93,10 +93,10 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	profiles := c.Profiles()
 	suite.Len(
@@ -129,7 +129,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	})
 	suite.Req.NoError(err)
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -139,7 +139,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 
 	state, ok := out.(*api.Instance)
 	suite.Req.True(ok)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	suite.Equal(
 		"unknownbr0",
@@ -170,10 +170,10 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.NoError(err)
 
 	// Create the container
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	poolName, err := c.StoragePool()
 	suite.Req.NoError(err)
@@ -217,10 +217,10 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	suite.Req.False(c.IsSnapshot(), "Should not be a snapshot.")
 	suite.Req.Equal(shared.VarPath("containers", "testFoo"), c.Path())
@@ -234,10 +234,10 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
 	suite.Req.Equal(shared.VarPath("logs", "testFoo"), c.LogPath())
 }
@@ -250,11 +250,11 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
-	suite.Req.NoError(c.Delete(true, ""), "Failed deleting the container.")
+	suite.Req.NoError(c.Delete(suite.T().Context(), true, "", nil), "Failed deleting the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
@@ -284,10 +284,10 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	err = c.Update(db.InstanceArgs{
+	err = c.Update(suite.T().Context(), db.InstanceArgs{
 		Type:     instancetype.Container,
 		Profiles: testProfiles,
 		Config:   c.LocalConfig(),
@@ -301,7 +301,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 
 	eth0["ipv6.gateway"] = "auto"
 	eth1["ipv6.gateway"] = ""
-	err = c.Update(db.InstanceArgs{
+	err = c.Update(suite.T().Context(), db.InstanceArgs{
 		Type:     instancetype.Container,
 		Profiles: testProfiles,
 		Config:   c.LocalConfig(),
@@ -314,7 +314,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 	suite.Req.Error(err,
 		"Adding multiple routed nic devices with any gateway mode ['auto',''] should throw error.")
 
-	err = c.Update(db.InstanceArgs{
+	err = c.Update(suite.T().Context(), db.InstanceArgs{
 		Type:     instancetype.Container,
 		Profiles: testProfiles,
 		Config:   c.LocalConfig(),
@@ -336,11 +336,11 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
-	suite.Req.NoError(c.Delete(true, ""), "Failed deleting the container.")
+	suite.Req.NoError(c.Delete(suite.T().Context(), true, "", nil), "Failed deleting the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_Rename() {
@@ -350,17 +350,17 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(suite.T().Context(), true, "", nil) }()
 
-	suite.Req.NoError(c.Rename("testFoo2", true), "Failed renaming the container.")
+	suite.Req.NoError(c.Rename(suite.T().Context(), "testFoo2", true), "Failed renaming the container.")
 	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.Path())
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
-	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
@@ -369,9 +369,9 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(suite.T().Context(), true, "", nil) }()
 
-	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c2, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-2",
 		Config: map[string]string{
@@ -380,7 +380,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c2.Delete(true, "") }()
+	defer func() { _ = c2.Delete(suite.T().Context(), true, "", nil) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -403,7 +403,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
-	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
@@ -412,9 +412,9 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(suite.T().Context(), true, "", nil) }()
 
-	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c2, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-2",
 		Config: map[string]string{
@@ -423,7 +423,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c2.Delete(true, "") }()
+	defer func() { _ = c2.Delete(suite.T().Context(), true, "", nil) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -446,7 +446,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
-	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
@@ -456,7 +456,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(suite.T().Context(), true, "", nil) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -487,7 +487,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 
 	instances := make([]instance.Instance, 0, 7)
 	for i := range 7 {
-		c, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+		c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), db.InstanceArgs{
 			Type: instancetype.Container,
 			Name: fmt.Sprintf("isol-%d", i),
 			Config: map[string]string{
@@ -525,7 +525,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 	}
 
 	for _, c := range instances {
-		err := c.Delete(true, "")
+		err := c.Delete(suite.T().Context(), true, "", nil)
 		suite.Req.Error(err)
 	}
 }

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -217,7 +217,7 @@ func instanceShouldAutoStart(inst instance.Instance) bool {
 	return shared.IsFalseOrEmpty(protectStart) && (shared.IsTrue(autoStart) || (autoStart == "" && lastState == instance.PowerStateRunning))
 }
 
-func instancesStart(s *state.State, instances []instance.Instance) {
+func instancesStart(ctx context.Context, s *state.State, instances []instance.Instance) {
 	// Check if the cluster is currently evacuated.
 	if s.DB.Cluster.LocalNodeIsEvacuated() {
 		return
@@ -254,7 +254,9 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 		var attempt = 0
 		for {
 			attempt++
-			err := inst.Start(false)
+
+			// Don't track progress here as there is no client to return the updates to.
+			err := inst.Start(ctx, nil, false)
 			if err != nil {
 				if api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
 					break // Don't log or retry instances that are not ready to start yet.
@@ -524,10 +526,10 @@ func instancesShutdown(ctx context.Context, instances []instance.Instance) {
 					timeoutSeconds, _ = strconv.Atoi(value)
 				}
 
-				err := inst.Shutdown(time.Second * time.Duration(timeoutSeconds))
+				err := inst.Shutdown(ctx, time.Second*time.Duration(timeoutSeconds))
 				if err != nil {
 					l.Warn("Failed shutting down instance, forcefully stopping", logger.Ctx{"err": err})
-					err = inst.Stop(false)
+					err = inst.Stop(ctx, false)
 					if err != nil {
 						l.Warn("Failed forcefully stopping instance", logger.Ctx{"err": err})
 					}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -137,12 +137,12 @@ func createFromImage(r *http.Request, s *state.State, p api.Project, profiles []
 		}
 
 		// Actually create the instance.
-		err = instanceCreateFromImage(s, img, args, op)
+		err = instanceCreateFromImage(ctx, s, img, args, op)
 		if err != nil {
 			return err
 		}
 
-		return instanceCreateFinish(s, req, args, nil)
+		return instanceCreateFinish(ctx, s, req, args, nil, op)
 	}
 
 	args := operations.OperationArgs{
@@ -196,14 +196,14 @@ func createFromNone(r *http.Request, s *state.State, projectName string, profile
 		args.Architecture = architecture
 	}
 
-	run := func(_ context.Context, _ *operations.Operation) error {
+	run := func(ctx context.Context, op *operations.Operation) error {
 		// Actually create the instance.
-		_, err := instanceCreateAsEmpty(s, args)
+		_, err := instanceCreateAsEmpty(ctx, s, args, op)
 		if err != nil {
 			return err
 		}
 
-		return instanceCreateFinish(s, req, args, nil)
+		return instanceCreateFinish(ctx, s, req, args, nil, op)
 	}
 
 	opArgs := operations.OperationArgs{
@@ -308,7 +308,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, instOp, cleanup, err = instance.CreateInternal(s, *args, true)
+		inst, instOp, cleanup, err = instance.CreateInternal(r.Context(), s, *args, true)
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed creating instance record: %w", err))
 		}
@@ -318,7 +318,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		// For refresh requests, validate and apply target config before migration transfer starts.
 		// Skip this during internal cluster move requests, where config update semantics differ.
 		if req.Source.Refresh && clusterMoveSourceName == "" {
-			err = inst.Update(*args, instance.UpdateActionUserRefresh)
+			err = inst.Update(r.Context(), *args, instance.UpdateActionUserRefresh)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed applying refresh target instance config: %w", err))
 			}
@@ -367,10 +367,8 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 	run := func(ctx context.Context, op *operations.Operation) error {
 		defer runRevert.Fail()
 
-		sink.instance.SetOperation(op)
-
 		// And finally run the migration.
-		err = sink.Do(s, instOp)
+		err = sink.Do(ctx, instOp, op)
 		if err != nil {
 			err = fmt.Errorf("Error transferring instance data: %w", err)
 			instOp.Done(err) // Complete operation that was created earlier, to release lock.
@@ -382,7 +380,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 
 		// Start up the instance if requested by the client.
 		if req != nil && req.Start {
-			err := inst.Start(false)
+			err := inst.Start(ctx, op, false)
 			if err != nil {
 				return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 			}
@@ -679,7 +677,7 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 		}
 
 		// Actually create the instance.
-		targetInst, err := instanceCreateAsCopy(s, instanceCreateAsCopyOpts{
+		targetInst, err := instanceCreateAsCopy(ctx, s, instanceCreateAsCopyOpts{
 			sourceInstance: source,
 			targetInstance: args,
 			// We keep the ContainerOnly for backward compatibility.
@@ -707,7 +705,7 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 			}
 		}
 
-		return instanceCreateFinish(s, req, args, targetClient)
+		return instanceCreateFinish(ctx, s, req, args, targetClient, op)
 	}
 
 	var opType operationtype.Type
@@ -979,7 +977,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		}
 
 		// Clean up created instance if the post hook fails below.
-		runRevert.Add(func() { _ = inst.Delete(true, "") })
+		runRevert.Add(func() { _ = inst.Delete(ctx, true, "", op) })
 
 		// Run the storage post hook to perform any final actions now that the instance has been created
 		// in the database (this normally includes unmounting volumes that were mounted).
@@ -993,7 +991,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 
 		runRevert.Success()
 
-		return instanceCreateFinish(s, &req, db.InstanceArgs{Name: bInfo.Name, Project: bInfo.Project}, nil)
+		return instanceCreateFinish(ctx, s, &req, db.InstanceArgs{Name: bInfo.Name, Project: bInfo.Project}, nil, op)
 	}
 
 	args := operations.OperationArgs{
@@ -1812,7 +1810,7 @@ func clusterCopyContainerInternal(r *http.Request, s *state.State, source instan
 
 // instanceCreateFinish finalizes the creation process of an instance by starting it based on
 // the Start field of the request.
-func instanceCreateFinish(s *state.State, req *api.InstancesPost, args db.InstanceArgs, client lxd.InstanceServer) error {
+func instanceCreateFinish(ctx context.Context, s *state.State, req *api.InstancesPost, args db.InstanceArgs, client lxd.InstanceServer, op *operations.Operation) error {
 	if req == nil || !req.Start {
 		return nil
 	}
@@ -1835,5 +1833,5 @@ func instanceCreateFinish(s *state.State, req *api.InstancesPost, args db.Instan
 		return fmt.Errorf("Failed loading the instance: %w", err)
 	}
 
-	return inst.Start(false)
+	return inst.Start(ctx, op, false)
 }

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -462,7 +462,7 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 	}
 
 	// Create the instance DB record for main instance.
-	inst, instOp, cleanup, err := instance.CreateInternal(s, *args, true)
+	inst, instOp, cleanup, err := instance.CreateInternal(r.Context(), s, *args, true)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed creating instance record: %w", err))
 	}
@@ -493,10 +493,8 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 	run := func(ctx context.Context, op *operations.Operation) error {
 		defer runRevert.Fail()
 
-		sink.instance.SetOperation(op)
-
 		// And finally run the migration.
-		err = sink.Do(s, instOp)
+		err = sink.Do(s, instOp, op)
 		if err != nil {
 			err = fmt.Errorf("Error transferring instance data: %w", err)
 			instOp.Done(err) // Complete operation that was created earlier, to release lock.

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -143,7 +143,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 			// However, the operation is not available on other members handling instance updates. So, we don't set
 			// the operation on instance here to keep the same behavior on all members.
 
-			return doInstanceStatePut(inst, *req.State)
+			return doInstanceStatePut(ctx, inst, *req.State, op)
 		}
 
 		// Record the results.

--- a/lxd/lifecycle/instance.go
+++ b/lxd/lifecycle/instance.go
@@ -1,7 +1,9 @@
 package lifecycle
 
 import (
-	"github.com/canonical/lxd/lxd/operations"
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -10,7 +12,6 @@ import (
 type instance interface {
 	Name() string
 	Project() api.Project
-	Operation() *operations.Operation
 }
 
 // InstanceAction represents a lifecycle event action for instances.
@@ -41,19 +42,14 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance.
-func (a InstanceAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
+func (a InstanceAction) Event(ctx context.Context, inst instance, eventCtx map[string]any) api.EventLifecycle {
 	url := api.NewURL().Path(version.APIVersion, "instances", inst.Name()).Project(inst.Project().Name)
-
-	var requestor *api.EventLifecycleRequestor
-	if inst.Operation() != nil {
-		requestor = inst.Operation().EventLifecycleRequestor()
-	}
 
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    url.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 		Name:      inst.Name(),
 		Project:   inst.Project().Name,
 	}

--- a/lxd/lifecycle/instance_backup.go
+++ b/lxd/lifecycle/instance_backup.go
@@ -1,6 +1,9 @@
 package lifecycle
 
 import (
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -17,20 +20,15 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance backup.
-func (a InstanceBackupAction) Event(fullBackupName string, inst instance, ctx map[string]any) api.EventLifecycle {
+func (a InstanceBackupAction) Event(ctx context.Context, fullBackupName string, inst instance, eventCtx map[string]any) api.EventLifecycle {
 	_, backupName, _ := api.GetParentAndSnapshotName(fullBackupName)
 
 	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", backupName).Project(inst.Project().Name)
 
-	var requestor *api.EventLifecycleRequestor
-	if inst.Operation() != nil {
-		requestor = inst.Operation().EventLifecycleRequestor()
-	}
-
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    u.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 	}
 }

--- a/lxd/lifecycle/instance_snapshot.go
+++ b/lxd/lifecycle/instance_snapshot.go
@@ -1,6 +1,9 @@
 package lifecycle
 
 import (
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -17,20 +20,15 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance snapshot.
-func (a InstanceSnapshotAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
+func (a InstanceSnapshotAction) Event(ctx context.Context, inst instance, eventCtx map[string]any) api.EventLifecycle {
 	parentName, snapName, _ := api.GetParentAndSnapshotName(inst.Name())
 
 	u := api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(inst.Project().Name)
 
-	var requestor *api.EventLifecycleRequestor
-	if inst.Operation() != nil {
-		requestor = inst.Operation().EventLifecycleRequestor()
-	}
-
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    u.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 	}
 }

--- a/lxd/lifecycle/storage_volume.go
+++ b/lxd/lifecycle/storage_volume.go
@@ -1,7 +1,9 @@
 package lifecycle
 
 import (
-	"github.com/canonical/lxd/lxd/operations"
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -25,18 +27,13 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a storage volume.
-func (a StorageVolumeAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]any) api.EventLifecycle {
+func (a StorageVolumeAction) Event(ctx context.Context, v volume, volumeType string, projectName string, eventCtx map[string]any) api.EventLifecycle {
 	u := api.NewURL().Path(version.APIVersion, "storage-pools", v.Pool(), "volumes", volumeType, v.Name()).Project(projectName)
-
-	var requestor *api.EventLifecycleRequestor
-	if op != nil {
-		requestor = op.EventLifecycleRequestor()
-	}
 
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    u.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 	}
 }

--- a/lxd/lifecycle/storage_volume_snapshot.go
+++ b/lxd/lifecycle/storage_volume_snapshot.go
@@ -1,7 +1,9 @@
 package lifecycle
 
 import (
-	"github.com/canonical/lxd/lxd/operations"
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -18,20 +20,15 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a storage volume snapshot.
-func (a StorageVolumeSnapshotAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]any) api.EventLifecycle {
+func (a StorageVolumeSnapshotAction) Event(ctx context.Context, v volume, volumeType string, projectName string, eventCtx map[string]any) api.EventLifecycle {
 	parentName, snapshotName, _ := api.GetParentAndSnapshotName(v.Name())
 
 	u := api.NewURL().Path(version.APIVersion, "storage-pools", v.Pool(), "volumes", volumeType, parentName, "snapshots", snapshotName).Project(projectName)
 
-	var requestor *api.EventLifecycleRequestor
-	if op != nil {
-		requestor = op.EventLifecycleRequestor()
-	}
-
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    u.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 	}
 }

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -81,15 +81,15 @@ func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool
 // Do performs the migration operation on the source side for the given state and
 // operation. It sets up the necessary websocket connections for control, state,
 // and filesystem, and then initiates the migration process.
-func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operation) error {
+func (s *migrationSourceWs) Do(ctx context.Context, state *state.State, migrateOp *operations.Operation) error {
 	l := logger.AddContext(logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name(), "live": s.live, "clusterMoveSourceName": s.clusterMoveSourceName, "push": s.pushOperationURL != ""})
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	connectCtx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
 	l.Info("Waiting for migration control connection on source")
 
-	_, err := s.conns[api.SecretNameControl].WebSocket(ctx)
+	_, err := s.conns[api.SecretNameControl].WebSocket(connectCtx)
 	if err != nil {
 		return fmt.Errorf("Failed waiting for migration control connection on source: %w", err)
 	}
@@ -127,8 +127,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 		return wsConn, nil
 	}
 
-	s.instance.SetOperation(migrateOp)
-	err = s.instance.MigrateSend(instance.MigrateSendArgs{
+	err = s.instance.MigrateSend(ctx, instance.MigrateSendArgs{
 		MigrateArgs: instance.MigrateArgs{
 			ControlSend:    s.send,
 			ControlReceive: s.recv,
@@ -146,7 +145,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 			ClusterMoveSourceName: s.clusterMoveSourceName,
 		},
 		AllowInconsistent: s.allowInconsistent,
-	})
+	}, migrateOp)
 	if err != nil {
 		l.Error("Failed migration on source", logger.Ctx{"err": err})
 		return fmt.Errorf("Failed migration on source: %w", err)
@@ -206,15 +205,15 @@ func newMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 // Do performs the migration operation on the target side (sink) for the given
 // state and instance operation. It sets up the necessary websocket connections
 // for control, state, and filesystem, and then receives the migration data.
-func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOperation) error {
+func (c *migrationSink) Do(ctx context.Context, instOpLock *operationlock.InstanceOperation, migrateOp *operations.Operation) error {
 	l := logger.AddContext(logger.Ctx{"project": c.instance.Project().Name, "instance": c.instance.Name(), "live": c.live, "clusterMoveSourceName": c.clusterMoveSourceName, "push": c.push})
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	connectCtx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
 	l.Info("Waiting for migration control connection on target")
 
-	_, err := c.conns[api.SecretNameControl].WebSocket(ctx)
+	_, err := c.conns[api.SecretNameControl].WebSocket(connectCtx)
 	if err != nil {
 		return fmt.Errorf("Failed waiting for migration control connection on target: %w", err)
 	}
@@ -255,7 +254,7 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 		return wsConn, nil
 	}
 
-	err = c.instance.MigrateReceive(instance.MigrateReceiveArgs{
+	err = c.instance.MigrateReceive(ctx, instance.MigrateReceiveArgs{
 		MigrateArgs: instance.MigrateArgs{
 			ControlSend:    c.send,
 			ControlReceive: c.recv,
@@ -272,9 +271,9 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 			},
 			ClusterMoveSourceName: c.clusterMoveSourceName,
 		},
-		InstanceOperation: instOp,
+		InstanceOperation: instOpLock,
 		Refresh:           c.refresh,
-	})
+	}, migrateOp)
 	if err != nil {
 		l.Error("Failed migration on target", logger.Ctx{"err": err})
 		return fmt.Errorf("Failed migration on target: %w", err)

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -251,10 +251,10 @@ func newStorageMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 
 // DoStorage handles the storage volume migration on the target side. It waits for
 // migration connections, negotiates migration types, and initiates the volume reception.
-func (c *migrationSink) DoStorage(state *state.State, projectName string, poolName string, req *api.StorageVolumesPost, op *operations.Operation) error {
+func (c *migrationSink) DoStorage(ctx context.Context, state *state.State, projectName string, poolName string, req *api.StorageVolumesPost, op *operations.Operation) error {
 	l := logger.AddContext(logger.Ctx{"project": projectName, "pool": poolName, "volume": req.Name, "push": c.push})
 
-	ctx, cancel := context.WithTimeout(state.ShutdownCtx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
 	l.Info("Waiting for migration connections on target")
@@ -346,7 +346,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			}
 		}
 
-		return pool.CreateCustomVolumeFromMigration(projectName, conn, volTargetArgs, op)
+		return pool.CreateCustomVolumeFromMigration(ctx, projectName, conn, volTargetArgs, op)
 	}
 
 	if c.refresh {
@@ -388,7 +388,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := pool.DeleteCustomVolumeSnapshot(projectName, targetSnapshots[deleteTargetSnapshotIndex].Name, op)
+			err := pool.DeleteCustomVolumeSnapshot(ctx, projectName, targetSnapshots[deleteTargetSnapshotIndex].Name, op)
 			if err != nil {
 				c.sendControl(err)
 				return err

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -2038,7 +2038,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 						if err != nil {
 							logger.Warn("Failed loading instances to start", logger.Ctx{"err": err})
 						} else {
-							instancesStart(s, instances)
+							instancesStart(s.ShutdownCtx, s, instances)
 						}
 					}
 

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -234,7 +234,7 @@ func doProfileUpdateInstance(ctx context.Context, s *state.State, args db.Instan
 	}
 
 	// Update will internally load the new profile configs and detect the changes to apply.
-	return inst.Update(db.InstanceArgs{
+	return inst.Update(ctx, db.InstanceArgs{
 		Architecture: inst.Architecture(),
 		Config:       inst.LocalConfig(),
 		Description:  inst.Description(),

--- a/lxd/request/request.go
+++ b/lxd/request/request.go
@@ -9,7 +9,7 @@ import (
 
 // CreateRequestor extracts the lifecycle event requestor data from the provided context.
 func CreateRequestor(ctx context.Context) *api.EventLifecycleRequestor {
-	requestor, err := GetRequestor(ctx)
+	requestor, err := GetRequestorAuditor(ctx)
 	if err != nil {
 		return &api.EventLifecycleRequestor{}
 	}

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -17,7 +17,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.T().Context(), suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	suite.True(snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -152,7 +152,7 @@ func storageStartup(s *state.State) error {
 						if err != nil {
 							logger.Error("Failed loading instances to start", logger.Ctx{"err": err})
 						} else {
-							instancesStart(s, instances)
+							instancesStart(s.ShutdownCtx, s, instances)
 						}
 					}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -39,7 +39,6 @@ import (
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/project/limits"
 	"github.com/canonical/lxd/lxd/request"
@@ -230,7 +229,7 @@ func (b *lxdBackend) MigrationTypes(contentType drivers.ContentType, refresh boo
 
 // Create creates the storage pool layout on the storage device.
 // localOnly is used for clustering where only a single node should do remote storage setup.
-func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operation) error {
+func (b *lxdBackend) Create(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"config": b.db.Config, "description": b.db.Description, "clientType": clientType})
 	l.Debug("Create started")
 	defer l.Debug("Create finished")
@@ -329,7 +328,7 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 			return err
 		}
 
-		revert.Add(func() { _ = b.driver.Delete(op) })
+		revert.Add(func() { _ = b.driver.Delete(progressReporter) })
 
 		// Mount the storage pool.
 		ourMount, err := b.driver.Mount()
@@ -390,7 +389,7 @@ func (b *lxdBackend) IsUsed() (bool, error) {
 }
 
 // Update updates the pool config.
-func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newConfig map[string]string, _ *operations.Operation) error {
+func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newConfig map[string]string, _ ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("Update started")
 	defer l.Debug("Update finished")
@@ -456,7 +455,7 @@ func (b *lxdBackend) warningsDelete() error {
 }
 
 // Delete removes the pool.
-func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operation) error {
+func (b *lxdBackend) Delete(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"clientType": clientType})
 	l.Debug("Delete started")
 	defer l.Debug("Delete finished")
@@ -498,7 +497,7 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 		vols, _ := b.driver.ListVolumes()
 		for _, vol := range vols {
 			if vol.Type() == drivers.VolumeTypeImage {
-				err := b.driver.DeleteVolume(vol, op)
+				err := b.driver.DeleteVolume(vol, progressReporter)
 				if err != nil {
 					return fmt.Errorf("Failed deleting left over image volume %q (%s): %w", vol.Name(), vol.ContentType(), err)
 				}
@@ -508,7 +507,7 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 		}
 
 		// Delete the low-level storage.
-		err := b.driver.Delete(op)
+		err := b.driver.Delete(progressReporter)
 		if err != nil {
 			return err
 		}
@@ -749,7 +748,7 @@ func (b *lxdBackend) applyInstanceRootDiskInitialValues(inst instance.Instance, 
 }
 
 // CreateInstance creates an empty instance.
-func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstance started")
 	defer l.Debug("CreateInstance finished")
@@ -791,12 +790,12 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 		return err
 	}
 
-	err = b.driver.CreateVolume(vol, nil, op)
+	err = b.driver.CreateVolume(vol, nil, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(inst, progressReporter) })
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
@@ -817,7 +816,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 // it is necessary to return two functions; a post hook that can be run once the instance has been
 // created in the database to run any storage layer finalisations, and a revert hook that can be
 // run if the instance database load process fails that will remove anything created thus far.
-func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
+func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (func(instance.Instance) error, revert.Hook, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": srcBackup.Project, "instance": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	l.Debug("CreateInstanceFromBackup started")
 	defer l.Debug("CreateInstanceFromBackup finished")
@@ -913,7 +912,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(volCopy, srcBackup, srcData, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(volCopy, srcBackup, srcData, progressReporter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1026,14 +1025,14 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 			return err
 		}
 
-		volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, op)
+		volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed generating instance custom volume config: %w", err)
 		}
 
 		// Save any changes that have occurred to the instance's config to the on-disk backup.yaml file.
 		// Use the global metadata version.
-		err = b.UpdateInstanceBackupFile(inst, false, volBackupConf, backupConfig.DefaultMetadataVersion, op)
+		err = b.UpdateInstanceBackupFile(inst, false, volBackupConf, backupConfig.DefaultMetadataVersion, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed updating backup file: %w", err)
 		}
@@ -1070,7 +1069,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				allowUnsafeResize = true
 			}
 
-			err = b.driver.SetVolumeQuota(vol, size, allowUnsafeResize, op)
+			err = b.driver.SetVolumeQuota(vol, size, allowUnsafeResize, progressReporter)
 			if err != nil {
 				// The restored volume can end up being larger than the root disk config's size
 				// property due to the block boundary rounding some storage drivers use. As such
@@ -1100,7 +1099,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				l.Debug("Applying filesystem volume quota from root disk config", logger.Ctx{"size.state": vmStateSize})
 
 				fsVol := vol.NewVMBlockFilesystemVolume()
-				err := b.driver.SetVolumeQuota(fsVol, vmStateSize, allowUnsafeResize, op)
+				err := b.driver.SetVolumeQuota(fsVol, vmStateSize, allowUnsafeResize, progressReporter)
 				if err != nil {
 					if !errors.Is(err, drivers.ErrCannotBeShrunk) {
 						return fmt.Errorf("Failed applying filesystem volume quota to root disk: %w", err)
@@ -1120,7 +1119,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 }
 
 // CreateInstanceFromCopy copies an instance volume and optionally its snapshots to new volume(s).
-func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "snapshots": snapshots})
 	l.Debug("CreateInstanceFromCopy started")
 	defer l.Debug("CreateInstanceFromCopy finished")
@@ -1152,13 +1151,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return errors.New("Source pool is not a lxdBackend")
 	}
 
-	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, op)
+	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume copy config: %w", err)
 	}
 
 	// Check source volume exists, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, op)
+	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance copy config: %w", err)
 	}
@@ -1218,12 +1217,12 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 	// Some driver backing stores require that running instances be frozen during copy.
 	if !src.IsSnapshot() && srcPoolBackend.driver.Info().RunningCopyFreeze && src.IsRunning() && !src.IsFrozen() && !allowInconsistent {
 		b.logger.Info("Freezing instance for consistent copy")
-		err = src.Freeze()
+		err = src.Freeze(ctx)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _ = src.Unfreeze() }()
+		defer func() { _ = src.Unfreeze(ctx) }()
 
 		// Attempt to sync the filesystem.
 		err = filesystem.SyncFS(src.Path())
@@ -1232,7 +1231,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		}
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(inst, progressReporter) })
 
 	if b.Name() == srcPool.Name() {
 		l.Debug("CreateInstanceFromCopy same-pool mode detected")
@@ -1292,7 +1291,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.CreateVolumeFromCopy(volCopy, srcVolCopy, allowInconsistent, op)
+		err = b.driver.CreateVolumeFromCopy(volCopy, srcVolCopy, allowInconsistent, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1313,13 +1312,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// For VMs, get source volume size so that target can create the volume the same size.
 		if src.Type() == instancetype.VM {
-			srcVolumeSize, err = InstanceDiskBlockSize(srcPool, src, op)
+			srcVolumeSize, err = InstanceDiskBlockSize(srcPool, src, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Failed getting source disk size: %w", err)
 			}
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// Run sender and receiver in separate go routines to prevent deadlocks.
@@ -1331,7 +1330,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// Start each side of the migration concurrently and collect any errors.
 		g.Go(func() error {
-			return srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
+			return srcPool.MigrateInstance(ctx, src, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               src.Name(),
 				Snapshots:          snapshotNames,
@@ -1340,11 +1339,11 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 				AllowInconsistent:  allowInconsistent,
 				VolumeOnly:         !snapshots,
 				Info:               &migration.Info{Config: srcConfig},
-			}, op)
+			}, progressReporter)
 		})
 
 		g.Go(func() error {
-			return b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
+			return b.CreateInstanceFromMigration(ctx, inst, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               inst.Name(),
 				Snapshots:          snapshotNames,
@@ -1352,7 +1351,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 				VolumeSize:         srcVolumeSize, // Block size setting override.
 				TrackProgress:      false,         // Do not use a progress tracker on receiver.
 				VolumeOnly:         !snapshots,
-			}, op)
+			}, progressReporter)
 		})
 
 		err = g.Wait()
@@ -1381,7 +1380,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 // RefreshCustomVolume refreshes custom volumes (and optionally snapshots) during the custom volume copy operations.
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronization.
-func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) RefreshCustomVolume(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "srcProjectName": srcProjectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "snapshots": snapshots})
 	l.Debug("RefreshCustomVolume started")
 	defer l.Debug("RefreshCustomVolume finished")
@@ -1408,7 +1407,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	}
 
 	// Check source volume exists and is custom type, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, op)
+	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating refresh config of volume %q in pool %q and project %q: %w", srcVolName, srcPoolName, srcProjectName, err)
 	}
@@ -1493,7 +1492,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 
 		// Delete extra snapshots first.
 		for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {
-			err = b.DeleteCustomVolumeSnapshot(projectName, targetSnaps[deleteTargetSnapIndex].Name, op)
+			err = b.DeleteCustomVolumeSnapshot(ctx, projectName, targetSnaps[deleteTargetSnapIndex].Name, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1561,7 +1560,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.RefreshVolume(volCopy, srcVolCopy, srcSnapVols, false, op)
+		err = b.driver.RefreshVolume(volCopy, srcVolCopy, srcSnapVols, false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1579,7 +1578,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		var volSize int64
 
 		if contentType == drivers.ContentTypeBlock {
-			err = srcVol.MountTask(func(_ string, _ *operations.Operation) error {
+			err = srcVol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				srcPoolBackend, ok := srcPool.(*lxdBackend)
 				if !ok {
 					return errors.New("Pool is not a lxdBackend")
@@ -1602,7 +1601,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			}
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 
 		// Use in-memory pipe pair to simulate a connection between the sender and receiver.
 		aEnd, bEnd := memorypipe.NewPipePair(ctx)
@@ -1619,7 +1618,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 				TrackProgress:      true, // Do use a progress tracker on sender.
 				ContentType:        string(contentType),
 				Info:               &migration.Info{Config: srcConfig},
-			}, op)
+			}, progressReporter)
 
 			if err != nil {
 				cancel()
@@ -1629,7 +1628,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		}()
 
 		go func() {
-			err := b.CreateCustomVolumeFromMigration(projectName, bEnd, migration.VolumeTargetArgs{
+			err := b.CreateCustomVolumeFromMigration(ctx, projectName, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               dbVol.Name,
 				Description:        desc,
@@ -1640,7 +1639,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 				ContentType:        string(contentType),
 				VolumeSize:         volSize, // Block size setting override.
 				Refresh:            true,
-			}, op)
+			}, progressReporter)
 
 			if err != nil {
 				cancel()
@@ -1677,7 +1676,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronisation. An empty srcSnapshots argument
 // indicates a volume-only refresh.
-func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
+func (b *lxdBackend) RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "srcSnapshots": len(srcSnapshots)})
 	l.Debug("RefreshInstance started")
 	defer l.Debug("RefreshInstance finished")
@@ -1726,13 +1725,13 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		return errors.New("Source pool is not a lxdBackend")
 	}
 
-	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, op)
+	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume refresh config: %w", err)
 	}
 
 	// Check source volume exists, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, op)
+	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance refresh config: %w", err)
 	}
@@ -1791,12 +1790,12 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	// Some driver backing stores require that running instances be frozen during copy.
 	if !src.IsSnapshot() && srcPoolBackend.driver.Info().RunningCopyFreeze && src.IsRunning() && !src.IsFrozen() && !allowInconsistent {
 		b.logger.Info("Freezing instance for consistent refresh")
-		err = src.Freeze()
+		err = src.Freeze(ctx)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _ = src.Unfreeze() }()
+		defer func() { _ = src.Unfreeze(ctx) }()
 
 		// Attempt to sync the filesystem.
 		err = filesystem.SyncFS(src.Path())
@@ -1850,7 +1849,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.RefreshVolume(volCopy, srcVolCopy, snapshotNames, allowInconsistent, op)
+		err = b.driver.RefreshVolume(volCopy, srcVolCopy, snapshotNames, allowInconsistent, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1867,7 +1866,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 			return fmt.Errorf("Failed negotiating copy migration type: %w", err)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// Run sender and receiver in separate go routines to prevent deadlocks.
@@ -1879,7 +1878,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 
 		// Start each side of the migration concurrently and collect any errors.
 		g.Go(func() error {
-			return srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
+			return srcPool.MigrateInstance(ctx, src, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               src.Name(),
 				Snapshots:          snapshotNames,
@@ -1889,11 +1888,11 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 				Refresh:            true, // Indicate to sender to use incremental streams.
 				Info:               &migration.Info{Config: srcConfig},
 				VolumeOnly:         !snapshots,
-			}, op)
+			}, progressReporter)
 		})
 
 		g.Go(func() error {
-			return b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
+			return b.CreateInstanceFromMigration(ctx, inst, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               inst.Name(),
 				Snapshots:          snapshotNames,
@@ -1901,7 +1900,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 				Refresh:            true,  // Indicate to receiver volume should exist.
 				TrackProgress:      false, // Do not use a progress tracker on receiver.
 				VolumeOnly:         !snapshots,
-			}, op)
+			}, progressReporter)
 		})
 
 		err = g.Wait()
@@ -1919,7 +1918,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	newConfig := rootVol.Config
 	instanceVolumeConfigPolicy.Apply(newConfig, dbVol.Config)
 
-	err = b.UpdateInstance(inst, dbVol.Description, newConfig, op)
+	err = b.UpdateInstance(ctx, inst, dbVol.Description, newConfig, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed applying refresh source root volume config: %w", err)
 	}
@@ -1936,17 +1935,17 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 // imageFiller returns a function that can be used as a filler function with CreateVolume().
 // The function returned will unpack the specified image archive into the specified mount path
 // provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
-func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation, projectName string) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
+func (b *lxdBackend) imageFiller(fingerprint string, progressReporter ioprogress.ProgressReporter, projectName string) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
 	return func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
 		var progressHandler ioprogress.ProgressHandler
-		if op != nil {
+		if progressReporter != nil {
 			// No operation is passed when this function is called as part of pre-migration setup.
 			// If an operation is passed, pass a progress handler to ImageUnpack.
 			// A progress handler is passed rather than a progress tracker so that the tracker does not need to be
 			// modified by the general archive functions that ImageUnpack calls out to.
 			// Those general archive functions don't know what description to apply to the progress data, so instead
 			// wrap the progress handler here and prepend the description.
-			opHandler := op.ProgressHandler("create_instance_from_image_unpack")
+			opHandler := progressReporter.ProgressHandler("create_instance_from_image_unpack")
 			progressHandler = func(data ioprogress.ProgressData) {
 				data.Text = "Unpacking image: " + data.Text
 				opHandler(data)
@@ -1976,7 +1975,7 @@ func (b *lxdBackend) isoFiller(data io.Reader) func(vol drivers.Volume, rootBloc
 
 // imageConversionFiller returns a function that converts an image from the given path to the instance's volume.
 // Function returns the unpacked image size on success. Otherwise, it returns -1 for size and an error.
-func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (sizeInBytes int64, err error) {
+func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, progressReporter ioprogress.ProgressReporter) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (sizeInBytes int64, err error) {
 	return func(vol drivers.Volume, _ string, _ bool) (int64, error) {
 		diskPath, err := b.driver.GetVolumeDiskPath(vol)
 		if err != nil {
@@ -1991,9 +1990,9 @@ func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, op 
 
 		// Setup the progress tracker.
 		var tracker *ioprogress.ProgressTracker
-		if op != nil {
+		if progressReporter != nil {
 			description := "Converting image format from " + imgFormat + " to raw"
-			tracker = ioprogress.NewProgressTracker(ioprogress.WithDescriptiveProgressReporter("format", description, op))
+			tracker = ioprogress.NewProgressTracker(ioprogress.WithDescriptiveProgressReporter("format", description, progressReporter))
 		}
 
 		// Convert uploaded image from backups directory into RAW format on the instance volume.
@@ -2043,11 +2042,11 @@ func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, op 
 
 // recvVolumeFiller returns a function that receives the instance's volume.
 // Function returns the volume size on success. Otherwise, it returns -1 for size and an error.
-func (b *lxdBackend) recvVolumeFiller(conn io.ReadWriteCloser, contentType drivers.ContentType, args migration.VolumeTargetArgs, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (sizeInBytes int64, err error) {
+func (b *lxdBackend) recvVolumeFiller(conn io.ReadWriteCloser, contentType drivers.ContentType, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (sizeInBytes int64, err error) {
 	return func(vol drivers.Volume, rootBlockPath string, _ bool) (int64, error) {
 		if contentType == drivers.ContentTypeFS {
 			// Receive filesystem.
-			err := b.recvFS(vol.MountPath(), vol.Name(), conn, args, op)
+			err := b.recvFS(vol.MountPath(), vol.Name(), conn, args, progressReporter)
 			if err != nil {
 				return -1, err
 			}
@@ -2060,7 +2059,7 @@ func (b *lxdBackend) recvVolumeFiller(conn io.ReadWriteCloser, contentType drive
 
 			defer func() { _ = to.Close() }()
 
-			err = b.recvBlockVol(to, vol.Name(), conn, args, op)
+			err = b.recvBlockVol(to, vol.Name(), conn, args, progressReporter)
 			if err != nil {
 				return -1, err
 			}
@@ -2076,13 +2075,13 @@ func (b *lxdBackend) recvVolumeFiller(conn io.ReadWriteCloser, contentType drive
 	}
 }
 
-func (b *lxdBackend) recvBlockVol(toFile *os.File, volName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) recvBlockVol(toFile *os.File, volName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	b.logger.Debug("Receive block volume started", logger.Ctx{"volName": volName})
 	defer b.logger.Debug("Receive block volume finished", logger.Ctx{"volName": volName})
 
 	fromPipe := io.ReadCloser(conn)
 	if args.TrackProgress {
-		fromPipe = ioprogress.NewProgressReader(conn, ioprogress.WithDescriptiveProgressReporter("block", "Transferring instance", op))
+		fromPipe = ioprogress.NewProgressReader(conn, ioprogress.WithDescriptiveProgressReporter("block", "Transferring instance", progressReporter))
 	}
 
 	_, err := io.Copy(toFile, fromPipe)
@@ -2105,13 +2104,13 @@ func (b *lxdBackend) recvBlockVol(toFile *os.File, volName string, conn io.ReadW
 	return toFile.Close()
 }
 
-func (b *lxdBackend) recvFS(path string, volName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) recvFS(path string, volName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	b.logger.Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path, "features": args.MigrationType.Features})
 	defer b.logger.Debug("Receiving filesystem volume stopped", logger.Ctx{"volName": volName, "path": path})
 
 	var wrapper ioprogress.ReaderWrapper
 	if args.TrackProgress {
-		wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", "Transferring instance", op))
+		wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", "Transferring instance", progressReporter))
 	}
 
 	return rsync.Recv(shared.AddSlash(path), conn, wrapper, args.MigrationType.Features)
@@ -2119,7 +2118,7 @@ func (b *lxdBackend) recvFS(path string, volName string, conn io.ReadWriteCloser
 
 // CreateInstanceFromImage creates a new volume for an instance populated with the image requested.
 // On failure caller is expected to call DeleteInstance() to clean up.
-func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstanceFromImage started")
 	defer l.Debug("CreateInstanceFromImage finished")
@@ -2176,7 +2175,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 	volFiller := drivers.VolumeFiller{
 		Fingerprint: fingerprint,
-		Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
+		Fill:        b.imageFiller(fingerprint, progressReporter, inst.Project().Name),
 	}
 
 	// If the driver supports optimized images and the instance's config is compatible
@@ -2189,7 +2188,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 	}
 
 	if canOptimizedImage {
-		err = b.EnsureImage(fingerprint, op, inst.Project().Name)
+		err = b.EnsureImage(ctx, fingerprint, inst.Project().Name, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2205,7 +2204,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 	// The driver decides whether to clone from the cached image volume or unpack
 	// directly, based on whether imgVol is set and config/size constraints.
-	err = b.driver.CreateVolumeFromImage(vol, imgVol, &volFiller, op)
+	err = b.driver.CreateVolumeFromImage(vol, imgVol, &volFiller, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -2226,7 +2225,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 // CreateInstanceFromMigration receives an instance being migrated.
 // The args.Name and args.Config fields are ignored and, instance properties are used instead.
-func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateInstanceFromMigration started")
 	defer l.Debug("CreateInstanceFromMigration finished")
@@ -2475,12 +2474,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 				// volume with the contents of the image.
 				preFiller = drivers.VolumeFiller{
 					Fingerprint: fingerprint,
-					Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
+					Fill:        b.imageFiller(fingerprint, progressReporter, inst.Project().Name),
 				}
 
 				// Ensure if the image doesn't yet exist on a driver which supports
 				// optimized storage, then it gets created first.
-				err = b.EnsureImage(preFiller.Fingerprint, op, inst.Project().Name)
+				err = b.EnsureImage(ctx, preFiller.Fingerprint, inst.Project().Name, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -2518,13 +2517,13 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 	volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 
-	err = b.driver.CreateVolumeFromMigration(volCopy, conn, args, &preFiller, op)
+	err = b.driver.CreateVolumeFromMigration(volCopy, conn, args, &preFiller, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	if !isRemoteClusterMove {
-		revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+		revert.Add(func() { _ = b.DeleteInstance(inst, progressReporter) })
 	}
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
@@ -2546,7 +2545,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 // CreateInstanceFromConversion receives a disk or filesystem and creates and instance from it.
 // Based on the provided conversion options, the received disk is converted into the raw format
 // and/or the virtio drivers are injected into it.
-func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateInstanceFromConversion started")
 	defer l.Debug("CreateInstanceFromConversion finished")
@@ -2662,7 +2661,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		}()
 
 		// Receive the image for conversion.
-		err = b.recvBlockVol(to, vol.Name(), conn, args, op)
+		err = b.recvBlockVol(to, vol.Name(), conn, args, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2682,7 +2681,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		}
 
 		// Convert received image into intance volume.
-		volFiller.Fill = b.imageConversionFiller(imgPath, imgFormat, op)
+		volFiller.Fill = b.imageConversionFiller(imgPath, imgFormat, progressReporter)
 	} else {
 		// If volume size is provided, then use that as block volume size instead of pool default.
 		// This way if the volume being received is larger than the pool default size, the created
@@ -2696,7 +2695,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 		// If formatting is not required, receive the volume (block / FS) directly
 		// into the instance volume.
-		volFiller.Fill = b.recvVolumeFiller(conn, contentType, args, op)
+		volFiller.Fill = b.recvVolumeFiller(conn, contentType, args, progressReporter)
 	}
 
 	// Parse volume size into bytes.
@@ -2719,12 +2718,12 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		return fmt.Errorf("Volume size (%s) is less than source disk size (%s)", volSize, imgSize)
 	}
 
-	err = b.driver.CreateVolume(vol, &volFiller, op)
+	err = b.driver.CreateVolume(vol, &volFiller, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(vol, progressReporter) })
 
 	// At this point, the instance's volume is populated. If "virtio" option is enabled,
 	// inject the virtio drivers.
@@ -2732,12 +2731,12 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		b.logger.Debug("Inject virtio drivers started")
 		defer b.logger.Debug("Inject virtio drivers finished")
 
-		err = b.driver.MountVolume(vol, op)
+		err = b.driver.MountVolume(vol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _, _ = b.driver.UnmountVolume(vol, true, op) }()
+		defer func() { _, _ = b.driver.UnmountVolume(vol, true, progressReporter) }()
 
 		diskPath, err := b.driver.GetVolumeDiskPath(vol)
 		if err != nil {
@@ -2773,7 +2772,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 }
 
 // RenameInstance renames the instance's root volume and any snapshot volumes.
-func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstance started")
 	defer l.Debug("RenameInstance finished")
@@ -2872,7 +2871,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 
 	vol := b.GetVolume(volType, contentType, volStorageName, volume.Config)
 
-	err = b.driver.RenameVolume(vol, newVolStorageName, op)
+	err = b.driver.RenameVolume(vol, newVolStorageName, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -2881,7 +2880,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 		// Renaming a volume doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newVol := b.GetVolume(volType, contentType, newVolStorageName, volume.Config)
-		_ = b.driver.RenameVolume(newVol, volStorageName, op)
+		_ = b.driver.RenameVolume(newVol, volStorageName, progressReporter)
 	})
 
 	// Remove old instance symlink and create new one.
@@ -2921,7 +2920,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 }
 
 // DeleteInstance removes the instance's root volume (all snapshots need to be removed first).
-func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstance started")
 	defer l.Debug("DeleteInstance finished")
@@ -2969,7 +2968,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(vol, op)
+		err = b.driver.DeleteVolume(vol, progressReporter)
 		if err != nil {
 			return fmt.Errorf("Error deleting storage volume: %w", err)
 		}
@@ -3022,7 +3021,7 @@ var unmappedVolumeIDMapPolicy = api.ConfigKeyPolicy{
 }
 
 // UpdateInstance updates an instance volume's config.
-func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstance started")
 	defer l.Debug("UpdateInstance finished")
@@ -3102,14 +3101,14 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 		}
 	}
 
-	b.state.Events.SendLifecycle(inst.Project().Name, lifecycle.StorageVolumeUpdated.Event(newVol, string(newVol.Type()), inst.Project().Name, op, nil))
+	b.state.Events.SendLifecycle(inst.Project().Name, lifecycle.StorageVolumeUpdated.Event(ctx, newVol, string(newVol.Type()), inst.Project().Name, nil))
 
 	return nil
 }
 
 // UpdateInstanceSnapshot updates an instance snapshot volume's description.
 // Volume config is not allowed to be updated and will return an error.
-func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstanceSnapshot started")
 	defer l.Debug("UpdateInstanceSnapshot finished")
@@ -3124,12 +3123,12 @@ func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc stri
 		return err
 	}
 
-	return b.updateVolumeDescriptionOnly(inst.Project().Name, inst.Name(), volType, newDesc, newConfig, op)
+	return b.updateVolumeDescriptionOnly(ctx, inst.Project().Name, inst.Name(), volType, newDesc, newConfig, progressReporter)
 }
 
 // MigrateInstance sends an instance volume for migration.
 // The args.Name field is ignored and the name of the instance is used instead.
-func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *lxdBackend) MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("MigrateInstance started")
 	defer l.Debug("MigrateInstance finished")
@@ -3224,12 +3223,12 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 	// possible to make a consistent copy with the instance running.
 	if !inst.IsSnapshot() && runningCopyFreeze && inst.IsRunning() && !inst.IsFrozen() && !args.AllowInconsistent {
 		b.logger.Info("Freezing instance for consistent migration transfer")
-		err = inst.Freeze()
+		err = inst.Freeze(ctx)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _ = inst.Unfreeze() }()
+		defer func() { _ = inst.Unfreeze(ctx) }()
 
 		// Attempt to sync the filesystem.
 		err = filesystem.SyncFS(inst.Path())
@@ -3250,7 +3249,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.MigrateVolume(volCopy, conn, args, op)
+	err = b.driver.MigrateVolume(volCopy, conn, args, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3259,7 +3258,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 }
 
 // CleanupInstancePaths removes any remaining mount paths and symlinks for the instance and its snapshots.
-func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.Operation) error {
+func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CleanupInstancePaths started")
 	defer l.Debug("CleanupInstancePaths finished")
@@ -3338,7 +3337,7 @@ func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.
 }
 
 // BackupInstance creates an instance backup.
-func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
+func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupInstance started")
 	defer l.Debug("BackupInstance finished")
@@ -3391,7 +3390,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.BackupVolume(volCopy, inst.Project().Name, tarWriter, optimized, snapNames, op)
+	err = b.driver.BackupVolume(volCopy, inst.Project().Name, tarWriter, optimized, snapNames, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3462,7 +3461,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 
 // SetInstanceQuota sets the quota on the instance's root volume.
 // Returns ErrInUse if the instance is running and the storage driver doesn't support online resizing.
-func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
+func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "size": size, "vm_state_size": vmStateSize})
 	l.Debug("SetInstanceQuota started")
 	defer l.Debug("SetInstanceQuota finished")
@@ -3484,7 +3483,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 
 	// Apply the main volume quota.
 	vol := b.GetVolume(volType, contentVolume, volStorageName, dbVol.Config)
-	err = b.driver.SetVolumeQuota(vol, size, false, op)
+	err = b.driver.SetVolumeQuota(vol, size, false, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3500,7 +3499,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 		}
 
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := b.driver.SetVolumeQuota(fsVol, vmStateSize, false, op)
+		err := b.driver.SetVolumeQuota(fsVol, vmStateSize, false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -3510,7 +3509,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 }
 
 // MountInstance mounts the instance's root volume.
-func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstance started")
 	defer l.Debug("MountInstance finished")
@@ -3553,12 +3552,12 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 		vol = b.GetVolume(volType, contentType, volStorageName, nil)
 	}
 
-	err = b.driver.MountVolume(vol, op)
+	err = b.driver.MountVolume(vol, progressReporter)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, op) })
+	revert.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, progressReporter) })
 
 	diskPath, err := b.getInstanceDisk(inst)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
@@ -3593,7 +3592,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 }
 
 // UnmountInstance unmounts the instance's root volume.
-func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UnmountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstance started")
 	defer l.Debug("UnmountInstance finished")
@@ -3627,7 +3626,7 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 		vol = b.GetVolume(volType, contentType, volStorageName, nil)
 	}
 
-	_, err = b.driver.UnmountVolume(vol, false, op)
+	_, err = b.driver.UnmountVolume(vol, false, progressReporter)
 
 	return err
 }
@@ -3666,7 +3665,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 }
 
 // CreateInstanceSnapshot creates a snaphot of an instance volume.
-func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("CreateInstanceSnapshot started")
 	defer l.Debug("CreateInstanceSnapshot finished")
@@ -3739,7 +3738,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		}
 	}
 
-	err = b.driver.CreateVolumeSnapshot(vol, op)
+	err = b.driver.CreateVolumeSnapshot(vol, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3754,7 +3753,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 }
 
 // RenameInstanceSnapshot renames an instance snapshot.
-func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstanceSnapshot started")
 	defer l.Debug("RenameInstanceSnapshot finished")
@@ -3803,7 +3802,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 
 	// Rename storage volume snapshot.
 	snapVol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
-	err = b.driver.RenameVolumeSnapshot(snapVol, newName, op)
+	err = b.driver.RenameVolumeSnapshot(snapVol, newName, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3815,7 +3814,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 		// Renaming a volume snapshot doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, newVolName), dbVol.Config)
-		_ = b.driver.RenameVolumeSnapshot(newSnapVol, oldSnapshotName, op)
+		_ = b.driver.RenameVolumeSnapshot(newSnapVol, oldSnapshotName, progressReporter)
 	})
 
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -3833,14 +3832,14 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 		})
 	})
 
-	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, op)
+	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume config: %w", err)
 	}
 
 	// Ensure the backup file reflects current config.
 	// Use the global metadata version.
-	err = b.UpdateInstanceBackupFile(inst, true, volBackupConf, backupConfig.DefaultMetadataVersion, op)
+	err = b.UpdateInstanceBackupFile(inst, true, volBackupConf, backupConfig.DefaultMetadataVersion, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3850,7 +3849,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 }
 
 // DeleteInstanceSnapshot removes the snapshot volume for the supplied snapshot instance.
-func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstanceSnapshot started")
 	defer l.Debug("DeleteInstanceSnapshot finished")
@@ -3901,7 +3900,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolumeSnapshot(vol, op)
+		err = b.driver.DeleteVolumeSnapshot(vol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -3923,7 +3922,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 }
 
 // RestoreInstanceSnapshot restores an instance snapshot.
-func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("RestoreInstanceSnapshot started")
 	defer l.Debug("RestoreInstanceSnapshot finished")
@@ -4022,7 +4021,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 	snapshotStorageName := project.StorageVolume(src.Project().Name, dbSnapVol.Name)
 	snapVol := b.GetVolume(volType, contentType, snapshotStorageName, dbSnapVol.Config)
 
-	err = b.driver.RestoreVolume(vol, snapVol, op)
+	err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
 		if ok {
@@ -4040,14 +4039,14 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 				}
 
 				// Delete snapshot instance if listed in the error as one that needs removing.
-				err := snap.Delete(true, "")
+				err := snap.Delete(ctx, true, "", progressReporter)
 				if err != nil {
 					return err
 				}
 			}
 
 			// Now try restoring again.
-			err = b.driver.RestoreVolume(vol, snapVol, op)
+			err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -4064,7 +4063,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 
 // MountInstanceSnapshot mounts an instance snapshot. It is mounted as read only so that the
 // snapshot cannot be modified.
-func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstanceSnapshot started")
 	defer l.Debug("MountInstanceSnapshot finished")
@@ -4106,7 +4105,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	// Mount the snapshot.
-	err = b.driver.MountVolumeSnapshot(vol, op)
+	err = b.driver.MountVolumeSnapshot(vol, progressReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -4128,7 +4127,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 }
 
 // UnmountInstanceSnapshot unmounts an instance snapshot.
-func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstanceSnapshot started")
 	defer l.Debug("UnmountInstanceSnapshot finished")
@@ -4170,7 +4169,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 	}
 
 	// Unmount volume.
-	_, err = b.driver.UnmountVolumeSnapshot(vol, op)
+	_, err = b.driver.UnmountVolumeSnapshot(vol, progressReporter)
 
 	return err
 }
@@ -4179,7 +4178,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 // doesn't already exist. If the volume already exists then it is checked to ensure it matches the pools current
 // volume settings ("volume.size" and "block.filesystem" if applicable). If not the optimized volume is removed
 // and regenerated to apply the pool's current volume settings.
-func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, projectName string) error {
+func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("EnsureImage started")
 	defer l.Debug("EnsureImage finished")
@@ -4253,7 +4252,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 		// to delete and re-create it.
 		if !b.driver.ImageVolumeConfigMatch(imgVol, tmpImgVol) {
 			l.Debug("Image volume configuration differs from storage pool configuration, regenerating image volume")
-			err = b.DeleteImage(image.Fingerprint, op)
+			err = b.DeleteImage(ctx, image.Fingerprint, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -4291,7 +4290,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// Try applying the current size policy to the existing volume. If it is the same the
 			// driver should make no changes, and if not then attempt to resize it to the new policy.
 			l.Debug("Setting image volume size", logger.Ctx{"size": imgVol.ConfigSize()})
-			err = b.driver.SetVolumeQuota(imgVol, imgVol.ConfigSize(), false, op)
+			err = b.driver.SetVolumeQuota(imgVol, imgVol.ConfigSize(), false, progressReporter)
 			if err == nil {
 				// We already have a valid volume at the correct size, just return.
 				return nil
@@ -4304,7 +4303,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// If the driver cannot resize the existing image volume to the new policy size
 			// then delete the image volume and try to recreate using the new policy settings.
 			l.Debug("Volume size of pool has changed since cached image volume created and cached volume cannot be resized, regenerating image volume")
-			err = b.DeleteImage(image.Fingerprint, op)
+			err = b.DeleteImage(ctx, image.Fingerprint, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -4319,7 +4318,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// This can occur if LXD process exits unexpectedly during an image unpack or if the
 			// storage pool has been recovered (which would not recreate the image volume DB records).
 			l.Warn("Deleting leftover/partially unpacked image volume")
-			err = b.driver.DeleteVolume(imgVol, op)
+			err = b.driver.DeleteVolume(imgVol, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Failed deleting leftover/partially unpacked image volume: %w", err)
 			}
@@ -4328,7 +4327,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 
 	volFiller := drivers.VolumeFiller{
 		Fingerprint: image.Fingerprint,
-		Fill:        b.imageFiller(image.Fingerprint, op, projectName),
+		Fill:        b.imageFiller(image.Fingerprint, progressReporter, projectName),
 	}
 
 	revert := revert.New()
@@ -4342,12 +4341,12 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 
 	revert.Add(func() { _ = VolumeDBDelete(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage) })
 
-	err = b.driver.CreateVolume(imgVol, &volFiller, op)
+	err = b.driver.CreateVolume(imgVol, &volFiller, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(imgVol, op) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(imgVol, progressReporter) })
 
 	// If the volume filler has recorded the size of the unpacked volume, then store this in the image DB row.
 	if volFiller.Size != 0 {
@@ -4366,7 +4365,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 }
 
 // DeleteImage removes an image from the database and underlying storage device if needed.
-func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteImage(ctx context.Context, fingerprint string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("DeleteImage started")
 	defer l.Debug("DeleteImage finished")
@@ -4401,7 +4400,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(vol, op)
+		err = b.driver.DeleteVolume(vol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -4412,7 +4411,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 		return err
 	}
 
-	b.state.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.StorageVolumeDeleted.Event(vol, string(vol.Type()), api.ProjectDefaultName, op, nil))
+	b.state.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.StorageVolumeDeleted.Event(ctx, vol, string(vol.Type()), api.ProjectDefaultName, nil))
 
 	return nil
 }
@@ -4420,7 +4419,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 // updateVolumeDescriptionOnly is a helper function used when handling update requests for volumes
 // that only allow their descriptions to be updated. If any config supplied differs from the
 // current volume's config then an error is returned.
-func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName string, volType drivers.VolumeType, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) updateVolumeDescriptionOnly(ctx context.Context, projectName string, volName string, volType drivers.VolumeType, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	volDBType, err := VolumeTypeToDBType(volType)
 	if err != nil {
 		return err
@@ -4461,25 +4460,25 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName str
 	vol := b.GetVolume(drivers.VolumeType(curVol.Type), contentType, volName, newConfig)
 
 	if !vol.IsSnapshot() {
-		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeUpdated.Event(vol, string(vol.Type()), projectName, op, nil))
+		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeUpdated.Event(ctx, vol, string(vol.Type()), projectName, nil))
 	} else {
-		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotUpdated.Event(vol, string(vol.Type()), projectName, op, nil))
+		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotUpdated.Event(ctx, vol, string(vol.Type()), projectName, nil))
 	}
 
 	return nil
 }
 
 // UpdateImage updates image config.
-func (b *lxdBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateImage(ctx context.Context, fingerprint string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint, "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateImage started")
 	defer l.Debug("UpdateImage finished")
 
-	return b.updateVolumeDescriptionOnly(api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage, newDesc, newConfig, op)
+	return b.updateVolumeDescriptionOnly(ctx, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage, newDesc, newConfig, progressReporter)
 }
 
 // CreateBucket creates an object bucket.
-func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
+func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucket.Name, "desc": bucket.Description, "config": bucket.Config})
 	l.Debug("CreateBucket started")
 	defer l.Debug("CreateBucket finished")
@@ -4511,7 +4510,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 	revert.Add(func() { _ = BucketDBDelete(context.TODO(), b, bucketID) })
 
 	// Handle per-driver implementation for remote storage drivers.
-	err = b.driver.CreateBucket(bucketVol, op)
+	err = b.driver.CreateBucket(bucketVol)
 	if err != nil {
 		return err
 	}
@@ -4521,7 +4520,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 }
 
 // UpdateBucket updates an object bucket.
-func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, _ *operations.Operation) error {
+func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "desc": bucket.Description, "config": bucket.Config})
 	l.Debug("UpdateBucket started")
 	defer l.Debug("UpdateBucket finished")
@@ -4603,7 +4602,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 }
 
 // DeleteBucket deletes an object bucket.
-func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteBucket(projectName string, bucketName string) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName})
 	l.Debug("DeleteBucket started")
 	defer l.Debug("DeleteBucket finished")
@@ -4630,7 +4629,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 	bucketVol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config)
 
 	// Handle per-driver implementation for remote storage drivers.
-	err = b.driver.DeleteBucket(bucketVol, op)
+	err = b.driver.DeleteBucket(bucketVol)
 	if err != nil {
 		return err
 	}
@@ -4639,7 +4638,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 }
 
 // CreateBucketKey creates an object bucket key.
-func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
+func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost) (*api.StorageBucketKey, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": key.Name, "desc": key.Description, "role": key.Role})
 	l.Debug("CreateBucketKey started")
 	defer l.Debug("CreateBucketKey finished")
@@ -4680,12 +4679,12 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 	}
 
 	// Handle per-driver implementation for remote storage drivers.
-	newCreds, err := b.driver.CreateBucketKey(bucketVol, key.Name, creds, key.Role, op)
+	newCreds, err := b.driver.CreateBucketKey(bucketVol, key.Name, creds, key.Role)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteBucketKey(bucketVol, key.Name, op) })
+	revert.Add(func() { _ = b.driver.DeleteBucketKey(bucketVol, key.Name) })
 
 	key.AccessKey = newCreds.AccessKey
 	key.SecretKey = newCreds.SecretKey
@@ -4712,7 +4711,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 }
 
 // UpdateBucketKey updates bucket key.
-func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
+func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": keyName, "desc": key.Description, "role": key.Role})
 	l.Debug("UpdateBucketKey started")
 	defer l.Debug("UpdateBucketKey finished")
@@ -4782,7 +4781,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 	}
 
 	// Handle per-driver implementation for remote storage drivers.
-	newCreds, err := b.driver.UpdateBucketKey(bucketVol, keyName, creds, key.Role, op)
+	newCreds, err := b.driver.UpdateBucketKey(bucketVol, keyName, creds, key.Role)
 	if err != nil {
 		return err
 	}
@@ -4802,7 +4801,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 }
 
 // DeleteBucketKey deletes an object bucket key.
-func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyName string) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": keyName})
 	l.Debug("DeleteBucketKey started")
 	defer l.Debug("DeleteBucketKey finished")
@@ -4840,7 +4839,7 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 	bucketVol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config)
 
 	// Delete the bucket key from the storage device.
-	err = b.driver.DeleteBucketKey(bucketVol, keyName, op)
+	err = b.driver.DeleteBucketKey(bucketVol, keyName)
 	if err != nil {
 		return err
 	}
@@ -4871,7 +4870,7 @@ func (b *lxdBackend) GetBucketURL(bucketName string) *url.URL {
 }
 
 // CreateCustomVolume creates an empty custom volume.
-func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "desc": desc, "config": config, "contentType": contentType})
 	l.Debug("CreateCustomVolume started")
 	defer l.Debug("CreateCustomVolume finished")
@@ -4903,7 +4902,7 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 	revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
 
 	// Create the empty custom volume on the storage device.
-	err = b.driver.CreateVolume(vol, nil, op)
+	err = b.driver.CreateVolume(vol, nil, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -4913,7 +4912,7 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 		eventCtx["location"] = b.state.ServerName
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), projectName, eventCtx))
 
 	revert.Success()
 	return nil
@@ -4921,7 +4920,7 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 
 // CreateCustomVolumeFromCopy creates a custom volume from an existing custom volume.
 // It copies the snapshots from the source volume by default, but can be disabled if requested.
-func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromCopy(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "srcProjectName": srcProjectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "snapshots": snapshots})
 	l.Debug("CreateCustomVolumeFromCopy started")
 	defer l.Debug("CreateCustomVolumeFromCopy finished")
@@ -4948,7 +4947,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	}
 
 	// Check source volume exists and is custom type, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, op)
+	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating copy config of volume %q in pool %q and project %q: %w", srcVolName, srcPoolName, srcProjectName, err)
 	}
@@ -5058,7 +5057,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.CreateVolumeFromCopy(volCopy, srcVolCopy, false, op)
+		err = b.driver.CreateVolumeFromCopy(volCopy, srcVolCopy, false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -5068,7 +5067,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 			eventCtx["location"] = b.state.ServerName
 		}
 
-		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
+		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), projectName, eventCtx))
 
 		revert.Success()
 		return nil
@@ -5092,7 +5091,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	var volSize int64
 
 	if drivers.IsContentBlock(contentType) {
-		err = srcVol.MountTask(func(_ string, _ *operations.Operation) error {
+		err = srcVol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 			srcPoolBackend, ok := srcPool.(*lxdBackend)
 			if !ok {
 				return errors.New("Pool is not a lxdBackend")
@@ -5115,7 +5114,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	// Use in-memory pipe pair to simulate a connection between the sender and receiver.
 	aEnd, bEnd := memorypipe.NewPipePair(ctx)
@@ -5133,7 +5132,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 			ContentType:        string(contentType),
 			Info:               &migration.Info{Config: srcConfig},
 			VolumeOnly:         !snapshots,
-		}, op)
+		}, progressReporter)
 
 		if err != nil {
 			cancel()
@@ -5143,7 +5142,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	}()
 
 	go func() {
-		err := b.CreateCustomVolumeFromMigration(projectName, bEnd, migration.VolumeTargetArgs{
+		err := b.CreateCustomVolumeFromMigration(ctx, projectName, bEnd, migration.VolumeTargetArgs{
 			IndexHeaderVersion: migration.IndexHeaderVersion,
 			Name:               volName,
 			Description:        desc,
@@ -5154,7 +5153,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 			ContentType:        string(contentType),
 			VolumeSize:         volSize, // Block size setting override.
 			VolumeOnly:         !snapshots,
-		}, op)
+		}, progressReporter)
 
 		if err != nil {
 			cancel()
@@ -5292,7 +5291,7 @@ func (b *lxdBackend) migrationIndexHeaderReceive(l logger.Logger, indexHeaderVer
 }
 
 // MigrateCustomVolume sends a volume for migration.
-func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": args.Name, "args": fmt.Sprintf("%+v", args)})
 	l.Debug("MigrateCustomVolume started")
 	defer l.Debug("MigrateCustomVolume finished")
@@ -5354,7 +5353,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.MigrateVolume(volCopy, conn, args, op)
+	err = b.driver.MigrateVolume(volCopy, conn, args, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -5363,7 +5362,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 }
 
 // CreateCustomVolumeFromMigration receives a volume being migrated.
-func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": args.Name, "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateCustomVolumeFromMigration started")
 	defer l.Debug("CreateCustomVolumeFromMigration finished")
@@ -5527,7 +5526,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 
 	volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 
-	err = b.driver.CreateVolumeFromMigration(volCopy, conn, args, nil, op)
+	err = b.driver.CreateVolumeFromMigration(volCopy, conn, args, nil, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -5537,14 +5536,14 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 		eventCtx["location"] = b.state.ServerName
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), projectName, eventCtx))
 
 	revert.Success()
 	return nil
 }
 
 // RenameCustomVolume renames a custom volume and its snapshots.
-func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameCustomVolume(ctx context.Context, projectName string, volName string, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newVolName": newVolName})
 	l.Debug("RenameCustomVolume started")
 	defer l.Debug("RenameCustomVolume finished")
@@ -5640,13 +5639,13 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
-	err = b.driver.RenameVolume(vol, newVolStorageName, op)
+	err = b.driver.RenameVolume(vol, newVolStorageName, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	vol = b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, nil)
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRenamed.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"old_name": volName}))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRenamed.Event(ctx, vol, string(vol.Type()), projectName, logger.Ctx{"old_name": volName}))
 
 	revert.Success()
 	return nil
@@ -5723,7 +5722,7 @@ func allowRemoveSecurityShared(s *state.State, projectName string, volume *api.S
 }
 
 // UpdateCustomVolume applies the supplied config to the custom volume.
-func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateCustomVolume started")
 	defer l.Debug("UpdateCustomVolume finished")
@@ -5831,7 +5830,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	// This ensures the updated DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
 		// Reset the instance backup file if the custom volume update didn't succeed.
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, progressReporter)
 	})
 
 	// Update the database.
@@ -5850,12 +5849,12 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	})
 
 	// Update the instance's backup files.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeUpdated.Event(newVol, string(newVol.Type()), projectName, op, nil))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeUpdated.Event(ctx, newVol, string(newVol.Type()), projectName, nil))
 
 	revert.Success()
 	return nil
@@ -5863,7 +5862,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 // UpdateCustomVolumeSnapshot updates the description of a custom volume snapshot.
 // Volume config is not allowed to be updated and will return an error.
-func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig, "newExpiryDate": newExpiryDate})
 	l.Debug("UpdateCustomVolumeSnapshot started")
 	defer l.Debug("UpdateCustomVolumeSnapshot finished")
@@ -5930,7 +5929,7 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the renamed DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, progressReporter)
 	})
 
 	// Update the database. Use current config.
@@ -5948,20 +5947,20 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	})
 
 	// Update the instance's backup files.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(curVol.ContentType), curVol.Name, curVol.Config)
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotUpdated.Event(vol, string(vol.Type()), projectName, op, nil))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotUpdated.Event(ctx, vol, string(vol.Type()), projectName, nil))
 
 	revert.Success()
 	return nil
 }
 
 // DeleteCustomVolume removes a custom volume and its snapshots.
-func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteCustomVolume(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("DeleteCustomVolume started")
 	defer l.Debug("DeleteCustomVolume finished")
@@ -5978,7 +5977,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 
 	// Remove each snapshot.
 	for _, snapshot := range snapshots {
-		err = b.DeleteCustomVolumeSnapshot(projectName, snapshot.Name, op)
+		err = b.DeleteCustomVolumeSnapshot(ctx, projectName, snapshot.Name, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -6010,7 +6009,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(vol, op)
+		err = b.driver.DeleteVolume(vol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -6029,7 +6028,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 		return err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeDeleted.Event(vol, string(vol.Type()), projectName, op, nil))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeDeleted.Event(ctx, vol, string(vol.Type()), projectName, nil))
 
 	return nil
 }
@@ -6081,7 +6080,7 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 }
 
 // MountCustomVolume mounts a custom volume.
-func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountCustomVolume(projectName, volName string, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("MountCustomVolume started")
 	defer l.Debug("MountCustomVolume finished")
@@ -6102,7 +6101,7 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 
 	// Perform the mount.
 	mountInfo := &MountInfo{}
-	err = b.driver.MountVolume(vol, op)
+	err = b.driver.MountVolume(vol, progressReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -6125,7 +6124,7 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 }
 
 // UnmountCustomVolume unmounts a custom volume.
-func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
+func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("UnmountCustomVolume started")
 	defer l.Debug("UnmountCustomVolume finished")
@@ -6139,13 +6138,13 @@ func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operat
 	volStorageName := project.StorageVolume(projectName, volName)
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
-	return b.driver.UnmountVolume(vol, false, op)
+	return b.driver.UnmountVolume(vol, false, progressReporter)
 }
 
 // ImportCustomVolume takes an existing custom volume on the storage backend and ensures that the DB records,
 // volume directories and symlinks are restored as needed to make it operational with LXD.
 // Used during the recovery import stage.
-func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, _ *operations.Operation) (revert.Hook, error) {
+func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, _ ioprogress.ProgressReporter) (revert.Hook, error) {
 	customVol, err := poolVol.CustomVolume()
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting the custom volume: %w", err)
@@ -6234,7 +6233,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
 // A new UUID is generated for the snapshot and returned upon success.
 // The UUID is used to fill "volatile.attached_volumes" for multi-volume snapshot and restore functionality.
-func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
+func (b *lxdBackend) CreateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, progressReporter ioprogress.ProgressReporter) (*uuid.UUID, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName, "newDescription": newDescription, "newExpiryDate": newExpiryDate})
 	l.Debug("CreateCustomVolumeSnapshot started")
 	defer l.Debug("CreateCustomVolumeSnapshot finished")
@@ -6357,7 +6356,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the added DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, progressReporter)
 	})
 
 	// Validate config and create database entry for new storage volume.
@@ -6370,27 +6369,27 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	revert.Add(func() { _ = VolumeDBDelete(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom) })
 
 	// Create the snapshot on the storage device.
-	err = b.driver.CreateVolumeSnapshot(vol, op)
+	err = b.driver.CreateVolumeSnapshot(vol, progressReporter)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(vol, op) })
+	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(vol, progressReporter) })
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, progressReporter)
 	if err != nil {
 		return nil, err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotCreated.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"type": vol.Type()}))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotCreated.Event(ctx, vol, string(vol.Type()), projectName, logger.Ctx{"type": vol.Type()}))
 
 	revert.Success()
 	return &snapshotUUID, nil
 }
 
 // RenameCustomVolumeSnapshot renames a custom volume.
-func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName})
 	l.Debug("RenameCustomVolumeSnapshot started")
 	defer l.Debug("RenameCustomVolumeSnapshot finished")
@@ -6446,7 +6445,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	revert := revert.New()
 	defer revert.Fail()
 
-	err = b.driver.RenameVolumeSnapshot(vol, newSnapshotName, op)
+	err = b.driver.RenameVolumeSnapshot(vol, newSnapshotName, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -6461,13 +6460,13 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 		// Renaming a volume snapshot doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newVol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, volume.Config)
-		_ = b.driver.RenameVolumeSnapshot(newVol, oldSnapshotName, op)
+		_ = b.driver.RenameVolumeSnapshot(newVol, oldSnapshotName, progressReporter)
 	})
 
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the renamed DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, progressReporter)
 	})
 
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -6484,19 +6483,19 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	})
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotRenamed.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"old_name": oldSnapshotName}))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotRenamed.Event(ctx, vol, string(vol.Type()), projectName, logger.Ctx{"old_name": oldSnapshotName}))
 
 	revert.Success()
 	return nil
 }
 
 // DeleteCustomVolumeSnapshot removes a custom volume snapshot.
-func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("DeleteCustomVolumeSnapshot started")
 	defer l.Debug("DeleteCustomVolumeSnapshot finished")
@@ -6565,7 +6564,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	}
 
 	if volExists {
-		err := b.driver.DeleteVolumeSnapshot(vol, op)
+		err := b.driver.DeleteVolumeSnapshot(vol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -6578,18 +6577,18 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	}
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentVolName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(projectName, parentVolName, true, instances, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotDeleted.Event(vol, string(vol.Type()), projectName, op, nil))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotDeleted.Event(ctx, vol, string(vol.Type()), projectName, nil))
 
 	return nil
 }
 
 // RestoreCustomVolume restores a custom volume from a snapshot.
-func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotName string, op *operations.Operation) error {
+func (b *lxdBackend) RestoreCustomVolume(ctx context.Context, projectName string, volName string, snapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "snapshotName": snapshotName})
 	l.Debug("RestoreCustomVolume started")
 	defer l.Debug("RestoreCustomVolume finished")
@@ -6647,20 +6646,20 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	snapshotStorageName := project.StorageVolume(projectName, dbSnapVol.Name)
 	snapVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, snapshotStorageName, dbSnapVol.Config)
 
-	err = b.driver.RestoreVolume(vol, snapVol, op)
+	err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
 		if ok {
 			// We need to delete some snapshots and try again.
 			for _, snapName := range snapErr.Snapshots {
-				err := b.DeleteCustomVolumeSnapshot(projectName, volName+"/"+snapName, op)
+				err := b.DeleteCustomVolumeSnapshot(ctx, projectName, volName+"/"+snapName, progressReporter)
 				if err != nil {
 					return err
 				}
 			}
 
 			// Now try again.
-			err = b.driver.RestoreVolume(vol, snapVol, op)
+			err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -6669,7 +6668,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 		return err
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRestored.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"snapshot": snapshotName}))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRestored.Event(ctx, vol, string(vol.Type()), projectName, logger.Ctx{"snapshot": snapshotName}))
 
 	return nil
 }
@@ -6689,7 +6688,7 @@ func (b *lxdBackend) createStorageStructure(path string) error {
 }
 
 // UpdateCustomVolumeBackupFiles writes the custom volume's config to the backup.yaml file of the corresponding instances.
-func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName, "snapshots": snapshots})
 	l.Debug("UpdateCustomVolumeBackupFiles started")
 	defer l.Debug("UpdateCustomVolumeBackupFiles finished")
@@ -6698,7 +6697,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 
 	// Update the backup config file of all instances.
 	for _, inst := range instances {
-		instanceVolBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, backupVolConfCache, snapshots, op)
+		instanceVolBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, backupVolConfCache, snapshots, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -6718,7 +6717,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 		// whilst this function tries to propagate an update of a custom volume.
 		// A lock isn't acquired in this case for all the instances as this might cause too much interruption
 		// as every update of an instance's backup file requires mounting the corresponding volume.
-		err = pool.UpdateInstanceBackupFile(inst, snapshots, instanceVolBackupConf, backupConfig.DefaultMetadataVersion, op)
+		err = pool.UpdateInstanceBackupFile(inst, snapshots, instanceVolBackupConf, backupConfig.DefaultMetadataVersion, progressReporter)
 		if err != nil {
 			logger.Error("Failed updating backup file", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 		}
@@ -6728,7 +6727,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 }
 
 // GenerateCustomVolumeBackupConfig returns the backup config entry for this volume.
-func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, _ *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, _ ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	vol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
@@ -6774,7 +6773,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 
 // GenerateInstanceBackupConfig returns the backup config entry for this instance.
 // The Instance field is only populated for non-snapshot instances.
-func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, _ *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, _ ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	// Generate the YAML.
 	ci, _, err := inst.Render()
 	if err != nil {
@@ -6896,7 +6895,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 }
 
 // UpdateInstanceBackupFile writes the instance's config to the backup.yaml file on the storage device.
-func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UpdateInstanceBackupFile started")
 	defer l.Debug("UpdateInstanceBackupFile finished")
@@ -6906,7 +6905,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		return nil
 	}
 
-	config, err := b.GenerateInstanceBackupConfig(inst, snapshots, volBackupConf, op)
+	config, err := b.GenerateInstanceBackupConfig(inst, snapshots, volBackupConf, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance config: %w", err)
 	}
@@ -6939,7 +6938,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 	}
 
 	// Update pool information in the backup.yaml file.
-	err = vol.MountTask(func(_ string, _ *operations.Operation) error {
+	err = vol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 		// Write the YAML
 		path := filepath.Join(inst.Path(), "backup.yaml")
 		f, err := os.Create(path)
@@ -6963,14 +6962,14 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		}
 
 		return f.Close()
-	}, op)
+	}, progressReporter)
 
 	return err
 }
 
 // CheckInstanceBackupFileSnapshots compares the snapshots on the storage device to those defined in the backup
 // config supplied and returns an error if they do not match.
-func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, progressReporter ioprogress.ProgressReporter) ([]*api.InstanceSnapshot, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "instance": backupConf.Instance.Name})
 	l.Debug("CheckInstanceBackupFileSnapshots started")
 	defer l.Debug("CheckInstanceBackupFileSnapshots finished")
@@ -7003,7 +7002,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 	vol := b.GetVolume(volType, contentType, volStorageName, rootVol.Config)
 
 	// Get a list of snapshots that exist on storage device.
-	driverSnapshots, err := vol.Snapshots(op)
+	driverSnapshots, err := vol.Snapshots(progressReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -7018,7 +7017,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 		volSnaps = append(volSnaps, b.GetVolume(volType, contentType, snapName, snap.Config))
 	}
 
-	err = b.driver.CheckVolumeSnapshots(vol, volSnaps, op)
+	err = b.driver.CheckVolumeSnapshots(vol, volSnaps)
 	if err != nil {
 		return nil, err
 	}
@@ -7112,7 +7111,7 @@ func (b *lxdBackend) normalizeUnknownVolumes(ctx context.Context, poolVols []dri
 
 // ListUnknownVolumes returns volumes that exist on the storage pool but don't have records in the database.
 // Returns the unknown volumes parsed/generated backup config in a slice (keyed on project name).
-func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
+func (b *lxdBackend) ListUnknownVolumes(progressReporter ioprogress.ProgressReporter) (map[string][]*backupConfig.Config, error) {
 	// Get a list of volumes on the storage pool. We only expect to get 1 volume per logical LXD volume.
 	// So for VMs we only expect to get the block volume for a VM and not its filesystem one too. This way we
 	// can operate on the volume using the existing storage pool functions and let the pool then handle the
@@ -7139,7 +7138,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 
 		switch volType {
 		case drivers.VolumeTypeVM, drivers.VolumeTypeContainer:
-			err = b.detectUnknownInstanceAndCustomVolumes(&poolVol, projectVols, op)
+			err = b.detectUnknownInstanceAndCustomVolumes(&poolVol, projectVols, progressReporter)
 			if err != nil {
 				return nil, fmt.Errorf("Failed detecting unknown instances: %w", err)
 			}
@@ -7148,7 +7147,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			// Get a new volume from the one returned by the storage driver.
 			// This sets a new UUID for the volume that will be used later on for its database entry.
 			poolVol = b.GetNewVolume(poolVol.Type(), poolVol.ContentType(), poolVol.Name(), poolVol.Config())
-			err = b.detectUnknownCustomVolume(&poolVol, projectVols, op)
+			err = b.detectUnknownCustomVolume(&poolVol, projectVols, progressReporter)
 			if err != nil {
 				return nil, fmt.Errorf("Failed detecting unknown custom volumes: %w", err)
 			}
@@ -7199,7 +7198,7 @@ func (b *lxdBackend) cleanupUnknownVolumeMountPath(poolVol *drivers.Volume) erro
 // In any case it also checks whether or not the instance has unknown custom volumes attached and appends them to projectVols too.
 // If any custom volumes were found, they are each put into their own backup config and removed from the instance's backup config.
 // This follows the same process applied by detectUnknownCustomVolume.
-func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, progressReporter ioprogress.ProgressReporter) error {
 	backupYamlPath := filepath.Join(vol.MountPath(), "backup.yaml")
 	var backupConf *backupConfig.Config
 	var err error
@@ -7221,14 +7220,14 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 		// If backup file not accessible, we take this to mean the instance isn't running
 		// and so we need to mount the volume to access the backup file and then unmount.
 		// This will also create the mount path if needed.
-		err = vol.MountTask(func(_ string, _ *operations.Operation) error {
+		err = vol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 			backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
 			if err != nil {
 				return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
 			}
 
 			return nil
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -7473,7 +7472,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 // detectUnknownCustomVolume detects if a volume is unknown and if so attempts to discover the filesystem of the
 // volume (for filesystem volumes). It then runs a series of consistency checks, and if all checks out, it adds
 // generates a simulated backup config for the custom volume and adds it to projectVols.
-func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, progressReporter ioprogress.ProgressReporter) error {
 	volType := vol.Type()
 
 	projectName, volName := project.StorageVolumeParts(vol.Name())
@@ -7488,7 +7487,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 	}
 
 	// Get a list of snapshots that exist on storage device.
-	snapshots, err := b.driver.VolumeSnapshots(*vol, op)
+	snapshots, err := b.driver.VolumeSnapshots(*vol)
 	if err != nil {
 		return err
 	}
@@ -7514,14 +7513,14 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 					return err
 				}
 			} else {
-				err = vol.MountTask(func(mountPath string, _ *operations.Operation) error {
+				err = vol.MountTask(func(mountPath string, _ ioprogress.ProgressReporter) error {
 					blockFS, err = filesystem.Detect(mountPath)
 					if err != nil {
 						return err
 					}
 
 					return nil
-				}, op)
+				}, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -7594,7 +7593,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 // and symlinks are restored as needed to make it operational with LXD. Used during the recovery import stage.
 // If the instance exists on the local cluster member then the local mount status is restored as needed.
 // If the optional poolVol argument is provided then it is used to create the storage volume database records.
-func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("ImportInstance started")
 	defer l.Debug("ImportInstance finished")
@@ -7740,7 +7739,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			// reference counter showing the volume is in use. If this is the case then call mount the
 			// volume to increment the reference counter.
 			if !vol.MountInUse() {
-				_, err = b.MountInstance(inst, op)
+				_, err = b.MountInstance(inst, progressReporter)
 				if err != nil {
 					return nil, fmt.Errorf("Failed mounting instance: %w", err)
 				}
@@ -7748,7 +7747,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 		} else {
 			// If the instance isn't running then try and unmount it to ensure consistent state after
 			// import.
-			err = b.UnmountInstance(inst, op)
+			err = b.UnmountInstance(inst, progressReporter)
 			if err != nil {
 				return nil, fmt.Errorf("Failed unmounting instance: %w", err)
 			}
@@ -7796,7 +7795,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 }
 
 // BackupCustomVolume creates a backup of an existing custom volume.
-func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName, "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupCustomVolume started")
 	defer l.Debug("BackupCustomVolume finished")
@@ -7844,7 +7843,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.BackupVolume(volCopy, projectName, tarWriter, optimized, snapNames, op)
+	err = b.driver.BackupVolume(volCopy, projectName, tarWriter, optimized, snapNames, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -7853,7 +7852,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 }
 
 // CreateCustomVolumeFromISO creates a custom volume from the given ISO source data.
-func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName})
 	l.Debug("CreateCustomVolumeFromISO started")
 	defer l.Debug("CreateCustomVolumeFromISO finished")
@@ -7916,7 +7915,7 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 	}
 
 	// Unpack the ISO into the new storage volume(s).
-	err = b.driver.CreateVolume(vol, &volFiller, op)
+	err = b.driver.CreateVolume(vol, &volFiller, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed creating volume: %w", err)
 	}
@@ -7926,14 +7925,14 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 		eventCtx["location"] = b.state.ServerName
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), projectName, eventCtx))
 
 	revert.Success()
 	return nil
 }
 
 // CreateCustomVolumeFromTarball creates a custom volume from the given backup info.
-func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName})
 	l.Debug("CreateCustomVolumeFromTarball started")
 	defer l.Debug("CreateCustomVolumeFromTarball finished")
@@ -7990,15 +7989,15 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(vol, progressReporter) })
 
 	// Mount the volume to unpack the tarball into it.
-	err = b.driver.MountVolume(vol, op)
+	err = b.driver.MountVolume(vol, progressReporter)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, op) })
+	revert.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, progressReporter) })
 
 	mountPath := vol.MountPath()
 	err = archive.UnpackRaw(b.state, srcData.Name(), mountPath, vol.IsBlockBacked(), nil)
@@ -8015,7 +8014,7 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 
 	revert.Success()
 
-	_, err = b.driver.UnmountVolume(vol, false, op)
+	_, err = b.driver.UnmountVolume(vol, false, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -8025,13 +8024,13 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 		eventCtx["location"] = b.state.ServerName
 	}
 
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), projectName, eventCtx))
 
 	return nil
 }
 
 // CreateCustomVolumeFromBackup creates a custom volume from the given backup info.
-func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": srcBackup.Project, "volume": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	l.Debug("CreateCustomVolumeFromBackup started")
 	defer l.Debug("CreateCustomVolumeFromBackup finished")
@@ -8147,7 +8146,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(volCopy, srcBackup, srcData, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(volCopy, srcBackup, srcData, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -8168,7 +8167,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 		eventCtx["location"] = b.state.ServerName
 	}
 
-	b.state.Events.SendLifecycle(srcBackup.Project, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), srcBackup.Project, op, eventCtx))
+	b.state.Events.SendLifecycle(srcBackup.Project, lifecycle.StorageVolumeCreated.Event(ctx, vol, string(vol.Type()), srcBackup.Project, eventCtx))
 
 	revert.Success()
 	return nil
@@ -8207,7 +8206,7 @@ func (b *lxdBackend) getParentVolumeUUID(vol drivers.Volume, projectName string)
 // The caller can decide to use this cache across multiple instances.
 // That is helpful in situations where a custom volume gets updated which causes the backup config files of all
 // instances using this volume to be updated.
-func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	// Setup a cache if not provided.
 	// This will allow caching pool and volume backup configs for the given instance.
 	if cache == nil {
@@ -8222,7 +8221,7 @@ func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Inst
 
 	// Skip non-disk devices, host filesystem shares without a pool and the instance's root disk itself.
 	for _, device := range inst.ExpandedDevices().Filter(filters.IsCustomVolumeDisk) {
-		vol, err := cache.getVolume(projectName, device["pool"], device["source"], snapshots, op)
+		vol, err := cache.getVolume(projectName, device["pool"], device["source"], snapshots, progressReporter)
 		if err != nil {
 			// When restoring an instance from snapshot, some of the custom vols which were attached
 			// whilst taking the snapshot might not exist anymore.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"os"
@@ -13,11 +14,11 @@ import (
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/storage/drivers"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
@@ -95,17 +96,17 @@ func (b *mockBackend) IsUsed() (bool, error) {
 }
 
 // Delete ...
-func (b *mockBackend) Delete(clientType request.ClientType, op *operations.Operation) error {
+func (b *mockBackend) Delete(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // Update ...
-func (b *mockBackend) Update(clientType request.ClientType, newDescription string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) Update(clientType request.ClientType, newDescription string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // Create ...
-func (b *mockBackend) Create(clientType request.ClientType, op *operations.Operation) error {
+func (b *mockBackend) Create(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -130,112 +131,112 @@ func (b *mockBackend) GetVolume(volType drivers.VolumeType, contentType drivers.
 }
 
 // CreateInstance ...
-func (b *mockBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CreateInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateInstanceFromBackup ...
-func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
+func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (func(instance.Instance) error, revert.Hook, error) {
 	return nil, nil, nil
 }
 
 // CreateInstanceFromCopy ...
-func (b *mockBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateInstanceFromImage ...
-func (b *mockBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateInstanceFromMigration ...
-func (b *mockBackend) CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateInstanceFromConversion ...
-func (b *mockBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RenameInstance ...
-func (b *mockBackend) RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameInstance(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteInstance ...
-func (b *mockBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateInstance ...
-func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // GenerateCustomVolumeBackupConfig ...
-func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // GenerateInstanceBackupConfig ...
-func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // GenerateInstanceCustomVolumeBackupConfig ...
-func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // UpdateInstanceBackupFile ...
-func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateCustomVolumeBackupFiles ...
-func (b *mockBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CheckInstanceBackupFileSnapshots checks the snapshots in storage against the given backup config.
-func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, progressReporter ioprogress.ProgressReporter) ([]*api.InstanceSnapshot, error) {
 	return nil, nil
 }
 
 // ListUnknownVolumes ...
-func (b *mockBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
+func (b *mockBackend) ListUnknownVolumes(progressReporter ioprogress.ProgressReporter) (map[string][]*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // ImportInstance ...
-func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	return nil, nil
 }
 
 // MigrateInstance ...
-func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *mockBackend) MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CleanupInstancePaths ...
-func (b *mockBackend) CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CleanupInstancePaths(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RefreshCustomVolume ...
-func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+func (b *mockBackend) RefreshCustomVolume(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RefreshInstance ...
-func (b *mockBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
+func (b *mockBackend) RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // BackupInstance ...
-func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
+func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -245,97 +246,97 @@ func (b *mockBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, er
 }
 
 // SetInstanceQuota ...
-func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
+func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // MountInstance ...
-func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	return &MountInfo{}, nil
 }
 
 // UnmountInstance ...
-func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UnmountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateInstanceSnapshot ...
-func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RenameInstanceSnapshot ...
-func (b *mockBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteInstanceSnapshot ...
-func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RestoreInstanceSnapshot ...
-func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // MountInstanceSnapshot ...
-func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	return &MountInfo{}, nil
 }
 
 // UnmountInstanceSnapshot ...
-func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateInstanceSnapshot ...
-func (b *mockBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // EnsureImage ...
-func (b *mockBackend) EnsureImage(fingerprint string, op *operations.Operation, projectName string) error {
+func (b *mockBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteImage ...
-func (b *mockBackend) DeleteImage(fingerprint string, op *operations.Operation) error {
+func (b *mockBackend) DeleteImage(ctx context.Context, fingerprint string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateImage ...
-func (b *mockBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateImage(ctx context.Context, fingerprint string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateBucket ...
-func (b *mockBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
+func (b *mockBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost) error {
 	return nil
 }
 
 // UpdateBucket ...
-func (b *mockBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error {
+func (b *mockBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut) error {
 	return nil
 }
 
 // DeleteBucket ...
-func (b *mockBackend) DeleteBucket(projectName string, bucketName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteBucket(projectName string, bucketName string) error {
 	return nil
 }
 
 // CreateBucketKey ...
-func (b *mockBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
+func (b *mockBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost) (*api.StorageBucketKey, error) {
 	return nil, nil
 }
 
 // UpdateBucketKey ...
-func (b *mockBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
+func (b *mockBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut) error {
 	return nil
 }
 
 // DeleteBucketKey ...
-func (b *mockBackend) DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteBucketKey(projectName string, bucketName string, keyName string) error {
 	return nil
 }
 
@@ -345,37 +346,37 @@ func (b *mockBackend) GetBucketURL(bucketName string) *url.URL {
 }
 
 // CreateCustomVolume ...
-func (b *mockBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateCustomVolumeFromCopy ...
-func (b *mockBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName string, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromCopy(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RenameCustomVolume ...
-func (b *mockBackend) RenameCustomVolume(projectName string, volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolume(ctx context.Context, projectName string, volName string, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateCustomVolume ...
-func (b *mockBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteCustomVolume ...
-func (b *mockBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolume(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // MigrateCustomVolume ...
-func (b *mockBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *mockBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateCustomVolumeFromMigration ...
-func (b *mockBackend) CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -385,61 +386,61 @@ func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (
 }
 
 // MountCustomVolume ...
-func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountCustomVolume(projectName string, volName string, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	return nil, nil
 }
 
 // UnmountCustomVolume ...
-func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
+func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return true, nil
 }
 
 // ImportCustomVolume ...
-func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	return nil, nil
 }
 
 // CreateCustomVolumeSnapshot ...
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
+func (b *mockBackend) CreateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, progressReporter ioprogress.ProgressReporter) (*uuid.UUID, error) {
 	return nil, nil
 }
 
 // RenameCustomVolumeSnapshot ...
-func (b *mockBackend) RenameCustomVolumeSnapshot(projectName string, volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteCustomVolumeSnapshot ...
-func (b *mockBackend) DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UpdateCustomVolumeSnapshot ...
-func (b *mockBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, expiryDate time.Time, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RestoreCustomVolume ...
-func (b *mockBackend) RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error {
+func (b *mockBackend) RestoreCustomVolume(ctx context.Context, projectName string, volName string, snapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // BackupCustomVolume ...
-func (b *mockBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *mockBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateCustomVolumeFromBackup ...
-func (b *mockBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateCustomVolumeFromISO ...
-func (b *mockBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateCustomVolumeFromTarball ...
-func (b *mockBackend) CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	backupConfig "github.com/canonical/lxd/lxd/backup/config"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/shared/ioprogress"
 )
 
 // storageCache is used to cache pools and volumes.
@@ -67,7 +67,7 @@ func (s *storageCache) GetPool(name string) (Pool, error) {
 
 // getVolume returns the volume's backup config either by loading it from the DB or from the cache (preferred).
 // If snapshots is true the volume's snapshots are included in the returned backup config.
-func (s *storageCache) getVolume(projectName string, poolName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Volume, error) {
+func (s *storageCache) getVolume(projectName string, poolName string, volName string, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Volume, error) {
 	// Create pool cache.
 	_, ok := s.volumes[poolName]
 	if !ok {
@@ -87,7 +87,7 @@ func (s *storageCache) getVolume(projectName string, poolName string, volName st
 			return nil, fmt.Errorf("Failed retrieving pool of volume %q in pool %q: %w", volName, poolName, err)
 		}
 
-		volConfig, err := pool.GenerateCustomVolumeBackupConfig(projectName, volName, snapshots, op)
+		volConfig, err := pool.GenerateCustomVolumeBackupConfig(projectName, volName, snapshots, progressReporter)
 		if err != nil {
 			return nil, fmt.Errorf("Failed generating backup config of volume %q in pool %q and project %q: %w", volName, poolName, projectName, err)
 		}

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/clients"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -270,7 +270,7 @@ func (d *alletra) Create() error {
 }
 
 // Delete removes a storage pool.
-func (d *alletra) Delete(op *operations.Operation) error {
+func (d *alletra) Delete(progressReporter ioprogress.ProgressReporter) error {
 	err := d.client().DeleteVolumeSet(d.name)
 	if err != nil {
 		return err

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -18,12 +18,12 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -406,18 +406,18 @@ func (d *alletra) GetVolumeDiskPath(vol Volume) (string, error) {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *alletra) MountVolume(vol Volume, op *operations.Operation) error {
-	return mountVolume(d, vol, d.getMappedDevPath, op)
+func (d *alletra) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return mountVolume(d, vol, d.getMappedDevPath, progressReporter)
 }
 
 // UnmountVolume simulates unmounting a volume.
 // keepBlockDev indicates if backing block device should not be unmapped if volume is unmounted.
-func (d *alletra) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, op)
+func (d *alletra) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, progressReporter)
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	client := d.client()
 
 	revert := revert.New()
@@ -465,20 +465,20 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			err := d.DeleteVolume(fsVol, op)
+			err := d.DeleteVolume(fsVol, progressReporter)
 			if err != nil {
 				d.logger.Warn("DeleteVolume failed on error path", logger.Ctx{"err": err})
 			}
 		})
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -532,7 +532,7 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -542,22 +542,22 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *alletra) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *alletra) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *alletra) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *alletra) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *alletra) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *alletra) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -566,16 +566,16 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 	postCreateTasks := func(v Volume) error {
 		if vol.contentType == ContentTypeFS {
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+			err := v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(v, v.config["size"], false, op)
+		err := d.SetVolumeQuota(v, v.config["size"], false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -603,13 +603,13 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 		fsVol.SetParentUUID(vol.parentUUID)
 		srcFSVol.SetParentUUID(srcVol.parentUUID)
 
-		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			err := d.DeleteVolume(fsVol.Volume, op)
+			err := d.DeleteVolume(fsVol.Volume, progressReporter)
 			if err != nil {
 				d.logger.Warn("DeleteVolume failed on error path", logger.Ctx{"err": err})
 			}
@@ -702,7 +702,7 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 			// Create snapshot from a new volume (that was created from the source snapshot).
 			// However, do not create VM's filesystem volume snapshot, as filesystem volume is
 			// copied before block volume.
-			err = d.createVolumeSnapshot(snapshot, false, op)
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -724,7 +724,7 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *alletra) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *alletra) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -744,7 +744,7 @@ func (d *alletra) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
 
-		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, allowInconsistent, op)
+		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, allowInconsistent, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -752,7 +752,7 @@ func (d *alletra) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 		revert.Add(cleanup)
 	}
 
-	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, op)
+	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -766,7 +766,7 @@ func (d *alletra) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 // refreshVolume updates an existing volume to match the state of another. For VMs, this function
 // refreshes either block or filesystem volume, depending on the volume type. Therefore, the caller
 // needs to ensure it is called twice - once for each volume type.
-func (d *alletra) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) (revert.Hook, error) {
+func (d *alletra) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -775,16 +775,16 @@ func (d *alletra) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 	postCreateTasks := func(v Volume) error {
 		if vol.contentType == ContentTypeFS {
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+			err := v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(v, v.config["size"], false, op)
+		err := d.SetVolumeQuota(v, v.config["size"], false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -882,13 +882,13 @@ func (d *alletra) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 
 			// Create snapshot of a new volume. Do not copy VM's filesystem volume snapshot,
 			// as FS volumes are already copied by this point.
-			err = d.createVolumeSnapshot(snapshot, false, op)
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
 			if err != nil {
 				return nil, err
 			}
 
 			revert.Add(func() {
-				err := d.DeleteVolumeSnapshot(snapshot, op)
+				err := d.DeleteVolumeSnapshot(snapshot, progressReporter)
 				if err != nil {
 					d.logger.Warn("DeleteVolumeSnapshot failed on error path", logger.Ctx{"err": err})
 				}
@@ -931,17 +931,17 @@ func (d *alletra) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapsh
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *alletra) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *alletra) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move don't do anything on the source member.
 	if volSrcArgs.ClusterMove {
 		return nil
 	}
 
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *alletra) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *alletra) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move prepare the volumes on the target side.
 	if volTargetArgs.ClusterMoveSourceName != "" {
 		err := vol.EnsureMountPath()
@@ -951,7 +951,7 @@ func (d *alletra) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClo
 
 		if vol.IsVMBlock() {
 			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
+			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -960,12 +960,12 @@ func (d *alletra) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClo
 		return nil
 	}
 
-	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 	return err
 }
 
 // DeleteVolume deletes the volume and all associated snapshots.
-func (d *alletra) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *alletra) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	volExists, err := d.HasVolume(vol)
 	if err != nil {
 		return err
@@ -1016,7 +1016,7 @@ func (d *alletra) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1081,7 +1081,7 @@ func (d *alletra) HasVolume(vol Volume) (bool, error) {
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *alletra) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *alletra) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume won't change an actual name of the volume on the storage array side.
 	return nil
 }
@@ -1242,7 +1242,7 @@ func (d *alletra) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *alletra) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *alletra) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -1361,13 +1361,13 @@ func (d *alletra) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *alletra) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
-	return d.createVolumeSnapshot(snapVol, true, op)
+func (d *alletra) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return d.createVolumeSnapshot(snapVol, true, progressReporter)
 }
 
 // createVolumeSnapshot creates a snapshot of a volume. If snapshotVMfilesystem is false, a VM's filesystem volume
 // is not copied.
-func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, op *operations.Operation) error {
+func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1418,7 +1418,7 @@ func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool
 	}
 
 	revert.Add(func() {
-		err := d.DeleteVolumeSnapshot(snapVol, op)
+		err := d.DeleteVolumeSnapshot(snapVol, progressReporter)
 		if err != nil {
 			d.logger.Warn("DeleteVolumeSnapshot failed on error path", logger.Ctx{"err": err})
 		}
@@ -1432,13 +1432,13 @@ func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool
 		// Set the parent volume's UUID.
 		fsVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.CreateVolumeSnapshot(fsVol, op)
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			err := d.DeleteVolumeSnapshot(fsVol, op)
+			err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 			if err != nil {
 				d.logger.Warn("DeleteVolumeSnapshot failed on error path", logger.Ctx{"err": err})
 			}
@@ -1451,7 +1451,7 @@ func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *alletra) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *alletra) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentVol := snapVol.GetParent()
 	parentVolName, err := d.getVolumeName(parentVol)
 	if err != nil {
@@ -1494,7 +1494,7 @@ func (d *alletra) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation)
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
 		fsVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.DeleteVolumeSnapshot(fsVol, op)
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1504,19 +1504,19 @@ func (d *alletra) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation)
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *alletra) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *alletra) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume snapshot won't change an actual name of the HPE Alletra volume snapshot.
 	return nil
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *alletra) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
-	return mountVolume(d, snapVol, d.getMappedDevPath, op)
+func (d *alletra) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return mountVolume(d, snapVol, d.getMappedDevPath, progressReporter)
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
-func (d *alletra) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
-	return unmountVolume(d, snapVol, false, d.getMappedDevPath, d.unmapVolume, op)
+func (d *alletra) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return unmountVolume(d, snapVol, false, d.getMappedDevPath, d.unmapVolume, progressReporter)
 }
 
 // ListVolumes returns a list of LXD volumes in storage pool.
@@ -1530,7 +1530,7 @@ func (d *alletra) ListVolumes() ([]Volume, error) {
 }
 
 // VolumeSnapshots returns a list of HPE Alletra storage snapshot names for the given volume (in no particular order).
-func (d *alletra) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *alletra) VolumeSnapshots(vol Volume) ([]string, error) {
 	volName, err := d.getVolumeName(vol)
 	if err != nil {
 		return nil, err
@@ -1555,8 +1555,8 @@ func (d *alletra) VolumeSnapshots(vol Volume, op *operations.Operation) ([]strin
 
 // CheckVolumeSnapshots checks that the volume's snapshots, according to the storage driver,
 // match those provided.
-func (d *alletra) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error {
-	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol, op)
+func (d *alletra) CheckVolumeSnapshots(vol Volume, snapVols []Volume) error {
+	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -1577,15 +1577,15 @@ func (d *alletra) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operat
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *alletra) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	ourUnmount, err := d.UnmountVolume(vol, false, op)
+func (d *alletra) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	ourUnmount, err := d.UnmountVolume(vol, false, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	if ourUnmount {
 		defer func() {
-			err := d.MountVolume(vol, op)
+			err := d.MountVolume(vol, progressReporter)
 			if err != nil {
 				d.logger.Warn("MountVolume failed on error path", logger.Ctx{"err": err})
 			}
@@ -1615,7 +1615,7 @@ func (d *alletra) RestoreVolume(vol Volume, snapVol Volume, op *operations.Opera
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
 		snapFSVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.RestoreVolume(fsVol, snapFSVol, op)
+		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -13,10 +13,10 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/validate"
@@ -277,7 +277,7 @@ func (d *btrfs) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *btrfs) Delete(op *operations.Operation) error {
+func (d *btrfs) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// If the user completely destroyed it, call it done.
 	if !shared.PathExists(GetPoolMountPath(d.name)) {
 		return nil

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -22,7 +22,6 @@ import (
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
@@ -34,7 +33,7 @@ import (
 )
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	volPath := vol.MountPath()
 
 	// Setup revert.
@@ -126,7 +125,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 	} else if vol.contentType == ContentTypeFS {
 		// Set initial quota for filesystem volumes.
-		err := d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+		err := d.SetVolumeQuota(vol, vol.ConfigSize(), false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -151,10 +150,10 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
-		return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+		return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 	}
 
 	volExists, err := d.HasVolume(vol.Volume)
@@ -175,11 +174,11 @@ func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, sr
 		for _, snapName := range srcBackup.Snapshots {
 			fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
 			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
-			_ = d.DeleteVolumeSnapshot(snapVol, op)
+			_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 		}
 
 		// And lastly the main volume.
-		_ = d.DeleteVolume(vol.Volume, op)
+		_ = d.DeleteVolume(vol.Volume, progressReporter)
 	}
 	// Only execute the revert function if we have had an error internally.
 	revert.Add(revertHook)
@@ -417,7 +416,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, sr
 
 // createVolumeFromCopy creates a volume from copy by snapshotting the parent volume.
 // It also copies the source volume's snapshots and supports refreshing an already existing volume.
-func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, refresh bool, op *operations.Operation) error {
+func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, refresh bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -463,7 +462,7 @@ func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInc
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol.Volume, vol.config["size"], false, op)
+	err = d.SetVolumeQuota(vol.Volume, vol.config["size"], false, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -479,7 +478,7 @@ func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInc
 	// Get snapshot list if copying snapshots.
 	if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 		// Get the list of source snapshots.
-		snapshots, err = d.VolumeSnapshots(srcVol.Volume, op)
+		snapshots, err = d.VolumeSnapshots(srcVol.Volume)
 		if err != nil {
 			return err
 		}
@@ -494,7 +493,7 @@ func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInc
 		}
 
 		// Get the list of target volume snapshots.
-		targetSnapshots, err := d.VolumeSnapshots(vol.Volume, op)
+		targetSnapshots, err := d.VolumeSnapshots(vol.Volume)
 		if err != nil {
 			return err
 		}
@@ -545,15 +544,15 @@ func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInc
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *btrfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
-	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, false, op)
+func (d *btrfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, false, progressReporter)
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volTargetArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
-		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 		return err
 	} else if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_BTRFS {
 		return ErrNotSupported
@@ -595,7 +594,7 @@ func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClose
 	}
 
 	if volTargetArgs.Refresh && slices.Contains(volTargetArgs.MigrationType.Features, migration.BTRFSFeatureSubvolumeUUIDs) {
-		snapshots, err := d.volumeSnapshotsSorted(vol.Volume, op)
+		snapshots, err := d.volumeSnapshotsSorted(vol.Volume, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -654,10 +653,10 @@ func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClose
 		syncSubvolumes = migrationHeader.Subvolumes
 	}
 
-	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, preFiller, syncSubvolumes, op)
+	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, preFiller, syncSubvolumes, progressReporter)
 }
 
-func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, subvolumes []BTRFSSubVolume, op *operations.Operation) error {
+func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, subvolumes []BTRFSSubVolume, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -678,7 +677,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 		// Setup progress tracking.
 		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, op))
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, progressReporter))
 		}
 
 		for _, subVol := range subvolumes {
@@ -820,7 +819,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 
 	if vol.contentType == ContentTypeFS {
 		// Apply the size limit.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -831,20 +830,20 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *btrfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *btrfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *btrfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
-	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, true, op)
+func (d *btrfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, true, progressReporter)
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
-func (d *btrfs) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *btrfs) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	// Check that we don't have snapshots.
-	snapshots, err := d.VolumeSnapshots(vol, op)
+	snapshots, err := d.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -921,7 +920,7 @@ func (d *btrfs) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size for block volumes, and for filesystem volumes removes quota.
-func (d *btrfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *btrfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -1079,7 +1078,7 @@ func (d *btrfs) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume simulates mounting a volume.
-func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *btrfs) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -1102,7 +1101,7 @@ func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) error {
 
 // UnmountVolume simulates unmounting a volume.
 // As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
-func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -1120,8 +1119,8 @@ func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Oper
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *btrfs) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
-	return genericVFSRenameVolume(d, vol, newVolName, op)
+func (d *btrfs) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSRenameVolume(d, vol, newVolName)
 }
 
 // readonlySnapshot creates a readonly snapshot.
@@ -1170,7 +1169,7 @@ func (d *btrfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		// If volume is filesystem type and is not already a snapshot, create a fast snapshot to ensure migration is consistent.
@@ -1188,7 +1187,7 @@ func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArg
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_BTRFS {
 		return ErrNotSupported
 	}
@@ -1204,7 +1203,7 @@ func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArg
 
 	if !volSrcArgs.VolumeOnly {
 		// Generate restoration header, containing info on the subvolumes and how they should be restored.
-		snapshots, err = d.volumeSnapshotsSorted(vol.Volume, op)
+		snapshots, err = d.volumeSnapshotsSorted(vol.Volume, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1270,10 +1269,10 @@ func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArg
 		}
 	}
 
-	return d.migrateVolumeOptimized(vol.Volume, conn, volSrcArgs, migrationHeader.Subvolumes, op)
+	return d.migrateVolumeOptimized(vol.Volume, conn, volSrcArgs, migrationHeader.Subvolumes, progressReporter)
 }
 
-func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, subvolumes []BTRFSSubVolume, op *operations.Operation) error {
+func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, subvolumes []BTRFSSubVolume, progressReporter ioprogress.ProgressReporter) error {
 	// sendVolume sends a volume and its subvolumes (if negotiated subvolumes feature) to recipient.
 	sendVolume := func(v Volume, sourcePrefix string, parentPrefix string) error {
 		snapName := "" // Default to empty (sending main volume) from migrationHeader.Subvolumes.
@@ -1287,7 +1286,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 		// Setup progress tracking.
 		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, op))
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, progressReporter))
 		}
 
 		sentVols := 0
@@ -1351,7 +1350,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 	lastVolPath := "" // Used as parent for differential transfers.
 
 	if !vol.IsSnapshot() && !volSrcArgs.VolumeOnly {
-		snapshots, err := vol.Snapshots(op)
+		snapshots, err := vol.Snapshots(progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1420,7 +1419,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *btrfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *btrfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
 	// Handle the non-optimized tarballs through the generic packer.
 	if !optimized {
 		// Because the generic backup method will not take a consistent backup if files are being modified
@@ -1439,14 +1438,14 @@ func (d *btrfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *inst
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 	}
 
 	// Optimized backup.
 
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots, op)
+		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots)
 		if err != nil {
 			return err
 		}
@@ -1678,7 +1677,7 @@ func (d *btrfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *inst
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *btrfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *btrfs) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
 	srcPath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
 	snapPath := snapVol.MountPath()
@@ -1728,7 +1727,7 @@ func (d *btrfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) e
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *btrfs) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *btrfs) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	snapPath := snapVol.MountPath()
 
 	// Delete the snapshot.
@@ -1748,7 +1747,7 @@ func (d *btrfs) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) e
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *btrfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *btrfs) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return err
@@ -1777,7 +1776,7 @@ func (d *btrfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
-func (d *btrfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *btrfs) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return false, err
@@ -1796,13 +1795,13 @@ func (d *btrfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *btrfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
-	return genericVFSVolumeSnapshots(d, vol, op)
+func (d *btrfs) VolumeSnapshots(vol Volume) ([]string, error) {
+	return genericVFSVolumeSnapshots(d, vol)
 }
 
 // volumeSnapshotsSorted returns a list of snapshots for the volume (ordered by subvolume ID).
 // Since the subvolume ID is incremental, this also represents the order of creation.
-func (d *btrfs) volumeSnapshotsSorted(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *btrfs) volumeSnapshotsSorted(vol Volume, progressReporter ioprogress.ProgressReporter) ([]string, error) {
 	stdout := bytes.Buffer{}
 
 	err := shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))
@@ -1838,7 +1837,7 @@ func (d *btrfs) volumeSnapshotsSorted(vol Volume, op *operations.Operation) ([]s
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *btrfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *btrfs) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1893,6 +1892,6 @@ func (d *btrfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operati
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *btrfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
-	return genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, op)
+func (d *btrfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, progressReporter)
 }

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -287,7 +287,7 @@ func (d *ceph) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *ceph) Delete(op *operations.Operation) error {
+func (d *ceph) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// Test if the pool exists.
 	poolExists, err := d.osdPoolExists()
 	if err != nil {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -19,7 +19,6 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
@@ -34,7 +33,7 @@ import (
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
 // filler function.
-func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// Function to rename an RBD volume.
 	renameVolume := func(oldName string, newName string) error {
 		_, err := shared.RunCommand(
@@ -147,7 +146,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol, progressReporter) })
 
 	devPath, err := d.rbdMapVolume(vol)
 	if err != nil {
@@ -170,15 +169,15 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -232,7 +231,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -318,12 +317,12 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *ceph) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *ceph) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	var err error
 	revert := revert.New()
 	defer revert.Fail()
@@ -348,9 +347,9 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 			}
 
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err = v.MountTask(func(_ string, _ *operations.Operation) error {
+			err = v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -358,7 +357,7 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 
 		// Resize volume to the size specified. Only uses volume "size" property and does not use
 		// pool/defaults to give the caller more control over the size being used.
-		err = d.SetVolumeQuota(vol.Volume, vol.config["size"], false, op)
+		err = d.SetVolumeQuota(vol.Volume, vol.config["size"], false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -371,19 +370,19 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 		// We can pass the regular volume's snapshots as only their presence is relevant.
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcVol.Snapshots...)
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), vol.Snapshots...)
-		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, progressReporter) })
 	}
 
 	// Retrieve snapshots on the source.
 	snapshots := []string{}
 	if !srcVol.IsSnapshot() && len(vol.Snapshots) > 0 {
-		snapshots, err = d.VolumeSnapshots(srcVol.Volume, op)
+		snapshots, err = d.VolumeSnapshots(srcVol.Volume)
 		if err != nil {
 			return err
 		}
@@ -406,7 +405,7 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 				return err
 			}
 
-			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 
 			_, err = d.rbdMapVolume(vol.Volume)
 			if err != nil {
@@ -447,7 +446,7 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 				return err
 			}
 
-			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 		}
 
 		err = postCreateTasks(vol.Volume)
@@ -527,11 +526,11 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 // CreateVolumeFromMigration creates a volume being sent via a migration.
 // It returns the cleanup hooks required to revert any changes made during the migration.
 // Only the RBD and RBD_AND_RSYNC migration types are covered by this function.
-func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) (revert.Hook, error) {
+func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	// Fallback to the generic migration for the VM's filesystem volume using rsync.
 	// This is the case if both sides have agreed on using RBD_AND_RSYNC.
 	if volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RBD_AND_RSYNC && vol.contentType == ContentTypeFS {
-		return genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+		return genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 	}
 
 	var lastCommonSnapshotName string
@@ -578,7 +577,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 		// This is required so that the target volume is at the exact same state as the source volume.
 		// We can then use the Ceph RBD export-diff/import-diff functions to create the delta
 		// between the latest snapshot and source volume and apply it on the target volume.
-		err := d.restoreVolume(vol.Volume, vol.Snapshots[lastCommonSnapshotIndex], op)
+		err := d.restoreVolume(vol.Volume, vol.Snapshots[lastCommonSnapshotIndex], progressReporter)
 		if err != nil {
 			return nil, err
 		}
@@ -632,7 +631,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 			}
 
 			fullSnapshotName := d.getRBDVolumeName(vol.Volume, targetSnapshotName, false, true)
-			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", fullSnapshotName, op))
+			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", fullSnapshotName, progressReporter))
 
 			err := d.receiveVolume(targetVolumeName, conn, wrapper)
 			if err != nil {
@@ -671,7 +670,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 		}
 	}()
 
-	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 
 	// Apply the diff.
 	err = d.receiveVolume(targetVolumeName, conn, wrapper)
@@ -685,7 +684,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	if volTargetArgs.ClusterMoveSourceName != "" {
 		err := vol.EnsureMountPath()
 		if err != nil {
@@ -694,7 +693,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 
 		if vol.IsVMBlock() {
 			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
+			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -705,7 +704,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 
 	// Handle simple RSYNC and BLOCK_AND_RSYNC through the generic function.
 	if slices.Contains([]migration.MigrationFSType{migration.MigrationFSType_RSYNC, migration.MigrationFSType_BLOCK_AND_RSYNC}, volTargetArgs.MigrationType.FSType) || volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RBD_AND_RSYNC && vol.contentType == ContentTypeFS {
-		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -732,7 +731,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 
 		// Migrate the VM's filesystem volume and record the cleanup hooks.
 		// This allows cleaning up any changes made during the generic migration.
-		cleanup, err := d.createVolumeFromMigration(fsVolCopy, conn, volTargetArgs, preFiller, op)
+		cleanup, err := d.createVolumeFromMigration(fsVolCopy, conn, volTargetArgs, preFiller, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -741,7 +740,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 	}
 
 	// Migrate the actual volume and record the cleanup hooks.
-	cleanup, err := d.createVolumeFromMigration(vol, conn, volTargetArgs, preFiller, op)
+	cleanup, err := d.createVolumeFromMigration(vol, conn, volTargetArgs, preFiller, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -753,16 +752,16 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *ceph) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *ceph) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // refreshVolume updates an existing volume to match the state of another.
 // It returns the cleanup hooks required to revert any changes made during the refresh.
-func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) (revert.Hook, error) {
+func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	// Copy volumes with content type filesystem using the generic approach.
 	if vol.contentType == ContentTypeFS {
-		return genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+		return genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 	}
 
 	var lastCommonSnapshotName string
@@ -813,7 +812,7 @@ func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 		// between the latest snapshot and source volume and apply it on the target volume.
 		// The VMs filesystem volume will not be restored.
 		// It already got refreshed using the generic approach.
-		err := d.restoreVolume(vol.Volume, vol.Snapshots[lastCommonSnapshotIndex], op)
+		err := d.restoreVolume(vol.Volume, vol.Snapshots[lastCommonSnapshotIndex], progressReporter)
 		if err != nil {
 			return nil, err
 		}
@@ -845,7 +844,7 @@ func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 		// The target volume was just deleted in the step before
 		// as there isn't any common snapshot when refreshing a volume from a snapshot.
 		// Simply copy the source volume again to the target.
-		return nil, d.CreateVolumeFromCopy(vol, srcVol, allowInconsistent, op)
+		return nil, d.CreateVolumeFromCopy(vol, srcVol, allowInconsistent, progressReporter)
 	}
 
 	// Refreshes the targetVol by applying the sourceVol.
@@ -936,7 +935,7 @@ func (d *ceph) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -959,7 +958,7 @@ func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 
 		// Refresh the VMs filesystem volume and record the cleanup hooks.
 		// This allows cleaning up any changes made during the generic refresh.
-		cleanup, err := d.refreshVolume(fsVolCopy, srcFsVolCopy, refreshSnapshots, allowInconsistent, op)
+		cleanup, err := d.refreshVolume(fsVolCopy, srcFsVolCopy, refreshSnapshots, allowInconsistent, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -968,7 +967,7 @@ func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 	}
 
 	// Refresh the actual volume and record the cleanup hooks.
-	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, op)
+	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -981,7 +980,7 @@ func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
-func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *ceph) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	volExists, err := d.HasVolume(vol)
 	if err != nil {
 		return err
@@ -993,7 +992,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 	if vol.volType == VolumeTypeImage {
 		// Unmount and unmap.
-		_, err := d.UnmountVolume(vol, false, op)
+		_, err := d.UnmountVolume(vol, false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1052,7 +1051,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 		}
 	} else {
 		// Unmount and unmap.
-		_, err := d.UnmountVolume(vol, false, op)
+		_, err := d.UnmountVolume(vol, false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1066,7 +1065,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1310,7 +1309,7 @@ func (d *ceph) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *ceph) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *ceph) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
 	// updated when the volume's size is changed, and this is what instances are created from.
 	// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
@@ -1534,7 +1533,7 @@ func (d *ceph) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *ceph) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *ceph) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -1586,7 +1585,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) error {
 		// For VMs, mount the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err = d.MountVolume(fsVol, op)
+			err = d.MountVolume(fsVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1600,7 +1599,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) error {
 
 // UnmountVolume simulates unmounting a volume.
 // keepBlockDev indicates if backing block device should be not be unmapped if volume is unmounted.
-func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -1640,7 +1639,7 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 		// For VMs, unmount the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+			ourUnmount, err = d.UnmountVolume(fsVol, false, progressReporter)
 			if err != nil {
 				return false, err
 			}
@@ -1670,8 +1669,8 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
-	return vol.UnmountTask(func(op *operations.Operation) error {
+func (d *ceph) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
+	return vol.UnmountTask(func(progressReporter ioprogress.ProgressReporter) error {
 		revert := revert.New()
 		defer revert.Fail()
 
@@ -1685,7 +1684,7 @@ func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 
 		// Rename volume dir.
 		if vol.contentType == ContentTypeFS {
-			err = genericVFSRenameVolume(d, vol, newVolName, op)
+			err = genericVFSRenameVolume(d, vol, newVolName)
 			if err != nil {
 				return err
 			}
@@ -1694,7 +1693,7 @@ func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 		// For VMs, also rename the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err = d.RenameVolume(fsVol, newVolName, op)
+			err = d.RenameVolume(fsVol, newVolName, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1702,11 +1701,11 @@ func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 
 		revert.Success()
 		return nil
-	}, false, op)
+	}, false, progressReporter)
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	if volSrcArgs.ClusterMove {
 		return nil // When performing a cluster member move don't do anything on the source member.
 	}
@@ -1718,14 +1717,14 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 		// activated to avoid issues activating the snapshot volume device.
 		parent, _, _ := api.GetParentAndSnapshotName(vol.Name())
 		parentVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, parent, vol.config, vol.poolConfig)
-		err := d.MountVolume(parentVol, op)
+		err := d.MountVolume(parentVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _, _ = d.UnmountVolume(parentVol, false, op) }()
+		defer func() { _, _ = d.UnmountVolume(parentVol, false, progressReporter) }()
 
-		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 	} else if !slices.Contains([]migration.MigrationFSType{migration.MigrationFSType_RBD, migration.MigrationFSType_RBD_AND_RSYNC}, volSrcArgs.MigrationType.FSType) {
 		return ErrNotSupported
 	}
@@ -1747,7 +1746,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 
 		fsVolCopy := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 
-		err := d.MigrateVolume(fsVolCopy, conn, volSrcArgs, op)
+		err := d.MigrateVolume(fsVolCopy, conn, volSrcArgs, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1787,7 +1786,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 		// Setup progress tracking.
 		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 		}
 
 		return d.sendVolume(conn, sendSnapName, "", writerWrapper)
@@ -1836,7 +1835,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 			// Setup progress tracking.
 			var writerWrapper ioprogress.WriterWrapper
 			if volSrcArgs.TrackProgress {
-				writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", targetSnapshot.name, op))
+				writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", targetSnapshot.name, progressReporter))
 			}
 
 			sendSnapName := d.getRBDVolumeName(vol.Volume, "snapshot_"+targetSnapshotName, false, true)
@@ -1858,7 +1857,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 	// Setup progress tracking.
 	var writerWrapper ioprogress.WriterWrapper
 	if volSrcArgs.TrackProgress {
-		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 	}
 
 	runningSnapName := "migration-send-" + uuid.New().String()
@@ -1875,12 +1874,12 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *ceph) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *ceph) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *ceph) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *ceph) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1917,17 +1916,17 @@ func (d *ceph) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, progressReporter) })
 
 	// For VM images, create a filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolumeSnapshot(fsVol, op)
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, progressReporter) })
 	}
 
 	revert.Success()
@@ -1935,7 +1934,7 @@ func (d *ceph) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.
-func (d *ceph) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *ceph) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	// Check if snapshot exists, and return if not.
 	_, err := shared.RunCommand(
 		context.Background(),
@@ -1982,7 +1981,7 @@ func (d *ceph) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 	// For VM images, delete the filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolumeSnapshot(fsVol, op)
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1992,7 +1991,7 @@ func (d *ceph) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 }
 
 // MountVolumeSnapshot simulates mounting a volume snapshot.
-func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *ceph) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return err
@@ -2079,7 +2078,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		// For VMs, mount the filesystem volume.
 		if snapVol.IsVMBlock() {
 			fsVol := snapVol.NewVMBlockFilesystemVolume()
-			err = d.MountVolumeSnapshot(fsVol, op)
+			err = d.MountVolumeSnapshot(fsVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -2092,7 +2091,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 }
 
 // UnmountVolumeSnapshot simulates unmounting a volume snapshot.
-func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return false, err
@@ -2145,7 +2144,7 @@ func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (
 	} else if snapVol.contentType == ContentTypeBlock {
 		if snapVol.IsVMBlock() {
 			fsVol := snapVol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolumeSnapshot(fsVol, op)
+			ourUnmount, err = d.UnmountVolumeSnapshot(fsVol, progressReporter)
 			if err != nil {
 				return false, err
 			}
@@ -2172,7 +2171,7 @@ func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *ceph) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *ceph) VolumeSnapshots(vol Volume) ([]string, error) {
 	snapshots, err := d.rbdListVolumeSnapshots(vol)
 	if err != nil {
 		if response.IsNotFoundError(err) {
@@ -2199,14 +2198,14 @@ func (d *ceph) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 
 // restoreVolume restores a volume from a snapshot.
 // Use RestoreVolume if a VM's filesystem volume should get restored too.
-func (d *ceph) restoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	ourUnmount, err := d.UnmountVolume(vol, false, op)
+func (d *ceph) restoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	ourUnmount, err := d.UnmountVolume(vol, false, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	if ourUnmount {
-		defer func() { _ = d.MountVolume(vol, op) }()
+		defer func() { _ = d.MountVolume(vol, progressReporter) }()
 	}
 
 	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
@@ -2246,8 +2245,8 @@ func (d *ceph) restoreVolume(vol Volume, snapVol Volume, op *operations.Operatio
 
 // RestoreVolume restores a volume from a snapshot.
 // Use restoreVolume if a VM's filesystem volume should not get restored.
-func (d *ceph) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	err := d.restoreVolume(vol, snapVol, op)
+func (d *ceph) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	err := d.restoreVolume(vol, snapVol, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -2256,7 +2255,7 @@ func (d *ceph) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operatio
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 		fsSnapVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.restoreVolume(fsVol, fsSnapVol, op)
+		err := d.restoreVolume(fsVol, fsSnapVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2266,7 +2265,7 @@ func (d *ceph) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operatio
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *ceph) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *ceph) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -2284,7 +2283,7 @@ func (d *ceph) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *
 	revert.Add(func() { _ = d.rbdRenameVolumeSnapshot(parentVol, newSnapOnlyName, oldSnapOnlyName) })
 
 	if snapVol.contentType == ContentTypeFS {
-		err = genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, op)
+		err = genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2293,14 +2292,14 @@ func (d *ceph) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *
 	// For VM images, create a filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.RenameVolumeSnapshot(fsVol, newSnapshotName, op)
+		err := d.RenameVolumeSnapshot(fsVol, newSnapshotName, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
 			newFsVol := NewVolume(d, d.name, snapVol.volType, ContentTypeFS, fmt.Sprintf("%s/%s", parentName, newSnapshotName), snapVol.config, snapVol.poolConfig)
-			_ = d.RenameVolumeSnapshot(newFsVol, snapVol.name, op)
+			_ = d.RenameVolumeSnapshot(newFsVol, snapVol.name, progressReporter)
 		})
 	}
 

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
@@ -352,7 +352,7 @@ func (d *cephfs) Create() error {
 }
 
 // Delete clears any local and remote data related to this driver instance.
-func (d *cephfs) Delete(op *operations.Operation) error {
+func (d *cephfs) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// Parse the namespace / path.
 	fsName, fsPath, _ := strings.Cut(d.config["cephfs.path"], "/")
 	fsPath = "/" + fsPath

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/rsync"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -23,7 +22,7 @@ import (
 )
 
 // CreateVolume creates a new storage volume on disk.
-func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	if vol.volType != VolumeTypeCustom {
 		return ErrNotSupported
 	}
@@ -48,7 +47,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 	}()
 
 	// Apply the volume quota if specified.
-	err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+	err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -64,17 +63,17 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *cephfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *cephfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
-func (d *cephfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return d.CreateVolume(vol, filler, op)
+func (d *cephfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return d.CreateVolume(vol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
-func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	bwlimit := d.config["rsync.bwlimit"]
 
 	// Create the main volume path.
@@ -96,18 +95,18 @@ func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
 
 			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
-			_ = d.DeleteVolumeSnapshot(snapVol, op)
+			_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 		}
 
 		_ = os.RemoveAll(volPath)
 	}()
 
 	// Ensure the volume is mounted.
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// If copying snapshots is indicated, check the source isn't itself a snapshot.
 		if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 			// Get the list of snapshots from the source.
-			srcSnapshots, err := srcVol.Volume.Snapshots(op)
+			srcSnapshots, err := srcVol.Volume.Snapshots(progressReporter)
 			if err != nil {
 				return err
 			}
@@ -116,14 +115,14 @@ func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 				_, snapName, _ := api.GetParentAndSnapshotName(srcSnapshot.name)
 
 				// Mount the source snapshot.
-				err = srcSnapshot.MountTask(func(srcMountPath string, op *operations.Operation) error {
+				err = srcSnapshot.MountTask(func(srcMountPath string, progressReporter ioprogress.ProgressReporter) error {
 					// Copy the snapshot.
 					_, err = rsync.LocalCopy(srcMountPath, mountPath, bwlimit, false)
 					return err
-				}, op)
+				}, progressReporter)
 
 				// Create the snapshot itself.
-				err = d.CreateVolumeSnapshot(srcSnapshot, op)
+				err = d.CreateVolumeSnapshot(srcSnapshot, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -134,16 +133,16 @@ func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 		}
 
 		// Apply the volume quota if specified.
-		err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
+		err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		// Copy source to destination (mounting each volume if needed).
-		err = srcVol.MountTask(func(srcMountPath string, op *operations.Operation) error {
+		err = srcVol.MountTask(func(srcMountPath string, progressReporter ioprogress.ProgressReporter) error {
 			_, err := rsync.LocalCopy(srcMountPath, mountPath, bwlimit, false)
 			return err
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -151,7 +150,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 		// Run EnsureMountPath after mounting and copying to ensure the mounted directory has the
 		// correct permissions set.
 		return vol.EnsureMountPath()
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -161,7 +160,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIn
 }
 
 // CreateVolumeFromMigration creates a new volume (with or without snapshots) from a migration data stream.
-func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_RSYNC {
 		return ErrNotSupported
 	}
@@ -185,14 +184,14 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
 			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 
-			_ = d.DeleteVolumeSnapshot(snapVol, op)
+			_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 		}
 
 		_ = os.RemoveAll(volPath)
 	}()
 
 	// Ensure the volume is mounted.
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		path := shared.AddSlash(mountPath)
 
 		// Snapshots are sent first by the sender, so create these first.
@@ -200,7 +199,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 			// Receive the snapshot.
 			var wrapper ioprogress.ReaderWrapper
 			if volTargetArgs.TrackProgress {
-				wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapName, op))
+				wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapName, progressReporter))
 			}
 
 			err = rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)
@@ -212,7 +211,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 
 			// Create the snapshot itself.
-			err = d.CreateVolumeSnapshot(snapVol, op)
+			err = d.CreateVolumeSnapshot(snapVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -223,7 +222,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 
 		if vol.contentType == ContentTypeFS {
 			// Apply the size limit.
-			err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
+			err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -232,11 +231,11 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 		// Receive the main volume from sender.
 		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 		}
 
 		return rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -246,8 +245,8 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 }
 
 // DeleteVolume destroys the on-disk state of a volume.
-func (d *cephfs) DeleteVolume(vol Volume, op *operations.Operation) error {
-	snapshots, err := d.VolumeSnapshots(vol, op)
+func (d *cephfs) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	snapshots, err := d.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -320,7 +319,7 @@ func (d *cephfs) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *cephfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *cephfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// If size not specified in volume config, then use pool's default volume.size setting.
 	if size == "" || size == "0" {
 		size = d.config["volume.size"]
@@ -346,7 +345,7 @@ func (d *cephfs) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume sets up the volume for use.
-func (d *cephfs) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *cephfs) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -360,7 +359,7 @@ func (d *cephfs) MountVolume(vol Volume, op *operations.Operation) error {
 
 // UnmountVolume clears any runtime state for the volume.
 // As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
-func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -378,7 +377,7 @@ func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Ope
 }
 
 // RenameVolume renames the volume and all related filesystem entries.
-func (d *cephfs) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *cephfs) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	// Create the parent directory.
 	err := createParentSnapshotDirIfMissing(d.name, vol.volType, newVolName)
 	if err != nil {
@@ -427,7 +426,7 @@ func (d *cephfs) RenameVolume(vol Volume, newVolName string, op *operations.Oper
 	}
 
 	// Rename any snapshots of the volume too.
-	snapshots, err := vol.Snapshots(op)
+	snapshots, err := vol.Snapshots(progressReporter)
 	if err != nil {
 		return err
 	}
@@ -473,17 +472,17 @@ func (d *cephfs) RenameVolume(vol Volume, newVolName string, op *operations.Oper
 }
 
 // MigrateVolume streams the volume (with or without snapshots).
-func (d *cephfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *cephfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *cephfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *cephfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a new snapshot.
-func (d *cephfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *cephfs) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, snapName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	// Create the snapshot.
@@ -512,7 +511,7 @@ func (d *cephfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 }
 
 // DeleteVolumeSnapshot deletes a snapshot.
-func (d *cephfs) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *cephfs) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, snapName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	// Delete the snapshot itself.
@@ -535,7 +534,7 @@ func (d *cephfs) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 }
 
 // MountVolumeSnapshot makes the snapshot available for use.
-func (d *cephfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *cephfs) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return err
@@ -548,7 +547,7 @@ func (d *cephfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) e
 }
 
 // UnmountVolumeSnapshot clears any runtime state for the snapshot.
-func (d *cephfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *cephfs) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return false, err
@@ -566,12 +565,12 @@ func (d *cephfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation)
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *cephfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
-	return genericVFSVolumeSnapshots(d, vol, op)
+func (d *cephfs) VolumeSnapshots(vol Volume) ([]string, error) {
+	return genericVFSVolumeSnapshots(d, vol)
 }
 
 // RestoreVolume resets a volume to its snapshotted state.
-func (d *cephfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *cephfs) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	sourcePath := GetVolumeMountPath(d.name, vol.volType, vol.name)
 	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 	cephSnapPath := filepath.Join(sourcePath, ".snap", snapshotName)
@@ -587,7 +586,7 @@ func (d *cephfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operat
 }
 
 // RenameVolumeSnapshot renames a snapshot.
-func (d *cephfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *cephfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	parentName, snapName, _ := api.GetParentAndSnapshotName(snapVol.name)
 	sourcePath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
 	oldCephSnapPath := filepath.Join(sourcePath, ".snap", snapName)

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -195,7 +195,7 @@ func (d *cephobject) Create() error {
 }
 
 // Delete clears any local and remote data related to this driver instance.
-func (d *cephobject) Delete(op *operations.Operation) error {
+func (d *cephobject) Delete(progressReporter ioprogress.ProgressReporter) error {
 	if shared.IsTrue(d.config["volatile.pool.pristine"]) {
 		err := d.radosgwadminUserDelete(context.TODO(), cephobjectRadosgwAdminUser)
 		if err != nil {

--- a/lxd/storage/drivers/driver_cephobject_buckets.go
+++ b/lxd/storage/drivers/driver_cephobject_buckets.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/revert"
@@ -20,7 +19,7 @@ func (d *cephobject) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 }
 
 // CreateBucket creates a new bucket.
-func (d *cephobject) CreateBucket(bucket Volume, op *operations.Operation) error {
+func (d *cephobject) CreateBucket(bucket Volume) error {
 	_, bucketName := project.StorageVolumeParts(bucket.name)
 	storageBucketName := d.radosgwBucketName(bucketName)
 
@@ -96,7 +95,7 @@ func (d *cephobject) setBucketQuota(bucket Volume, quotaSize string) error {
 }
 
 // DeleteBucket deletes an existing bucket.
-func (d *cephobject) DeleteBucket(bucket Volume, op *operations.Operation) error {
+func (d *cephobject) DeleteBucket(bucket Volume) error {
 	_, bucketName := project.StorageVolumeParts(bucket.name)
 	storageBucketName := d.radosgwBucketName(bucketName)
 
@@ -139,7 +138,7 @@ func (d *cephobject) bucketKeyRadosgwAccessRole(roleName string) (string, error)
 }
 
 // CreateBucketKey creates a new bucket key.
-func (d *cephobject) CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *cephobject) CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error) {
 	_, bucketName := project.StorageVolumeParts(bucket.name)
 	storageBucketName := d.radosgwBucketName(bucketName)
 
@@ -168,7 +167,7 @@ func (d *cephobject) CreateBucketKey(bucket Volume, keyName string, creds S3Cred
 }
 
 // UpdateBucketKey updates bucket key.
-func (d *cephobject) UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *cephobject) UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error) {
 	_, bucketName := project.StorageVolumeParts(bucket.name)
 	storageBucketName := d.radosgwBucketName(bucketName)
 
@@ -204,7 +203,7 @@ func (d *cephobject) UpdateBucketKey(bucket Volume, keyName string, creds S3Cred
 }
 
 // DeleteBucketKey deletes an existing bucket key.
-func (d *cephobject) DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error {
+func (d *cephobject) DeleteBucketKey(bucket Volume, keyName string) error {
 	_, bucketName := project.StorageVolumeParts(bucket.name)
 	storageBucketName := d.radosgwBucketName(bucketName)
 

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -15,13 +15,13 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
@@ -362,37 +362,37 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller, all
 }
 
 // CreateVolume creates a new storage volume on disk.
-func (d *common) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *common) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *common) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *common) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, ErrNotSupported
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
-func (d *common) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *common) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // CreateVolumeFromImage creates volume from images.
-func (d *common) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *common) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // CreateVolumeFromMigration creates a new volume (with or without snapshots) from a migration data stream.
-func (d *common) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *common) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *common) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *common) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // DeleteVolume destroys the on-disk state of a volume.
-func (d *common) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *common) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
@@ -417,7 +417,7 @@ func (d *common) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *common) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *common) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
@@ -432,13 +432,13 @@ func (d *common) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume sets up the volume for use.
-func (d *common) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *common) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // UnmountVolume clears any runtime state for the volume.
 // As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
-func (d *common) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *common) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return false, ErrNotSupported
 }
 
@@ -453,49 +453,49 @@ func (d *common) DelegateVolume(vol Volume, pid int) error {
 }
 
 // RenameVolume renames the volume and all related filesystem entries.
-func (d *common) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *common) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // MigrateVolume streams the volume (with or without snapshots).
-func (d *common) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *common) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *common) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *common) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // CreateVolumeSnapshot creates a new snapshot.
-func (d *common) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *common) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // DeleteVolumeSnapshot deletes a snapshot.
-func (d *common) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *common) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // MountVolumeSnapshot makes the snapshot available for use.
-func (d *common) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *common) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // UnmountVolumeSnapshot clears any runtime state for the snapshot.
-func (d *common) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *common) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return false, ErrNotSupported
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *common) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *common) VolumeSnapshots(vol Volume) ([]string, error) {
 	return nil, ErrNotSupported
 }
 
 // CheckVolumeSnapshots checks that the volume's snapshots, according to the storage driver, match those provided.
-func (d *common) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error {
+func (d *common) CheckVolumeSnapshots(vol Volume, snapVols []Volume) error {
 	// Use the volume's driver reference to pick the actual method as implemented by the driver.
-	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol, op)
+	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -525,12 +525,12 @@ func (d *common) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operati
 }
 
 // RestoreVolume resets a volume to its snapshotted state.
-func (d *common) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *common) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
 // RenameVolumeSnapshot renames a snapshot.
-func (d *common) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *common) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	return ErrNotSupported
 }
 
@@ -559,12 +559,12 @@ func (d *common) GetBucketURL(bucketName string) *url.URL {
 }
 
 // CreateBucket creates a new bucket.
-func (d *common) CreateBucket(bucket Volume, op *operations.Operation) error {
+func (d *common) CreateBucket(bucket Volume) error {
 	return ErrNotSupported
 }
 
 // DeleteBucket deletes an existing bucket.
-func (d *common) DeleteBucket(bucket Volume, op *operations.Operation) error {
+func (d *common) DeleteBucket(bucket Volume) error {
 	return ErrNotSupported
 }
 
@@ -588,17 +588,17 @@ func (d *common) ValidateBucketKey(keyName string, creds S3Credentials, roleName
 }
 
 // CreateBucketKey create bucket key.
-func (d *common) CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *common) CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error) {
 	return nil, ErrNotSupported
 }
 
 // UpdateBucketKey updates bucket key.
-func (d *common) UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *common) UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error) {
 	return nil, ErrNotSupported
 }
 
 // DeleteBucketKey deletes the bucket key.
-func (d *common) DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error {
+func (d *common) DeleteBucketKey(bucket Volume, keyName string) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -10,10 +10,10 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 )
 
 type dir struct {
@@ -126,7 +126,7 @@ func (d *dir) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *dir) Delete(op *operations.Operation) error {
+func (d *dir) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// On delete, wipe everything in the directory.
 	err := wipeDirectory(GetPoolMountPath(d.name))
 	if err != nil {

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -10,13 +10,13 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/rsync"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/storage/quota"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -24,7 +24,7 @@ import (
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
 // filler function.
-func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	volPath := vol.MountPath()
 
 	revert := revert.New()
@@ -99,9 +99,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	// Run the generic backup unpacker
-	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), d.state, vol, srcBackup.Snapshots, srcData, op)
+	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,17 +138,17 @@ func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcD
 }
 
 // CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
-func (d *dir) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return d.CreateVolume(vol, filler, op)
+func (d *dir) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return d.CreateVolume(vol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *dir) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *dir) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	var srcSnapshots []string
 
 	if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 		// Get the list of snapshots from the source.
-		allSrcSnapshots, err := srcVol.Volume.Snapshots(op)
+		allSrcSnapshots, err := srcVol.Volume.Snapshots(progressReporter)
 		if err != nil {
 			return err
 		}
@@ -160,26 +160,26 @@ func (d *dir) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 	}
 
 	// Run the generic copy.
-	_, err := genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, srcSnapshots, false, allowInconsistent, op)
+	_, err := genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, srcSnapshots, false, allowInconsistent, progressReporter)
 	return err
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *dir) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
-	_, err := genericVFSCreateVolumeFromMigration(d, d.setupInitialQuota, vol, conn, volTargetArgs, preFiller, op)
+func (d *dir) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	_, err := genericVFSCreateVolumeFromMigration(d, d.setupInitialQuota, vol, conn, volTargetArgs, preFiller, progressReporter)
 	return err
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *dir) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
-	_, err := genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+func (d *dir) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	_, err := genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 	return err
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
-func (d *dir) DeleteVolume(vol Volume, op *operations.Operation) error {
-	snapshots, err := d.VolumeSnapshots(vol, op)
+func (d *dir) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	snapshots, err := d.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (d *dir) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size for block volumes, and for filesystem volumes removes quota.
-func (d *dir) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *dir) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -362,7 +362,7 @@ func (d *dir) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume simulates mounting a volume.
-func (d *dir) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *dir) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -385,7 +385,7 @@ func (d *dir) MountVolume(vol Volume, op *operations.Operation) error {
 
 // UnmountVolume simulates unmounting a volume.
 // As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
-func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -403,23 +403,23 @@ func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *dir) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
-	return genericVFSRenameVolume(d, vol, newVolName, op)
+func (d *dir) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSRenameVolume(d, vol, newVolName)
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *dir) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *dir) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *dir) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *dir) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *dir) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	// Create snapshot directory.
@@ -483,7 +483,7 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *dir) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *dir) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	snapPath := snapVol.MountPath()
 
 	// Remove the snapshot from the storage device.
@@ -504,7 +504,7 @@ func (d *dir) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *dir) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *dir) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return err
@@ -533,7 +533,7 @@ func (d *dir) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) erro
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
-func (d *dir) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *dir) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return false, err
@@ -559,12 +559,12 @@ func (d *dir) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *dir) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
-	return genericVFSVolumeSnapshots(d, vol, op)
+func (d *dir) VolumeSnapshots(vol Volume) ([]string, error) {
+	return genericVFSVolumeSnapshots(d, vol)
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *dir) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *dir) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 	snapVol, err := vol.NewSnapshot(snapshotName)
 	if err != nil {
@@ -622,6 +622,6 @@ func (d *dir) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *dir) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
-	return genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, op)
+func (d *dir) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSRenameVolumeSnapshot(d, snapVol, newSnapshotName, progressReporter)
 }

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -424,7 +424,7 @@ func (d *lvm) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *lvm) Delete(op *operations.Operation) error {
+func (d *lvm) Delete(progressReporter ioprogress.ProgressReporter) error {
 	var err error
 	var loopDevPath string
 

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/canonical/lxd/lxd/locking"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/refcount"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -652,7 +652,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 		}
 
 		// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-		err = vol.MountTask(func(_ string, _ *operations.Operation) error {
+		err = vol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 			return vol.EnsureMountPath()
 		}, nil)
 		if err != nil {

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -17,19 +17,19 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/rsync"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 )
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -46,20 +46,20 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		return fmt.Errorf("Error creating LVM logical volume: %w", err)
 	}
 
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol, progressReporter) })
 
 	// For VMs, also create the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -113,7 +113,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -123,18 +123,18 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *lvm) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *lvm) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	var err error
 	var srcSnapshots []string
 
 	if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 		// Get the list of snapshots from the source.
-		allSrcSnapshots, err := srcVol.Volume.Snapshots(op)
+		allSrcSnapshots, err := srcVol.Volume.Snapshots(progressReporter)
 		if err != nil {
 			return err
 		}
@@ -163,37 +163,37 @@ func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 	}
 
 	// Otherwise run the generic copy.
-	_, err = genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, false, allowInconsistent, op)
+	_, err = genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, false, allowInconsistent, progressReporter)
 	return err
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *lvm) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
-	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+func (d *lvm) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 	return err
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *lvm) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *lvm) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *lvm) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *lvm) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	// We can use optimised copying when the pool is backed by an LVM thinpool.
 	if d.usesThinpool() {
 		return d.copyThinpoolVolume(vol.Volume, srcVol.Volume, refreshSnapshots, true)
 	}
 
 	// Otherwise run the generic copy.
-	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 	return err
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then this function
 // will return an error.
-func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
-	snapshots, err := d.VolumeSnapshots(vol, op)
+func (d *lvm) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	snapshots, err := d.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if lvExists {
 		// Only call UnmountVolume if mounted to avoid breaking deactivaion ref counts.
 		if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(vol.MountPath()) {
-			_, err = d.UnmountVolume(vol, false, op)
+			_, err = d.UnmountVolume(vol, false, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 			}
@@ -242,7 +242,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 	// For VMs, also delete the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -424,7 +424,7 @@ func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Do nothing if size isn't specified.
 	if size == "" || size == "0" {
 		return nil
@@ -718,7 +718,7 @@ func (d *lvm) ListVolumes() ([]Volume, error) {
 }
 
 // mountCommon includes the logic for mounting either a volume or a volume snapshot as they follow very similar procedures.
-func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
+func (d *lvm) mountCommon(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -827,7 +827,7 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		// For VMs, mount the filesystem volume.
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err = d.MountVolumeSnapshot(fsVol, op)
+		err = d.MountVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -839,12 +839,12 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
-	return d.mountCommon(vol, op)
+func (d *lvm) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return d.mountCommon(vol, progressReporter)
 }
 
 // unmountCommon includes the logic for unmounting either a volume or a volume snapshot as they follow very similar procedures.
-func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -860,7 +860,7 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 	// For VMs, unmount the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+		ourUnmount, err = d.UnmountVolume(fsVol, false, progressReporter)
 
 		// If the VMBlockFilesystem volume is still in use, we use the refCount
 		// of the block volume instead.
@@ -932,16 +932,16 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 
 // UnmountVolume unmounts volume if mounted and not in use. Returns true if this unmounted the volume.
 // keepBlockDev indicates if backing block device should not be deactivated when volume is unmounted.
-func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return d.unmountCommon(vol, keepBlockDev, op)
+func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return d.unmountCommon(vol, keepBlockDev, progressReporter)
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *lvm) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
 
-	return vol.UnmountTask(func(op *operations.Operation) error {
-		snapNames, err := d.VolumeSnapshots(vol, op)
+	return vol.UnmountTask(func(progressReporter ioprogress.ProgressReporter) error {
+		snapNames, err := d.VolumeSnapshots(vol)
 		if err != nil {
 			return err
 		}
@@ -1001,7 +1001,7 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 		// For VMs, also rename the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err = d.RenameVolume(fsVol, newVolName, op)
+			err = d.RenameVolume(fsVol, newVolName, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1009,22 +1009,22 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 
 		revert.Success()
 		return nil
-	}, false, op)
+	}, false, progressReporter)
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *lvm) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *lvm) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *lvm) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, _ bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *lvm) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, _ bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *lvm) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
 	parentVol := NewVolume(d, d.name, snapVol.volType, snapVol.contentType, parentName, snapVol.config, snapVol.poolConfig)
 	snapPath := snapVol.MountPath()
@@ -1073,7 +1073,7 @@ func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	// Remove the snapshot from the storage device.
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], snapVol.volType, snapVol.contentType, snapVol.name)
 	lvExists, err := d.logicalVolumeExists(volDevPath)
@@ -1084,7 +1084,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	if lvExists {
 		// Only call UnmountVolumeSnapshot if mounted to avoid breaking deactivaion ref counts.
 		if snapVol.contentType == ContentTypeFS && filesystem.IsMountPoint(snapVol.MountPath()) {
-			_, err = d.UnmountVolumeSnapshot(snapVol, op)
+			_, err = d.UnmountVolumeSnapshot(snapVol, progressReporter)
 			if err != nil {
 				return fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 			}
@@ -1099,7 +1099,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	// For VMs, also remove the snapshot filesystem volume.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err = d.DeleteVolumeSnapshot(fsVol, op)
+		err = d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1123,18 +1123,18 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *lvm) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
-	return d.mountCommon(snapVol, op)
+func (d *lvm) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return d.mountCommon(snapVol, progressReporter)
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
 // If a temporary snapshot volume exists then it will attempt to remove it.
-func (d *lvm) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
-	return d.unmountCommon(snapVol, false, op)
+func (d *lvm) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return d.unmountCommon(snapVol, false, progressReporter)
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *lvm) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *lvm) VolumeSnapshots(vol Volume) ([]string, error) {
 	// We use the volume list rather than inspecting the logical volumes themselves because the origin
 	// property of an LVM snapshot can be removed/changed when restoring snapshots, such that they are no
 	// marked as origin of the parent volume. Instead we use prefix matching on the volume names to find the
@@ -1180,7 +1180,7 @@ func (d *lvm) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	restoreThinPoolVolume := func(restoreVol Volume) (revert.Hook, error) {
@@ -1190,7 +1190,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 			return nil, err
 		}
 
-		_, err = d.UnmountVolume(restoreVol, false, op)
+		_, err = d.UnmountVolume(restoreVol, false, progressReporter)
 		if err != nil {
 			return nil, fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 		}
@@ -1325,9 +1325,9 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 	}
 
 	// Mount source and target, copy, then unmount.
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Copy source to destination (mounting each volume if needed).
-		err = snapVol.MountTask(func(srcMountPath string, op *operations.Operation) error {
+		err = snapVol.MountTask(func(srcMountPath string, progressReporter ioprogress.ProgressReporter) error {
 			if snapVol.IsVMBlock() || snapVol.contentType == ContentTypeFS {
 				bwlimit := d.config["rsync.bwlimit"]
 				d.Logger().Debug("Copying fileystem volume", logger.Ctx{"sourcePath": srcMountPath, "targetPath": mountPath, "bwlimit": bwlimit})
@@ -1356,7 +1356,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 			}
 
 			return nil
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1369,7 +1369,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Error restoring LVM logical volume snapshot: %w", err)
 	}
@@ -1379,7 +1379,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *lvm) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *lvm) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], snapVol.volType, snapVol.contentType, snapVol.name)
 
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -6,8 +6,8 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 )
 
@@ -50,7 +50,7 @@ func (d *mock) Create() error {
 }
 
 // Delete removes a storage pool.
-func (d *mock) Delete(op *operations.Operation) error {
+func (d *mock) Delete(progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -80,33 +80,33 @@ func (d *mock) GetResources() (*api.ResourcesStoragePool, error) {
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *mock) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *mock) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *mock) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *mock) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then this function
 // will return an error.
-func (d *mock) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *mock) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -143,7 +143,7 @@ func (d *mock) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *mock) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *mock) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
@@ -158,64 +158,64 @@ func (d *mock) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume simulates mounting a volume.
-func (d *mock) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *mock) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UnmountVolume simulates unmounting a volume. As dir driver doesn't have volumes to unmount it
 // returns false indicating the volume was already unmounted.
-func (d *mock) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *mock) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return false, nil
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *mock) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *mock) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *mock) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *mock) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *mock) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *mock) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *mock) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *mock) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *mock) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
-func (d *mock) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *mock) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return true, nil
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *mock) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *mock) VolumeSnapshots(vol Volume) ([]string, error) {
 	return nil, nil
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *mock) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *mock) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *mock) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *mock) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	return nil
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -209,7 +209,7 @@ func (d *powerflex) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *powerflex) Delete(op *operations.Operation) error {
+func (d *powerflex) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// On delete, wipe everything in the directory.
 	return wipeDirectory(GetPoolMountPath(d.name))
 }

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -15,10 +15,10 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -29,7 +29,7 @@ import (
 const factorGiB = 1024 * 1024 * 1024
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -87,15 +87,15 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -141,7 +141,7 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -151,17 +151,17 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *powerflex) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *powerflex) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
-func (d *powerflex) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return d.CreateVolume(vol, filler, op)
+func (d *powerflex) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return d.CreateVolume(vol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -170,9 +170,9 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 	postCreateTasks := func(v Volume) error {
 		if vol.contentType == ContentTypeFS {
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+			err := v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -180,7 +180,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 
 		// Resize volume to the size specified.
 		// In case there isn't any explicit size set, it's a noop.
-		err := d.SetVolumeQuota(vol.Volume, vol.config["size"], false, op)
+		err := d.SetVolumeQuota(vol.Volume, vol.config["size"], false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -223,13 +223,13 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 
 		// For VMs, also copy the filesystem volume.
 		if vol.IsVMBlock() {
 			srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
 			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+			err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -253,7 +253,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 	// Copy "lazy" with snapshots.
 	// If clone copies are enforced by the pools config or the volume has snapshots that need to be copied,
 	// fallback to simply copying the contents between source and target volumes.
-	cleanup, err := genericVFSCopyVolume(d, nil, vol, srcVol, srcVolumeSnapshots, false, allowInconsistent, op)
+	cleanup, err := genericVFSCopyVolume(d, nil, vol, srcVol, srcVolumeSnapshots, false, allowInconsistent, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *powerflex) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *powerflex) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move prepare the volumes on the target side.
 	if volTargetArgs.ClusterMoveSourceName != "" {
 		err := vol.EnsureMountPath()
@@ -275,7 +275,7 @@ func (d *powerflex) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteC
 
 		if vol.IsVMBlock() {
 			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
+			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -284,19 +284,19 @@ func (d *powerflex) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteC
 		return nil
 	}
 
-	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 	return err
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *powerflex) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
-	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+func (d *powerflex) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 	return err
 }
 
 // DeleteVolume deletes a volume of the storage device.
 // If any snapshots of the volume remain then this function will return an error.
-func (d *powerflex) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *powerflex) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	volExists, err := d.HasVolume(vol)
 	if err != nil {
 		return err
@@ -337,7 +337,7 @@ func (d *powerflex) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -526,7 +526,7 @@ func (d *powerflex) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
 	// updated when the volume's size is changed, and this is what instances are created from.
 	// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
@@ -760,39 +760,39 @@ func (d *powerflex) defaultBlockVolumeSize() string {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *powerflex) MountVolume(vol Volume, op *operations.Operation) error {
-	return mountVolume(d, vol, d.getMappedDevPath, op)
+func (d *powerflex) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return mountVolume(d, vol, d.getMappedDevPath, progressReporter)
 }
 
 // UnmountVolume simulates unmounting a volume.
 // keepBlockDev indicates if backing block device should not be unmapped if volume is unmounted.
-func (d *powerflex) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, op)
+func (d *powerflex) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, progressReporter)
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *powerflex) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *powerflex) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume in PowerFlex won't change it's name in storage.
 	return nil
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *powerflex) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *powerflex) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move don't do anything on the source member.
 	if volSrcArgs.ClusterMove {
 		return nil
 	}
 
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *powerflex) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *powerflex) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -853,7 +853,7 @@ func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, op *operations.Operatio
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, progressReporter) })
 
 	// For VM images, create a filesystem volume too.
 	if snapVol.IsVMBlock() {
@@ -862,12 +862,12 @@ func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, op *operations.Operatio
 		// Set the parent volume's UUID.
 		fsVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.CreateVolumeSnapshot(fsVol, op)
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, progressReporter) })
 	}
 
 	revert.Success()
@@ -875,7 +875,7 @@ func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, op *operations.Operatio
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.
-func (d *powerflex) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *powerflex) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	snapVolName, err := d.getVolumeName(snapVol)
 	if err != nil {
 		return err
@@ -917,7 +917,7 @@ func (d *powerflex) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operatio
 	// For VM images, delete the filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolumeSnapshot(fsVol, op)
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -927,21 +927,21 @@ func (d *powerflex) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operatio
 }
 
 // MountVolumeSnapshot simulates mounting a volume snapshot.
-func (d *powerflex) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *powerflex) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	// A snapshot in PowerFlex is just another volume.
 	// We can reuse the volume mounting procedures.
-	return d.MountVolume(snapVol, op)
+	return d.MountVolume(snapVol, progressReporter)
 }
 
 // UnmountVolumeSnapshot simulates unmounting a volume snapshot.
-func (d *powerflex) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *powerflex) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	// A snapshot in PowerFlex is just another volume.
 	// We can reuse the volume mounting procedures.
-	return d.UnmountVolume(snapVol, false, op)
+	return d.UnmountVolume(snapVol, false, progressReporter)
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *powerflex) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *powerflex) VolumeSnapshots(vol Volume) ([]string, error) {
 	volName, err := d.getVolumeName(vol)
 	if err != nil {
 		return nil, err
@@ -973,9 +973,9 @@ func (d *powerflex) VolumeSnapshots(vol Volume, op *operations.Operation) ([]str
 }
 
 // CheckVolumeSnapshots checks that the volume's snapshots, according to the storage driver, match those provided.
-func (d *powerflex) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error {
+func (d *powerflex) CheckVolumeSnapshots(vol Volume, snapVols []Volume) error {
 	// Get all of the volume's snapshots in base64 encoded format.
-	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol, op)
+	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -1010,14 +1010,14 @@ func (d *powerflex) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *oper
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *powerflex) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	ourUnmount, err := d.UnmountVolume(vol, false, op)
+func (d *powerflex) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	ourUnmount, err := d.UnmountVolume(vol, false, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	if ourUnmount {
-		defer func() { _ = d.MountVolume(vol, op) }()
+		defer func() { _ = d.MountVolume(vol, progressReporter) }()
 	}
 
 	volName, err := d.getVolumeName(vol)
@@ -1050,7 +1050,7 @@ func (d *powerflex) RestoreVolume(vol Volume, snapVol Volume, op *operations.Ope
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.RestoreVolume(fsVol, snapFSVol, op)
+		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1060,7 +1060,7 @@ func (d *powerflex) RestoreVolume(vol Volume, snapVol Volume, op *operations.Ope
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *powerflex) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *powerflex) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume snapshot in PowerFlex won't change it's name in storage.
 	return nil
 }

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/validate"
@@ -287,7 +287,7 @@ func (d *pure) Update(changedConfig map[string]string) error {
 }
 
 // Delete removes the storage pool (Pure Storage pod).
-func (d *pure) Delete(op *operations.Operation) error {
+func (d *pure) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// First delete the storage pool on Pure Storage.
 	err := d.client().deleteStoragePool(d.name)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -12,10 +12,10 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -53,7 +53,7 @@ func (d *pure) commonVolumeRules() map[string]func(value string) error {
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	client := d.client()
 
 	revert := revert.New()
@@ -98,15 +98,15 @@ func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -160,7 +160,7 @@ func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -170,17 +170,17 @@ func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *pure) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *pure) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *pure) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *pure) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -189,16 +189,16 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 	postCreateTasks := func(v Volume) error {
 		if vol.contentType == ContentTypeFS {
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+			err := v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(v, vol.config["size"], false, op)
+		err := d.SetVolumeQuota(v, vol.config["size"], false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -226,12 +226,12 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 		fsVol.SetParentUUID(vol.parentUUID)
 		srcFSVol.SetParentUUID(srcVol.parentUUID)
 
-		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, progressReporter) })
 	}
 
 	poolName := vol.pool
@@ -288,7 +288,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 			if deleteVolCopy {
 				// If at least one snapshot is copied into destination volume, we need to remove
 				// that volume as well in case of an error.
-				revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+				revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 				deleteVolCopy = false
 			}
 
@@ -298,7 +298,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 			// Create snapshot from a new volume (that was created from the source snapshot).
 			// However, do not create VM's filesystem volume snapshot, as filesystem volume is
 			// copied before block volume.
-			err = d.createVolumeSnapshot(snapshot, false, op)
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -328,7 +328,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 
 	// Add reverted to delete destination volume, if not already added.
 	if deleteVolCopy {
-		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 	}
 
 	err = postCreateTasks(vol.Volume)
@@ -341,7 +341,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *pure) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *pure) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move prepare the volumes on the target side.
 	if volTargetArgs.ClusterMoveSourceName != "" {
 		err := vol.EnsureMountPath()
@@ -351,7 +351,7 @@ func (d *pure) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 
 		if vol.IsVMBlock() {
 			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
+			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -360,12 +360,12 @@ func (d *pure) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 		return nil
 	}
 
-	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 	return err
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *pure) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *pure) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -385,7 +385,7 @@ func (d *pure) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
 
-		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, allowInconsistent, op)
+		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, allowInconsistent, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -393,7 +393,7 @@ func (d *pure) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 		revert.Add(cleanup)
 	}
 
-	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, op)
+	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (d *pure) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 // refreshVolume updates an existing volume to match the state of another. For VMs, this function
 // refreshes either block or filesystem volume, depending on the volume type. Therefore, the caller
 // needs to ensure it is called twice - once for each volume type.
-func (d *pure) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) (revert.Hook, error) {
+func (d *pure) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -416,16 +416,16 @@ func (d *pure) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 	postCreateTasks := func(v Volume) error {
 		if vol.contentType == ContentTypeFS {
 			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+			err := v.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 				return v.EnsureMountPath()
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
+		err := d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -517,12 +517,12 @@ func (d *pure) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 
 			// Create snapshot of a new volume. Do not copy VM's filesystem volume snapshot,
 			// as FS volumes are already copied by this point.
-			err = d.createVolumeSnapshot(snapshot, false, op)
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
 			if err != nil {
 				return nil, err
 			}
 
-			revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapshot, op) })
+			revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapshot, progressReporter) })
 
 			// Append snapshot to the list of successfully refreshed snapshots.
 			refreshedSnapshots = append(refreshedSnapshots, snapshotShortName)
@@ -571,7 +571,7 @@ func (d *pure) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 }
 
 // DeleteVolume deletes the volume and all associated snapshots.
-func (d *pure) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *pure) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	volExists, err := d.HasVolume(vol)
 	if err != nil {
 		return err
@@ -611,7 +611,7 @@ func (d *pure) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -777,7 +777,7 @@ func (d *pure) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an non-positive size.
-func (d *pure) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *pure) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -1024,31 +1024,31 @@ func (d *pure) ListVolumes() ([]Volume, error) {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *pure) MountVolume(vol Volume, op *operations.Operation) error {
-	return mountVolume(d, vol, d.getMappedDevPath, op)
+func (d *pure) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return mountVolume(d, vol, d.getMappedDevPath, progressReporter)
 }
 
 // UnmountVolume simulates unmounting a volume.
 // keepBlockDev indicates if backing block device should not be unmapped if volume is unmounted.
-func (d *pure) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, op)
+func (d *pure) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevPath, d.unmapVolume, progressReporter)
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *pure) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *pure) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume won't change an actual name of the Pure Storage volume.
 	return nil
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *pure) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	ourUnmount, err := d.UnmountVolume(vol, false, op)
+func (d *pure) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	ourUnmount, err := d.UnmountVolume(vol, false, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	if ourUnmount {
-		defer func() { _ = d.MountVolume(vol, op) }()
+		defer func() { _ = d.MountVolume(vol, progressReporter) }()
 	}
 
 	volName, err := d.getVolumeName(vol)
@@ -1074,7 +1074,7 @@ func (d *pure) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operatio
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
 		snapFSVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.RestoreVolume(fsVol, snapFSVol, op)
+		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1084,28 +1084,28 @@ func (d *pure) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operatio
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *pure) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *pure) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	// When performing a cluster member move don't do anything on the source member.
 	if volSrcArgs.ClusterMove {
 		return nil
 	}
 
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *pure) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *pure) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *pure) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
-	return d.createVolumeSnapshot(snapVol, true, op)
+func (d *pure) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return d.createVolumeSnapshot(snapVol, true, progressReporter)
 }
 
 // createVolumeSnapshot creates a snapshot of a volume. If snapshotVMfilesystem is false, a VM's filesystem volume
 // is not copied.
-func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, op *operations.Operation) error {
+func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1150,7 +1150,7 @@ func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, o
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, progressReporter) })
 
 	// For VMs, create a snapshot of the filesystem volume too.
 	// Skip if snapshotVMfilesystem is false to prevent overwriting separately copied volumes.
@@ -1160,12 +1160,12 @@ func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, o
 		// Set the parent volume's UUID.
 		fsVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.CreateVolumeSnapshot(fsVol, op)
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, progressReporter) })
 	}
 
 	revert.Success()
@@ -1173,7 +1173,7 @@ func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, o
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.
-func (d *pure) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *pure) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentVol := snapVol.GetParent()
 	parentVolName, err := d.getVolumeName(parentVol)
 	if err != nil {
@@ -1232,7 +1232,7 @@ func (d *pure) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
 		fsVol.SetParentUUID(snapVol.parentUUID)
 
-		err := d.DeleteVolumeSnapshot(fsVol, op)
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1242,7 +1242,7 @@ func (d *pure) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 }
 
 // MountVolumeSnapshot creates a new temporary volume from a volume snapshot to allow mounting it.
-func (d *pure) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *pure) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1295,7 +1295,7 @@ func (d *pure) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		revert.Add(func() { _ = d.client().deleteVolume(snapVol.pool, snapFsVolName) })
 	}
 
-	err = d.MountVolume(snapVol, op)
+	err = d.MountVolume(snapVol, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -1306,8 +1306,8 @@ func (d *pure) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 // UnmountVolumeSnapshot unmountes and deletes volume that was temporary created from a snapshot
 // to allow mounting it.
-func (d *pure) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
-	ourUnmount, err := d.UnmountVolume(snapVol, false, op)
+func (d *pure) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	ourUnmount, err := d.UnmountVolume(snapVol, false, progressReporter)
 	if err != nil {
 		return false, err
 	}
@@ -1345,7 +1345,7 @@ func (d *pure) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (
 }
 
 // VolumeSnapshots returns a list of Pure Storage snapshot names for the given volume (in no particular order).
-func (d *pure) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *pure) VolumeSnapshots(vol Volume) ([]string, error) {
 	volName, err := d.getVolumeName(vol)
 	if err != nil {
 		return nil, err
@@ -1376,9 +1376,9 @@ func (d *pure) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 // CheckVolumeSnapshots checks that the volume's snapshots, according to the storage driver,
 // match those provided. Note that additional snapshots may exist within the Pure Storage pool
 // if protection groups are configured outside of LXD.
-func (d *pure) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error {
+func (d *pure) CheckVolumeSnapshots(vol Volume, snapVols []Volume) error {
 	// Get all of the volume's snapshots in base64 encoded format.
-	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol, op)
+	storageSnapshotNames, err := vol.driver.VolumeSnapshots(vol)
 	if err != nil {
 		return err
 	}
@@ -1399,7 +1399,7 @@ func (d *pure) CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operation
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *pure) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *pure) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	// Renaming a volume snapshot won't change an actual name of the Pure Storage volume snapshot.
 	return nil
 }

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -404,7 +404,7 @@ func (d *zfs) Create() error {
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *zfs) Delete(op *operations.Operation) error {
+func (d *zfs) Delete(progressReporter ioprogress.ProgressReporter) error {
 	// Check if the dataset/pool is already gone.
 	exists, err := d.datasetExists(d.config["zfs.pool_name"])
 	if err != nil {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -27,7 +27,6 @@ import (
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/linux"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -46,7 +45,7 @@ type sortableEntry struct {
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
 // filler function.
-func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// Revert handling
 	revert := revert.New()
 	defer revert.Fail()
@@ -150,7 +149,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	}
 
 	// After this point we'll have a volume, so setup revert.
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol, progressReporter) })
 
 	if vol.contentType == ContentTypeFS && !d.isBlockBacked(vol) {
 		// Create the filesystem dataset.
@@ -160,7 +159,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		// Apply the size limit.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -247,15 +246,15 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(fsVol, nil, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
 	}
 
-	err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err := vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -309,7 +308,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -346,10 +345,10 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
-		return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+		return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 	}
 
 	volExists, err := d.HasVolume(vol.Volume)
@@ -370,11 +369,11 @@ func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcD
 		for _, snapName := range srcBackup.Snapshots {
 			fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
 			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
-			_ = d.DeleteVolumeSnapshot(snapVol, op)
+			_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 		}
 
 		// And lastly the main volume.
-		_ = d.DeleteVolume(vol.Volume, op)
+		_ = d.DeleteVolume(vol.Volume, progressReporter)
 	}
 
 	// Only execute the revert function if we have had an error internally.
@@ -545,15 +544,15 @@ func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcD
 		// Only mount instance filesystem volumes for backup.yaml access.
 		if v.volType != VolumeTypeCustom && v.contentType != ContentTypeBlock {
 			// The import requires a mounted volume, so mount it and have it unmounted as a post hook.
-			err = d.MountVolume(v, op)
+			err = d.MountVolume(v, progressReporter)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			revert.Add(func() { _, _ = d.UnmountVolume(v, false, op) })
+			revert.Add(func() { _, _ = d.UnmountVolume(v, false, progressReporter) })
 
 			postHook = func(postVol Volume) error {
-				_, err := d.UnmountVolume(postVol, false, op)
+				_, err := d.UnmountVolume(postVol, false, progressReporter)
 				return err
 			}
 		}
@@ -565,7 +564,7 @@ func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcD
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	// Revert handling
 	revert := revert.New()
 	defer revert.Fail()
@@ -578,13 +577,13 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcVol.Snapshots...)
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), vol.Snapshots...)
 
-		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, progressReporter) })
 	}
 
 	// Rebase mode is only used for instance copies when enabled.
@@ -678,7 +677,7 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 	}
 
 	// Delete the volume created on failure.
-	revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 
 	if fullCopy {
 		_, snapName, found := strings.Cut(srcSnapshot, "@")
@@ -899,9 +898,9 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 		}
 
 		// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-		err := vol.MountTask(func(_ string, _ *operations.Operation) error {
+		err := vol.MountTask(func(_ string, _ ioprogress.ProgressReporter) error {
 			return vol.EnsureMountPath()
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -918,7 +917,7 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol.Volume, vol.config["size"], allowUnsafeResize, op)
+	err = d.SetVolumeQuota(vol.Volume, vol.config["size"], allowUnsafeResize, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -929,10 +928,10 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volTargetArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
-		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
 		return err
 	} else if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_ZFS {
 		return ErrNotSupported
@@ -960,7 +959,7 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 
 	// If we're refreshing, send back all snapshots of the target.
 	if volTargetArgs.Refresh && slices.Contains(volTargetArgs.MigrationType.Features, migration.ZFSFeatureMigrationHeader) {
-		snapshots, err := vol.Volume.Snapshots(op)
+		snapshots, err := vol.Volume.Snapshots(progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed getting volume snapshots: %w", err)
 		}
@@ -1015,7 +1014,7 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 		if !volumeOnly && len(respSnapshots) > 0 && len(migrationHeader.SnapshotDatasets) > 0 && respSnapshots[0].GUID != migrationHeader.SnapshotDatasets[0].GUID {
 			for _, snapVol := range snapshots {
 				// Delete
-				err = d.DeleteVolume(snapVol, op)
+				err = d.DeleteVolume(snapVol, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -1045,7 +1044,7 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 
 				if targetOnlySnapshot {
 					// Delete
-					err = d.DeleteVolume(snapVol, op)
+					err = d.DeleteVolume(snapVol, progressReporter)
 					if err != nil {
 						return err
 					}
@@ -1078,13 +1077,13 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 		}
 	}
 
-	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, volumeOnly, preFiller, op)
+	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, volumeOnly, preFiller, progressReporter)
 }
 
-func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, volumeOnly bool, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, volumeOnly bool, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.createVolumeFromMigrationOptimized(fsVol, conn, volTargetArgs, volumeOnly, preFiller, op)
+		err := d.createVolumeFromMigrationOptimized(fsVol, conn, volTargetArgs, volumeOnly, preFiller, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1095,14 +1094,14 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 
 	// Rollback to the latest identical snapshot if performing a refresh.
 	if volTargetArgs.Refresh {
-		snapshots, err = vol.Snapshots(op)
+		snapshots, err = vol.Snapshots(progressReporter)
 		if err != nil {
 			return err
 		}
 
 		if len(snapshots) > 0 {
 			lastIdenticalSnapshot := snapshots[len(snapshots)-1]
-			err = d.restoreVolume(vol, lastIdenticalSnapshot, true, op)
+			err = d.restoreVolume(vol, lastIdenticalSnapshot, true, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1127,28 +1126,28 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 				return err
 			}
 
-			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapVol.Name(), op))
+			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapVol.Name(), progressReporter))
 
 			err = d.receiveDataset(snapVol, conn, wrapper)
 			if err != nil {
-				_ = d.DeleteVolume(snapVol, op)
+				_ = d.DeleteVolume(snapVol, progressReporter)
 				return fmt.Errorf("Failed receiving snapshot volume %q: %w", snapVol.Name(), err)
 			}
 
 			revert.Add(func() {
-				_ = d.DeleteVolumeSnapshot(snapVol, op)
+				_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 			})
 		}
 	}
 
 	if !volTargetArgs.Refresh {
 		revert.Add(func() {
-			_ = d.DeleteVolume(vol, op)
+			_ = d.DeleteVolume(vol, progressReporter)
 		})
 	}
 
 	// Transfer the main volume.
-	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 	err = d.receiveDataset(vol, conn, wrapper)
 	if err != nil {
 		return fmt.Errorf("Failed receiving volume %q: %w", vol.Name(), err)
@@ -1217,7 +1216,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 			}
 
 			// Apply the size limit.
-			err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+			err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1253,24 +1252,24 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 }
 
 // CreateVolumeFromImage creates volume from image by using createVolumeFromImage utility function.
-func (d *zfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
-	return createVolumeFromImage(vol, imgVol, filler, op)
+func (d *zfs) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
 	var err error
 	var targetSnapshots []Volume
 	var srcSnapshotsAll []Volume
 
 	if !srcVol.IsSnapshot() {
 		// Get target snapshots
-		targetSnapshots, err = vol.Volume.Snapshots(op)
+		targetSnapshots, err = vol.Volume.Snapshots(progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed getting target snapshots: %w", err)
 		}
 
-		srcSnapshotsAll, err = srcVol.Volume.Snapshots(op)
+		srcSnapshotsAll, err = srcVol.Volume.Snapshots(progressReporter)
 		if err != nil {
 			return fmt.Errorf("Failed getting source snapshots: %w", err)
 		}
@@ -1289,12 +1288,12 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 	// We cannot use generic vfs volume copy here, as zfs will complain if a generic
 	// copy/refresh is followed by an optimized refresh.
 	if len(targetSnapshots) == 0 || len(srcSnapshotsAll) == 0 {
-		err = d.DeleteVolume(vol.Volume, op)
+		err = d.DeleteVolume(vol.Volume, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		return d.CreateVolumeFromCopy(vol, srcVol, false, op)
+		return d.CreateVolumeFromCopy(vol, srcVol, false, progressReporter)
 	}
 
 	transfer := func(src Volume, target Volume, origin Volume) error {
@@ -1386,7 +1385,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 	_, lastIdenticalSnapshotOnlyName, _ := api.GetParentAndSnapshotName(lastIdenticalSnapshot.Name())
 
 	// Rollback target volume to the latest identical snapshot
-	err = d.RestoreVolume(vol.Volume, lastIdenticalSnapshot, op)
+	err = d.RestoreVolume(vol.Volume, lastIdenticalSnapshot, progressReporter)
 	if err != nil {
 		return fmt.Errorf("Failed restoring volume: %w", err)
 	}
@@ -1418,7 +1417,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 			// refresh instead.
 			if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 				d.logger.Debug("Cannot perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-				_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+				_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 				return err
 			}
 
@@ -1436,7 +1435,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 				// refresh instead.
 				if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 					d.logger.Debug("Cannot perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-					_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+					_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 					return err
 				}
 
@@ -1453,7 +1452,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 		return err
 	}
 
-	err = d.CreateVolumeSnapshot(srcSnap, op)
+	err = d.CreateVolumeSnapshot(srcSnap, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -1466,7 +1465,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 		// refresh instead.
 		if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 			d.logger.Debug("Cannot perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-			_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+			_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 			return err
 		}
 
@@ -1484,7 +1483,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 			// refresh instead.
 			if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 				d.logger.Debug("Cannot perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-				_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+				_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
 				return err
 			}
 
@@ -1493,13 +1492,13 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 	}
 
 	// Restore target volume from main source snapshot.
-	err = d.RestoreVolume(vol.Volume, srcSnap, op)
+	err = d.RestoreVolume(vol.Volume, srcSnap, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	// Delete temporary source snapshot.
-	err = d.DeleteVolumeSnapshot(srcSnap, op)
+	err = d.DeleteVolumeSnapshot(srcSnap, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -1510,7 +1509,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 		return err
 	}
 
-	err = d.DeleteVolumeSnapshot(targetSnap, op)
+	err = d.DeleteVolumeSnapshot(targetSnap, progressReporter)
 	if err != nil {
 		return err
 	}
@@ -1521,7 +1520,7 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
 // For image volumes, both filesystem and block volumes will be removed.
-func (d *zfs) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *zfs) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	if vol.volType == VolumeTypeImage {
 		// We need to clone vol the otherwise changing `zfs.block_mode`
 		// in tmpVol will also change it in vol.
@@ -1530,17 +1529,17 @@ func (d *zfs) DeleteVolume(vol Volume, op *operations.Operation) error {
 		for _, filesystem := range blockBackedAllowedFilesystems {
 			tmpVol.config["block.filesystem"] = filesystem
 
-			err := d.deleteVolume(tmpVol, op)
+			err := d.deleteVolume(tmpVol, progressReporter)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	return d.deleteVolume(vol, op)
+	return d.deleteVolume(vol, progressReporter)
 }
 
-func (d *zfs) deleteVolume(vol Volume, op *operations.Operation) error {
+func (d *zfs) deleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	dataset := d.dataset(vol, false)
 
 	// Check that we have a dataset to delete.
@@ -1587,7 +1586,7 @@ func (d *zfs) deleteVolume(vol Volume, op *operations.Operation) error {
 	// For VMs, also delete the filesystem dataset.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1795,7 +1794,7 @@ func (d *zfs) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota sets the quota/reservation on the volume.
 // Does nothing if supplied with an empty/zero size for block volumes.
-func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
 	dataset := d.dataset(vol, false)
 
 	// Convert to bytes.
@@ -1913,14 +1912,14 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as
 		// it is expected the caller will do all necessary post resize actions themselves).
 		if vol.IsVMBlock() && !allowUnsafeResize {
-			err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+			err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 				devPath, err := d.GetVolumeDiskPath(vol)
 				if err != nil {
 					return err
 				}
 
 				return d.moveGPTAltHeader(devPath)
-			}, op)
+			}, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -2296,7 +2295,7 @@ func (d *zfs) deactivateVolume(vol Volume) (bool, error) {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *zfs) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -2380,7 +2379,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 		if vol.IsVMBlock() {
 			// For VMs, also mount the filesystem dataset.
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err = d.MountVolume(fsVol, op)
+			err = d.MountVolume(fsVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -2394,7 +2393,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 
 // UnmountVolume unmounts volume if mounted and not in use. Returns true if this unmounted the volume.
 // keepBlockDev indicates if backing block device should be not be deactivated when volume is unmounted.
-func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return false, err
@@ -2447,7 +2446,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 		// For VMs, also unmount the filesystem dataset.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+			ourUnmount, err = d.UnmountVolume(fsVol, false, progressReporter)
 			if err != nil {
 				return false, err
 			}
@@ -2471,7 +2470,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *zfs) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolName, vol.config, vol.poolConfig)
 
 	// Revert handling.
@@ -2479,13 +2478,13 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 	defer revert.Fail()
 
 	// First rename the VFS paths.
-	err := genericVFSRenameVolume(d, vol, newVolName, op)
+	err := genericVFSRenameVolume(d, vol, newVolName)
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		_ = genericVFSRenameVolume(d, newVol, vol.name, op)
+		_ = genericVFSRenameVolume(d, newVol, vol.name)
 	})
 
 	// Rename the ZFS datasets.
@@ -2509,14 +2508,14 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.RenameVolume(fsVol, newVolName, op)
+		err := d.RenameVolume(fsVol, newVolName, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
 			newFsVol := NewVolume(d, d.name, newVol.volType, ContentTypeFS, newVol.name, newVol.config, newVol.poolConfig)
-			_ = d.RenameVolume(newFsVol, vol.name, op)
+			_ = d.RenameVolume(newFsVol, vol.name, progressReporter)
 		})
 	}
 
@@ -2562,19 +2561,19 @@ func (d *zfs) DelegateVolume(vol Volume, pid int) error {
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	if !volSrcArgs.AllowInconsistent && vol.contentType == ContentTypeFS && vol.IsBlockBacked() {
 		// When migrating using zfs volumes (not datasets), ensure that the filesystem is synced
 		// otherwise the source and target volumes may differ. Tests have shown that only calling
 		// os.SyncFS() doesn't suffice. A freeze and unfreeze is needed.
-		err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
+		err := vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 			unfreezeFS, err := d.filesystemFreeze(mountPath)
 			if err != nil {
 				return err
 			}
 
 			return unfreezeFS()
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2597,7 +2596,7 @@ func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_ZFS {
 		return ErrNotSupported
 	}
@@ -2612,7 +2611,7 @@ func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 
 	// The target will validate the GUIDs and if successful proceed with the refresh.
 	if slices.Contains(volSrcArgs.MigrationType.Features, migration.ZFSFeatureMigrationHeader) {
-		snapshots, err := d.VolumeSnapshots(vol.Volume, op)
+		snapshots, err := d.VolumeSnapshots(vol.Volume)
 		if err != nil {
 			return err
 		}
@@ -2686,13 +2685,13 @@ func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 		}
 	}
 
-	return d.migrateVolumeOptimized(vol.Volume, conn, volSrcArgs, incrementalStream, op)
+	return d.migrateVolumeOptimized(vol.Volume, conn, volSrcArgs, incrementalStream, progressReporter)
 }
 
-func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, incremental bool, op *operations.Operation) error {
+func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, incremental bool, progressReporter ioprogress.ProgressReporter) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.migrateVolumeOptimized(fsVol, conn, volSrcArgs, incremental, op)
+		err := d.migrateVolumeOptimized(fsVol, conn, volSrcArgs, incremental, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2708,7 +2707,7 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 		// Figure out parent and current subvolumes.
 		parent := ""
 		if i == 0 && volSrcArgs.Refresh {
-			snapshots, err := vol.Snapshots(op)
+			snapshots, err := vol.Snapshots(progressReporter)
 			if err != nil {
 				return err
 			}
@@ -2731,7 +2730,7 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 		// Setup progress tracking.
 		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapshot.name, op))
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapshot.name, progressReporter))
 		}
 
 		// Send snapshot to recipient (ensure local snapshot volume is mounted if needed).
@@ -2746,7 +2745,7 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 	// Setup progress tracking.
 	var writerWrapper ioprogress.WriterWrapper
 	if volSrcArgs.TrackProgress {
-		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 	}
 
 	srcSnapshot := d.dataset(vol, false)
@@ -2769,7 +2768,7 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 
 	// Get parent snapshot of the main volume which can then be used to send an incremental stream.
 	if volSrcArgs.Refresh && incremental {
-		localSnapshots, err := vol.Snapshots(op)
+		localSnapshots, err := vol.Snapshots(progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2843,7 +2842,7 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *zfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *zfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
 	// Handle the non-optimized tarballs through the generic packer.
 	if !optimized {
 		// Because the generic backup method will not take a consistent backup if files are being modified
@@ -2862,14 +2861,14 @@ func (d *zfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instan
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 	}
 
 	// Optimized backup.
 
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots, op)
+		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots)
 		if err != nil {
 			return err
 		}
@@ -2878,7 +2877,7 @@ func (d *zfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instan
 	// Backup VM config volumes first.
 	if vol.IsVMBlock() {
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-		err := d.BackupVolume(fsVol, projectName, tarWriter, optimized, snapshots, op)
+		err := d.BackupVolume(fsVol, projectName, tarWriter, optimized, snapshots, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -3011,7 +3010,7 @@ func (d *zfs) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instan
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
+func (d *zfs) CreateVolumeSnapshot(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(vol.name)
 
 	// Revert handling.
@@ -3036,17 +3035,17 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolumeSnapshot(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(vol, progressReporter) })
 
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolumeSnapshot(fsVol, op)
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, progressReporter) })
 	}
 
 	// All done.
@@ -3056,7 +3055,7 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.
-func (d *zfs) DeleteVolumeSnapshot(vol Volume, op *operations.Operation) error {
+func (d *zfs) DeleteVolumeSnapshot(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(vol.name)
 
 	dataset := d.dataset(vol, false)
@@ -3096,7 +3095,7 @@ func (d *zfs) DeleteVolumeSnapshot(vol Volume, op *operations.Operation) error {
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolumeSnapshot(fsVol, op)
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -3106,7 +3105,7 @@ func (d *zfs) DeleteVolumeSnapshot(vol Volume, op *operations.Operation) error {
 }
 
 // MountVolumeSnapshot simulates mounting a volume snapshot.
-func (d *zfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *zfs) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return err
@@ -3114,7 +3113,7 @@ func (d *zfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) erro
 
 	defer unlock()
 
-	_, err = d.mountVolumeSnapshot(snapVol, d.dataset(snapVol, false), snapVol.MountPath(), op)
+	_, err = d.mountVolumeSnapshot(snapVol, d.dataset(snapVol, false), snapVol.MountPath(), progressReporter)
 	if err != nil {
 		return err
 	}
@@ -3123,7 +3122,7 @@ func (d *zfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) erro
 	return nil
 }
 
-func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountPath string, op *operations.Operation) (revert.Hook, error) {
+func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountPath string, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -3149,12 +3148,12 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 		parent, snapshotOnlyName, _ := api.GetParentAndSnapshotName(snapVol.Name())
 		parentVol := NewVolume(d, d.Name(), snapVol.volType, snapVol.contentType, parent, snapVol.config, snapVol.poolConfig)
 
-		err := d.MountVolume(parentVol, op)
+		err := d.MountVolume(parentVol, progressReporter)
 		if err != nil {
 			return nil, err
 		}
 
-		revert.Add(func() { _, _ = d.UnmountVolume(parentVol, false, op) })
+		revert.Add(func() { _, _ = d.UnmountVolume(parentVol, false, progressReporter) })
 
 		parentDataset := d.dataset(parentVol, false)
 
@@ -3263,7 +3262,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 		if snapVol.IsVMBlock() {
 			// For VMs, also mount the filesystem dataset.
 			fsVol := snapVol.NewVMBlockFilesystemVolume()
-			err = d.MountVolumeSnapshot(fsVol, op)
+			err = d.MountVolumeSnapshot(fsVol, progressReporter)
 			if err != nil {
 				return nil, err
 			}
@@ -3287,7 +3286,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 }
 
 // UnmountVolumeSnapshot simulates unmounting a volume snapshot.
-func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {
 		return false, err
@@ -3306,7 +3305,7 @@ func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 		// For VMs, also mount the filesystem dataset.
 		if snapVol.IsVMBlock() {
 			fsSnapVol := snapVol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolumeSnapshot(fsSnapVol, op)
+			ourUnmount, err = d.UnmountVolumeSnapshot(fsSnapVol, progressReporter)
 			if err != nil {
 				return false, err
 			}
@@ -3367,7 +3366,7 @@ func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 			d.logger.Debug("Deactivated ZFS snapshot volume", logger.Ctx{"dev": snapshotDataset})
 
 			// Ensure snap volume parent is deactivated in case we activated it when mounting snapshot.
-			_, err = d.UnmountVolume(parentVol, false, op)
+			_, err = d.UnmountVolume(parentVol, false, progressReporter)
 			if err != nil {
 				return false, err
 			}
@@ -3393,7 +3392,7 @@ func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *zfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *zfs) VolumeSnapshots(vol Volume) ([]string, error) {
 	// Get all children datasets.
 	entries, err := d.getDatasets(d.dataset(vol, false), "snapshot")
 	if err != nil {
@@ -3413,11 +3412,11 @@ func (d *zfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *zfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
-	return d.restoreVolume(vol, snapVol, false, op)
+func (d *zfs) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return d.restoreVolume(vol, snapVol, false, progressReporter)
 }
 
-func (d *zfs) restoreVolume(vol Volume, snapVol Volume, migration bool, op *operations.Operation) error {
+func (d *zfs) restoreVolume(vol Volume, snapVol Volume, migration bool, progressReporter ioprogress.ProgressReporter) error {
 	// Get the list of snapshots.
 	entries, err := d.getDatasets(d.dataset(vol, false), "snapshot")
 	if err != nil {
@@ -3515,7 +3514,7 @@ func (d *zfs) restoreVolume(vol Volume, snapVol Volume, migration bool, op *oper
 	if !migration && vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 		fsSnapVol := snapVol.NewVMBlockFilesystemVolume()
-		err := d.restoreVolume(fsVol, fsSnapVol, migration, op)
+		err := d.restoreVolume(fsVol, fsSnapVol, migration, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -3525,7 +3524,7 @@ func (d *zfs) restoreVolume(vol Volume, snapVol Volume, migration bool, op *oper
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(vol.name)
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, parentName+"/"+newSnapshotName, vol.config, vol.poolConfig)
 
@@ -3534,13 +3533,13 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 	defer revert.Fail()
 
 	// First rename the VFS paths.
-	err := genericVFSRenameVolumeSnapshot(d, vol, newSnapshotName, op)
+	err := genericVFSRenameVolumeSnapshot(d, vol, newSnapshotName, progressReporter)
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		_ = genericVFSRenameVolumeSnapshot(d, newVol, vol.name, op)
+		_ = genericVFSRenameVolumeSnapshot(d, newVol, vol.name, progressReporter)
 	})
 
 	// Rename the ZFS datasets.
@@ -3556,14 +3555,14 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.RenameVolumeSnapshot(fsVol, newSnapshotName, op)
+		err := d.RenameVolumeSnapshot(fsVol, newSnapshotName, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
 			newFsVol := NewVolume(d, d.name, newVol.volType, ContentTypeFS, newVol.name, newVol.config, newVol.poolConfig)
-			_ = d.RenameVolumeSnapshot(newFsVol, vol.name, op)
+			_ = d.RenameVolumeSnapshot(newFsVol, vol.name, progressReporter)
 		})
 	}
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/rsync"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/storage/block"
@@ -63,7 +62,7 @@ func genericVFSGetResources(d Driver) (*api.ResourcesStoragePool, error) {
 }
 
 // genericVFSRenameVolume is a generic RenameVolume implementation for VFS-only drivers.
-func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operations.Operation) error {
+func genericVFSRenameVolume(d Driver, vol Volume, newVolName string) error {
 	if vol.IsSnapshot() {
 		return errors.New("Volume must not be a snapshot")
 	}
@@ -102,7 +101,7 @@ func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operati
 }
 
 // genericVFSVolumeSnapshots is a generic VolumeSnapshots implementation for VFS-only drivers.
-func genericVFSVolumeSnapshots(d Driver, vol Volume, op *operations.Operation) ([]string, error) {
+func genericVFSVolumeSnapshots(d Driver, vol Volume) ([]string, error) {
 	snapshotDir := GetVolumeSnapshotDir(d.Name(), vol.volType, vol.name)
 	snapshots := []string{}
 
@@ -133,7 +132,7 @@ func genericVFSVolumeSnapshots(d Driver, vol Volume, op *operations.Operation) (
 }
 
 // genericVFSRenameVolumeSnapshot is a generic RenameVolumeSnapshot implementation for VFS-only drivers.
-func genericVFSRenameVolumeSnapshot(d Driver, snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func genericVFSRenameVolumeSnapshot(d Driver, snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
 	if !snapVol.IsSnapshot() {
 		return errors.New("Volume must be a snapshot")
 	}
@@ -151,7 +150,7 @@ func genericVFSRenameVolumeSnapshot(d Driver, snapVol Volume, newSnapshotName st
 }
 
 // genericVFSMigrateVolume is a generic MigrateVolume implementation for VFS-only drivers.
-func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
 	bwlimit := d.Config()["rsync.bwlimit"]
 	var rsyncArgs []string
 
@@ -177,7 +176,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 	sendFSVol := func(vol Volume, conn io.ReadWriteCloser, mountPath string) error {
 		var wrapper ioprogress.ReaderWrapper
 		if volSrcArgs.TrackProgress {
-			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, progressReporter))
 		}
 
 		path := shared.AddSlash(mountPath)
@@ -213,7 +212,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 		// Setup progress tracker.
 		fromPipe := io.ReadCloser(from)
 		if volSrcArgs.TrackProgress {
-			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", vol.name, op))
+			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", vol.name, progressReporter))
 		}
 
 		d.Logger().Debug("Sending block volume", logger.Ctx{"volName": vol.name, "path": path})
@@ -248,7 +247,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 		}
 
 		// Send snapshot to target (ensure local snapshot volume is mounted if needed).
-		err := snapVol.MountTask(func(mountPath string, op *operations.Operation) error {
+		err := snapVol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 			if vol.contentType != ContentTypeBlock || vol.volType != VolumeTypeCustom {
 				err := sendFSVol(snapVol, conn, mountPath)
 				if err != nil {
@@ -264,14 +263,14 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 			}
 
 			return nil
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Send volume to target (ensure local volume is mounted if needed).
-	return vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	return vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		if !IsContentBlock(vol.contentType) || vol.volType != VolumeTypeCustom {
 			err := sendFSVol(vol.Volume, conn, mountPath)
 			if err != nil {
@@ -287,12 +286,12 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 }
 
 // genericVFSCreateVolumeFromMigration receives a volume and its snapshots over a non-optimized method.
 // initVolume is run against the main volume (not the snapshots) and is often used for quota initialization.
-func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) (revert.Hook, error) {
+func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	// Check migration transport type matches volume type.
 	if IsContentBlock(vol.contentType) {
 		if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_BLOCK_AND_RSYNC {
@@ -307,18 +306,18 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 
 	// Create the main volume if not refreshing.
 	if !volTargetArgs.Refresh {
-		err := d.CreateVolume(vol.Volume, preFiller, op)
+		err := d.CreateVolume(vol.Volume, preFiller, progressReporter)
 		if err != nil {
 			return nil, err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 	}
 
 	recvFSVol := func(volName string, conn io.ReadWriteCloser, path string) error {
 		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", volName, op))
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", volName, progressReporter))
 		}
 
 		d.Logger().Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path, "features": volTargetArgs.MigrationType.Features})
@@ -338,7 +337,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		// Setup progress tracker.
 		fromPipe := io.ReadCloser(conn)
 		if volTargetArgs.TrackProgress {
-			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", volName, op))
+			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", volName, progressReporter))
 		}
 
 		d.Logger().Debug("Receiving block volume started", logger.Ctx{"volName": volName, "path": path})
@@ -353,7 +352,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 	}
 
 	// Ensure the volume is mounted.
-	err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err := vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		var err error
 
 		// Setup paths to the main volume. We will receive each snapshot to these paths and then create
@@ -402,14 +401,14 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 
 			// Create the snapshot itself.
 			d.Logger().Debug("Creating snapshot", logger.Ctx{"volName": snapVol.Name()})
-			err = d.CreateVolumeSnapshot(snapVol, op)
+			err = d.CreateVolumeSnapshot(snapVol, progressReporter)
 			if err != nil {
 				return err
 			}
 
 			// Setup the revert.
 			revert.Add(func() {
-				_ = d.DeleteVolumeSnapshot(snapVol, op)
+				_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 			})
 		}
 
@@ -454,7 +453,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -488,10 +487,10 @@ func genericVFSGetVolumeDiskPath(vol Volume) (string, error) {
 }
 
 // genericVFSBackupVolume is a generic BackupVolume implementation for VFS-only drivers.
-func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, snapshots []string, op *operations.Operation) error {
+func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots, op)
+		err := d.CheckVolumeSnapshots(vol.Volume, vol.Snapshots)
 		if err != nil {
 			return err
 		}
@@ -499,7 +498,7 @@ func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.
 
 	// Define a function that can copy a volume into the backup target location.
 	backupVolume := func(v Volume, prefix string) error {
-		return v.MountTask(func(mountPath string, op *operations.Operation) error {
+		return v.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 			// Reset hard link cache as we are copying a new volume (instance or snapshot).
 			tarWriter.ResetHardLinkMap()
 
@@ -641,7 +640,7 @@ func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.
 			}
 
 			return nil
-		}, op)
+		}, progressReporter)
 	}
 
 	// Handle snapshots.
@@ -698,7 +697,7 @@ func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.
 // created and a revert function that can be used to undo the actions this function performs should something
 // subsequently fail. For VolumeTypeCustom volumes, a nil post hook is returned as it is expected that the DB
 // record be created before the volume is unpacked due to differences in the archive format that allows this.
-func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots []string, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots []string, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	// Define function to unpack a volume from a backup tarball file.
 	unpackVolume := func(r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
 		volTypeName := "container"
@@ -802,7 +801,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 				// Allow potentially destructive resize of volume as we are going to be
 				// overwriting it entirely anyway. This allows shrinking of block volumes.
 				allowUnsafeResize = true
-				err = d.SetVolumeQuota(vol.Volume, strconv.FormatInt(size, 10), allowUnsafeResize, op)
+				err = d.SetVolumeQuota(vol.Volume, strconv.FormatInt(size, 10), allowUnsafeResize, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -872,7 +871,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 		return nil, nil, err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 
 	if len(snapshots) > 0 {
 		// Create new snapshots directory.
@@ -911,29 +910,29 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 			return nil, nil, fmt.Errorf("Snapshot %q missing in volume's list", snapName)
 		}
 
-		err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+		err = vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 			backupSnapshotPrefix := backupSnapshotsPrefix + "/" + snapName
 			return unpackVolume(srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath)
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		d.Logger().Debug("Creating volume snapshot", logger.Ctx{"snapshotName": snapVol.Name()})
-		err = d.CreateVolumeSnapshot(snapVol, op)
+		err = d.CreateVolumeSnapshot(snapVol, progressReporter)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, progressReporter) })
 	}
 
-	err = d.MountVolume(vol.Volume, op)
+	err = d.MountVolume(vol.Volume, progressReporter)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	revert.Add(func() { _, _ = d.UnmountVolume(vol.Volume, false, op) })
+	revert.Add(func() { _, _ = d.UnmountVolume(vol.Volume, false, progressReporter) })
 
 	backupPrefix := "backup/container"
 	if vol.IsVMBlock() {
@@ -964,7 +963,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 		// backup restoration process). Create a post hook function that will be called at the end of the
 		// backup restore process to unmount the volume if needed.
 		postHook = func(vol Volume) error {
-			_, err = d.UnmountVolume(vol, false, op)
+			_, err = d.UnmountVolume(vol, false, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -973,7 +972,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 		}
 	} else {
 		// For custom volumes unmount now, there is no post hook as there is no backup.yaml to generate.
-		_, err = d.UnmountVolume(vol.Volume, false, op)
+		_, err = d.UnmountVolume(vol.Volume, false, progressReporter)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -984,7 +983,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 
 // genericVFSCopyVolume copies a volume and its snapshots using a non-optimized method.
 // initVolume is run against the main volume (not the snapshots) and is often used for quota initialization.
-func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, refresh bool, allowInconsistent bool, op *operations.Operation) (revert.Hook, error) {
+func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, refresh bool, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
 	if vol.contentType != srcVol.contentType {
 		return nil, errors.New("Content type of source and target must be the same")
 	}
@@ -1002,12 +1001,12 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 
 	// Create the main volume if not refreshing.
 	if !refresh {
-		err := d.CreateVolume(vol.Volume, nil, op)
+		err := d.CreateVolume(vol.Volume, nil, progressReporter)
 		if err != nil {
 			return nil, err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
+		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
 	}
 
 	// Define function to send a filesystem volume.
@@ -1045,7 +1044,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 	}
 
 	// Ensure the volume is mounted.
-	err := vol.MountTask(func(targetMountPath string, op *operations.Operation) error {
+	err := vol.MountTask(func(targetMountPath string, progressReporter ioprogress.ProgressReporter) error {
 		// If copying snapshots is indicated, check the source isn't itself a snapshot.
 		if len(refreshSnapshots) > 0 && !srcVol.IsSnapshot() {
 			for _, refreshSnapshot := range refreshSnapshots {
@@ -1053,7 +1052,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 				// A snapshot will then be taken next so it is stored in the correct volume and
 				// subsequent filesystem rsync transfers benefit from only transferring the files
 				// that changed between snapshots.
-				err := srcVol.MountTask(func(srcMountPath string, op *operations.Operation) error {
+				err := srcVol.MountTask(func(srcMountPath string, progressReporter ioprogress.ProgressReporter) error {
 					if srcVol.contentType != ContentTypeBlock || srcVol.volType != VolumeTypeCustom {
 						err := sendFSVol(srcMountPath, targetMountPath)
 						if err != nil {
@@ -1069,7 +1068,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 					}
 
 					return nil
-				}, op)
+				}, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -1091,14 +1090,14 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 
 				// Create the snapshot itself.
 				d.Logger().Debug("Creating snapshot", logger.Ctx{"volName": snapVol.Name()})
-				err = d.CreateVolumeSnapshot(snapVol, op)
+				err = d.CreateVolumeSnapshot(snapVol, progressReporter)
 				if err != nil {
 					return err
 				}
 
 				// Setup the revert.
 				revert.Add(func() {
-					_ = d.DeleteVolumeSnapshot(snapVol, op)
+					_ = d.DeleteVolumeSnapshot(snapVol, progressReporter)
 				})
 			}
 		}
@@ -1112,7 +1111,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 		}
 
 		// Copy source to destination (mounting each volume if needed).
-		err := srcVol.MountTask(func(srcMountPath string, op *operations.Operation) error {
+		err := srcVol.MountTask(func(srcMountPath string, progressReporter ioprogress.ProgressReporter) error {
 			if srcVol.contentType != ContentTypeBlock || srcVol.volType != VolumeTypeCustom {
 				err := sendFSVol(srcMountPath, targetMountPath)
 				if err != nil {
@@ -1128,7 +1127,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 			}
 
 			return nil
-		}, op)
+		}, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -1141,7 +1140,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 		}
 
 		return nil
-	}, op)
+	}, progressReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -1195,7 +1194,7 @@ type getVolumePathFunc func(Volume, bool) (string, revert.Hook, error)
 type volumeUnmapFunc func(vol Volume) error
 
 // mountVolume mounts a volume and increments ref counter. Please use unmountVolume() helper when done with the volume.
-func mountVolume(d Driver, vol Volume, getDevicePath getVolumePathFunc, op *operations.Operation) error {
+func mountVolume(d Driver, vol Volume, getDevicePath getVolumePathFunc, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := vol.MountLock()
 	if err != nil {
 		return err
@@ -1245,7 +1244,7 @@ func mountVolume(d Driver, vol Volume, getDevicePath getVolumePathFunc, op *oper
 		// For VMs, mount the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err := d.MountVolume(fsVol, op)
+			err := d.MountVolume(fsVol, progressReporter)
 			if err != nil {
 				return err
 			}
@@ -1257,7 +1256,7 @@ func mountVolume(d Driver, vol Volume, getDevicePath getVolumePathFunc, op *oper
 	return nil
 }
 
-func unmountVolume(d Driver, vol Volume, keepBlockDev bool, getDevicePath getVolumePathFunc, unmapVolume volumeUnmapFunc, op *operations.Operation) (bool, error) {
+func unmountVolume(d Driver, vol Volume, keepBlockDev bool, getDevicePath getVolumePathFunc, unmapVolume volumeUnmapFunc, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	l := d.Logger().AddContext(logger.Ctx{"volName": vol.name})
 	unlock, err := vol.MountLock()
 	if err != nil {
@@ -1297,7 +1296,7 @@ func unmountVolume(d Driver, vol Volume, keepBlockDev bool, getDevicePath getVol
 		// For VMs, unmount the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+			ourUnmount, err = d.UnmountVolume(fsVol, false, progressReporter)
 			if err != nil {
 				return false, err
 			}

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -7,9 +7,9 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
@@ -42,7 +42,7 @@ type Driver interface {
 	// Pool.
 	FillConfig() error
 	Create() error
-	Delete(op *operations.Operation) error
+	Delete(progressReporter ioprogress.ProgressReporter) error
 	// Mount mounts a storage pool if needed, returns true if we caused a new mount, false if already mounted.
 	Mount() (bool, error)
 
@@ -57,34 +57,34 @@ type Driver interface {
 	// Buckets.
 	ValidateBucket(bucket Volume) error
 	GetBucketURL(bucketName string) *url.URL
-	CreateBucket(bucket Volume, op *operations.Operation) error
-	DeleteBucket(bucket Volume, op *operations.Operation) error
+	CreateBucket(bucket Volume) error
+	DeleteBucket(bucket Volume) error
 	UpdateBucket(bucket Volume, changedConfig map[string]string) error
 	ValidateBucketKey(keyName string, creds S3Credentials, roleName string) error
-	CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error
+	CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error)
+	UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string) (*S3Credentials, error)
+	DeleteBucketKey(bucket Volume, keyName string) error
 
 	// Volumes.
 	FillVolumeConfig(vol Volume) error
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
-	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
-	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error
-	CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error
-	RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error
-	DeleteVolume(vol Volume, op *operations.Operation) error
-	RenameVolume(vol Volume, newName string, op *operations.Operation) error
+	CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error
+	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error
+	CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error
+	RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error
+	DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error
+	RenameVolume(vol Volume, newName string, progressReporter ioprogress.ProgressReporter) error
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
 	GetVolumeUsage(vol Volume) (int64, error)
-	SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error
+	SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error
 	GetVolumeDiskPath(vol Volume) (string, error)
 	ListVolumes() ([]Volume, error)
 
 	// MountVolume mounts a storage volume (if not mounted) and increments reference counter.
-	MountVolume(vol Volume, op *operations.Operation) error
+	MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error
 
 	// MountVolumeSnapshot mounts a storage volume snapshot as readonly.
-	MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error
+	MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error
 
 	// CanDelegateVolume checks whether the volume can be delegated.
 	CanDelegateVolume(vol Volume) bool
@@ -94,25 +94,25 @@ type Driver interface {
 
 	// UnmountVolume unmounts a storage volume, returns true if unmounted, false if was not
 	// mounted.
-	UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error)
+	UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error)
 
 	// UnmountVolume unmounts a storage volume snapshot, returns true if unmounted, false if was
 	// not mounted.
-	UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
+	UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error)
 
-	CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error
-	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error
-	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error
-	VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error)
-	CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error
-	RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error
+	CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error
+	DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error
+	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error
+	VolumeSnapshots(vol Volume) ([]string, error)
+	CheckVolumeSnapshots(vol Volume, snapVols []Volume) error
+	RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error
 
 	// Migration.
 	MigrationTypes(contentType ContentType, refresh bool, copySnapshots bool) []migration.Type
-	MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error
-	CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
+	MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error
+	CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error
 
 	// Backup.
-	BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
-	CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
+	BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error
+	CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error)
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/canonical/lxd/lxd/idmap"
 	"github.com/canonical/lxd/lxd/locking"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -452,7 +452,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 
 	switch fsType {
 	case "ext4":
-		return vol.UnmountTask(func(op *operations.Operation) error {
+		return vol.UnmountTask(func(progressReporter ioprogress.ProgressReporter) error {
 			output, err := shared.RunCommand(context.TODO(), "e2fsck", "-f", "-y", devPath)
 			if err != nil {
 				exitCodeFSModified := false
@@ -492,7 +492,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 			return nil
 		}, true, nil)
 	case "btrfs":
-		return vol.MountTask(func(mountPath string, op *operations.Operation) error {
+		return vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 			_, err := shared.RunCommand(context.TODO(), "btrfs", "filesystem", "resize", strSize, mountPath)
 			if err != nil {
 				return err
@@ -511,7 +511,7 @@ func growFileSystem(fsType string, devPath string, vol Volume) error {
 		fsType = DefaultFilesystem
 	}
 
-	return vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	return vol.MountTask(func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
 		var err error
 		switch fsType {
 		case "ext4":

--- a/lxd/storage/drivers/utils_image.go
+++ b/lxd/storage/drivers/utils_image.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"maps"
 
-	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/shared/ioprogress"
 )
 
 // imageVolumeConfigMatchesPoolDefault checks whether the instance volume's effective config
@@ -51,14 +51,14 @@ func CanUseOptimizedImage(vol Volume) (bool, error) {
 // volume via the filler. Otherwise it verifies that the cached image volume's config still
 // matches the pool's defaults and clones from it, falling back to a direct unpack if the
 // configs have drifted or the image volume cannot be shrunk to the requested size.
-func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op *operations.Operation) error {
+func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	// vol is passed by value so it is never nil, but its driver field may be unset.
 	if vol.driver == nil {
 		return errors.New("Volume has no associated driver")
 	}
 
 	if imgVol == nil {
-		return vol.driver.CreateVolume(vol, filler, op)
+		return vol.driver.CreateVolume(vol, filler, progressReporter)
 	}
 
 	// Pool settings may have changed since the cached image volume was created.
@@ -69,7 +69,7 @@ func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op 
 	}
 
 	if !vol.driver.ImageVolumeConfigMatch(*imgVol, poolDefaultVol) {
-		return vol.driver.CreateVolume(vol, filler, op)
+		return vol.driver.CreateVolume(vol, filler, progressReporter)
 	}
 
 	// Derive the volume size to use for the new volume when copying from the image volume.
@@ -84,7 +84,7 @@ func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op 
 	vol.SetConfigSize(newVolSize)
 
 	// Clone the new volume from the cached image volume.
-	err = vol.driver.CreateVolumeFromCopy(NewVolumeCopy(vol), NewVolumeCopy(*imgVol), false, op)
+	err = vol.driver.CreateVolumeFromCopy(NewVolumeCopy(vol), NewVolumeCopy(*imgVol), false, progressReporter)
 	if err != nil {
 		if !errors.Is(err, ErrCannotBeShrunk) {
 			return err
@@ -93,7 +93,7 @@ func createVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, op 
 		// The cached image volume is larger than the requested new volume size and cannot
 		// be shrunk. Fall back to unpacking the image directly into a new volume. This is
 		// slower but allows creating volumes smaller than the pool's volume settings.
-		return vol.driver.CreateVolume(vol, filler, op)
+		return vol.driver.CreateVolume(vol, filler, progressReporter)
 	}
 
 	return nil

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -8,10 +8,10 @@ import (
 	"os"
 
 	"github.com/canonical/lxd/lxd/locking"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/refcount"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
 )
@@ -286,28 +286,28 @@ func (v Volume) EnsureMountPath() error {
 
 // MountTask runs the supplied task after mounting the volume if needed. If the volume was mounted
 // for this then it is unmounted when the task finishes.
-func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) error, op *operations.Operation) error {
+func (v Volume) MountTask(task func(mountPath string, progressReporter ioprogress.ProgressReporter) error, progressReporter ioprogress.ProgressReporter) error {
 	// If the volume is a snapshot then call the snapshot specific mount/unmount functions as
 	// these will mount the snapshot read only.
 	var err error
 
 	if v.IsSnapshot() {
-		err = v.driver.MountVolumeSnapshot(v, op)
+		err = v.driver.MountVolumeSnapshot(v, progressReporter)
 	} else {
-		err = v.driver.MountVolume(v, op)
+		err = v.driver.MountVolume(v, progressReporter)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	taskErr := task(v.MountPath(), op)
+	taskErr := task(v.MountPath(), progressReporter)
 
 	// Try and unmount, even on task error.
 	if v.IsSnapshot() {
-		_, err = v.driver.UnmountVolumeSnapshot(v, op)
+		_, err = v.driver.UnmountVolumeSnapshot(v, progressReporter)
 	} else {
-		_, err = v.driver.UnmountVolume(v, false, op)
+		_, err = v.driver.UnmountVolume(v, false, progressReporter)
 	}
 
 	// Return task error if failed.
@@ -326,39 +326,39 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 // UnmountTask runs the supplied task after unmounting the volume if needed.
 // If the volume was unmounted for this then it is mounted when the task finishes.
 // keepBlockDev indicates if backing block device should be not be deactivated if volume is unmounted.
-func (v Volume) UnmountTask(task func(op *operations.Operation) error, keepBlockDev bool, op *operations.Operation) error {
+func (v Volume) UnmountTask(task func(progressReporter ioprogress.ProgressReporter) error, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) error {
 	// If the volume is a snapshot then call the snapshot specific mount/unmount functions as
 	// these will mount the snapshot read only.
 	if v.IsSnapshot() {
-		ourUnmount, err := v.driver.UnmountVolumeSnapshot(v, op)
+		ourUnmount, err := v.driver.UnmountVolumeSnapshot(v, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		if ourUnmount {
-			defer func() { _ = v.driver.MountVolumeSnapshot(v, op) }()
+			defer func() { _ = v.driver.MountVolumeSnapshot(v, progressReporter) }()
 		}
 	} else {
-		ourUnmount, err := v.driver.UnmountVolume(v, keepBlockDev, op)
+		ourUnmount, err := v.driver.UnmountVolume(v, keepBlockDev, progressReporter)
 		if err != nil {
 			return err
 		}
 
 		if ourUnmount {
-			defer func() { _ = v.driver.MountVolume(v, op) }()
+			defer func() { _ = v.driver.MountVolume(v, progressReporter) }()
 		}
 	}
 
-	return task(op)
+	return task(progressReporter)
 }
 
 // Snapshots returns a list of snapshots for the volume (in no particular order).
-func (v Volume) Snapshots(op *operations.Operation) ([]Volume, error) {
+func (v Volume) Snapshots(progressReporter ioprogress.ProgressReporter) ([]Volume, error) {
 	if v.IsSnapshot() {
 		return nil, errors.New("Volume is a snapshot")
 	}
 
-	snapshots, err := v.driver.VolumeSnapshots(v, op)
+	snapshots, err := v.driver.VolumeSnapshots(v)
 	if err != nil {
 		return nil, err
 	}
@@ -433,8 +433,8 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 }
 
 // SetQuota calls SetVolumeQuota on the Volume's driver.
-func (v Volume) SetQuota(size string, allowUnsafeResize bool, op *operations.Operation) error {
-	return v.driver.SetVolumeQuota(v, size, allowUnsafeResize, op)
+func (v Volume) SetQuota(size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
+	return v.driver.SetVolumeQuota(v, size, allowUnsafeResize, progressReporter)
 }
 
 // SetConfigSize sets the size config property on the Volume (does not resize volume).

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"os"
@@ -14,10 +15,10 @@ import (
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/storage/drivers"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 )
 
@@ -54,10 +55,10 @@ type Pool interface {
 
 	GetResources() (*api.ResourcesStoragePool, error)
 	IsUsed() (bool, error)
-	Delete(clientType request.ClientType, op *operations.Operation) error
-	Update(clientType request.ClientType, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	Delete(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error
+	Update(clientType request.ClientType, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
 
-	Create(clientType request.ClientType, op *operations.Operation) error
+	Create(clientType request.ClientType, progressReporter ioprogress.ProgressReporter) error
 	Mount() (bool, error)
 	Unmount() (bool, error)
 
@@ -66,87 +67,87 @@ type Pool interface {
 	GetVolume(volumeType drivers.VolumeType, contentType drivers.ContentType, name string, config map[string]string) drivers.Volume
 
 	// Instances.
-	CreateInstance(inst instance.Instance, op *operations.Operation) error
-	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
-	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error
-	CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error
-	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstance(inst instance.Instance, op *operations.Operation) error
-	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
-	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
-	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
-	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
-	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error
+	CreateInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (func(instance.Instance) error, revert.Hook, error)
+	CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error
+	CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, progressReporter ioprogress.ProgressReporter) error
+	CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error
+	CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error
+	RenameInstance(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error
+	DeleteInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
+	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, progressReporter ioprogress.ProgressReporter) error
+	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error)
+	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error)
+	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, progressReporter ioprogress.ProgressReporter) ([]*api.InstanceSnapshot, error)
+	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (revert.Hook, error)
+	CleanupInstancePaths(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
 
-	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
-	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
-	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error
+	MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error
+	RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error
+	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, progressReporter ioprogress.ProgressReporter) error
 
 	GetInstanceUsage(inst instance.Instance) (*VolumeUsage, error)
-	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
+	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, progressReporter ioprogress.ProgressReporter) error
 
-	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstance(inst instance.Instance, op *operations.Operation) error
+	MountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error)
+	UnmountInstance(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
 
 	// Instance snapshots.
-	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
-	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
-	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
-	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
-	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	RenameInstanceSnapshot(inst instance.Instance, newName string, progressReporter ioprogress.ProgressReporter) error
+	DeleteInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	MountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error)
+	UnmountInstanceSnapshot(inst instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
 
 	// Images.
-	EnsureImage(fingerprint string, op *operations.Operation, projectName string) error
-	DeleteImage(fingerprint string, op *operations.Operation) error
-	UpdateImage(fingerprint string, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) error
+	DeleteImage(ctx context.Context, fingerprint string, progressReporter ioprogress.ProgressReporter) error
+	UpdateImage(ctx context.Context, fingerprint string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
 
 	// Buckets.
-	CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error
-	UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error
-	DeleteBucket(projectName string, bucketName string, op *operations.Operation) error
-	CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error)
-	UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error
-	DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error
+	CreateBucket(projectName string, bucket api.StorageBucketsPost) error
+	UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut) error
+	DeleteBucket(projectName string, bucketName string) error
+	CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost) (*api.StorageBucketKey, error)
+	UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut) error
+	DeleteBucketKey(projectName string, bucketName string, keyName string) error
 	GetBucketURL(bucketName string) *url.URL
 
 	// Custom volumes.
-	CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error
-	CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
-	UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
-	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
+	CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, progressReporter ioprogress.ProgressReporter) error
+	CreateCustomVolumeFromCopy(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error
+	UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
+	RenameCustomVolume(ctx context.Context, projectName string, volName string, newVolName string, progressReporter ioprogress.ProgressReporter) error
+	DeleteCustomVolume(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error
 	GetCustomVolumeUsage(projectName string, volName string) (*VolumeUsage, error)
-	MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error)
-	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
-	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
-	UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error
-	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
-	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
-	CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error
+	MountCustomVolume(projectName string, volName string, progressReporter ioprogress.ProgressReporter) (*MountInfo, error)
+	UnmountCustomVolume(projectName string, volName string, progressReporter ioprogress.ProgressReporter) (bool, error)
+	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, progressReporter ioprogress.ProgressReporter) (revert.Hook, error)
+	RefreshCustomVolume(ctx context.Context, projectName, srcProjectName, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, progressReporter ioprogress.ProgressReporter) error
+	UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, progressReporter ioprogress.ProgressReporter) error
+	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, progressReporter ioprogress.ProgressReporter) (*backupConfig.Config, error)
+	CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, progressReporter ioprogress.ProgressReporter) error
+	CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, progressReporter ioprogress.ProgressReporter) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error)
-	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
-	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
-	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error
-	RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, progressReporter ioprogress.ProgressReporter) (*uuid.UUID, error)
+	RenameCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error
+	DeleteCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, progressReporter ioprogress.ProgressReporter) error
+	UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, progressReporter ioprogress.ProgressReporter) error
+	RestoreCustomVolume(ctx context.Context, projectName string, volName string, snapshotName string, progressReporter ioprogress.ProgressReporter) error
 
 	// Custom volume migration.
 	MigrationTypes(contentType drivers.ContentType, refresh bool, copySnapshots bool) []migration.Type
-	CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
+	CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, progressReporter ioprogress.ProgressReporter) error
+	MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error
 
 	// Custom volume backups.
-	BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
-	CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error
+	BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, progressReporter ioprogress.ProgressReporter) error
+	CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) error
 
 	// Storage volume recovery.
-	ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error)
+	ListUnknownVolumes(progressReporter ioprogress.ProgressReporter) (map[string][]*backupConfig.Config, error)
 }

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -26,7 +26,6 @@ import (
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/node"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/rsync"
@@ -1219,17 +1218,17 @@ func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(respon
 
 // InstanceMount mounts an instance's storage volume (if not already mounted).
 // Please call InstanceUnmount when finished.
-func InstanceMount(pool Pool, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func InstanceMount(pool Pool, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*MountInfo, error) {
 	var err error
 	var mountInfo *MountInfo
 
 	if inst.IsSnapshot() {
-		mountInfo, err = pool.MountInstanceSnapshot(inst, op)
+		mountInfo, err = pool.MountInstanceSnapshot(inst, progressReporter)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mountInfo, err = pool.MountInstance(inst, op)
+		mountInfo, err = pool.MountInstance(inst, progressReporter)
 		if err != nil {
 			return nil, err
 		}
@@ -1239,13 +1238,13 @@ func InstanceMount(pool Pool, inst instance.Instance, op *operations.Operation) 
 }
 
 // InstanceUnmount unmounts an instance's storage volume (if not in use).
-func InstanceUnmount(pool Pool, inst instance.Instance, op *operations.Operation) error {
+func InstanceUnmount(pool Pool, inst instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	var err error
 
 	if inst.IsSnapshot() {
-		err = pool.UnmountInstanceSnapshot(inst, op)
+		err = pool.UnmountInstanceSnapshot(inst, progressReporter)
 	} else {
-		err = pool.UnmountInstance(inst, op)
+		err = pool.UnmountInstance(inst, progressReporter)
 	}
 
 	return err
@@ -1253,13 +1252,13 @@ func InstanceUnmount(pool Pool, inst instance.Instance, op *operations.Operation
 
 // InstanceDiskBlockSize returns the block device size for the instance's disk.
 // This will mount the instance if not already mounted and will unmount at the end if needed.
-func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Operation) (int64, error) {
-	mountInfo, err := InstanceMount(pool, inst, op)
+func InstanceDiskBlockSize(pool Pool, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (int64, error) {
+	mountInfo, err := InstanceMount(pool, inst, progressReporter)
 	if err != nil {
 		return -1, err
 	}
 
-	defer func() { _ = InstanceUnmount(pool, inst, op) }()
+	defer func() { _ = InstanceUnmount(pool, inst, progressReporter) }()
 
 	devSource, isPath := mountInfo.DevSource.(deviceConfig.DevSourcePath)
 

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -482,12 +482,12 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		reverter := revert.New()
 		defer reverter.Fail()
 
-		err := pool.CreateBucket(bucketProjectName, req, nil)
+		err := pool.CreateBucket(bucketProjectName, req)
 		if err != nil {
 			return fmt.Errorf("Failed creating storage bucket: %w", err)
 		}
 
-		reverter.Add(func() { _ = pool.DeleteBucket(bucketProjectName, req.Name, nil) })
+		reverter.Add(func() { _ = pool.DeleteBucket(bucketProjectName, req.Name) })
 
 		// Create admin key for new bucket.
 		adminKeyReq := api.StorageBucketKeysPost{
@@ -498,7 +498,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 			Name: "admin",
 		}
 
-		adminKey, err := pool.CreateBucketKey(bucketProjectName, req.Name, adminKeyReq, nil)
+		adminKey, err := pool.CreateBucketKey(bucketProjectName, req.Name, adminKeyReq)
 		if err != nil {
 			return fmt.Errorf("Failed creating storage bucket admin key: %w", err)
 		}
@@ -675,7 +675,7 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 	entityURL := entity.StorageBucketURL(effectiveProjectName, location, details.pool.Name(), details.bucketName)
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		err := details.pool.UpdateBucket(effectiveProjectName, details.bucketName, req, nil)
+		err := details.pool.UpdateBucket(effectiveProjectName, details.bucketName, req)
 		if err != nil {
 			return fmt.Errorf("Failed updating storage bucket: %w", err)
 		}
@@ -785,7 +785,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 
 // doStorageBucketDelete deletes a storage bucket in the given project and pool.
 func doStorageBucketDelete(pool storagePools.Pool, projectName string, name string) error {
-	err := pool.DeleteBucket(projectName, name, nil)
+	err := pool.DeleteBucket(projectName, name)
 	if err != nil {
 		return fmt.Errorf("Failed deleting storage bucket %q: %w", name, err)
 	}
@@ -1018,7 +1018,7 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 	entityURL := entity.StorageBucketURL(effectiveProjectName, location, details.pool.Name(), details.bucketName)
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		key, err := details.pool.CreateBucketKey(effectiveProjectName, details.bucketName, req, nil)
+		key, err := details.pool.CreateBucketKey(effectiveProjectName, details.bucketName, req)
 		if err != nil {
 			return fmt.Errorf("Failed creating storage bucket key: %w", err)
 		}
@@ -1110,7 +1110,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 	entityURL := entity.StorageBucketURL(effectiveProjectName, location, details.pool.Name(), details.bucketName)
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		err := details.pool.DeleteBucketKey(effectiveProjectName, details.bucketName, keyName, nil)
+		err := details.pool.DeleteBucketKey(effectiveProjectName, details.bucketName, keyName)
 		if err != nil {
 			return fmt.Errorf("Failed deleting storage bucket key: %w", err)
 		}
@@ -1306,7 +1306,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 	entityURL := entity.StorageBucketURL(effectiveProjectName, location, details.pool.Name(), details.bucketName)
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		err := details.pool.UpdateBucketKey(effectiveProjectName, details.bucketName, keyName, req, nil)
+		err := details.pool.UpdateBucketKey(effectiveProjectName, details.bucketName, keyName, req)
 		if err != nil {
 			return fmt.Errorf("Failed updating storage bucket key: %w", err)
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -1143,7 +1143,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 			}
 
 			for _, removeImgFingerprint := range removeImgFingerprints {
-				err = pool.DeleteImage(removeImgFingerprint, nil)
+				err = pool.DeleteImage(ctx, removeImgFingerprint, nil)
 				if err != nil {
 					return fmt.Errorf("Error deleting image %q from storage pool %q: %w", removeImgFingerprint, pool.Name(), err)
 				}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1231,7 +1231,7 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 			return errors.New("No source volume name supplied")
 		}
 
-		err = pool.RefreshCustomVolume(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		err = pool.RefreshCustomVolume(ctx, projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		if err != nil {
 			return err
 		}
@@ -1298,7 +1298,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		entityURL = requestProjectURL
 		metadata[api.MetadataEntityURL] = api.NewURL().Path(version.APIVersion, "storage-pools", pool.Name(), "volumes", cluster.StoragePoolVolumeTypeNameCustom, req.Name).Project(requestProjectName).String()
 		run = func(ctx context.Context, op *operations.Operation) error {
-			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
+			return pool.CreateCustomVolume(ctx, projectName, req.Name, req.Description, req.Config, contentType, op)
 		}
 	} else {
 		// We're copying a volume from this node.
@@ -1319,7 +1319,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		}
 
 		run = func(ctx context.Context, op *operations.Operation) error {
-			return pool.CreateCustomVolumeFromCopy(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+			return pool.CreateCustomVolumeFromCopy(ctx, projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		}
 	}
 
@@ -1391,7 +1391,7 @@ func doVolumeMigration(s *state.State, r *http.Request, requestProjectName strin
 
 	run := func(ctx context.Context, op *operations.Operation) error {
 		// And finally run the migration.
-		err = sink.DoStorage(s, projectName, poolName, req, op)
+		err = sink.DoStorage(ctx, s, projectName, poolName, req, op)
 		if err != nil {
 			logger.Error("Error during migration sink", logger.Ctx{"err": err})
 			return fmt.Errorf("Error transferring storage volume: %s", err)
@@ -1812,7 +1812,7 @@ func storageVolumePostClusteringMigrate(s *state.State, srcPool storagePools.Poo
 				return err
 			}
 
-			err = srcPool.DeleteCustomVolume(srcProjectName, srcVolumeName, op)
+			err = srcPool.DeleteCustomVolume(ctx, srcProjectName, srcVolumeName, op)
 			if err != nil {
 				return err
 			}
@@ -1949,13 +1949,13 @@ func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName s
 		revert := revert.New()
 		defer revert.Fail()
 
-		err = pool.RenameCustomVolume(projectName, vol.Name, req.Name, op)
+		err = pool.RenameCustomVolume(ctx, projectName, vol.Name, req.Name, op)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = pool.RenameCustomVolume(projectName, req.Name, vol.Name, op)
+			_ = pool.RenameCustomVolume(ctx, projectName, req.Name, vol.Name, op)
 		})
 
 		// Update devices using the volume in instances and profiles.
@@ -2024,12 +2024,12 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
-		err = newPool.CreateCustomVolumeFromCopy(projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
+		err = newPool.CreateCustomVolumeFromCopy(ctx, projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
 		if err != nil {
 			return err
 		}
 
-		err = pool.DeleteCustomVolume(requestProjectName, vol.Name, op)
+		err = pool.DeleteCustomVolume(ctx, requestProjectName, vol.Name, op)
 		if err != nil {
 			return err
 		}
@@ -2267,7 +2267,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 			// before applying config changes so that changes are applied to the
 			// restored volume.
 			if req.Restore != "" {
-				err = details.pool.RestoreCustomVolume(effectiveProjectName, dbVolume.Name, req.Restore, op)
+				err = details.pool.RestoreCustomVolume(ctx, effectiveProjectName, dbVolume.Name, req.Restore, op)
 				if err != nil {
 					return err
 				}
@@ -2285,7 +2285,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 					return err
 				}
 
-				err = details.pool.UpdateCustomVolume(effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
+				err = details.pool.UpdateCustomVolume(ctx, effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
 				if err != nil {
 					return err
 				}
@@ -2297,14 +2297,14 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Handle instance volume update requests.
-			err = details.pool.UpdateInstance(inst, req.Description, req.Config, op)
+			err = details.pool.UpdateInstance(ctx, inst, req.Description, req.Config, op)
 			if err != nil {
 				return err
 			}
 
 		case cluster.StoragePoolVolumeTypeImage:
 			// Handle image update requests.
-			err = details.pool.UpdateImage(dbVolume.Name, req.Description, req.Config, op)
+			err = details.pool.UpdateImage(ctx, dbVolume.Name, req.Description, req.Config, op)
 			if err != nil {
 				return err
 			}
@@ -2444,7 +2444,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		return details.pool.UpdateCustomVolume(effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
+		return details.pool.UpdateCustomVolume(ctx, effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
 	}
 
 	volumeURL := entity.StorageVolumeURL(effectiveProjectName, details.location, details.pool.Name(), details.volumeTypeName, details.volumeName)
@@ -2582,9 +2582,9 @@ func doStoragePoolVolumeDelete(ctx context.Context, opScheduler operations.Opera
 	run := func(ctx context.Context, op *operations.Operation) error {
 		switch volType {
 		case cluster.StoragePoolVolumeTypeCustom:
-			return pool.DeleteCustomVolume(effectiveProjectName, name, op)
+			return pool.DeleteCustomVolume(ctx, effectiveProjectName, name, op)
 		case cluster.StoragePoolVolumeTypeImage:
-			return pool.DeleteImage(name, op)
+			return pool.DeleteImage(ctx, name, op)
 		default:
 			return api.StatusErrorf(http.StatusBadRequest, "Storage volumes of type %q cannot be deleted directly", volType.String())
 		}
@@ -2658,7 +2658,7 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 		}
 
 		// Dump ISO to storage.
-		err = pool.CreateCustomVolumeFromISO(projectName, volName, isoFile, size, op)
+		err = pool.CreateCustomVolumeFromISO(ctx, projectName, volName, isoFile, size, op)
 		if err != nil {
 			return fmt.Errorf("Failed creating custom volume from ISO: %w", err)
 		}
@@ -2718,7 +2718,7 @@ func createStoragePoolVolumeFromTarball(s *state.State, r *http.Request, request
 		}
 
 		// Dump tarball to storage.
-		err = pool.CreateCustomVolumeFromTarball(projectName, volName, tarFile, op)
+		err = pool.CreateCustomVolumeFromTarball(ctx, projectName, volName, tarFile, op)
 		if err != nil {
 			return fmt.Errorf("Failed creating custom volume from tar archive: %w", err)
 		}
@@ -2892,7 +2892,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		}
 
 		// Dump tarball to storage.
-		err = pool.CreateCustomVolumeFromBackup(*bInfo, backupFile, nil)
+		err = pool.CreateCustomVolumeFromBackup(ctx, *bInfo, backupFile, op)
 		if err != nil {
 			return fmt.Errorf("Create custom volume from backup: %w", err)
 		}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -215,7 +215,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Create the snapshot.
 	snapshot := func(ctx context.Context, op *operations.Operation) error {
-		_, err = details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, req.ExpiresAt, op)
+		_, err = details.pool.CreateCustomVolumeSnapshot(ctx, effectiveProjectName, details.volumeName, req.Name, req.Description, req.ExpiresAt, op)
 		if err != nil {
 			return err
 		}
@@ -555,7 +555,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 
 	// Rename the snapshot.
 	snapshotRename := func(ctx context.Context, op *operations.Operation) error {
-		return details.pool.RenameCustomVolumeSnapshot(effectiveProjectName, fullSnapshotName, req.Name, op)
+		return details.pool.RenameCustomVolumeSnapshot(ctx, effectiveProjectName, fullSnapshotName, req.Name, op)
 	}
 
 	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(requestProjectName)
@@ -977,7 +977,7 @@ func doStoragePoolVolumeSnapshotUpdate(ctx context.Context, s *state.State, pool
 
 	// Update the database.
 	if volumeType == dbCluster.StoragePoolVolumeTypeCustom {
-		err := pool.UpdateCustomVolumeSnapshot(projectName, volName, req.Description, nil, expiry, op)
+		err := pool.UpdateCustomVolumeSnapshot(ctx, projectName, volName, req.Description, nil, expiry, op)
 		if err != nil {
 			return err
 		}
@@ -987,7 +987,7 @@ func doStoragePoolVolumeSnapshotUpdate(ctx context.Context, s *state.State, pool
 			return err
 		}
 
-		err = pool.UpdateInstanceSnapshot(inst, req.Description, nil, op)
+		err = pool.UpdateInstanceSnapshot(ctx, inst, req.Description, nil, op)
 		if err != nil {
 			return err
 		}
@@ -1067,7 +1067,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
 
 	snapshotDelete := func(ctx context.Context, op *operations.Operation) error {
-		return details.pool.DeleteCustomVolumeSnapshot(effectiveProjectName, fullSnapshotName, op)
+		return details.pool.DeleteCustomVolumeSnapshot(ctx, effectiveProjectName, fullSnapshotName, op)
 	}
 
 	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
@@ -1345,7 +1345,7 @@ func pruneExpiredCustomVolumeSnapshots(ctx context.Context, s *state.State, expi
 			return fmt.Errorf("Error loading pool for volume snapshot %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		err = pool.DeleteCustomVolumeSnapshot(v.ProjectName, v.Name, nil)
+		err = pool.DeleteCustomVolumeSnapshot(ctx, v.ProjectName, v.Name, nil)
 		customVolSnapshotsPruneRunning.Delete(v.ID)
 		if err != nil {
 			return fmt.Errorf("Error deleting custom volume snapshot %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
@@ -1373,7 +1373,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volume
 			return fmt.Errorf("Error loading pool for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		_, err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, nil, nil)
+		_, err = pool.CreateCustomVolumeSnapshot(ctx, v.ProjectName, v.Name, snapshotName, v.Description, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Error creating snapshot for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -72,13 +72,13 @@ func storagePoolVolumeUpdateUsers(ctx context.Context, s *state.State, projectNa
 			Snapshot:     inst.IsSnapshot(),
 		}
 
-		err = inst.Update(args, instance.UpdateActionInternal)
+		err = inst.Update(ctx, args, instance.UpdateActionInternal)
 		if err != nil {
 			return nil, err
 		}
 
 		revert.Add(func() {
-			err := inst.Update(instancesOldArgs[i], instance.UpdateActionInternal)
+			err := inst.Update(ctx, instancesOldArgs[i], instance.UpdateActionInternal)
 			if err != nil {
 				logger.Error("Failed reverting instance update", logger.Ctx{"project": instancesOldArgs[i].Project, "instance": instancesOldArgs[i].Name, "error": err})
 			}


### PR DESCRIPTION
Updates the storage driver, storage pool, and instance interfaces and drivers to accept a context argument (containing the requestor) and an `ioprogress.ProgressReporter` for progress updates (which operations.Operation implements).

Removes the `Operation` and `SetOperation` methods from the `Instance` interface and removes the `op` field from `instanceCommon`. This enforces that these drivers are able to use the operation only for progress reporting on large I/O tasks. Lifecycle events report the requestor via context, which is present in both the request context and operation context.

This closes #16072 and reinstates the requestor on lifecycle events during bulk instance state update.

Depends on #18126 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
