### PR TITLE
lxd: Async network peer endpoints

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -220,7 +220,7 @@ type InstanceServer interface {
 	GetNetworkPeerNames(networkName string) ([]string, error)
 	GetNetworkPeers(networkName string) ([]api.NetworkPeer, error)
 	GetNetworkPeer(networkName string, peerName string) (peer *api.NetworkPeer, ETag string, err error)
-	CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) error
+	CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) (op Operation, err error)
 	UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) (err error)
 	DeleteNetworkPeer(networkName string, peerName string) (err error)
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -221,7 +221,7 @@ type InstanceServer interface {
 	GetNetworkPeers(networkName string) ([]api.NetworkPeer, error)
 	GetNetworkPeer(networkName string, peerName string) (peer *api.NetworkPeer, ETag string, err error)
 	CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) (op Operation, err error)
-	UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) (err error)
+	UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) (op Operation, err error)
 	DeleteNetworkPeer(networkName string, peerName string) (op Operation, err error)
 
 	// Network ACL functions ("network_acl" API extension)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -222,7 +222,7 @@ type InstanceServer interface {
 	GetNetworkPeer(networkName string, peerName string) (peer *api.NetworkPeer, ETag string, err error)
 	CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) (op Operation, err error)
 	UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) (err error)
-	DeleteNetworkPeer(networkName string, peerName string) (err error)
+	DeleteNetworkPeer(networkName string, peerName string) (op Operation, err error)
 
 	// Network ACL functions ("network_acl" API extension)
 	GetNetworkACLNames() (names []string, err error)

--- a/client/lxd_network_peer.go
+++ b/client/lxd_network_peer.go
@@ -91,19 +91,31 @@ func (r *ProtocolLXD) CreateNetworkPeer(networkName string, peer api.NetworkPeer
 }
 
 // UpdateNetworkPeer updates the network peer to match the provided struct.
