### PR TITLE
doc: fix to prevent indexing older versions (stable-5.0)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,3 +207,14 @@ if 'READTHEDOCS_VERSION' in os.environ:
     sitemap_url_scheme = f'{rtd_version}/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
+
+
+###########################################
+### Prevent indexing of older docs versions
+###########################################
+
+# Add RTD docs version slugs for versions that should not be indexed by search engines
+noindex_versions = {"stable-5.0", "stable-4.0", "v4", "v5"}
+
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+html_context["seo_noindex"] = rtd_version in noindex_versions

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -416,15 +416,3 @@ else:
 
 
 sys.path.append(os.path.abspath('.sphinx/_extensions/'))
-
-
-
-###########################################
-### Prevent indexing of older docs versions
-###########################################
-
-# Add RTD docs version slugs for versions that should not be indexed by search engines
-noindex_versions = {"stable-5.0", "stable-4.0", "v4", "v5"}
-
-rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
-html_context["seo_noindex"] = rtd_version in noindex_versions


### PR DESCRIPTION
Fix to https://github.com/canonical/lxd/pull/18053/ - found that `custom_conf.py` is ignored in `stable-5.0`. This PR moves relevant code to `conf.py`.
