### PR TITLE
Improve error messages for phantom db entries

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -35,6 +35,7 @@ How to recover a cluster:
 :titlesonly:
 
 Recover a cluster </howto/cluster_recover>
+Recover orphaned volume entries </howto/cluster_recover_volumes>
 ```
 
 How to set up a highly available virtual IP for clusters:

--- a/doc/howto/cluster_recover_volumes.md
+++ b/doc/howto/cluster_recover_volumes.md
@@ -1,0 +1,53 @@
+(cluster-recover-volumes)=
+# How to recover orphaned volume database entries
+
+When a {ref}`cluster instance migration <howto-cluster-manage-instance-migrate>` or {ref}`custom volume migration <howto-storage-move-volume-cluster>` is interrupted mid-transfer (for example, due to a network failure or a killed LXD process), the target member may be left with a volume record in the global database that has no corresponding storage on disk.
+These orphaned entries block future migrations for the affected instance or custom volume with an error like:
+
+    Volume "myinstance" exists in database on member "member2" but not on storage
+
+## Recover instance volumes
+
+### Identify orphaned entries
+
+List all volume entries for the affected instance across cluster members:
+
+    lxd sql global "SELECT storage_volumes.id, storage_volumes.name, nodes.name AS member FROM storage_volumes JOIN nodes ON storage_volumes.node_id = nodes.id WHERE storage_volumes.name = '<instance-name>'"
+
+Replace `<instance-name>` with the name of the affected instance.
+
+Orphaned entries appear as rows on a member where the instance does not actually reside and no storage exists on disk.
+
+### Remove orphaned entries
+
+Once you have identified the orphaned entry, remove it with:
+
+    lxd sql global "DELETE FROM storage_volumes WHERE name='<instance-name>' AND node_id=(SELECT id FROM nodes WHERE name='<member-name>')"
+
+Replace `<instance-name>`, as well as `<member-name>` with the cluster member that holds the orphaned entry.
+
+After removing the orphaned entry, retry the {ref}`instance migration <howto-cluster-manage-instance-migrate>`.
+
+## Recover custom volumes
+
+The same issue can occur with custom storage volumes during migration.
+
+### Identify orphaned entries
+
+List all volume entries for the affected custom volume across cluster members:
+
+    lxd sql global "SELECT storage_volumes.id, storage_volumes.name, nodes.name AS member FROM storage_volumes JOIN nodes ON storage_volumes.node_id = nodes.id WHERE storage_volumes.name = '<volume-name>'"
+
+Replace `<volume-name>` with the name of the custom volume.
+
+Orphaned entries appear as rows on a member where the volume does not actually reside and no storage exists on disk.
+
+### Remove orphaned entries
+
+Once you have identified the orphaned entry, remove it with:
+
+    lxd sql global "DELETE FROM storage_volumes WHERE name='<volume-name>' AND node_id=(SELECT id FROM nodes WHERE name='<member-name>')"
+
+Replace `<volume-name>`, as well as `<member-name>` with the cluster member that holds the orphaned entry.
+
+After removing the orphaned entry, retry the {ref}`volume migration <howto-storage-move-volume-cluster>`.

--- a/doc/howto/storage_move_volume.md
+++ b/doc/howto/storage_move_volume.md
@@ -77,6 +77,7 @@ To rename a custom storage volume, navigate to its {guilabel}`Overview` page and
 ````
 `````
 
+(howto-storage-move-volume-cluster)=
 ## Copy or migrate between cluster members
 
 `````{tabs}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2349,7 +2349,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	}
 
 	if dbVol != nil && !volExists {
-		return errors.New("Volume exists in database but not on storage")
+		return fmt.Errorf("Volume %q exists in database on member %q but not on storage, this may be an orphaned entry from a previous failed migration. Refer to the how-to guide on recovering orphaned volume entries in the documentation", inst.Name(), dbVol.Location)
 	}
 
 	// Consistency check for refresh mode.
@@ -5420,7 +5420,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	}
 
 	if dbVol != nil && !volExists {
-		return errors.New("Volume exists in database but not on storage")
+		return fmt.Errorf("Volume %q exists in database on member %q but not on storage, this may be an orphaned entry from a previous failed migration. Refer to the how-to guide on recovering orphaned volume entries in the documentation", args.Name, dbVol.Location)
 	}
 
 	// Disable refresh mode if volume doesn't exist yet.

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -150,16 +150,16 @@ test_clustering_move() {
 
   LXD_DIR="${LXD_ONE_DIR}" lxc profile delete prof1
 
-  sub_test "Phantom volume DB entry error after failed migration"
-  # When a cluster move fails mid-transfer (e.g. due to network disruption), LXD may leave a
-  # phantom storage_volumes DB entry on the target node if the target's revert chain could not
+  sub_test "Orphaned volume DB entry error after failed migration"
+  # When a cluster move fails mid-transfer (e.g. due to network disruption), LXD may leave an
+  # orphaned storage_volumes DB entry on the target member if the target's revert chain could not
   # reach the distributed DB while the network was down. Simulate this by directly inserting an
-  # orphaned row on node2 (no corresponding storage backing exists there), then verify LXD
+  # orphaned row on member2 (no corresponding storage backing exists there), then verify LXD
   # returns an actionable error message telling the administrator how to fix it.
 
-  # c1 is on node1 at this point.
+  # c1 is on member1 at this point.
 
-  # Inject a phantom storage_volumes row for c1 on node2, mimicking what is left behind
+  # Inject an orphaned storage_volumes row for c1 on member2, mimicking what is left behind
   # when a migration fails mid-transfer and the target cannot run its DB revert.
   LXD_DIR="${LXD_ONE_DIR}" lxd sql global "INSERT INTO storage_volumes (name, storage_pool_id, node_id, type, description, project_id) SELECT 'c1', (SELECT id FROM storage_pools WHERE name='data'), (SELECT id FROM nodes WHERE name='node2'), 0, '', (SELECT id FROM projects WHERE name='default')"
 
@@ -168,12 +168,12 @@ test_clustering_move() {
   exit_code=0
   err_msg="$(LXD_DIR="${LXD_ONE_DIR}" lxc move cluster:c1 --target node2 2>&1)" || exit_code=$?
   [[ "${exit_code}" -ne 0 ]]
-  [[ "${err_msg}" == *"exists in database but not on storage"* ]]
+  [[ "${err_msg}" == *"orphaned entry from a previous failed migration"* ]]
 
-  # Remove the phantom entry as directed by the error message.
+  # Remove the orphaned entry as directed by the error message.
   LXD_DIR="${LXD_ONE_DIR}" lxd sql global "DELETE FROM storage_volumes WHERE name='c1' AND node_id=(SELECT id FROM nodes WHERE name='node2') AND storage_pool_id=(SELECT id FROM storage_pools WHERE name='data')"
 
-  # After removing the phantom, migration to node2 succeeds.
+  # After removing the orphaned entry, migration to node2 succeeds.
   LXD_DIR="${LXD_ONE_DIR}" lxc move cluster:c1 --target node2
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list --format csv --columns L cluster:c1)" = "node2" ]
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

Follow-up to #17969 (the first phantom DB entries PR):

- Add a documentation page covering manual recovery of phantom volume database entries left by interrupted cluster migrations.
- Improve the error message in `CreateInstanceFromMigration` and `CreateCustomVolumeFromMigration` to include the volume name, affected cluster member, and a link to the recovery documentation.
- Update the integration test assertion to match the improved error message (after rebase on the first PR landed)