### PR TITLE
lxd: Async network zone and zone records endpoints

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -252,7 +252,7 @@ type InstanceServer interface {
 	GetNetworkZoneRecord(zone string, name string) (record *api.NetworkZoneRecord, ETag string, err error)
 	CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) (op Operation, err error)
 	UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) (err error)
-	DeleteNetworkZoneRecord(zone string, name string) (err error)
+	DeleteNetworkZoneRecord(zone string, name string) (op Operation, err error)
 
 	// Operation functions
 	GetOperationUUIDs() (uuids []string, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -243,7 +243,7 @@ type InstanceServer interface {
 	GetNetworkZoneNames() (names []string, err error)
 	GetNetworkZones() (zones []api.NetworkZone, err error)
 	GetNetworkZone(name string) (zone *api.NetworkZone, ETag string, err error)
-	CreateNetworkZone(zone api.NetworkZonesPost) (err error)
+	CreateNetworkZone(zone api.NetworkZonesPost) (op Operation, err error)
 	UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) (err error)
 	DeleteNetworkZone(name string) (err error)
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -244,7 +244,7 @@ type InstanceServer interface {
 	GetNetworkZones() (zones []api.NetworkZone, err error)
 	GetNetworkZone(name string) (zone *api.NetworkZone, ETag string, err error)
 	CreateNetworkZone(zone api.NetworkZonesPost) (op Operation, err error)
-	UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) (err error)
+	UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) (op Operation, err error)
 	DeleteNetworkZone(name string) (op Operation, err error)
 
 	GetNetworkZoneRecordNames(zone string) (names []string, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -251,7 +251,7 @@ type InstanceServer interface {
 	GetNetworkZoneRecords(zone string) (records []api.NetworkZoneRecord, err error)
 	GetNetworkZoneRecord(zone string, name string) (record *api.NetworkZoneRecord, ETag string, err error)
 	CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) (op Operation, err error)
-	UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) (err error)
+	UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) (op Operation, err error)
 	DeleteNetworkZoneRecord(zone string, name string) (op Operation, err error)
 
 	// Operation functions

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -245,7 +245,7 @@ type InstanceServer interface {
 	GetNetworkZone(name string) (zone *api.NetworkZone, ETag string, err error)
 	CreateNetworkZone(zone api.NetworkZonesPost) (op Operation, err error)
 	UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) (err error)
-	DeleteNetworkZone(name string) (err error)
+	DeleteNetworkZone(name string) (op Operation, err error)
 
 	GetNetworkZoneRecordNames(zone string) (names []string, err error)
 	GetNetworkZoneRecords(zone string) (records []api.NetworkZoneRecord, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -250,7 +250,7 @@ type InstanceServer interface {
 	GetNetworkZoneRecordNames(zone string) (names []string, err error)
 	GetNetworkZoneRecords(zone string) (records []api.NetworkZoneRecord, err error)
 	GetNetworkZoneRecord(zone string, name string) (record *api.NetworkZoneRecord, ETag string, err error)
-	CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) (err error)
+	CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) (op Operation, err error)
 	UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) (err error)
 	DeleteNetworkZoneRecord(zone string, name string) (err error)
 

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -124,19 +124,31 @@ func (r *ProtocolLXD) UpdateNetworkZone(name string, zone api.NetworkZonePut, ET
 }
 
 // DeleteNetworkZone deletes an existing network zone.