-func (r *ProtocolLXD) UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) error {
+func (r *ProtocolLXD) UpdateNetworkPeer(networkName string, peerName string, peer api.NetworkPeerPut, ETag string) (Operation, error) {
 	err := r.CheckExtension("network_peer")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("networks", networkName, "peers", peerName)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPut, "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), peer, ETag)
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPut, path.String(), peer, ETag)
+	} else {
+		op, _, err = r.queryOperation(http.MethodPut, path.String(), peer, ETag, true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // DeleteNetworkPeer deletes an existing network peer.

--- a/client/lxd_network_peer.go
+++ b/client/lxd_network_peer.go
@@ -63,20 +63,31 @@ func (r *ProtocolLXD) GetNetworkPeer(networkName string, peerName string) (*api.
 }
 
 // CreateNetworkPeer defines a new network peer using the provided struct.
-// Returns true if the peer connection has been mutually created. Returns false if peering has been only initiated.
-func (r *ProtocolLXD) CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) error {
+func (r *ProtocolLXD) CreateNetworkPeer(networkName string, peer api.NetworkPeersPost) (Operation, error) {
 	err := r.CheckExtension("network_peer")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("networks", networkName, "peers")
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPost, "/networks/"+url.PathEscape(networkName)+"/peers", peer, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPost, path.String(), peer, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodPost, path.String(), peer, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // UpdateNetworkPeer updates the network peer to match the provided struct.

--- a/client/lxd_network_peer.go
+++ b/client/lxd_network_peer.go
@@ -107,17 +107,29 @@ func (r *ProtocolLXD) UpdateNetworkPeer(networkName string, peerName string, pee
 }
 
 // DeleteNetworkPeer deletes an existing network peer.
-func (r *ProtocolLXD) DeleteNetworkPeer(networkName string, peerName string) error {
+func (r *ProtocolLXD) DeleteNetworkPeer(networkName string, peerName string) (Operation, error) {
 	err := r.CheckExtension("network_peer")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("networks", networkName, "peers", peerName)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodDelete, "/networks/"+url.PathEscape(networkName)+"/peers/"+url.PathEscape(peerName), nil, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodDelete, path.String(), nil, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodDelete, path.String(), nil, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -15102,10 +15102,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
                 "202":
-                    $ref: '#/responses/EmptySyncResponse'
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15128,8 +15126,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15198,8 +15196,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15231,8 +15229,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -546,7 +546,12 @@ func (c *cmdNetworkPeerSet) run(cmd *cobra.Command, args []string) error {
 		maps.Copy(writable.Config, keys)
 	}
 
-	return client.UpdateNetworkPeer(resource.name, peer.Name, writable, etag)
+	op, err := client.UpdateNetworkPeer(resource.name, peer.Name, writable, etag)
+	if err == nil {
+		err = op.Wait()
+	}
+
+	return err
 }
 
 // Unset.
@@ -682,7 +687,12 @@ func (c *cmdNetworkPeerEdit) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		return client.UpdateNetworkPeer(resource.name, args[1], newData.Writable(), "")
+		op, err := client.UpdateNetworkPeer(resource.name, args[1], newData.Writable(), "")
+		if err == nil {
+			err = op.Wait()
+		}
+
+		return err
 	}
 
 	// Get the current config.
@@ -707,7 +717,11 @@ func (c *cmdNetworkPeerEdit) run(cmd *cobra.Command, args []string) error {
 		newData := api.NetworkPeer{} // We show the full info, but only send the writable fields.
 		err = yaml.UnmarshalStrict(content, &newData)
 		if err == nil {
-			err = client.UpdateNetworkPeer(resource.name, args[1], newData.Writable(), etag)
+			var op lxd.Operation
+			op, err = client.UpdateNetworkPeer(resource.name, args[1], newData.Writable(), etag)
+			if err == nil {
+				err = op.Wait()
+			}
 		}
 
 		// Respawn the editor.

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -789,7 +789,11 @@ func (c *cmdNetworkPeerDelete) run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	// Delete the network peer.
-	err = client.DeleteNetworkPeer(resource.name, args[1])
+	op, err := client.DeleteNetworkPeer(resource.name, args[1])
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
 
+	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -337,7 +338,11 @@ func (c *cmdNetworkPeerCreate) run(cmd *cobra.Command, args []string) error {
 
 	client := resource.server
 
-	err = client.CreateNetworkPeer(resource.name, peer)
+	op, err := client.CreateNetworkPeer(resource.name, peer)
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -130,6 +130,9 @@ const (
 	NetworkForwardUpdate
 	NetworkForwardDelete
 	RefreshClusterLinkVolatileAddresses
+	NetworkPeerCreate
+	NetworkPeerUpdate
+	NetworkPeerDelete
 
 	// upperBound is used only to enforce consistency in the package on init.
 	// Make sure it's always the last item in this list.
@@ -351,6 +354,12 @@ func (t Type) Description() string {
 		return "Deleting network forward"
 	case RefreshClusterLinkVolatileAddresses:
 		return "Refreshing cluster link volatile addresses"
+	case NetworkPeerCreate:
+		return "Creating network peer"
+	case NetworkPeerUpdate:
+		return "Updating network peer"
+	case NetworkPeerDelete:
+		return "Deleting network peer"
 
 	// It should never be possible to reach the default clause.
 	// See the init function.
@@ -435,6 +444,10 @@ func (t Type) EntityType() entity.Type {
 
 	// Network forward operations.
 	case NetworkForwardCreate, NetworkForwardUpdate, NetworkForwardDelete:
+		return entity.TypeNetwork
+
+	// Network peer operations.
+	case NetworkPeerCreate, NetworkPeerUpdate, NetworkPeerDelete:
 		return entity.TypeNetwork
 
 	// It should never be possible to reach the default clause.

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -515,8 +515,8 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 //      schema:
 //        $ref: "#/definitions/NetworkPeerPut"
 //  responses:
-//    "200":
-//      $ref: "#/responses/EmptySyncResponse"
+//    "202":
+//      $ref: "#/responses/Operation"
 //    "400":
 //      $ref: "#/responses/BadRequest"
 //    "403":
@@ -550,8 +550,8 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkPeerPut"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -605,12 +605,30 @@ func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	err = n.PeerUpdate(peerName, req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating peer: %w", err))
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = n.PeerUpdate(peerName, req)
+		if err != nil {
+			return fmt.Errorf("Failed updating peer: %w", err)
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkPeerUpdated.Event(n, peerName, requestor, nil))
+
+		return nil
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkPeerUpdated.Event(n, peerName, request.CreateRequestor(r.Context()), nil))
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkPeerUpdate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkURL(effectiveProjectName, details.networkName),
+	}
 
-	return response.EmptySyncResponse
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
+	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/network"
+	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
@@ -227,10 +229,8 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkPeersPost"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
 //	  "202":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -277,15 +277,33 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support peering", n.Type()))
 	}
 
-	err = n.PeerCreate(req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed creating peer: %w", err))
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = n.PeerCreate(req)
+		if err != nil {
+			return fmt.Errorf("Failed creating peer: %w", err)
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		lc := lifecycle.NetworkPeerCreated.Event(n, req.Name, requestor, nil)
+		s.Events.SendLifecycle(effectiveProjectName, lc)
+
+		return nil
 	}
 
-	lc := lifecycle.NetworkPeerCreated.Event(n, req.Name, request.CreateRequestor(r.Context()), nil)
-	s.Events.SendLifecycle(effectiveProjectName, lc)
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkPeerCreate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkURL(effectiveProjectName, details.networkName),
+	}
 
-	return response.SyncResponseLocation(true, nil, lc.Source)
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }
 
 // swagger:operation DELETE /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_delete

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -322,8 +322,8 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 //	    type: string
 //	    example: default
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -368,14 +368,32 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = n.PeerDelete(peerName)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed deleting peer: %w", err))
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = n.PeerDelete(peerName)
+		if err != nil {
+			return fmt.Errorf("Failed deleting peer: %w", err)
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkPeerDeleted.Event(n, peerName, requestor, nil))
+
+		return nil
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkPeerDeleted.Event(n, peerName, request.CreateRequestor(r.Context()), nil))
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkPeerDelete,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkURL(effectiveProjectName, details.networkName),
+	}
 
-	return response.EmptySyncResponse
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }
 
 // swagger:operation GET /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_get


### PR DESCRIPTION
This PR converts network peer endpoints from synchronous to asynchronous, returning operations instead of immediate responses.

API extension: `storage_and_network_operations` (extension already landed).

Affected endpoints:
- `POST /1.0/networks/{name}/peers`
- `PUT /1.0/networks/{name}/peers/{peer}`
- `PATCH /1.0/networks/{name}/peers/{peer}`
- `DELETE /1.0/networks/{name}/peers/{peer}`