### PR TITLE
Replace new occurrences of `gopkg.in/yaml.v2` by `go.yaml.in/yaml/v2`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,7 @@
 version: "2"
 linters:
   enable:
+    - depguard
     - godot
     - misspell
     - musttag
@@ -10,6 +11,14 @@ linters:
     - testifylint
     - whitespace
   settings:
+    depguard:
+      rules:
+        yaml-legacy:
+          deny:
+            - pkg: gopkg.in/yaml.v2
+              desc: Use go.yaml.in/yaml/v2 instead.
+            - pkg: gopkg.in/yaml.v3
+              desc: Use go.yaml.in/yaml/v3 instead.
     errcheck:
       exclude-functions:
         - (io.ReadCloser).Close

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	golang.org/x/tools v0.43.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	tags.cncf.io/container-device-interface v1.1.0
 	tags.cncf.io/container-device-interface/specs-go v1.1.0
@@ -148,6 +147,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/shared"
 	cli "github.com/canonical/lxd/shared/cmd"

--- a/lxc/cluster_link.go
+++ b/lxc/cluster_link.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"

--- a/lxc/placement_group.go
+++ b/lxc/placement_group.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"


### PR DESCRIPTION
The initial replacement took place in #16262 but new occurrences crept in. Let's prevent them with a linter.