### PR TITLE
lxd/storage/drivers: Skip `loopFileSizeDefault` tests when space is low

### DIFF
--- a/lxd/storage/drivers/utils_test.go
+++ b/lxd/storage/drivers/utils_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // Test GetVolumeMountPath.
@@ -152,7 +153,17 @@ func TestLoopFileSizeResolve(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, strconv.FormatInt(3*1024*1024*1024+512, 10)+"B", size)
 
-	// sourceRecover=false or nonexistent file falls back to loopFileSizeDefault.
+	// sourceRecover=false or nonexistent file falls back to loopFileSizeDefault
+	// which requires at least 5GiB free on the LXD_DIR filesystem.
+	var st unix.Statfs_t
+	err = unix.Statfs(dir, &st)
+	require.NoError(t, err)
+
+	gibFree := uint64(st.Frsize) * st.Bavail / (1024 * 1024 * 1024)
+	if gibFree < 5 {
+		t.Skipf("Skipping loopFileSizeDefault tests: only %d GiB free, need at least 5 GiB", gibFree)
+	}
+
 	size, err = loopFileSizeResolve(existingFile, false)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, size)


### PR DESCRIPTION
The `loopFileSizeDefault` tests require at least 5GiB of free space on the `LXD_DIR` filesystem (a tmpdir). When the test tmpdir is on a small `tmpfs` (e.g. a 3GiB `/tmp`), this threshold is not met and the test fails with `Insufficient free space to create default sized 5GiB pool`.

Skip these specific test cases with a descriptive message when the free space is below 5GiB, while still running the `sourceRecover` tests that do not depend on available disk space.

Here it is on my 3GiB `/tmp`:

```
$ df -h /tmp/
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3.0G  119M  2.9G   4% /tmp

$ go test ./lxd/storage/drivers/ -run TestLoopFileSizeResolve -v
=== RUN   TestLoopFileSizeResolve
    utils_test.go:164: Skipping loopFileSizeDefault tests: only 2 GiB free, need
 at least 5 GiB
--- SKIP: TestLoopFileSizeResolve (0.00s)
PASS
ok      github.com/canonical/lxd/lxd/storage/drivers    0.008s
```