-func (r *ProtocolLXD) DeleteNetworkZone(name string) error {
+func (r *ProtocolLXD) DeleteNetworkZone(name string) (Operation, error) {
 	err := r.CheckExtension("network_dns")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("network-zones", name)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodDelete, "/network-zones/"+url.PathEscape(name), nil, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodDelete, path.String(), nil, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodDelete, path.String(), nil, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // GetNetworkZoneRecordNames returns a list of network zone record names.

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -220,19 +220,31 @@ func (r *ProtocolLXD) GetNetworkZoneRecord(zone string, name string) (*api.Netwo
 }
 
 // CreateNetworkZoneRecord defines a new Network zone record using the provided struct.
-func (r *ProtocolLXD) CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) error {
+func (r *ProtocolLXD) CreateNetworkZoneRecord(zone string, record api.NetworkZoneRecordsPost) (Operation, error) {
 	err := r.CheckExtension("network_dns_records")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("network-zones", zone, "records")
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPost, fmt.Sprintf("/network-zones/%s/records", url.PathEscape(zone)), record, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPost, path.String(), record, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodPost, path.String(), record, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // UpdateNetworkZoneRecord updates the network zone record to match the provided struct.

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -264,17 +264,29 @@ func (r *ProtocolLXD) UpdateNetworkZoneRecord(zone string, name string, record a
 }
 
 // DeleteNetworkZoneRecord deletes an existing network zone record.
-func (r *ProtocolLXD) DeleteNetworkZoneRecord(zone string, name string) error {
+func (r *ProtocolLXD) DeleteNetworkZoneRecord(zone string, name string) (Operation, error) {
 	err := r.CheckExtension("network_dns_records")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("network-zones", zone, "records", name)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodDelete, fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), nil, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodDelete, path.String(), nil, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodDelete, path.String(), nil, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -82,19 +82,29 @@ func (r *ProtocolLXD) GetNetworkZone(name string) (*api.NetworkZone, string, err
 }
 
 // CreateNetworkZone defines a new Network zone using the provided struct.
-func (r *ProtocolLXD) CreateNetworkZone(zone api.NetworkZonesPost) error {
+func (r *ProtocolLXD) CreateNetworkZone(zone api.NetworkZonesPost) (Operation, error) {
 	err := r.CheckExtension("network_dns")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPost, "/network-zones", zone, "")
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPost, "/network-zones", zone, "")
+	} else {
+		op, _, err = r.queryOperation(http.MethodPost, "/network-zones", zone, "", true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // UpdateNetworkZone updates the network zone to match the provided struct.

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -108,19 +108,32 @@ func (r *ProtocolLXD) CreateNetworkZone(zone api.NetworkZonesPost) (Operation, e
 }
 
 // UpdateNetworkZone updates the network zone to match the provided struct.
-func (r *ProtocolLXD) UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) error {
+func (r *ProtocolLXD) UpdateNetworkZone(name string, zone api.NetworkZonePut, ETag string) (Operation, error) {
 	err := r.CheckExtension("network_dns")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("network-zones", name)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPut, "/network-zones/"+url.PathEscape(name), zone, ETag)
-	if err != nil {
-		return err
+	err = r.CheckExtension("storage_and_network_operations")
+	if err != nil || r.isClusterOperationNotification() {
+		// Use a synchronous request when the server lacks async endpoint support
+		// or when handling a cluster operation notification.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPut, path.String(), zone, ETag)
+	} else {
+		op, _, err = r.queryOperation(http.MethodPut, path.String(), zone, ETag, true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // DeleteNetworkZone deletes an existing network zone.

--- a/client/lxd_network_zones.go
+++ b/client/lxd_network_zones.go
@@ -248,19 +248,31 @@ func (r *ProtocolLXD) CreateNetworkZoneRecord(zone string, record api.NetworkZon
 }
 
 // UpdateNetworkZoneRecord updates the network zone record to match the provided struct.
-func (r *ProtocolLXD) UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) error {
+func (r *ProtocolLXD) UpdateNetworkZoneRecord(zone string, name string, record api.NetworkZoneRecordPut, ETag string) (Operation, error) {
 	err := r.CheckExtension("network_dns_records")
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	path := api.NewURL().Path("network-zones", zone, "records", name)
+
+	var op Operation
 
 	// Send the request.
-	_, _, err = r.query(http.MethodPut, fmt.Sprintf("/network-zones/%s/records/%s", url.PathEscape(zone), url.PathEscape(name)), record, ETag)
+	err = r.CheckExtension("storage_and_network_operations")
 	if err != nil {
-		return err
+		// Fallback to older behavior without operations.
+		op = noopOperation{}
+		_, _, err = r.query(http.MethodPut, path.String(), record, ETag)
+	} else {
+		op, _, err = r.queryOperation(http.MethodPut, path.String(), record, ETag, true)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 // DeleteNetworkZoneRecord deletes an existing network zone record.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -13730,8 +13730,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -13754,12 +13754,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Delete the network zone
@@ -13824,12 +13826,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "412":
                     $ref: '#/responses/PreconditionFailed'
                 "500":
@@ -13857,12 +13861,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "412":
                     $ref: '#/responses/PreconditionFailed'
                 "500":
@@ -13938,8 +13944,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -13962,12 +13968,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Delete the network zone record
@@ -14032,12 +14040,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "412":
                     $ref: '#/responses/PreconditionFailed'
                 "500":
@@ -14065,12 +14075,14 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
                     $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
                 "412":
                     $ref: '#/responses/PreconditionFailed'
                 "500":

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -1130,7 +1130,11 @@ func (c *cmdNetworkZoneRecordCreate) run(cmd *cobra.Command, args []string) erro
 		record.Config[entry[0]] = entry[1]
 	}
 
-	err = resource.server.CreateNetworkZoneRecord(resource.name, record)
+	op, err := resource.server.CreateNetworkZoneRecord(resource.name, record)
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
 
+	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -508,7 +509,12 @@ func (c *cmdNetworkZoneSet) run(cmd *cobra.Command, args []string) error {
 		maps.Copy(writable.Config, keys)
 	}
 
-	return resource.server.UpdateNetworkZone(resource.name, writable, etag)
+	op, err := resource.server.UpdateNetworkZone(resource.name, writable, etag)
+	if err == nil {
+		err = op.Wait()
+	}
+
+	return err
 }
 
 // Unset.
@@ -630,7 +636,12 @@ func (c *cmdNetworkZoneEdit) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		return resource.server.UpdateNetworkZone(resource.name, newdata.Writable(), "")
+		op, err := resource.server.UpdateNetworkZone(resource.name, newdata.Writable(), "")
+		if err == nil {
+			err = op.Wait()
+		}
+
+		return err
 	}
 
 	// Get the current config.
@@ -655,7 +666,11 @@ func (c *cmdNetworkZoneEdit) run(cmd *cobra.Command, args []string) error {
 		newdata := api.NetworkZone{} // We show the full Zone info, but only send the writable fields.
 		err = yaml.UnmarshalStrict(content, &newdata)
 		if err == nil {
-			err = resource.server.UpdateNetworkZone(resource.name, newdata.Writable(), etag)
+			var op lxd.Operation
+			op, err = resource.server.UpdateNetworkZone(resource.name, newdata.Writable(), etag)
+			if err == nil {
+				err = op.Wait()
+			}
 		}
 
 		// Respawn the editor.

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -411,7 +411,11 @@ func (c *cmdNetworkZoneCreate) run(cmd *cobra.Command, args []string) error {
 		zone.Config[entry[0]] = entry[1]
 	}
 
-	err = resource.server.CreateNetworkZone(zone)
+	op, err := resource.server.CreateNetworkZone(zone)
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -1228,7 +1228,12 @@ func (c *cmdNetworkZoneRecordSet) run(cmd *cobra.Command, args []string) error {
 		maps.Copy(writable.Config, keys)
 	}
 
-	return resource.server.UpdateNetworkZoneRecord(resource.name, args[1], writable, etag)
+	op, err := resource.server.UpdateNetworkZoneRecord(resource.name, args[1], writable, etag)
+	if err == nil {
+		err = op.Wait()
+	}
+
+	return err
 }
 
 // Unset.
@@ -1357,7 +1362,12 @@ func (c *cmdNetworkZoneRecordEdit) run(cmd *cobra.Command, args []string) error 
 			return err
 		}
 
-		return resource.server.UpdateNetworkZoneRecord(resource.name, args[1], newdata.Writable(), "")
+		op, err := resource.server.UpdateNetworkZoneRecord(resource.name, args[1], newdata.Writable(), "")
+		if err == nil {
+			err = op.Wait()
+		}
+
+		return err
 	}
 
 	// Get the current config.
@@ -1382,7 +1392,11 @@ func (c *cmdNetworkZoneRecordEdit) run(cmd *cobra.Command, args []string) error 
 		newdata := api.NetworkZoneRecord{} // We show the full Zone info, but only send the writable fields.
 		err = yaml.UnmarshalStrict(content, &newdata)
 		if err == nil {
-			err = resource.server.UpdateNetworkZoneRecord(resource.name, args[1], newdata.Writable(), etag)
+			var op lxd.Operation
+			op, err = resource.server.UpdateNetworkZoneRecord(resource.name, args[1], newdata.Writable(), etag)
+			if err == nil {
+				err = op.Wait()
+			}
 		}
 
 		// Respawn the editor.
@@ -1551,7 +1565,12 @@ func (c *cmdNetworkZoneRecordEntry) runAdd(cmd *cobra.Command, args []string) er
 	}
 
 	netRecord.Entries = append(netRecord.Entries, entry)
-	return resource.server.UpdateNetworkZoneRecord(resource.name, args[1], netRecord.Writable(), etag)
+	op, err := resource.server.UpdateNetworkZoneRecord(resource.name, args[1], netRecord.Writable(), etag)
+	if err == nil {
+		err = op.Wait()
+	}
+
+	return err
 }
 
 func (c *cmdNetworkZoneRecordEntry) commandRemove() *cobra.Command {
@@ -1614,5 +1633,10 @@ func (c *cmdNetworkZoneRecordEntry) runRemove(cmd *cobra.Command, args []string)
 		return errors.New("Could not find a matching entry")
 	}
 
-	return resource.server.UpdateNetworkZoneRecord(resource.name, args[1], netRecord.Writable(), etag)
+	op, err := resource.server.UpdateNetworkZoneRecord(resource.name, args[1], netRecord.Writable(), etag)
+	if err == nil {
+		err = op.Wait()
+	}
+
+	return err
 }

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -727,7 +727,11 @@ func (c *cmdNetworkZoneDelete) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Delete the network zone.
-	err = resource.server.DeleteNetworkZone(resource.name)
+	op, err := resource.server.DeleteNetworkZone(resource.name)
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -1457,7 +1457,11 @@ func (c *cmdNetworkZoneRecordDelete) run(cmd *cobra.Command, args []string) erro
 	}
 
 	// Delete the network zone.
-	err = resource.server.DeleteNetworkZoneRecord(resource.name, args[1])
+	op, err := resource.server.DeleteNetworkZoneRecord(resource.name, args[1])
+	if err == nil {
+		err = op.Wait()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -133,6 +133,12 @@ const (
 	NetworkPeerCreate
 	NetworkPeerUpdate
 	NetworkPeerDelete
+	NetworkZoneCreate
+	NetworkZoneUpdate
+	NetworkZoneDelete
+	NetworkZoneRecordCreate
+	NetworkZoneRecordUpdate
+	NetworkZoneRecordDelete
 
 	// upperBound is used only to enforce consistency in the package on init.
 	// Make sure it's always the last item in this list.
@@ -360,6 +366,18 @@ func (t Type) Description() string {
 		return "Updating network peer"
 	case NetworkPeerDelete:
 		return "Deleting network peer"
+	case NetworkZoneCreate:
+		return "Creating network zone"
+	case NetworkZoneUpdate:
+		return "Updating network zone"
+	case NetworkZoneDelete:
+		return "Deleting network zone"
+	case NetworkZoneRecordCreate:
+		return "Creating network zone record"
+	case NetworkZoneRecordUpdate:
+		return "Updating network zone record"
+	case NetworkZoneRecordDelete:
+		return "Deleting network zone record"
 
 	// It should never be possible to reach the default clause.
 	// See the init function.
@@ -385,7 +403,8 @@ func (t Type) EntityType() entity.Type {
 	// If creating a resource, then the parent project is the primary entity
 	// (the entity being created is not yet referenceable).
 	case VolumeCreate, ProjectRename, InstanceCreate, ImageDownload, ImageUploadToken, CustomVolumeBackupRestore,
-		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, NetworkCreate, NetworkACLCreate, StorageBucketCreate:
+		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, NetworkCreate, NetworkACLCreate, StorageBucketCreate,
+		NetworkZoneCreate:
 		return entity.TypeProject
 
 	// Storage bucket operations.
@@ -450,6 +469,10 @@ func (t Type) EntityType() entity.Type {
 	// Network peer operations.
 	case NetworkPeerCreate, NetworkPeerUpdate, NetworkPeerDelete:
 		return entity.TypeNetwork
+
+	// Network zone operations.
+	case NetworkZoneUpdate, NetworkZoneDelete, NetworkZoneRecordCreate, NetworkZoneRecordUpdate, NetworkZoneRecordDelete:
+		return entity.TypeNetworkZone
 
 	// It should never be possible to reach the default clause.
 	// See the init function.

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -298,13 +298,18 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 		})
 
 		// Notify all other nodes to update the network zone if no target specified.
-		notifier, err := cluster.NewNotifier(d.state, d.state.Endpoints.NetworkCert(), d.state.ServerCert(), cluster.NotifyAll)
+		notifier, err := cluster.NewOperationNotifier(d.state, d.state.Endpoints.NetworkCert(), d.state.ServerCert(), cluster.NotifyAll)
 		if err != nil {
 			return err
 		}
 
 		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
-			return client.UseProject(d.projectName).UpdateNetworkZone(d.info.Name, d.info.Writable(), "")
+			op, err := client.UseProject(d.projectName).UpdateNetworkZone(d.info.Name, d.info.Writable(), "")
+			if err == nil {
+				err = op.Wait()
+			}
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -583,12 +583,14 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 //      schema:
 //        $ref: "#/definitions/NetworkZonePut"
 //  responses:
-//    "200":
-//      $ref: "#/responses/EmptySyncResponse"
+//    "202":
+//      $ref: "#/responses/Operation"
 //    "400":
 //      $ref: "#/responses/BadRequest"
 //    "403":
 //      $ref: "#/responses/Forbidden"
+//    "404":
+//      $ref: "#/responses/NotFound"
 //    "412":
 //      $ref: "#/responses/PreconditionFailed"
 //    "500":
@@ -618,10 +620,12 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkZonePut"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
 //	  "412":
@@ -677,12 +681,45 @@ func networkZonePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = netzone.Update(&req, requestor.ClientType())
-	if err != nil {
-		return response.SmartError(err)
+	clientType := requestor.ClientType()
+	entityURL := entity.NetworkZoneURL(effectiveProjectName, details.zoneName)
+
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = netzone.Update(&req, clientType)
+		if err != nil {
+			return err
+		}
+
+		if !clientType.IsClusterOperationNotification() {
+			requestor := request.CreateRequestor(ctx)
+			s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneUpdated.Event(netzone, requestor, nil))
+		}
+
+		return nil
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneUpdated.Event(netzone, requestor.EventLifecycleRequestor(), nil))
+	if clientType.IsClusterOperationNotification() {
+		// Handle cluster operation notification synchronously.
+		err := run(r.Context(), nil)
+		if err != nil {
+			return response.SmartError(err)
+		}
 
-	return response.EmptySyncResponse
+		return response.EmptySyncResponse
+	}
+
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkZoneUpdate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entityURL,
+	}
+
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -412,12 +412,14 @@ func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 //	    type: string
 //	    example: default
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
@@ -433,12 +435,30 @@ func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = doNetworkZoneDelete(r.Context(), s, details.zoneName, effectiveProjectName)
+	// Ensure network zone exists before creating new operation.
+	_, err = zone.LoadByNameAndProject(r.Context(), s, effectiveProjectName, details.zoneName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	return response.EmptySyncResponse
+	run := func(ctx context.Context, op *operations.Operation) error {
+		return doNetworkZoneDelete(ctx, s, details.zoneName, effectiveProjectName)
+	}
+
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkZoneDelete,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkZoneURL(effectiveProjectName, details.zoneName),
+	}
+
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }
 
 // doNetworkZoneDelete deletes the named network zone in the given project.

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
+	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/network/zone"
+	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
@@ -329,8 +331,8 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkZonesPost"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -340,7 +342,8 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, _, err := project.NetworkZoneProject(s.DB.Cluster, request.ProjectParam(r))
+	requestProjectName := request.ProjectParam(r)
+	projectName, _, err := project.NetworkZoneProject(s.DB.Cluster, requestProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -353,26 +356,44 @@ func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Create the zone.
+	// Check the zone doesn't already exist.
 	err = zone.Exists(r.Context(), s, req.Name)
 	if err == nil {
 		return response.BadRequest(errors.New("The network zone already exists"))
 	}
 
-	err = zone.Create(r.Context(), s, projectName, &req)
-	if err != nil {
-		return response.SmartError(err)
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = zone.Create(ctx, s, projectName, &req)
+		if err != nil {
+			return err
+		}
+
+		netzone, err := zone.LoadByNameAndProject(ctx, s, projectName, req.Name)
+		if err != nil {
+			return err
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		lc := lifecycle.NetworkZoneCreated.Event(netzone, requestor, nil)
+		s.Events.SendLifecycle(projectName, lc)
+
+		return nil
 	}
 
-	netzone, err := zone.LoadByNameAndProject(r.Context(), s, projectName, req.Name)
-	if err != nil {
-		return response.BadRequest(err)
+	args := operations.OperationArgs{
+		ProjectName: requestProjectName,
+		Type:        operationtype.NetworkZoneCreate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.ProjectURL(projectName),
 	}
 
-	lc := lifecycle.NetworkZoneCreated.Event(netzone, request.CreateRequestor(r.Context()), nil)
-	s.Events.SendLifecycle(projectName, lc)
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
 
-	return response.SyncResponseLocation(true, nil, lc.Source)
+	return operations.OperationResponse(op)
 }
 
 // swagger:operation DELETE /1.0/network-zones/{zone} network-zones network_zone_delete

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -280,12 +280,14 @@ func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
 //	    type: string
 //	    example: default
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
@@ -312,15 +314,38 @@ func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Delete the record.
-	err = netzone.DeleteRecord(r.Context(), recordName)
+	// Ensure network zone record exists before creating an operation.
+	_, err = netzone.GetRecord(r.Context(), recordName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneRecordDeleted.Event(netzone, recordName, request.CreateRequestor(r.Context()), nil))
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = netzone.DeleteRecord(ctx, recordName)
+		if err != nil {
+			return err
+		}
 
-	return response.EmptySyncResponse
+		requestor := request.CreateRequestor(ctx)
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneRecordDeleted.Event(netzone, recordName, requestor, nil))
+
+		return nil
+	}
+
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkZoneRecordDelete,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkZoneURL(effectiveProjectName, details.zoneName),
+	}
+
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }
 
 // swagger:operation GET /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_get

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -8,8 +9,10 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/network/zone"
+	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
@@ -198,8 +201,8 @@ func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkZoneRecordsPost"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -232,16 +235,33 @@ func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Create the record.
-	err = netzone.AddRecord(r.Context(), req)
-	if err != nil {
-		return response.SmartError(err)
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = netzone.AddRecord(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		lc := lifecycle.NetworkZoneRecordCreated.Event(netzone, req.Name, requestor, nil)
+		s.Events.SendLifecycle(effectiveProjectName, lc)
+
+		return nil
 	}
 
-	lc := lifecycle.NetworkZoneRecordCreated.Event(netzone, req.Name, request.CreateRequestor(r.Context()), nil)
-	s.Events.SendLifecycle(effectiveProjectName, lc)
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkZoneRecordCreate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkZoneURL(effectiveProjectName, details.zoneName),
+	}
 
