### PR TITLE
  lxd/db/cluster: Fix instance backup entity URL lookup

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/logger"
 )
 
 type cmdExport struct {
@@ -152,10 +153,16 @@ func (c *cmdExport) run(cmd *cobra.Command, args []string) error {
 	}
 
 	defer func() {
-		// Delete backup after we're done
+		// Delete the server-side backup after export. Log errors rather than
+		// discarding them silently so that cleanup failures are visible.
 		op, err = d.DeleteInstanceBackup(name, backupName)
-		if err == nil {
-			_ = op.Wait()
+		if err != nil {
+			logger.Warn("Failed deleting instance backup", logger.Ctx{"err": err})
+		} else {
+			err = op.Wait()
+			if err != nil {
+				logger.Warn("Failed waiting for instance backup deletion", logger.Ctx{"err": err})
+			}
 		}
 	}()
 

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -5,6 +5,11 @@ import (
 )
 
 // entityTypeInstanceBackup implements entityTypeDBInfo for an InstanceBackup.
+//
+// Note: instances_backups.name stores the full prefixed name "instanceName/backupName"
+// (e.g. "c1/backup0"), unlike instance snapshots which store just the snapshot name.
+// The queries below must account for this by stripping the prefix in allURLsQuery
+// and concatenating it back in idFromURLQuery.
 type entityTypeInstanceBackup struct {
 	entityTypeCommon
 }
@@ -15,9 +20,9 @@ func (e entityTypeInstanceBackup) code() int64 {
 
 func (e entityTypeInstanceBackup) allURLsQuery() string {
 	return fmt.Sprintf(`
-SELECT %d, instances_backups.id, projects.name, '', json_array(instances.name, instances_backups.name)
-FROM instances_backups 
-JOIN instances ON instances_backups.instance_id = instances.id 
+SELECT %d, instances_backups.id, projects.name, '', json_array(instances.name, substr(instances_backups.name, length(instances.name) + 2))
+FROM instances_backups
+JOIN instances ON instances_backups.instance_id = instances.id
 JOIN projects ON instances.project_id = projects.id`, e.code())
 }
 
@@ -37,8 +42,8 @@ JOIN instances ON instances_backups.instance_id = instances.id
 JOIN projects ON instances.project_id = projects.id 
 WHERE projects.name = ? 
 	AND '' = ? 
-	AND instances.name = ? 
-	AND instances_backups.name = ?`
+	AND instances.name = ?
+	AND instances_backups.name = instances.name || '/' || ?`
 }
 
 func (e entityTypeInstanceBackup) onDeleteTriggerSQL() (name string, sql string) {

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -480,6 +480,10 @@ _backup_import_with_project() {
   fi
 
   lxc export c1 "${LXD_DIR}/c1.tar.gz" --instance-only
+
+  # The server-side backup directory must be cleaned up after export.
+  [ ! -d "${LXD_DIR}/backups/instances/c1" ]
+
   lxc delete c1
 
   # import backup, and ensure it's valid and runnable


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description
Fixes the backup directory cleanup issue reported in #17987. After lxc export completes, the server-side backup directory (`backups/instances/{instance}`) was not being removed.

## Root Cause
`instances_backups.name` stores the full prefixed name (e.g. "c1/backup0"), but the entity URL lookup query in `entity_type_instance_backup.go` compared against just the bare backup name from the URL (e.g. "backup0"). This caused `registerDBOperation` to fail with "No such entity" when scheduling the backup delete operation, making the `DELETE` handler return `HTTP 500`. The client silently discards this error, so cleanup never happens.

This was introduced by the operation system refactoring between 6.6 and 6.7. In 6.6, `registerDBOperation` didn't exist; operations were tracked in-memory only, so the broken SQL was never executed. In 6.7+, every operation goes through `registerDBOperation` which calls the broken query.

## Fix
- Fix `idFromURLQuery` to concatenate the instance name when matching.
- Fix `allURLsQuery` to strip the instance prefix when constructing entity URLs.
- Log backup cleanup errors in `lxc export` instead of silently discarding them. (Used Warn level since the export itself has already succeeded at that point.)
- Add inline cleanup assertion in the existing backup test.


Fixes #17987