### PR TITLE
Take architecture from source config while copying

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1297,6 +1297,12 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 			req.Type = api.InstanceType(sourceInst.Type.String())
 
+			// Use source instance's architecture.
+			req.Architecture, err = osarch.ArchitectureName(sourceInst.Architecture)
+			if err != nil {
+				return err
+			}
+
 			// Use source instance's profiles if no profile override.
 			if req.Profiles == nil {
 				sourceInstArgs, err := tx.InstancesToInstanceArgs(ctx, true, *sourceInst)

--- a/test/suites/container_copy.sh
+++ b/test/suites/container_copy.sh
@@ -131,6 +131,20 @@ test_container_copy_start() {
   lxc copy c1 c2
   [ "$(lxc list -f csv -c s c2)" = "STOPPED" ]
 
+  sub_test "Copied container inherits the source architecture via raw API without architecture field"
+  lxc delete -f c2
+  lxc query --request POST --wait /1.0/instances --data '{
+    "name": "c2",
+    "source": {
+      "type": "copy",
+      "source": "c1"
+    }
+  }'
+  local source_arch target_arch
+  source_arch="$(lxc query /1.0/instances/c1 | jq --exit-status --raw-output '.architecture')"
+  target_arch="$(lxc query /1.0/instances/c2 | jq --exit-status --raw-output '.architecture')"
+  [ "${source_arch}" = "${target_arch}" ]
+
   lxc delete -f c2
 
   echo "==> Check that a container can be copied and started with the same command"


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description
Copying an instance via the API without specifying Architecture in the request returns an "Architecture is not supported" error as mentioned in #18100. The API should inherit the architecture from the source instance automatically, as it cannot be changed during copy.

## Root cause
In `instancesPost()`, the `SourceTypeCopy` case populates `req.Type` and `req.Profiles` from the source instance but does not populate `req.Architecture`. The `SourceTypeImage` case does set it.

## Fix
Populate `req.Architecture` from the source instance in the `SourceTypeCopy` case, consistent with how `req.Type` is already handled on the line above.

Fixes #18100

