### PR TITLE
Improved `ceph.conf` parsing to support messenger protocol v2

### DIFF
--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -215,9 +215,24 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			execPath = execPathFull
 		}
 
+		// Extra (read-only) config paths.
+		extraConfig := []string{}
+		if shared.PathExists("/etc/ceph") {
+			extraConfig = append(extraConfig, "/etc/ceph")
+
+			// See if default config points to another path.
+			if shared.PathExists("/etc/ceph/ceph.conf") {
+				target, err := filepath.EvalSymlinks("/etc/ceph/ceph.conf")
+				if err == nil && target != "/etc/ceph/ceph.conf" {
+					extraConfig = append(extraConfig, filepath.Dir(target))
+				}
+			}
+		}
+
 		err = qemuProfileTpl.Execute(sb, map[string]any{
 			"devicesPath":       inst.DevicesPath(),
 			"exePath":           execPath,
+			"extra_config":      extraConfig,
 			"libraryPath":       strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
 			"logPath":           inst.LogPath(),
 			"name":              InstanceProfileName(inst),

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -30,7 +30,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /dev/vfio/**                              rw,
   /dev/vhost-net                            rw,
   /dev/vhost-vsock                          rw,
-  /etc/ceph/**                              r,
   /etc/machine-id                           r,
   /run/udev/data/*                          r,
   @{PROC}/sys/vm/max_map_count              r,
@@ -53,6 +52,11 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .rootPath }}/etc/passwd                r,
   {{ .rootPath }}/etc/group                 r,
   @{PROC}/version                           r,
+
+  # Extra config paths
+{{- range $index, $element := .extra_config }}
+  {{ $element }}/** kr,
+{{- end }}
 
   # Used by qemu for live migration NBD server and client or when in a container
   unix (bind, listen, accept, send, receive, connect) type=stream,

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -174,26 +174,34 @@ again:
 
 // diskCephfsOptions returns the mntSrcPath and fsOptions to use for mounting a cephfs share.
 func diskCephfsOptions(clusterName string, userName string, fsName string, fsPath string) (string, []string, error) {
+	ctx := context.TODO()
+
+	// Get the FSID.
+	fsid, err := storageDrivers.CephFSID(ctx, clusterName)
+	if err != nil {
+		return "", nil, err
+	}
+
 	// Get the monitor list.
-	monAddresses, err := storageDrivers.CephMonitors(clusterName)
+	monitors, err := storageDrivers.CephMonitors(ctx, clusterName)
 	if err != nil {
 		return "", nil, err
 	}
 
 	// Get the keyring entry.
-	secret, err := storageDrivers.CephKeyring(clusterName, userName)
+	secret, err := storageDrivers.CephKeyring(ctx, clusterName, userName)
 	if err != nil {
 		return "", nil, err
 	}
 
-	// Prepare mount entry.
-	fsOptions := []string{
-		"name=" + userName,
-		"secret=" + secret,
-		"mds_namespace=" + fsName,
+	// Get the messenger mode.
+	msMode, err := storageDrivers.CephMSMode(ctx, clusterName)
+	if err != nil {
+		return "", nil, err
 	}
 
-	srcPath := strings.Join(monAddresses, ",") + ":/" + fsPath
+	srcPath, fsOptions := storageDrivers.CephBuildMount(userName, secret, fsid, monitors, fsName, fsPath, msMode)
+
 	return srcPath, fsOptions, nil
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4380,31 +4380,22 @@ func (d *qemu) addDriveConfig(busAllocate busAllocator, bootIndexes map[string]i
 		blockDev["pool"] = rbdSource.PoolName
 		blockDev["image"] = rbdSource.ImageName
 		blockDev["user"] = rbdSource.UserName
-		blockDev["server"] = []map[string]string{}
-		blockDev["conf"] = "/etc/ceph/" + rbdSource.ClusterName + ".conf"
+
+		// Dereference ceph config path in case it's a symlink (e.g. MicroCeph).
+		cephConfPath := "/etc/ceph/" + rbdSource.ClusterName + ".conf"
+		target, err := filepath.EvalSymlinks(cephConfPath)
+		if err == nil {
+			cephConfPath = target
+		}
+
+		blockDev["conf"] = cephConfPath
 
 		if rbdSource.Snapshot != "" {
 			blockDev["snapshot"] = rbdSource.Snapshot
 		}
 
-		// Setup the Ceph cluster config (monitors and keyring).
-		monitors, err := storageDrivers.CephMonitors(rbdSource.ClusterName)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, monitor := range monitors {
-			idx := strings.LastIndex(monitor, ":")
-			host := monitor[:idx]
-			port := monitor[idx+1:]
-
-			blockDev["server"] = append(blockDev["server"].([]map[string]string), map[string]string{
-				"host": strings.Trim(host, "[]"),
-				"port": port,
-			})
-		}
-
-		rbdSecret, err = storageDrivers.CephKeyring(rbdSource.ClusterName, rbdSource.UserName)
+		// Parse the secret (QEMU runs unprivileged and cannot read the keyring directly).
+		rbdSecret, err = storageDrivers.CephKeyring(context.TODO(), rbdSource.ClusterName, rbdSource.UserName)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 )
@@ -143,12 +144,8 @@ func (d *cephfs) Create() error {
 	defer revert.Fail()
 
 	// Parse the namespace / path.
-	fields := strings.SplitN(d.config["cephfs.path"], "/", 2)
-	fsName := fields[0]
-	fsPath := "/"
-	if len(fields) > 1 {
-		fsPath = fields[1]
-	}
+	fsName, fsPath, _ := strings.Cut(d.config["cephfs.path"], "/")
+	fsPath = "/" + fsPath
 
 	// If the filesystem already exists, disallow keys associated to creating the filesystem.
 	fsExists, err := d.fsExists(d.config["cephfs.cluster_name"], d.config["cephfs.user.name"], fsName)
@@ -296,15 +293,41 @@ func (d *cephfs) Create() error {
 		return fmt.Errorf("Failed creating directory %q: %w", mountPoint, err)
 	}
 
-	// Get the credentials and host.
-	monAddresses, userSecret, err := d.getConfig(d.config["cephfs.cluster_name"], d.config["cephfs.user.name"])
+	// Collect Ceph information.
+	clusterName := d.config["cephfs.cluster_name"]
+	userName := d.config["cephfs.user.name"]
+
+	ctx := context.TODO()
+
+	fsid, err := CephFSID(ctx, clusterName)
 	if err != nil {
 		return err
 	}
 
+	monitors, err := CephMonitors(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	key, err := CephKeyring(ctx, clusterName, userName)
+	if err != nil {
+		return err
+	}
+
+	if key == "" {
+		d.logger.Warn("No Ceph keyring found, cephx may be disabled", logger.Ctx{"cluster": clusterName, "user": userName})
+	}
+
+	msMode, err := CephMSMode(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode)
+	options = append(options, "mount_timeout=10")
+
 	// Mount the pool.
-	srcPath := strings.Join(monAddresses, ",") + ":/"
-	err = TryMount(context.TODO(), srcPath, mountPoint, "ceph", 0, d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(ctx, srcPath, mountPoint, "ceph", 0, strings.Join(options, ","))
 	if err != nil {
 		return err
 	}
@@ -331,12 +354,8 @@ func (d *cephfs) Create() error {
 // Delete clears any local and remote data related to this driver instance.
 func (d *cephfs) Delete(op *operations.Operation) error {
 	// Parse the namespace / path.
-	fields := strings.SplitN(d.config["cephfs.path"], "/", 2)
-	fsName := fields[0]
-	fsPath := "/"
-	if len(fields) > 1 {
-		fsPath = fields[1]
-	}
+	fsName, fsPath, _ := strings.Cut(d.config["cephfs.path"], "/")
+	fsPath = "/" + fsPath
 
 	// Create a temporary mountpoint.
 	mountPath, err := os.MkdirTemp("", "lxd_cephfs_")
@@ -357,15 +376,41 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 		return fmt.Errorf("Failed creating directory %q: %w", mountPoint, err)
 	}
 
-	// Get the credentials and host.
-	monAddresses, userSecret, err := d.getConfig(d.config["cephfs.cluster_name"], d.config["cephfs.user.name"])
+	// Collect Ceph information.
+	clusterName := d.config["cephfs.cluster_name"]
+	userName := d.config["cephfs.user.name"]
+
+	ctx := context.TODO()
+
+	fsid, err := CephFSID(ctx, clusterName)
 	if err != nil {
 		return err
 	}
 
+	monitors, err := CephMonitors(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	key, err := CephKeyring(ctx, clusterName, userName)
+	if err != nil {
+		return err
+	}
+
+	if key == "" {
+		d.logger.Warn("No Ceph keyring found, cephx may be disabled", logger.Ctx{"cluster": clusterName, "user": userName})
+	}
+
+	msMode, err := CephMSMode(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode)
+	options = append(options, "mount_timeout=10")
+
 	// Mount the pool.
-	srcPath := strings.Join(monAddresses, ",") + ":/"
-	err = TryMount(context.TODO(), srcPath, mountPoint, "ceph", 0, d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(ctx, srcPath, mountPoint, "ceph", 0, strings.Join(options, ","))
 	if err != nil {
 		return err
 	}
@@ -525,28 +570,47 @@ func (d *cephfs) Mount() (bool, error) {
 	}
 
 	// Parse the namespace / path.
-	fields := strings.SplitN(d.config["cephfs.path"], "/", 2)
-	fsName := fields[0]
-	fsPath := ""
-	if len(fields) > 1 {
-		fsPath = fields[1]
-	}
+	fsName, fsPath, _ := strings.Cut(d.config["cephfs.path"], "/")
 
-	// Get the credentials and host.
-	monAddresses, userSecret, err := d.getConfig(d.config["cephfs.cluster_name"], d.config["cephfs.user.name"])
+	// Collect Ceph information.
+	clusterName := d.config["cephfs.cluster_name"]
+	userName := d.config["cephfs.user.name"]
+
+	ctx := context.TODO()
+
+	fsid, err := CephFSID(ctx, clusterName)
 	if err != nil {
 		return false, err
 	}
 
-	// Mount options.
-	options := d.getMountOptions(d.config["cephfs.user.name"], userSecret, fsName)
+	monitors, err := CephMonitors(ctx, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	key, err := CephKeyring(ctx, clusterName, userName)
+	if err != nil {
+		return false, err
+	}
+
+	if key == "" {
+		d.logger.Warn("No Ceph keyring found, cephx may be disabled", logger.Ctx{"cluster": clusterName, "user": userName})
+	}
+
+	msMode, err := CephMSMode(ctx, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, fsPath, msMode)
+	options = append(options, "mount_timeout=10")
+
 	if shared.IsTrue(d.config["cephfs.fscache"]) {
-		options += ",fsc"
+		options = append(options, "fsc")
 	}
 
 	// Mount the pool.
-	srcPath := strings.Join(monAddresses, ",") + ":/" + fsPath
-	err = TryMount(context.TODO(), srcPath, GetPoolMountPath(d.name), "ceph", 0, options)
+	err = TryMount(ctx, srcPath, GetPoolMountPath(d.name), "ceph", 0, strings.Join(options, ","))
 	if err != nil {
 		return false, err
 	}

--- a/lxd/storage/drivers/driver_cephfs_utils.go
+++ b/lxd/storage/drivers/driver_cephfs_utils.go
@@ -3,7 +3,6 @@ package drivers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/canonical/lxd/shared"
 )
@@ -69,28 +68,4 @@ func (d *cephfs) getOSDPoolDefaultSize() (int, error) {
 	}
 
 	return sizeInt, nil
-}
-
-// getConfig parses the Ceph configuration file and returns the list of monitors and secret key.
-func (d *cephfs) getConfig(clusterName string, userName string) ([]string, string, error) {
-	// Get the monitor list.
-	monitors, err := CephMonitors(clusterName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// Get the keyring entry.
-	secret, err := CephKeyring(clusterName, userName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return monitors, secret, nil
-}
-
-// getMountOptions returns the common mount options for volumes.
-func (d *cephfs) getMountOptions(name string, secret string, namespace string) string {
-	// The default mount_timeout is 60s.
-	// Setting it to 10s ensures the mount operation doesn't take longer than the default deadline which is used by TryMount.
-	return fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v,mount_timeout=10", name, secret, namespace)
 }

--- a/lxd/storage/drivers/utils_ceph.go
+++ b/lxd/storage/drivers/utils_ceph.go
@@ -2,6 +2,8 @@ package drivers
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -60,93 +62,144 @@ func CephGetRBDImageName(vol Volume, zombie bool) (imageName string, snapName st
 	return imageName, snapName
 }
 
-// CephMonitors gets the mon-host field for the relevant cluster and extracts the list of addresses and ports.
-func CephMonitors(cluster string) ([]string, error) {
-	// Open the CEPH configuration.
-	cephConf, err := os.Open("/etc/ceph/" + cluster + ".conf")
+// callCeph makes a call to ceph with the given args.
+func callCeph(ctx context.Context, args ...string) (string, error) {
+	out, err := shared.RunCommand(ctx, "ceph", args...)
+	return strings.TrimSpace(out), err
+}
+
+// callCephJSON makes a call to the ceph admin tool with the given args then parses the JSON output into out.
+func callCephJSON(ctx context.Context, out any, args ...string) error {
+	// Get as JSON format.
+	args = append([]string{"--format", "json"}, args...)
+
+	// Make the call.
+	jsonOut, err := callCeph(ctx, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed opening %q: %w", "/etc/ceph/"+cluster+".conf", err)
+		return err
 	}
 
-	defer func() { _ = cephConf.Close() }()
+	// Parse the JSON.
+	return json.Unmarshal([]byte(jsonOut), out)
+}
 
-	// Locate the mon-host key and its values.
-	cephMon := []string{}
-	scan := bufio.NewScanner(cephConf)
-	for scan.Scan() {
-		line := scan.Text()
-		line = strings.TrimSpace(line)
+// Monitors holds a list of Ceph monitor addresses based on which protocol they expect.
+type Monitors struct {
+	V1 []string
+	V2 []string
+}
 
-		if line == "" {
-			continue
-		}
+// CephMonitors returns a list of public monitor addresses for the given cluster.
+func CephMonitors(ctx context.Context, cluster string) (Monitors, error) {
+	// Get the monitor dump.
+	monitors := struct {
+		Mons []struct {
+			PublicAddrs struct {
+				Addrvec []struct {
+					Type string `json:"type"`
+					Addr string `json:"addr"`
+				} `json:"addrvec"`
+			} `json:"public_addrs"`
+		} `json:"mons"`
+	}{}
 
-		if strings.HasPrefix(line, "mon_host") || strings.HasPrefix(line, "mon-host") || strings.HasPrefix(line, "mon host") {
-			fields := strings.SplitN(line, "=", 2)
-			if len(fields) < 2 {
-				continue
-			}
+	err := callCephJSON(ctx, &monitors, "--cluster", cluster, "mon", "dump")
+	if err != nil {
+		return Monitors{}, fmt.Errorf("Ceph mon dump for %q failed: %w", cluster, err)
+	}
 
-			// Parsing mon_host is quite tricky.
-			// It supports a space separate list of comma separated lists of:
-			//  - DNS names
-			//  - IPv4 addresses
-			//  - IPv6 addresses (square brackets)
-			//  - Optional version indicator
-			//  - Optional port numbers
-			//  - Optional data (after / separator)
-			//  - Tuples of addresses with all the above still applying inside the tuple
-			//
-			// As this function is primarily used for cephfs which
-			// doesn't take the version indication, trailing bits or supports those
-			// tuples, all of those effectively get stripped away to get a clean
-			// address list (with ports).
-			entries := strings.SplitSeq(fields[1], " ")
-			for entry := range entries {
-				servers := strings.SplitSeq(entry, ",")
-				for server := range servers {
-					// Trim leading/trailing spaces.
-					server = strings.TrimSpace(server)
-
-					// Trim leading protocol version.
-					server = strings.TrimPrefix(server, "v1:")
-					server = strings.TrimPrefix(server, "v2:")
-					server = strings.TrimPrefix(server, "[v1:")
-					server = strings.TrimPrefix(server, "[v2:")
-
-					// Trim trailing divider.
-					server = strings.Split(server, "/")[0]
-
-					// Handle end of nested blocks.
-					server = strings.ReplaceAll(server, "]]", "]")
-					if !strings.HasPrefix(server, "[") {
-						server = strings.TrimSuffix(server, "]")
-					}
-
-					// Trim any spaces.
-					server = strings.TrimSpace(server)
-
-					// If nothing left, skip.
-					if server == "" {
-						continue
-					}
-
-					// Append the default v1 port if none are present.
-					if !strings.HasSuffix(server, ":6789") && !strings.HasSuffix(server, ":3300") {
-						server += ":6789"
-					}
-
-					cephMon = append(cephMon, strings.TrimSpace(server))
-				}
+	// Loop through monitors then monitor addresses and add them to the list.
+	var ep Monitors
+	for _, mon := range monitors.Mons {
+		for _, addr := range mon.PublicAddrs.Addrvec {
+			switch addr.Type {
+			case "v1":
+				ep.V1 = append(ep.V1, addr.Addr)
+			case "v2":
+				ep.V2 = append(ep.V2, addr.Addr)
 			}
 		}
 	}
 
-	if len(cephMon) == 0 {
-		return nil, errors.New("Could not find a CEPH mon")
+	if len(ep.V2) == 0 {
+		if len(ep.V1) == 0 {
+			return Monitors{}, fmt.Errorf("No Ceph monitors found for %q", cluster)
+		}
 	}
 
-	return cephMon, nil
+	return ep, nil
+}
+
+// CephFSID retrieves the FSID for the given cluster.
+func CephFSID(ctx context.Context, cluster string) (string, error) {
+	fsid := struct {
+		FSID string `json:"fsid"`
+	}{}
+
+	err := callCephJSON(ctx, &fsid, "--cluster", cluster, "fsid")
+	if err != nil {
+		return "", fmt.Errorf("Failed getting fsid for %q: %w", cluster, err)
+	}
+
+	return fsid.FSID, nil
+}
+
+// CephBuildMount creates a mount string and option list from mount parameters.
+func CephBuildMount(user string, key string, fsid string, monitors Monitors, fsName string, path string, msMode string) (source string, options []string) {
+	// Ceph mount paths must begin with a '/'. If it doesn't (or is empty),
+	// prefix it now.
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Prefer V2 addresses when available; fall back to V1.
+	monAddrs := monitors.V1
+	if len(monitors.V2) > 0 {
+		monAddrs = monitors.V2
+	}
+
+	// Build the source path.
+	source = fmt.Sprintf("%s@%s.%s=%s", user, fsid, fsName, path)
+
+	// Build the options list.
+	options = []string{
+		"mon_addr=" + strings.Join(monAddrs, "/"),
+		"name=" + user,
+	}
+
+	// If key is blank assume cephx is disabled.
+	if key != "" {
+		options = append(options, "secret="+key)
+	}
+
+	options = append(options, "ms_mode="+msMode)
+
+	return source, options
+}
+
+// CephMSMode queries the cluster for the client messenger mode and maps it to
+// the equivalent kernel ms_mode mount option. The Ceph config key
+// ms_client_mode is a space-separated preference list (e.g. "crc secure");
+// the first entry is the preferred mode which maps to a kernel "prefer-*"
+// variant.
+func CephMSMode(ctx context.Context, cluster string) (string, error) {
+	raw, err := callCeph(ctx, "--cluster", cluster, "config", "get", "client", "ms_client_mode")
+	if err != nil {
+		return "", fmt.Errorf("Failed querying ms_client_mode for %q: %w", cluster, err)
+	}
+
+	modes := strings.Fields(raw)
+	if len(modes) == 0 {
+		return "prefer-crc", nil
+	}
+
+	// Single mode means no fallback — use it as-is (e.g. "secure" or "crc").
+	if len(modes) == 1 {
+		return modes[0], nil
+	}
+
+	// Multiple modes — the first one is preferred, map to kernel "prefer-*".
+	return "prefer-" + modes[0], nil
 }
 
 func getCephKeyFromFile(path string) (string, error) {
@@ -187,7 +240,46 @@ func getCephKeyFromFile(path string) (string, error) {
 }
 
 // CephKeyring gets the key for a particular Ceph cluster and client name.
-func CephKeyring(cluster string, client string) (string, error) {
+func CephKeyring(ctx context.Context, cluster string, client string) (string, error) {
+	// Try to find the key from the filesystem directly (fast path).
+	value, err := cephKeyringFromFile(cluster, client)
+	if err == nil {
+		return value, nil
+	}
+
+	// Fall back to using the ceph CLI.
+
+	// If client isn't prefixed, prefix it with 'client.'.
+	cephClient := client
+	if !strings.Contains(cephClient, ".") {
+		cephClient = "client." + cephClient
+	}
+
+	// Check that cephx is enabled.
+	authType, err := callCeph(ctx, "--cluster", cluster, "config", "get", cephClient, "auth_service_required")
+	if err != nil {
+		return "", fmt.Errorf("Failed querying Ceph config for auth_service_required: %w", err)
+	}
+
+	if authType == "none" {
+		return "", nil
+	}
+
+	// Call ceph auth get-key.
+	key := struct {
+		Key string `json:"key"`
+	}{}
+
+	err = callCephJSON(ctx, &key, "--cluster", cluster, "auth", "get-key", cephClient)
+	if err != nil {
+		return "", fmt.Errorf("Failed getting keyring for %q on %q: %w", client, cluster, err)
+	}
+
+	return key.Key, nil
+}
+
+// cephKeyringFromFile gets the key for a particular Ceph cluster and client name from local files.
+func cephKeyringFromFile(cluster string, client string) (string, error) {
 	var cephSecret string
 	cephConfigPath := "/etc/ceph/" + cluster + ".conf"
 

--- a/lxd/storage/drivers/utils_ceph_test.go
+++ b/lxd/storage/drivers/utils_ceph_test.go
@@ -1,0 +1,276 @@
+package drivers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCephBuildMount(t *testing.T) {
+	tests := []struct {
+		name        string
+		user        string
+		key         string
+		fsid        string
+		monitors    Monitors
+		fsName      string
+		path        string
+		msMode      string
+		wantSource  string
+		wantOptions []string
+	}{
+		{
+			name: "V2 monitors with key",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:     "myfs",
+			path:       "/",
+			msMode:     "prefer-secure",
+			wantSource: "admin@abc-def-123.myfs=/",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:3300",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "V1 only monitors",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789", "10.0.0.2:6789"},
+			},
+			fsName:     "myfs",
+			path:       "/subdir",
+			msMode:     "prefer-secure",
+			wantSource: "admin@abc-def-123.myfs=/subdir",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Multiple V2 monitors",
+			user: "client1",
+			key:  "secret123",
+			fsid: "uuid-456",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+				V2: []string{"10.0.0.1:3300", "10.0.0.2:3300", "10.0.0.3:3300"},
+			},
+			fsName:     "cephfs",
+			path:       "/data/pool",
+			msMode:     "prefer-secure",
+			wantSource: "client1@uuid-456.cephfs=/data/pool",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:3300/10.0.0.2:3300/10.0.0.3:3300",
+				"name=client1",
+				"secret=secret123",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "No key (cephx disabled)",
+			user: "admin",
+			key:  "",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:     "myfs",
+			path:       "/",
+			msMode:     "prefer-secure",
+			wantSource: "admin@abc-def-123.myfs=/",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:3300",
+				"name=admin",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Path without leading slash",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+			},
+			fsName:     "myfs",
+			path:       "subdir",
+			msMode:     "prefer-secure",
+			wantSource: "admin@abc-def-123.myfs=/subdir",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:6789",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Empty path",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+			},
+			fsName:     "myfs",
+			path:       "",
+			msMode:     "prefer-secure",
+			wantSource: "admin@abc-def-123.myfs=/",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:6789",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Strict secure mode",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:     "myfs",
+			path:       "/",
+			msMode:     "secure",
+			wantSource: "admin@abc-def-123.myfs=/",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:3300",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=secure",
+			},
+		},
+		{
+			name: "Prefer CRC mode",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:     "myfs",
+			path:       "/",
+			msMode:     "prefer-crc",
+			wantSource: "admin@abc-def-123.myfs=/",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:3300",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-crc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, options := CephBuildMount(tt.user, tt.key, tt.fsid, tt.monitors, tt.fsName, tt.path, tt.msMode)
+			assert.Equal(t, tt.wantSource, source)
+			assert.Equal(t, tt.wantOptions, options)
+		})
+	}
+}
+
+func TestGetCephKeyFromFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantKey string
+		wantErr bool
+	}{
+		{
+			name: "Standard keyring format",
+			content: `[client.admin]
+	key = AQBxyz123456789==
+	caps mds = "allow *"
+	caps mon = "allow *"
+	caps osd = "allow *"
+`,
+			wantKey: "AQBxyz123456789==",
+		},
+		{
+			name: "Key without spaces around equals",
+			content: `[client.admin]
+	key=AQBnoSpaces==
+`,
+			wantKey: "AQBnoSpaces==",
+		},
+		{
+			name: "Key with extra whitespace",
+			content: `[client.admin]
+	key =   AQBextraSpaces==   
+`,
+			wantKey: "AQBextraSpaces==",
+		},
+		{
+			name: "No key entry",
+			content: `[client.admin]
+	caps mds = "allow *"
+`,
+			wantErr: true,
+		},
+		{
+			name:    "Empty file",
+			content: "",
+			wantErr: true,
+		},
+		{
+			name: "Key line without value",
+			content: `[client.admin]
+	key
+`,
+			wantErr: true,
+		},
+		{
+			name: "Key with blank lines",
+			content: `
+[client.admin]
+
+	key = AQBblankLines==
+
+	caps mds = "allow *"
+`,
+			wantKey: "AQBblankLines==",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write the keyring content to a temp file.
+			dir := t.TempDir()
+			keyringPath := filepath.Join(dir, "test.keyring")
+			err := os.WriteFile(keyringPath, []byte(tt.content), 0600)
+			require.NoError(t, err)
+
+			key, err := getCephKeyFromFile(keyringPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKey, key)
+		})
+	}
+}
+
+func TestGetCephKeyFromFile_nonexistent(t *testing.T) {
+	_, err := getCephKeyFromFile("/nonexistent/path/keyring")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}


### PR DESCRIPTION
Based/inspired by changes in Incus:

- https://github.com/lxc/incus/pull/1081
- https://github.com/lxc/incus/pull/1181
- https://github.com/lxc/incus/pull/1538
- https://github.com/lxc/incus/pull/1709
- https://github.com/lxc/incus/pull/1716

With the addition of unit tests by Claude. 