-	return response.SyncResponseLocation(true, nil, lc.Source)
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }
 
 // swagger:operation DELETE /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_delete

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -445,12 +445,14 @@ func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 //      schema:
 //        $ref: "#/definitions/NetworkZoneRecordPut"
 //  responses:
-//    "200":
-//      $ref: "#/responses/EmptySyncResponse"
+//    "202":
+//      $ref: "#/responses/Operation"
 //    "400":
 //      $ref: "#/responses/BadRequest"
 //    "403":
 //      $ref: "#/responses/Forbidden"
+//    "404":
+//      $ref: "#/responses/NotFound"
 //    "412":
 //      $ref: "#/responses/PreconditionFailed"
 //    "500":
@@ -480,12 +482,14 @@ func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkZoneRecordPut"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
 //	  "412":
 //	    $ref: "#/responses/PreconditionFailed"
 //	  "500":
@@ -552,12 +556,30 @@ func networkZoneRecordPut(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	err = netzone.UpdateRecord(r.Context(), recordName, req)
-	if err != nil {
-		return response.SmartError(err)
+	run := func(ctx context.Context, op *operations.Operation) error {
+		err = netzone.UpdateRecord(ctx, recordName, req)
+		if err != nil {
+			return err
+		}
+
+		requestor := request.CreateRequestor(ctx)
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneRecordUpdated.Event(netzone, recordName, requestor, nil))
+
+		return nil
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneRecordUpdated.Event(netzone, recordName, request.CreateRequestor(r.Context()), nil))
+	args := operations.OperationArgs{
+		ProjectName: details.requestProject.Name,
+		Type:        operationtype.NetworkZoneRecordUpdate,
+		Class:       operations.OperationClassTask,
+		RunHook:     run,
+		EntityURL:   entity.NetworkZoneURL(effectiveProjectName, details.zoneName),
+	}
 
-	return response.EmptySyncResponse
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, args)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return operations.OperationResponse(op)
 }


### PR DESCRIPTION
This PR converts network zone and zone record endpoints from synchronous to asynchronous, returning operations instead of immediate responses.

API extension: `storage_and_network_operations` (extension already landed).

Affected network zone endpoints:
- `POST /1.0/network-zones`
- `PUT /1.0/network-zones/{name}`
- `PATCH /1.0/network-zones/{name}`
- `DELETE /1.0/network-zones/{name}`

Affected network zone record endpoints:
- `POST /1.0/network-zones/{zone}/records`
- `PUT /1.0/network-zones/{zone}/records/{name}`
- `PATCH /1.0/network-zones/{zone}/records/{name}`
- `DELETE /1.0/network-zones/{zone}/records/{name}`