### PR TITLE
go: Update Go minimum version to 1.26.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 LXD is a modern, secure system container and virtual machine manager written in Go.
 
-LXD requires Go 1.26.1 or higher and is only tested with the Golang compiler.
+LXD requires Go 1.26.2 or higher and is only tested with the Golang compiler.
 
 ## Project Layout and Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,8 @@ ifeq "$(GOMIN)" "$(NEW_GOMIN)"
 	@echo "Error: NEW_GOMIN ($(NEW_GOMIN)) is the same as current GOMIN ($(GOMIN))"
 	exit 1
 endif
+	@# Verify the new Go version snap is uniformly available for all architectures
+	@./scripts/check-go-snap.sh "$(NEW_GOMIN)"
 	@echo "Updating Go minimum version from $(GOMIN) to $(NEW_GOMIN)"
 
 	@# Update GOMIN in Makefile

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH ?= $(shell go env GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
-GOMIN=1.26.1
+GOMIN=1.26.2
 GOTOOLCHAIN=local
 export GOTOOLCHAIN
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -4,7 +4,7 @@
 (requirements-go)=
 ## Go
 
-LXD requires Go 1.26.1 or higher and is only tested with the Golang compiler.
+LXD requires Go 1.26.2 or higher and is only tested with the Golang compiler.
 
 We recommend having at least 2GiB of RAM to allow the build to complete.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/NVIDIA/nvidia-container-toolkit v1.19.0

--- a/scripts/check-go-snap.sh
+++ b/scripts/check-go-snap.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify that the Go snap is available for all required architectures.
+#
+# Arguments:
+# $1: expected Go version (e.g. "1.26.2")
+
+EXPECTED_VERSION="${1}"
+REQUIRED_ARCHES="amd64 arm64 armhf ppc64el riscv64 s390x"
+
+# Derive the channel track from the major.minor of the expected version
+CHANNEL="$(echo "${EXPECTED_VERSION}" | grep -oE '^[0-9]+\.[0-9]+')/stable"
+
+SNAP_OUT="$(./scripts/check-snap.py go --channel "${CHANNEL}" --format plain)"
+
+SNAP_LINE="$(echo "${SNAP_OUT}" | grep "^${EXPECTED_VERSION}:" || true)"
+if [ -z "${SNAP_LINE}" ]; then
+    echo "Error: Go snap ${EXPECTED_VERSION} not found in ${CHANNEL} channel" >&2
+    echo "${SNAP_OUT}" >&2
+    exit 1
+fi
+
+MISSING_ARCHES=""
+for arch in ${REQUIRED_ARCHES}; do
+    if ! echo "${SNAP_LINE}" | grep -qw "${arch}"; then
+        MISSING_ARCHES="${MISSING_ARCHES} ${arch}"
+    fi
+done
+
+if [ -n "${MISSING_ARCHES}" ]; then
+    echo "Error: Go snap ${EXPECTED_VERSION} is missing architectures:${MISSING_ARCHES} in ${CHANNEL} channel" >&2
+    echo "${SNAP_OUT}" >&2
+    exit 1
+fi

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd/tools
 
-go 1.26.1
+go 1.26.2
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 


### PR DESCRIPTION
And have `make update-gomin` do the verification for the Go snap version availability on all arches.

We should be good to proceed for all arches:

```
$ ./scripts/check-snap.py go --channel 1.26/stable
1.26.2: amd64 (59MiB, rev: 11127),  arm64 (55MiB, rev: 11122),  armhf (56MiB, rev: 11125),  ppc64el (56MiB, rev: 11130),  riscv64 (57MiB, rev: 11152),  s390x (57MiB, rev: 11120)
```