### PR TITLE
Refactor `ioprogress` usage

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -251,27 +251,7 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, do func(
 	}
 
 	// Handle the data
-	body := response.Body
-	if req.ProgressHandler != nil {
-		reader := &ioprogress.ProgressReader{
-			ReadCloser: response.Body,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: response.ContentLength,
-			},
-		}
-
-		if response.ContentLength > 0 {
-			reader.Tracker.Handler = func(percent int64, speed int64) {
-				req.ProgressHandler(ioprogress.ProgressData{Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)"})
-			}
-		} else {
-			reader.Tracker.Handler = func(received int64, speed int64) {
-				req.ProgressHandler(ioprogress.ProgressData{Text: units.GetByteSizeString(received, 2) + " (" + units.GetByteSizeString(speed, 2) + "/s)"})
-			}
-		}
-
-		body = reader
-	}
+	body := ioprogress.NewProgressReader(response.Body, ioprogress.WithLength(response.ContentLength), ioprogress.WithProgressHandler(req.ProgressHandler))
 
 	// Hashing
 	sha256 := sha256.New()

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
-	"github.com/canonical/lxd/shared/units"
 )
 
 // Image handling functions
@@ -501,19 +499,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 		}()
 
 		// Setup progress handler
-		if args.ProgressHandler != nil {
-			body = &ioprogress.ProgressReader{
-				ReadCloser: pr,
-				Tracker: &ioprogress.ProgressTracker{
-					Handler: func(received int64, speed int64) {
-						args.ProgressHandler(ioprogress.ProgressData{Text: units.GetByteSizeString(received, 2) + " (" + units.GetByteSizeString(speed, 2) + "/s)"})
-					},
-				},
-			}
-		} else {
-			body = pr
-		}
-
+		body = ioprogress.NewProgressReader(pr, ioprogress.WithProgressHandler(args.ProgressHandler))
 		contentType = w.FormDataContentType()
 	}
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -23,7 +23,6 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/tcp"
-	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/ws"
 )
 
@@ -2960,19 +2959,7 @@ func (r *ProtocolLXD) GetInstanceBackupFile(instanceName string, name string, re
 	}
 
 	// Handle the data
-	body := response.Body
-	if req.ProgressHandler != nil {
-		body = &ioprogress.ProgressReader{
-			ReadCloser: response.Body,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: response.ContentLength,
-				Handler: func(percent int64, speed int64) {
-					req.ProgressHandler(ioprogress.ProgressData{Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)"})
-				},
-			},
-		}
-	}
-
+	body := ioprogress.NewProgressReader(response.Body, ioprogress.WithLength(response.ContentLength), ioprogress.WithProgressHandler(req.ProgressHandler))
 	size, err := io.Copy(req.BackupFile, body)
 	if err != nil {
 		return nil, err

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -6,13 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
-	"github.com/canonical/lxd/shared/units"
 )
 
 // Storage volumes handling function
@@ -1047,19 +1045,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackupFile(pool string, volName string
 	}
 
 	// Handle the data
-	body := response.Body
-	if req.ProgressHandler != nil {
-		body = &ioprogress.ProgressReader{
-			ReadCloser: response.Body,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: response.ContentLength,
-				Handler: func(percent int64, speed int64) {
-					req.ProgressHandler(ioprogress.ProgressData{Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)"})
-				},
-			},
-		}
-	}
-
+	body := ioprogress.NewProgressReader(response.Body, ioprogress.WithLength(response.ContentLength), ioprogress.WithProgressHandler(req.ProgressHandler))
 	size, err := io.Copy(req.BackupFile, body)
 	if err != nil {
 		return nil, err

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -27,7 +27,6 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/termios"
-	"github.com/canonical/lxd/shared/units"
 )
 
 const (
@@ -276,17 +275,7 @@ func (c *cmdFileCreate) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if readCloser != nil {
-		fileArgs.Content = shared.NewReadSeeker(&ioprogress.ProgressReader{
-			ReadCloser: readCloser,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: contentLength,
-				Handler: func(percent int64, speed int64) {
-					progress.UpdateProgress(ioprogress.ProgressData{
-						Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)",
-					})
-				},
-			},
-		}, fileArgs.Content)
+		fileArgs.Content = shared.NewReadSeeker(ioprogress.NewProgressReader(readCloser, ioprogress.WithLength(contentLength), ioprogress.WithProgressUpdater(&progress)), fileArgs.Content)
 	}
 
 	err = resource.server.CreateInstanceFile(resource.name, targetPath, fileArgs)
@@ -646,19 +635,9 @@ func (c *cmdFilePull) run(cmd *cobra.Command, args []string) error {
 			Quiet:  c.global.flagQuiet,
 		}
 
-		writer := &ioprogress.ProgressWriter{
-			WriteCloser: f,
-			Tracker: &ioprogress.ProgressTracker{
-				Handler: func(bytesReceived int64, speed int64) {
-					if targetPath == "-" {
-						return
-					}
-
-					progress.UpdateProgress(ioprogress.ProgressData{
-						Text: units.GetByteSizeString(bytesReceived, 2) + " (" + units.GetByteSizeString(speed, 2) + "/s)",
-					})
-				},
-			},
+		var writer io.WriteCloser = f
+		if targetPath != "-" {
+			writer = ioprogress.NewProgressWriter(writer, ioprogress.WithProgressUpdater(&progress))
 		}
 
 		_, err = io.Copy(writer, buf)
@@ -929,18 +908,7 @@ func (c *cmdFilePush) run(cmd *cobra.Command, args []string) error {
 			Quiet:  c.global.flagQuiet,
 		}
 
-		args.Content = shared.NewReadSeeker(&ioprogress.ProgressReader{
-			ReadCloser: f,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: fstat.Size(),
-				Handler: func(percent int64, speed int64) {
-					progress.UpdateProgress(ioprogress.ProgressData{
-						Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)",
-					})
-				},
-			},
-		}, f)
-
+		args.Content = shared.NewReadSeeker(ioprogress.NewProgressReader(f, ioprogress.WithLength(fstat.Size()), ioprogress.WithProgressUpdater(&progress)), f)
 		logger.Infof("Pushing %s to %s (%s)", f.Name(), fpath, args.Type)
 		err = resource.server.CreateInstanceFile(resource.name, fpath, args)
 		if err != nil {
@@ -1019,17 +987,7 @@ func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, inst string, p string,
 			Quiet:  c.global.flagQuiet,
 		}
 
-		writer := &ioprogress.ProgressWriter{
-			WriteCloser: f,
-			Tracker: &ioprogress.ProgressTracker{
-				Handler: func(bytesReceived int64, speed int64) {
-					progress.UpdateProgress(ioprogress.ProgressData{
-						Text: units.GetByteSizeString(bytesReceived, 2) + " (" + units.GetByteSizeString(speed, 2) + "/s)",
-					})
-				},
-			},
-		}
-
+		writer := ioprogress.NewProgressWriter(f, ioprogress.WithProgressUpdater(&progress))
 		_, err = io.Copy(writer, buf)
 		if err != nil {
 			progress.Done("")
@@ -1159,17 +1117,7 @@ func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, inst string, source st
 				return err
 			}
 
-			args.Content = shared.NewReadSeeker(&ioprogress.ProgressReader{
-				ReadCloser: readCloser,
-				Tracker: &ioprogress.ProgressTracker{
-					Length: contentLength,
-					Handler: func(percent int64, speed int64) {
-						progress.UpdateProgress(ioprogress.ProgressData{
-							Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)",
-						})
-					},
-				},
-			}, args.Content)
+			args.Content = shared.NewReadSeeker(ioprogress.NewProgressReader(readCloser, ioprogress.WithLength(contentLength), ioprogress.WithProgressUpdater(&progress)), args.Content)
 		}
 
 		logger.Infof("Pushing %s to %s (%s)", p, targetPath, args.Type)

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,7 +10,6 @@ import (
 	"github.com/canonical/lxd/shared"
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/ioprogress"
-	"github.com/canonical/lxd/shared/units"
 )
 
 type cmdImport struct {
@@ -114,18 +112,10 @@ func (c *cmdImport) run(cmd *cobra.Command, args []string) error {
 	}
 
 	createArgs := lxd.InstanceBackupArgs{
-		BackupFile: &ioprogress.ProgressReader{
-			ReadCloser: file,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: fstat.Size(),
-				Handler: func(percent int64, speed int64) {
-					progress.UpdateProgress(ioprogress.ProgressData{Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)"})
-				},
-			},
-		},
-		PoolName: c.flagStorage,
-		Name:     instanceName,
-		Devices:  deviceMap,
+		BackupFile: ioprogress.NewProgressReader(file, ioprogress.WithLength(fstat.Size()), ioprogress.WithProgressUpdater(&progress)),
+		PoolName:   c.flagStorage,
+		Name:       instanceName,
+		Devices:    deviceMap,
 	}
 
 	op, err := resource.server.CreateInstanceFromBackup(createArgs)

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2928,16 +2928,8 @@ func (c *cmdStorageVolumeImport) run(cmd *cobra.Command, args []string) error {
 	}
 
 	createArgs := lxd.StoragePoolVolumeBackupArgs{
-		BackupFile: &ioprogress.ProgressReader{
-			ReadCloser: file,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: fstat.Size(),
-				Handler: func(percent int64, speed int64) {
-					progress.UpdateProgress(ioprogress.ProgressData{Text: strconv.FormatInt(percent, 10) + "% (" + units.GetByteSizeString(speed, 2) + "/s)"})
-				},
-			},
-		},
-		Name: volName,
+		BackupFile: ioprogress.NewProgressReader(file, ioprogress.WithLength(fstat.Size()), ioprogress.WithProgressUpdater(&progress)),
+		Name:       volName,
 	}
 
 	var op lxd.Operation

--- a/lxd/apparmor/qemuimg.go
+++ b/lxd/apparmor/qemuimg.go
@@ -74,7 +74,7 @@ func (w writerFunc) Write(b []byte) (n int, err error) {
 	return w(b)
 }
 
-func handleWriter(out io.Writer, hand func(int64, int64)) io.Writer {
+func handleWriter(out io.Writer, hand func(int64, int64, int64)) io.Writer {
 	var current int64
 	return writerFunc(func(b []byte) (int, error) {
 		n, _ := out.Write(b)
@@ -87,7 +87,7 @@ func handleWriter(out io.Writer, hand func(int64, int64)) io.Writer {
 		percent := int64(f)
 		if percent != current {
 			current = percent
-			hand(percent, 0)
+			hand(percent, 0, 0)
 		}
 
 		return n, nil

--- a/lxd/apparmor/qemuimg_test.go
+++ b/lxd/apparmor/qemuimg_test.go
@@ -9,7 +9,7 @@ import (
 func TestHandleWriter(t *testing.T) {
 	status := []int64{}
 	var buffer bytes.Buffer
-	out := &nullWriteCloser{handleWriter(&buffer, func(percent int64, _ int64) {
+	out := &nullWriteCloser{handleWriter(&buffer, func(percent int64, _ int64, _ int64) {
 		status = append(status, percent)
 	})}
 

--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -126,7 +126,7 @@ func CompressedTarReader(s *state.State, ctx context.Context, r io.ReadSeeker, u
 	return tr, cancelFunc, nil
 }
 
-func doUnpack(s *state.State, file string, path string, blockBackend bool, excludeDevices bool, tracker *ioprogress.ProgressTracker) error {
+func doUnpack(s *state.State, file string, path string, blockBackend bool, excludeDevices bool, progressHandler ioprogress.ProgressHandler) error {
 	extractArgs, extension, unpacker, err := shared.DetectCompression(file)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func doUnpack(s *state.State, file string, path string, blockBackend bool, exclu
 	command := ""
 	args := []string{}
 	var allowedCmds []string
-	var reader io.Reader
+	var reader io.ReadCloser
 	if strings.HasPrefix(extension, ".tar") {
 		command = "tar"
 		if excludeDevices && s.OS.RunningInUserNS {
@@ -163,19 +163,13 @@ func doUnpack(s *state.State, file string, path string, blockBackend bool, exclu
 		defer func() { _ = f.Close() }()
 
 		reader = f
-
-		// Attach the ProgressTracker if supplied.
-		if tracker != nil {
+		if progressHandler != nil {
 			fsinfo, err := f.Stat()
 			if err != nil {
 				return err
 			}
 
-			tracker.Length = fsinfo.Size()
-			reader = &ioprogress.ProgressReader{
-				ReadCloser: f,
-				Tracker:    tracker,
-			}
+			reader = ioprogress.NewProgressReader(f, ioprogress.WithLength(fsinfo.Size()), ioprogress.WithProgressHandler(progressHandler))
 		}
 
 		// Allow supplementary commands for the unpacker to use.
@@ -209,12 +203,7 @@ func doUnpack(s *state.State, file string, path string, blockBackend bool, exclu
 
 	defer func() { _ = outputDir.Close() }()
 
-	var readCloser io.ReadCloser
-	if reader != nil {
-		readCloser = io.NopCloser(reader)
-	}
-
-	err = ExtractWithFds(s, command, args, allowedCmds, readCloser, outputDir)
+	err = ExtractWithFds(s, command, args, allowedCmds, reader, outputDir)
 	if err != nil {
 		// We can't create char/block devices in unpriv containers so ignore related errors.
 		if s.OS.RunningInUserNS && command == "unsquashfs" {
@@ -279,11 +268,11 @@ func doUnpack(s *state.State, file string, path string, blockBackend bool, exclu
 }
 
 // UnpackImage extracts image from archive.
-func UnpackImage(s *state.State, file string, path string, blockBackend bool, tracker *ioprogress.ProgressTracker) error {
-	return doUnpack(s, file, path, blockBackend, true, tracker)
+func UnpackImage(s *state.State, file string, path string, blockBackend bool, progressHandler ioprogress.ProgressHandler) error {
+	return doUnpack(s, file, path, blockBackend, true, progressHandler)
 }
 
 // UnpackRaw extracts all content from archive.
-func UnpackRaw(s *state.State, file string, path string, blockBackend bool, tracker *ioprogress.ProgressTracker) error {
-	return doUnpack(s, file, path, blockBackend, false, tracker)
+func UnpackRaw(s *state.State, file string, path string, blockBackend bool, progressHandler ioprogress.ProgressHandler) error {
+	return doUnpack(s, file, path, blockBackend, false, progressHandler)
 }

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -33,7 +33,6 @@ import (
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
-	"github.com/canonical/lxd/shared/units"
 )
 
 // Create a new backup.
@@ -156,28 +155,19 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	tarWriterRes := make(chan error)
 	var compressErr error
 
-	backupProgressWriter := &ioprogress.ProgressWriter{
-		Tracker: &ioprogress.ProgressTracker{
-			Handler: func(value, speed int64) {
-				_ = op.ExtendMetadata(map[string]any{"create_backup_progress": fmt.Sprintf("%s (%s/s)", units.GetByteSizeString(value, 2), units.GetByteSizeString(speed, 2))})
-			},
-		},
-	}
-
+	writerWrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithProgressReporter("create_backup", op))
 	go func(resCh chan<- error) {
 		l.Debug("Started backup tarball writer")
 		defer l.Debug("Finished backup tarball writer")
 		if compress != "none" {
-			backupProgressWriter.WriteCloser = tarFileWriter
-			compressErr = compressFile(compress, tarPipeReader, backupProgressWriter)
+			compressErr = compressFile(compress, tarPipeReader, writerWrapper(tarFileWriter))
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {
 				_ = tarPipeWriter.Close()
 			}
 		} else {
-			backupProgressWriter.WriteCloser = tarFileWriter
-			_, err = io.Copy(backupProgressWriter, tarPipeReader)
+			_, err = io.Copy(writerWrapper(tarFileWriter), tarPipeReader)
 		}
 
 		resCh <- err

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -29,7 +29,6 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -352,19 +351,9 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 	defer cleanup()
 
 	// Setup a progress handler
-	progress := func(progress ioprogress.ProgressData) {
-		if op == nil {
-			return
-		}
-
-		meta := op.Metadata()
-		if meta == nil {
-			meta = make(map[string]any)
-		}
-
-		if meta["download_progress"] != progress.Text {
-			_ = op.ExtendMetadata(map[string]any{"download_progress": progress.Text})
-		}
+	var progress ioprogress.ProgressHandler
+	if op != nil {
+		progress = op.ProgressHandler("download")
 	}
 
 	var canceler *cancel.HTTPRequestCanceller
@@ -509,16 +498,8 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 			return nil, fmt.Errorf("Cannot fetch %q: %s", args.Server, raw.Status)
 		}
 
-		// Progress handler
-		body := &ioprogress.ProgressReader{
-			ReadCloser: raw.Body,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: raw.ContentLength,
-				Handler: func(percent int64, speed int64) {
-					progress(ioprogress.ProgressData{Text: fmt.Sprintf("%d%% (%s/s)", percent, units.GetByteSizeString(speed, 2))})
-				},
-			},
-		}
+		// Track progress
+		body := ioprogress.NewProgressReader(raw.Body, ioprogress.WithLength(raw.ContentLength), ioprogress.WithProgressHandler(progress))
 
 		// Create the target files
 		f, err := os.Create(destName)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -435,27 +435,11 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	}
 
 	// Track progress creating image.
-	imageProgressWriter := &ioprogress.ProgressWriter{
-		Tracker: &ioprogress.ProgressTracker{
-			Handler: func(value, speed int64) {
-				percent := int64(0)
-				var processed int64
-
-				if totalSize > 0 {
-					percent = value
-					processed = totalSize * (percent / 100.0)
-				} else {
-					processed = value
-				}
-
-				_ = op.UpdateProgress("create_image_from_instance_pack", "Image pack", percent, processed, speed)
-			},
-			Length: totalSize,
-		},
-	}
+	imageProgressWriterWrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithLength(totalSize), ioprogress.WithDescriptiveProgressReporter("create_image_from_instance_pack", "Image pack", op))
 
 	sha256 := sha256.New()
 	var compress string
+	var imageProgressWriter io.WriteCloser
 	var writer io.Writer
 
 	if req.CompressionAlgorithm != "" {
@@ -489,7 +473,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	if compress != "none" {
 		wg.Add(1)
 		tarReader, tarWriter := io.Pipe()
-		imageProgressWriter.WriteCloser = tarWriter
+		imageProgressWriter = imageProgressWriterWrapper(tarWriter)
 		writer = imageProgressWriter
 		compressWriter := io.MultiWriter(imageFile, sha256)
 		go func() {
@@ -502,16 +486,11 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 			}
 		}()
 	} else {
-		imageProgressWriter.WriteCloser = imageFile
+		imageProgressWriter = imageProgressWriterWrapper(imageFile)
 		writer = io.MultiWriter(imageProgressWriter, sha256)
 	}
 
-	// Tracker instance for the export phase.
-	tracker := &ioprogress.ProgressTracker{
-		Handler: func(value, speed int64) {
-			_ = op.UpdateProgress("create_image_from_instance_pack", "Exporting", value, 0, 0)
-		},
-	}
+	tracker := ioprogress.NewProgressTracker(ioprogress.WithDescriptiveProgressReporter("create_image_from_instance_pack", "Exporting", op))
 
 	// Export instance to writer.
 	var meta api.ImageMetadata

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -2,15 +2,11 @@ package migration
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"slices"
 
 	backupConfig "github.com/canonical/lxd/lxd/backup/config"
-	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/ioprogress"
-	"github.com/canonical/lxd/shared/units"
 )
 
 // Info represents the index frame sent if supported.
@@ -253,75 +249,4 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 	}
 
 	return matchedTypes, nil
-}
-
-func progressWrapperRender(op *operations.Operation, key string, description string, progressInt int64, speedInt int64) {
-	meta := map[string]any{}
-
-	progress := fmt.Sprintf("%s (%s/s)", units.GetByteSizeString(progressInt, 2), units.GetByteSizeString(speedInt, 2))
-	if description != "" {
-		progress = fmt.Sprintf("%s: %s (%s/s)", description, units.GetByteSizeString(progressInt, 2), units.GetByteSizeString(speedInt, 2))
-	}
-
-	if meta[key] != progress {
-		meta[key] = progress
-		_ = op.ExtendMetadata(meta)
-	}
-}
-
-// ProgressReader reports the read progress.
-func ProgressReader(op *operations.Operation, key string, description string) func(io.ReadCloser) io.ReadCloser {
-	return func(reader io.ReadCloser) io.ReadCloser {
-		if op == nil {
-			return reader
-		}
-
-		progress := func(progressInt int64, speedInt int64) {
-			progressWrapperRender(op, key, description, progressInt, speedInt)
-		}
-
-		readPipe := &ioprogress.ProgressReader{
-			ReadCloser: reader,
-			Tracker: &ioprogress.ProgressTracker{
-				Handler: progress,
-			},
-		}
-
-		return readPipe
-	}
-}
-
-// ProgressWriter reports the write progress.
-func ProgressWriter(op *operations.Operation, key string, description string) func(io.WriteCloser) io.WriteCloser {
-	return func(writer io.WriteCloser) io.WriteCloser {
-		if op == nil {
-			return writer
-		}
-
-		progress := func(progressInt int64, speedInt int64) {
-			progressWrapperRender(op, key, description, progressInt, speedInt)
-		}
-
-		writePipe := &ioprogress.ProgressWriter{
-			WriteCloser: writer,
-			Tracker: &ioprogress.ProgressTracker{
-				Handler: progress,
-			},
-		}
-
-		return writePipe
-	}
-}
-
-// ProgressTracker returns a migration I/O tracker.
-func ProgressTracker(op *operations.Operation, key string, description string) *ioprogress.ProgressTracker {
-	progress := func(progressInt int64, speedInt int64) {
-		progressWrapperRender(op, key, description, progressInt, speedInt)
-	}
-
-	tracker := &ioprogress.ProgressTracker{
-		Handler: progress,
-	}
-
-	return tracker
 }

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -22,8 +22,8 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/validate"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -1051,12 +1051,21 @@ func validateMetadata(metadata map[string]any) (map[string]any, error) {
 	return metadata, nil
 }
 
-// UpdateProgress updates the operation metadata with progress information, including
-// the percentage complete, data processed, and speed. It formats and stores these values for
-// both API callers and CLI display purposes.
-func (op *Operation) UpdateProgress(stage string, displayPrefix string, percent int64, processed int64, speed int64) error {
-	// Copy current metadata.
+// ProgressHandler implements [ioprogress.ProgressHandlerFactory]. This is used by instance and storage drivers to
+// report I/O progress as they perform different actions (migration, download, image unpack, etc.).
+func (op *Operation) ProgressHandler(action string) ioprogress.ProgressHandler {
+	return func(data ioprogress.ProgressData) {
+		_ = op.updateProgress(action, data)
+	}
+}
+
+// updateProgress updates the operation metadata with progress information for a specific action.
+func (op *Operation) updateProgress(action string, data ioprogress.ProgressData) error {
+	// Copy current metadata and ensure it is non-nil.
 	metadata := op.Metadata()
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
 
 	// Delete any keys that end in "_progress", we rely on there only being one.
 	for k := range metadata {
@@ -1065,35 +1074,23 @@ func (op *Operation) UpdateProgress(stage string, displayPrefix string, percent 
 		}
 	}
 
-	// Create a map for progress.
-	// stage, percent, speed sent for API callers.
 	progress := make(map[string]string)
-	progress["stage"] = stage
-	if processed > 0 {
-		progress["processed"] = strconv.FormatInt(processed, 10)
+	progress["stage"] = action
+
+	if data.TransferredBytes > 0 {
+		progress["processed"] = strconv.FormatInt(data.TransferredBytes, 10)
 	}
 
-	if percent > 0 {
-		progress["percent"] = strconv.FormatInt(percent, 10)
+	if data.Percentage > 0 {
+		progress["percent"] = strconv.Itoa(data.Percentage)
 	}
 
-	progress["speed"] = strconv.FormatInt(speed, 10)
+	if data.BytesPerSecond > 0 {
+		progress["speed"] = strconv.FormatInt(data.BytesPerSecond, 10)
+	}
 
+	metadata[action+"_progress"] = data.Text
 	metadata["progress"] = progress
-
-	// <stage>_progress with formatted text sent for lxc cli.
-	activeStageProgress := stage + "_progress"
-	if percent > 0 {
-		if speed > 0 {
-			metadata[activeStageProgress] = fmt.Sprintf("%s: %d%% (%s/s)", displayPrefix, percent, units.GetByteSizeString(speed, 2))
-		} else {
-			metadata[activeStageProgress] = fmt.Sprintf("%s: %d%%", displayPrefix, percent)
-		}
-	} else if processed > 0 {
-		metadata[activeStageProgress] = displayPrefix + ": " + units.GetByteSizeString(processed, 2) + " (" + units.GetByteSizeString(speed, 2) + "/s)"
-	} else {
-		metadata[activeStageProgress] = displayPrefix + ": " + units.GetByteSizeString(speed, 2) + "/s"
-	}
 
 	// Write the updated metadata.
 	return op.UpdateMetadata(metadata)

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -131,7 +131,7 @@ func CopyFile(source string, dest string, bwlimit string, xattrs bool, rsyncArgs
 
 // Send sets up the sending half of an rsync, to recursively send the
 // directory pointed to by path over the websocket.
-func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTracker, features []string, bwlimit string, execPath string, rsyncArgs ...string) error {
+func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.ReaderWrapper, features []string, bwlimit string, execPath string, rsyncArgs ...string) error {
 	/*
 	 * The way rsync works, it invokes a subprocess that does the actual
 	 * talking (given to it by a -E argument). Since there isn't an easy
@@ -248,11 +248,8 @@ func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress
 	// Setup progress tracker.
 	netcatConn := *ncConn
 	readNetcatPipe := io.ReadCloser(netcatConn)
-	if tracker != nil {
-		readNetcatPipe = &ioprogress.ProgressReader{
-			ReadCloser: netcatConn,
-			Tracker:    tracker,
-		}
+	if wrapper != nil {
+		readNetcatPipe = wrapper(readNetcatPipe)
 	}
 
 	// Forward from netcat to target.
@@ -309,7 +306,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress
 // Recv sets up the receiving half of the websocket to rsync (the other
 // half set up by rsync.Send), putting the contents in the directory specified
 // by path.
-func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTracker, features []string) error {
+func Recv(path string, conn io.ReadWriteCloser, readWrapper func(closer io.ReadCloser) io.ReadCloser, features []string) error {
 	args := []string{
 		"--server",
 		"-vlogDtpre.iLsfx",
@@ -361,11 +358,8 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 	}
 
 	readSourcePipe := io.ReadCloser(conn)
-	if tracker != nil {
-		readSourcePipe = &ioprogress.ProgressReader{
-			ReadCloser: conn,
-			Tracker:    tracker,
-		}
+	if readWrapper != nil {
+		readSourcePipe = readWrapper(readSourcePipe)
 	}
 
 	chCopySource := make(chan error, 1)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1938,16 +1938,23 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 // provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
 func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation, projectName string) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
 	return func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
-		var tracker *ioprogress.ProgressTracker
-		if op != nil { // Not passed when being done as part of pre-migration setup.
-			tracker = &ioprogress.ProgressTracker{
-				Handler: func(percent, speed int64) {
-					_ = op.UpdateProgress("create_instance_from_image_unpack", "Unpacking image", percent, 0, speed)
-				}}
+		var progressHandler ioprogress.ProgressHandler
+		if op != nil {
+			// No operation is passed when this function is called as part of pre-migration setup.
+			// If an operation is passed, pass a progress handler to ImageUnpack.
+			// A progress handler is passed rather than a progress tracker so that the tracker does not need to be
+			// modified by the general archive functions that ImageUnpack calls out to.
+			// Those general archive functions don't know what description to apply to the progress data, so instead
+			// wrap the progress handler here and prepend the description.
+			opHandler := op.ProgressHandler("create_instance_from_image_unpack")
+			progressHandler = func(data ioprogress.ProgressData) {
+				data.Text = "Unpacking image: " + data.Text
+				opHandler(data)
+			}
 		}
 
 		imageFile := filepath.Join(b.state.ImagesStoragePath(projectName), fingerprint)
-		return ImageUnpack(b.state, projectName, imageFile, vol, rootBlockPath, allowUnsafeResize, tracker)
+		return ImageUnpack(b.state, projectName, imageFile, vol, rootBlockPath, allowUnsafeResize, progressHandler)
 	}
 }
 
@@ -1985,12 +1992,8 @@ func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, op 
 		// Setup the progress tracker.
 		var tracker *ioprogress.ProgressTracker
 		if op != nil {
-			tracker = &ioprogress.ProgressTracker{
-				Handler: func(percent, speed int64) {
-					displayPrefix := "Converting image format from " + imgFormat + " to raw"
-					_ = op.UpdateProgress("format_progress", displayPrefix, percent, 0, speed)
-				},
-			}
+			description := "Converting image format from " + imgFormat + " to raw"
+			tracker = ioprogress.NewProgressTracker(ioprogress.WithDescriptiveProgressReporter("format", description, op))
 		}
 
 		// Convert uploaded image from backups directory into RAW format on the instance volume.
@@ -2077,18 +2080,9 @@ func (b *lxdBackend) recvBlockVol(toFile *os.File, volName string, conn io.ReadW
 	b.logger.Debug("Receive block volume started", logger.Ctx{"volName": volName})
 	defer b.logger.Debug("Receive block volume finished", logger.Ctx{"volName": volName})
 
-	var wrapper *ioprogress.ProgressTracker
-	if args.TrackProgress {
-		wrapper = migration.ProgressTracker(op, "block_progress", "Transferring instance")
-	}
-
-	// Setup progress tracker.
 	fromPipe := io.ReadCloser(conn)
-	if wrapper != nil {
-		fromPipe = &ioprogress.ProgressReader{
-			ReadCloser: fromPipe,
-			Tracker:    wrapper,
-		}
+	if args.TrackProgress {
+		fromPipe = ioprogress.NewProgressReader(conn, ioprogress.WithDescriptiveProgressReporter("block", "Transferring instance", op))
 	}
 
 	_, err := io.Copy(toFile, fromPipe)
@@ -2115,9 +2109,9 @@ func (b *lxdBackend) recvFS(path string, volName string, conn io.ReadWriteCloser
 	b.logger.Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path, "features": args.MigrationType.Features})
 	defer b.logger.Debug("Receiving filesystem volume stopped", logger.Ctx{"volName": volName, "path": path})
 
-	var wrapper *ioprogress.ProgressTracker
+	var wrapper ioprogress.ReaderWrapper
 	if args.TrackProgress {
-		wrapper = migration.ProgressTracker(op, "fs_progress", "Transferring instance")
+		wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", "Transferring instance", op))
 	}
 
 	return rsync.Recv(shared.AddSlash(path), conn, wrapper, args.MigrationType.Features)

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -344,7 +344,7 @@ func (d *btrfs) getQGroup(path string) (string, int64, error) {
 	return qgroup, usage, nil
 }
 
-func (d *btrfs) sendSubvolume(path string, parent string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTracker) error {
+func (d *btrfs) sendSubvolume(path string, parent string, conn io.ReadWriteCloser, writerWrapper ioprogress.WriterWrapper) error {
 	defer func() { _ = conn.Close() }()
 
 	// Assemble btrfs send command.
@@ -363,11 +363,8 @@ func (d *btrfs) sendSubvolume(path string, parent string, conn io.ReadWriteClose
 
 	// Setup progress tracker.
 	var stdout io.WriteCloser = conn
-	if tracker != nil {
-		stdout = &ioprogress.ProgressWriter{
-			WriteCloser: conn,
-			Tracker:     tracker,
-		}
+	if writerWrapper != nil {
+		stdout = writerWrapper(conn)
 	}
 
 	cmd.Stdout = stdout
@@ -604,7 +601,7 @@ func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker, mountPath string) (*B
 }
 
 // receiveSubVolume receives a subvolume from an io.Reader into the receivePath and returns the path to the received subvolume.
-func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string, tracker *ioprogress.ProgressTracker) (string, error) {
+func (d *btrfs) receiveSubVolume(r io.ReadCloser, receivePath string, wrapper ioprogress.ReaderWrapper) (string, error) {
 	files, err := os.ReadDir(receivePath)
 	if err != nil {
 		return "", fmt.Errorf("Failed listing contents of %q: %w", receivePath, err)
@@ -612,11 +609,8 @@ func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string, tracker *iopro
 
 	// Setup progress tracker.
 	stdin := r
-	if tracker != nil {
-		stdin = &ioprogress.ProgressReader{
-			Reader:  r,
-			Tracker: tracker,
-		}
+	if wrapper != nil {
+		stdin = wrapper(r)
 	}
 
 	err = shared.RunCommandWithFds(d.state.ShutdownCtx, stdin, nil, "btrfs", "receive", "-e", receivePath)

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -256,7 +256,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, sr
 			}
 
 			if hdr.Name == srcFile {
-				subVolRecvPath, err := d.receiveSubVolume(tr, targetPath, nil)
+				subVolRecvPath, err := d.receiveSubVolume(io.NopCloser(tr), targetPath, nil)
 				if err != nil {
 					return "", err
 				}
@@ -676,9 +676,9 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 		_, snapName, _ := api.GetParentAndSnapshotName(v.name)
 
 		// Setup progress tracking.
-		var wrapper *ioprogress.ProgressTracker
+		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", v.name)
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, op))
 		}
 
 		for _, subVol := range subvolumes {
@@ -1285,9 +1285,9 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 		}
 
 		// Setup progress tracking.
-		var wrapper *ioprogress.ProgressTracker
+		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", v.name)
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", v.name, op))
 		}
 
 		sentVols := 0
@@ -1331,7 +1331,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 			}
 
 			d.logger.Debug("Sending subvolume", logger.Ctx{"name": v.name, "source": sourcePath, "parent": parentPath, "path": subVolume.Path})
-			err := d.sendSubvolume(sourcePath, parentPath, conn, wrapper)
+			err := d.sendSubvolume(sourcePath, parentPath, conn, writerWrapper)
 			if err != nil {
 				return fmt.Errorf("Failed sending volume %v:%s: %w", v.name, subVolume.Path, err)
 			}

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -1191,7 +1191,7 @@ func (d *ceph) getRBDVolumeName(vol Volume, snapName string, zombie bool, withPo
 //
 //	rbd export-diff pool1/container_a@snapshot_snap1 --from-snap snapshot_snap0 - | rbd import-diff - pool2/container_a
 //	rbd export-diff pool1/container_a --from-snap snapshot_snap1 - | rbd import-diff - pool2/container_a
-func (d *ceph) sendVolume(conn io.ReadWriteCloser, volumeName string, volumeParentName string, tracker *ioprogress.ProgressTracker) error {
+func (d *ceph) sendVolume(conn io.ReadWriteCloser, volumeName string, volumeParentName string, writerWrapper ioprogress.WriterWrapper) error {
 	defer func() { _ = conn.Close() }()
 
 	args := []string{
@@ -1217,11 +1217,8 @@ func (d *ceph) sendVolume(conn io.ReadWriteCloser, volumeName string, volumePare
 
 	// Setup progress tracker.
 	var stdout io.WriteCloser = conn
-	if tracker != nil {
-		stdout = &ioprogress.ProgressWriter{
-			WriteCloser: conn,
-			Tracker:     tracker,
-		}
+	if writerWrapper != nil {
+		stdout = writerWrapper(conn)
 	}
 
 	cmd.Stdout = stdout

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -632,7 +632,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 			}
 
 			fullSnapshotName := d.getRBDVolumeName(vol.Volume, targetSnapshotName, false, true)
-			wrapper := migration.ProgressWriter(op, "fs_progress", fullSnapshotName)
+			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", fullSnapshotName, op))
 
 			err := d.receiveVolume(targetVolumeName, conn, wrapper)
 			if err != nil {
@@ -671,7 +671,7 @@ func (d *ceph) createVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 		}
 	}()
 
-	wrapper := migration.ProgressWriter(op, "fs_progress", vol.name)
+	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 
 	// Apply the diff.
 	err = d.receiveVolume(targetVolumeName, conn, wrapper)
@@ -1785,12 +1785,12 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 		sendSnapName := d.getRBDVolumeName(cloneVol, "", false, true)
 
 		// Setup progress tracking.
-		var wrapper *ioprogress.ProgressTracker
+		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", vol.name)
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 		}
 
-		return d.sendVolume(conn, sendSnapName, "", wrapper)
+		return d.sendVolume(conn, sendSnapName, "", writerWrapper)
 	}
 
 	var lastSnap string
@@ -1834,15 +1834,14 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 			lastSnap = sourceParentSnapshotName
 
 			// Setup progress tracking.
-			var wrapper *ioprogress.ProgressTracker
-
+			var writerWrapper ioprogress.WriterWrapper
 			if volSrcArgs.TrackProgress {
-				wrapper = migration.ProgressTracker(op, "fs_progress", targetSnapshot.name)
+				writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", targetSnapshot.name, op))
 			}
 
 			sendSnapName := d.getRBDVolumeName(vol.Volume, "snapshot_"+targetSnapshotName, false, true)
 
-			err := d.sendVolume(conn, sendSnapName, lastSnap, wrapper)
+			err := d.sendVolume(conn, sendSnapName, lastSnap, writerWrapper)
 			if err != nil {
 				return err
 			}
@@ -1857,9 +1856,9 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 	}
 
 	// Setup progress tracking.
-	var wrapper *ioprogress.ProgressTracker
+	var writerWrapper ioprogress.WriterWrapper
 	if volSrcArgs.TrackProgress {
-		wrapper = migration.ProgressTracker(op, "fs_progress", vol.name)
+		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 	}
 
 	runningSnapName := "migration-send-" + uuid.New().String()
@@ -1872,7 +1871,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 	defer func() { _ = d.rbdDeleteVolumeSnapshot(vol.Volume, runningSnapName) }()
 
 	cur := d.getRBDVolumeName(vol.Volume, runningSnapName, false, true)
-	return d.sendVolume(conn, cur, lastSnap, wrapper)
+	return d.sendVolume(conn, cur, lastSnap, writerWrapper)
 }
 
 // BackupVolume creates an exported version of a volume.

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -198,9 +198,9 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 		// Snapshots are sent first by the sender, so create these first.
 		for _, snapName := range volTargetArgs.Snapshots {
 			// Receive the snapshot.
-			var wrapper *ioprogress.ProgressTracker
+			var wrapper ioprogress.ReaderWrapper
 			if volTargetArgs.TrackProgress {
-				wrapper = migration.ProgressTracker(op, "fs_progress", snapName)
+				wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapName, op))
 			}
 
 			err = rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)
@@ -230,9 +230,9 @@ func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClos
 		}
 
 		// Receive the main volume from sender.
-		var wrapper *ioprogress.ProgressTracker
+		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", vol.name)
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 		}
 
 		return rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -389,7 +389,7 @@ func (d *zfs) needsRecursion(dataset string) bool {
 	return len(entries) != 0
 }
 
-func (d *zfs) sendDataset(dataset string, parent string, volSrcArgs *migration.VolumeSourceArgs, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTracker) error {
+func (d *zfs) sendDataset(dataset string, parent string, volSrcArgs *migration.VolumeSourceArgs, conn io.ReadWriteCloser, wrapper ioprogress.WriterWrapper) error {
 	defer func() { _ = conn.Close() }()
 
 	// Assemble zfs send command.
@@ -422,11 +422,8 @@ func (d *zfs) sendDataset(dataset string, parent string, volSrcArgs *migration.V
 
 	// Setup progress tracker.
 	var stdout io.WriteCloser = conn
-	if tracker != nil {
-		stdout = &ioprogress.ProgressWriter{
-			WriteCloser: conn,
-			Tracker:     tracker,
-		}
+	if wrapper != nil {
+		stdout = wrapper(conn)
 	}
 
 	cmd.Stdout = stdout

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1127,7 +1127,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 				return err
 			}
 
-			wrapper := migration.ProgressWriter(op, "fs_progress", snapVol.Name())
+			wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapVol.Name(), op))
 
 			err = d.receiveDataset(snapVol, conn, wrapper)
 			if err != nil {
@@ -1148,7 +1148,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 	}
 
 	// Transfer the main volume.
-	wrapper := migration.ProgressWriter(op, "fs_progress", vol.name)
+	wrapper := ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 	err = d.receiveDataset(vol, conn, wrapper)
 	if err != nil {
 		return fmt.Errorf("Failed receiving volume %q: %w", vol.Name(), err)
@@ -2729,13 +2729,13 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 		}
 
 		// Setup progress tracking.
-		var wrapper *ioprogress.ProgressTracker
+		var writerWrapper ioprogress.WriterWrapper
 		if volSrcArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", snapshot.name)
+			writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", snapshot.name, op))
 		}
 
 		// Send snapshot to recipient (ensure local snapshot volume is mounted if needed).
-		err := d.sendDataset(d.dataset(snapshot, false), parent, volSrcArgs, conn, wrapper)
+		err := d.sendDataset(d.dataset(snapshot, false), parent, volSrcArgs, conn, writerWrapper)
 		if err != nil {
 			return err
 		}
@@ -2744,9 +2744,9 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 	}
 
 	// Setup progress tracking.
-	var wrapper *ioprogress.ProgressTracker
+	var writerWrapper ioprogress.WriterWrapper
 	if volSrcArgs.TrackProgress {
-		wrapper = migration.ProgressTracker(op, "fs_progress", vol.name)
+		writerWrapper = ioprogress.NewProgressWriterWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 	}
 
 	srcSnapshot := d.dataset(vol, false)
@@ -2780,7 +2780,7 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 	}
 
 	// Send the volume itself.
-	err := d.sendDataset(srcSnapshot, finalParent, volSrcArgs, conn, wrapper)
+	err := d.sendDataset(srcSnapshot, finalParent, volSrcArgs, conn, writerWrapper)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -175,9 +175,9 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 
 	// Define function to send a filesystem volume.
 	sendFSVol := func(vol Volume, conn io.ReadWriteCloser, mountPath string) error {
-		var wrapper *ioprogress.ProgressTracker
+		var wrapper ioprogress.ReaderWrapper
 		if volSrcArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", vol.name)
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", vol.name, op))
 		}
 
 		path := shared.AddSlash(mountPath)
@@ -198,11 +198,6 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 		// Close when done to indicate to target side we are finished sending this volume.
 		defer func() { _ = conn.Close() }()
 
-		var wrapper *ioprogress.ProgressTracker
-		if volSrcArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "block_progress", vol.name)
-		}
-
 		path, err := d.GetVolumeDiskPath(vol)
 		if err != nil {
 			return fmt.Errorf("Error getting VM block volume disk path: %w", err)
@@ -217,11 +212,8 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 
 		// Setup progress tracker.
 		fromPipe := io.ReadCloser(from)
-		if wrapper != nil {
-			fromPipe = &ioprogress.ProgressReader{
-				ReadCloser: fromPipe,
-				Tracker:    wrapper,
-			}
+		if volSrcArgs.TrackProgress {
+			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", vol.name, op))
 		}
 
 		d.Logger().Debug("Sending block volume", logger.Ctx{"volName": vol.name, "path": path})
@@ -324,9 +316,9 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 	}
 
 	recvFSVol := func(volName string, conn io.ReadWriteCloser, path string) error {
-		var wrapper *ioprogress.ProgressTracker
+		var wrapper ioprogress.ReaderWrapper
 		if volTargetArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "fs_progress", volName)
+			wrapper = ioprogress.NewProgressReaderWrapper(ioprogress.WithDescriptiveProgressReporter("fs", volName, op))
 		}
 
 		d.Logger().Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path, "features": volTargetArgs.MigrationType.Features})
@@ -336,11 +328,6 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 	}
 
 	recvBlockVol := func(volName string, conn io.ReadWriteCloser, path string) error {
-		var wrapper *ioprogress.ProgressTracker
-		if volTargetArgs.TrackProgress {
-			wrapper = migration.ProgressTracker(op, "block_progress", volName)
-		}
-
 		to, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 		if err != nil {
 			return fmt.Errorf("Error opening file for writing %q: %w", path, err)
@@ -350,11 +337,8 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 
 		// Setup progress tracker.
 		fromPipe := io.ReadCloser(conn)
-		if wrapper != nil {
-			fromPipe = &ioprogress.ProgressReader{
-				ReadCloser: fromPipe,
-				Tracker:    wrapper,
-			}
+		if volTargetArgs.TrackProgress {
+			fromPipe = ioprogress.NewProgressReader(fromPipe, ioprogress.WithDescriptiveProgressReporter("block", volName, op))
 		}
 
 		d.Logger().Debug("Receiving block volume started", logger.Ctx{"volName": volName, "path": path})

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -670,7 +670,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 // VM Format A: Separate metadata tarball and root qcow2 file.
 //   - Unpack metadata tarball into mountPath.
 //   - Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
-func ImageUnpack(s *state.State, projectName string, imageFile string, vol drivers.Volume, destBlockFile string, allowUnsafeResize bool, tracker *ioprogress.ProgressTracker) (int64, error) {
+func ImageUnpack(s *state.State, projectName string, imageFile string, vol drivers.Volume, destBlockFile string, allowUnsafeResize bool, progressHandler ioprogress.ProgressHandler) (int64, error) {
 	l := logger.Log.AddContext(logger.Ctx{"imageFile": imageFile, "volName": vol.Name()})
 	l.Info("Image unpack started")
 	defer l.Info("Image unpack stopped")
@@ -684,7 +684,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 		rootfsPath := filepath.Join(destPath, "rootfs")
 
 		// Unpack the main image file.
-		err := archive.UnpackImage(s, imageFile, destPath, vol.IsBlockBacked(), tracker)
+		err := archive.UnpackImage(s, imageFile, destPath, vol.IsBlockBacked(), progressHandler)
 		if err != nil {
 			return -1, err
 		}
@@ -695,7 +695,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 			return -1, errors.New("Error creating rootfs directory")
 		}
 
-		err = archive.UnpackImage(s, imageRootfsFile, rootfsPath, vol.IsBlockBacked(), tracker)
+		err = archive.UnpackImage(s, imageRootfsFile, rootfsPath, vol.IsBlockBacked(), progressHandler)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return -1, err
 		}
@@ -725,7 +725,8 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 
 	// convertBlockImage converts the qcow2 block image file into a raw block device. If needed it will attempt
 	// to enlarge the destination volume to accommodate the unpacked qcow2 image file.
-	convertBlockImage := func(imgPath string, dstPath string, tracker *ioprogress.ProgressTracker) (int64, error) {
+	convertBlockImage := func(imgPath string, dstPath string, progressHandler ioprogress.ProgressHandler) (int64, error) {
+		tracker := ioprogress.NewProgressTracker(ioprogress.WithProgressHandler(progressHandler))
 		imgFormat, imgVirtualSize, err := qemuImageInfo(s.OS, imgPath, tracker)
 		if err != nil {
 			return -1, err
@@ -809,13 +810,13 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 
 	if shared.PathExists(imageRootfsFile) {
 		// Unpack the main image file.
-		err := archive.UnpackImage(s, imageFile, destPath, vol.IsBlockBacked(), tracker)
+		err := archive.UnpackImage(s, imageFile, destPath, vol.IsBlockBacked(), progressHandler)
 		if err != nil {
 			return -1, err
 		}
 
 		// Convert the qcow2 format to a raw block device.
-		imgSize, err = convertBlockImage(imageRootfsFile, destBlockFile, tracker)
+		imgSize, err = convertBlockImage(imageRootfsFile, destBlockFile, progressHandler)
 		if err != nil {
 			return -1, err
 		}
@@ -829,7 +830,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		// Unpack the whole image.
-		err = archive.UnpackImage(s, imageFile, tempDir, vol.IsBlockBacked(), tracker)
+		err = archive.UnpackImage(s, imageFile, tempDir, vol.IsBlockBacked(), progressHandler)
 		if err != nil {
 			return -1, err
 		}
@@ -837,7 +838,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 		imgPath := filepath.Join(tempDir, "rootfs.img")
 
 		// Convert the qcow2 format to a raw block device.
-		imgSize, err = convertBlockImage(imgPath, destBlockFile, tracker)
+		imgSize, err = convertBlockImage(imgPath, destBlockFile, progressHandler)
 		if err != nil {
 			return -1, err
 		}

--- a/shared/ioprogress/data.go
+++ b/shared/ioprogress/data.go
@@ -13,4 +13,7 @@ type ProgressData struct {
 
 	// Total number of bytes (for files)
 	TotalBytes int64
+
+	// Bytes per second (mean value calculated since I/O operation started).
+	BytesPerSecond int64
 }

--- a/shared/ioprogress/data.go
+++ b/shared/ioprogress/data.go
@@ -1,17 +1,17 @@
 package ioprogress
 
-// The ProgressData struct represents new progress information on an operation.
+// The ProgressData struct contains details about an I/O task.
 type ProgressData struct {
-	// Preferred string representation of progress (always set)
+	// Text is a string representation of progress.
 	Text string
 
-	// Progress in percent
+	// Percentage is the percentage progress. This is only set if TotalBytes is non-zero.
 	Percentage int
 
-	// Number of bytes transferred (for files)
+	// TransferredBytes is the number of transferred bytes.
 	TransferredBytes int64
 
-	// Total number of bytes (for files)
+	// TotalBytes is the number of expected bytes.
 	TotalBytes int64
 
 	// Bytes per second (mean value calculated since I/O operation started).

--- a/shared/ioprogress/reader.go
+++ b/shared/ioprogress/reader.go
@@ -5,7 +5,45 @@ import (
 	"io"
 )
 
-// ProgressReader is a wrapper around ReadCloser which allows for progress tracking.
+// ReaderWrapper is a function that returns a [ProgressReader] from a given [io.ReadCloser] using a previously
+// configured [ProgressReader].
+type ReaderWrapper func(closer io.ReadCloser) io.ReadCloser
+
+// NewProgressReader returns a [ProgressReader] with the given list of [TrackerOption].
+func NewProgressReader(readCloser io.ReadCloser, trackerOpts ...TrackerOption) io.ReadCloser {
+	tracker := NewProgressTracker(trackerOpts...)
+
+	// If the caller did not set a handler via any options then there is nothing to report to, so avoid the wrapper
+	// and have the caller read directly from the input reader.
+	if tracker.Handler == nil {
+		return readCloser
+	}
+
+	return &ProgressReader{
+		ReadCloser: readCloser,
+		Tracker:    tracker,
+	}
+}
+
+// NewProgressReaderWrapper returns a [ReaderWrapper] with the given list of [TrackerOption].
+func NewProgressReaderWrapper(trackerOpts ...TrackerOption) ReaderWrapper {
+	tracker := NewProgressTracker(trackerOpts...)
+
+	return func(readCloser io.ReadCloser) io.ReadCloser {
+		// If the caller did not set a handler via any options then there is nothing to report to, so avoid the wrapper
+		// and have the caller read directly from the input reader.
+		if tracker.Handler == nil {
+			return readCloser
+		}
+
+		return &ProgressReader{
+			ReadCloser: readCloser,
+			Tracker:    tracker,
+		}
+	}
+}
+
+// ProgressReader is a wrapper around [io.ReadCloser] which allows for progress tracking.
 type ProgressReader struct {
 	io.ReadCloser
 	Tracker *ProgressTracker

--- a/shared/ioprogress/reader.go
+++ b/shared/ioprogress/reader.go
@@ -28,7 +28,6 @@ func (pt *ProgressReader) Read(p []byte) (int, error) {
 
 	// Do the actual progress tracking
 	if pt.Tracker != nil {
-		pt.Tracker.total += int64(n)
 		pt.Tracker.update(n)
 	}
 

--- a/shared/ioprogress/reader.go
+++ b/shared/ioprogress/reader.go
@@ -7,24 +7,18 @@ import (
 
 // ProgressReader is a wrapper around ReadCloser which allows for progress tracking.
 type ProgressReader struct {
-	io.Reader
 	io.ReadCloser
 	Tracker *ProgressTracker
 }
 
-// Read in ProgressReader is the same as io.Read.
+// Read in [ProgressReader] is the same as io.Read.
 func (pt *ProgressReader) Read(p []byte) (int, error) {
-	var reader io.Reader
-	if pt.ReadCloser != nil {
-		reader = pt.ReadCloser
-	} else if pt.Reader != nil {
-		reader = pt.Reader
-	} else {
-		return -1, errors.New("ProgressReader is missing a reader")
+	if pt.ReadCloser == nil {
+		return 0, errors.New("ProgressReader is missing a reader")
 	}
 
 	// Do normal reader tasks
-	n, err := reader.Read(p)
+	n, err := pt.ReadCloser.Read(p)
 
 	// Do the actual progress tracking
 	if pt.Tracker != nil {

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -16,6 +16,8 @@ type ProgressTracker struct {
 }
 
 func (pt *ProgressTracker) update(n int) {
+	pt.total += int64(n)
+
 	// Skip the rest if no handler attached
 	if pt.Handler == nil {
 		return
@@ -33,7 +35,7 @@ func (pt *ProgressTracker) update(n int) {
 		return
 	}
 
-	// Update interval handling
+	// Update interval handling (this is to prevent the tracker hook from being called too frequently).
 	var percentage float64
 	if pt.Length > 0 {
 		// If running in relative mode, check that we increased by at least 1%

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -7,7 +7,7 @@ import (
 // ProgressTracker provides the stream information needed for tracking.
 type ProgressTracker struct {
 	Length  int64
-	Handler func(int64, int64)
+	Handler func(percentage int64, bytesTransferred int64, bytesPerSecond int64)
 
 	percentage float64
 	total      int64
@@ -60,17 +60,13 @@ func (pt *ProgressTracker) update(n int) {
 	}
 
 	// Determine progress
-	var progressInt int64
 	if pt.Length > 0 {
 		pt.percentage = percentage
-		progressInt = min(int64(1+int(percentage)), 100)
 	} else {
-		progressInt = pt.total
-
 		// Update timestamp
 		cur := time.Now()
 		pt.last = &cur
 	}
 
-	pt.Handler(progressInt, speedInt)
+	pt.Handler(min(int64(pt.percentage)+1, 100), pt.total, speedInt)
 }

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -1,7 +1,11 @@
 package ioprogress
 
 import (
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/canonical/lxd/shared/units"
 )
 
 // ProgressTracker provides the stream information needed for tracking.
@@ -69,4 +73,53 @@ func (pt *ProgressTracker) update(n int) {
 	}
 
 	pt.Handler(min(int64(pt.percentage)+1, 100), pt.total, speedInt)
+}
+
+func (pt *ProgressTracker) buildProgressData(description string, percentage int64, bytesTransferred int64, bytesPerSecond int64) ProgressData {
+	var b strings.Builder
+
+	// Expected max size of string is:
+	// - Length of description + 2 (for colon and space)
+	// - Length of total byte transfer representation <= 8 (up to 3 digits, 2 decimals, 2 units).
+	// - Length of bytes per second representation <= 13 (as above, plus 5 for space, brackets, and "/s")
+	// Percentage not included in calculation since the total bytes representation is longer.
+	b.Grow(len(description) + 23)
+
+	// Write the description followed by a colon if given.
+	if description != "" {
+		b.WriteString(description)
+		b.WriteString(": ")
+	}
+
+	// Write the progress as {x}% if percentage is given (only set when Length is set).
+	// Otherwise, write the total number of transferred bytes in human-readable form.
+	var noProgress bool
+	if percentage > 0 {
+		b.WriteString(strconv.FormatInt(percentage, 10))
+		b.WriteString("%")
+	} else if bytesTransferred > 0 {
+		b.WriteString(units.GetByteSizeString(bytesTransferred, 2))
+	} else {
+		noProgress = true
+	}
+
+	// Write the bytes per second if given. Wrap with brackets if progress was written.
+	if bytesPerSecond > 0 {
+		if noProgress {
+			b.WriteString(units.GetByteSizeString(bytesPerSecond, 2))
+			b.WriteString("/s")
+		} else {
+			b.WriteString(" (")
+			b.WriteString(units.GetByteSizeString(bytesPerSecond, 2))
+			b.WriteString("/s)")
+		}
+	}
+
+	return ProgressData{
+		Text:             b.String(),
+		Percentage:       int(percentage),
+		TransferredBytes: bytesTransferred,
+		TotalBytes:       pt.Length,
+		BytesPerSecond:   bytesPerSecond,
+	}
 }

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -8,6 +8,23 @@ import (
 	"github.com/canonical/lxd/shared/units"
 )
 
+// TrackerOption is a function that configures a [ProgressTracker].
+type TrackerOption func(tracker *ProgressTracker)
+
+// ProgressReporter is a type which, given some action, can return a [ProgressHandler].
+// This is useful when several different I/O actions are performed in the same API call or code path.
+type ProgressReporter interface {
+	ProgressHandler(action string) ProgressHandler
+}
+
+// ProgressUpdater is a type with a function defining what to do with [ProgressData].
+type ProgressUpdater interface {
+	UpdateProgress(data ProgressData)
+}
+
+// ProgressHandler is a function that receives [ProgressData] and performs some action with it (e.g. printing to stdout).
+type ProgressHandler func(ProgressData)
+
 // ProgressTracker provides the stream information needed for tracking.
 type ProgressTracker struct {
 	Length  int64
@@ -17,6 +34,83 @@ type ProgressTracker struct {
 	total      int64
 	start      *time.Time
 	last       *time.Time
+}
+
+// NewProgressTracker returns a [ProgressTracker] configured with the given list of [TrackerOption].
+func NewProgressTracker(opts ...TrackerOption) *ProgressTracker {
+	tracker := &ProgressTracker{}
+	for _, option := range opts {
+		option(tracker)
+	}
+
+	return tracker
+}
+
+// WithProgressReporter is a convenience for configuring a [ProgressTracker] for types that implement
+// [ProgressReporter].
+func WithProgressReporter(action string, reporter ProgressReporter) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		if reporter == nil {
+			return
+		}
+
+		(*ProgressTracker).withDescriptiveProgressHandler(tracker, "", reporter.ProgressHandler(action))
+	}
+}
+
+// WithDescriptiveProgressReporter is a convenience for configuring a [ProgressTracker] for types that implement
+// [ProgressReporter]. The description is prepended to [ProgressData.Text] with a ": " separator.
+func WithDescriptiveProgressReporter(action string, description string, reporter ProgressReporter) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		if reporter == nil {
+			return
+		}
+
+		(*ProgressTracker).withDescriptiveProgressHandler(tracker, description, reporter.ProgressHandler(action))
+	}
+}
+
+// WithProgressUpdater is a convenience for configuring a [ProgressTracker] for types that implement [ProgressUpdater].
+func WithProgressUpdater(updater ProgressUpdater) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		if updater == nil {
+			return
+		}
+
+		(*ProgressTracker).withDescriptiveProgressHandler(tracker, "", updater.UpdateProgress)
+	}
+}
+
+// WithProgressHandler sets a [ProgressHandler] for tracker updates.
+func WithProgressHandler(handler ProgressHandler) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		(*ProgressTracker).withDescriptiveProgressHandler(tracker, "", handler)
+	}
+}
+
+// WithDescriptiveProgressHandler sets a [ProgressHandler] for tracker updates.
+// The description is prepended to [ProgressData.Text] with a ": " separator.
+func WithDescriptiveProgressHandler(description string, handler func(data ProgressData)) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		(*ProgressTracker).withDescriptiveProgressHandler(tracker, description, handler)
+	}
+}
+
+// WithLength sets the expected total number of bytes to be read.
+func WithLength(length int64) TrackerOption {
+	return func(tracker *ProgressTracker) {
+		tracker.Length = length
+	}
+}
+
+func (pt *ProgressTracker) withDescriptiveProgressHandler(description string, handler ProgressHandler) {
+	if handler == nil {
+		return
+	}
+
+	pt.Handler = func(percentage int64, bytesTransferred int64, bytesPerSecond int64) {
+		handler(pt.buildProgressData(description, percentage, bytesTransferred, bytesPerSecond))
+	}
 }
 
 func (pt *ProgressTracker) update(n int) {

--- a/shared/ioprogress/writer.go
+++ b/shared/ioprogress/writer.go
@@ -17,7 +17,6 @@ func (pt *ProgressWriter) Write(p []byte) (int, error) {
 
 	// Do the actual progress tracking
 	if pt.Tracker != nil {
-		pt.Tracker.total += int64(n)
 		pt.Tracker.update(n)
 	}
 

--- a/shared/ioprogress/writer.go
+++ b/shared/ioprogress/writer.go
@@ -1,6 +1,7 @@
 package ioprogress
 
 import (
+	"errors"
 	"io"
 )
 
@@ -10,9 +11,13 @@ type ProgressWriter struct {
 	Tracker *ProgressTracker
 }
 
-// Write in ProgressWriter is the same as io.Write.
+// Write in [ProgressWriter] is the same as io.Write.
 func (pt *ProgressWriter) Write(p []byte) (int, error) {
 	// Do normal writer tasks
+	if pt.WriteCloser == nil {
+		return 0, errors.New("ProgressWriter is missing a writer")
+	}
+
 	n, err := pt.WriteCloser.Write(p)
 
 	// Do the actual progress tracking

--- a/shared/ioprogress/writer.go
+++ b/shared/ioprogress/writer.go
@@ -5,7 +5,44 @@ import (
 	"io"
 )
 
-// ProgressWriter is a wrapper around WriteCloser which allows for progress tracking.
+// WriterWrapper is a function that returns a [ProgressWriter] from a given [io.WriteCloser] using a previously
+// configured [ProgressWriter].
+type WriterWrapper func(closer io.WriteCloser) io.WriteCloser
+
+// NewProgressWriter returns a [ProgressWriter] with the given list of [TrackerOption].
+func NewProgressWriter(writeCloser io.WriteCloser, trackerOpts ...TrackerOption) io.WriteCloser {
+	tracker := NewProgressTracker(trackerOpts...)
+
+	// If the caller did not set a handler via any options then there is nothing to report to, so avoid the wrapper
+	// and have the caller write directly to the input writer.
+	if tracker.Handler == nil {
+		return writeCloser
+	}
+
+	return &ProgressWriter{
+		WriteCloser: writeCloser,
+		Tracker:     tracker,
+	}
+}
+
+// NewProgressWriterWrapper returns a [WriterWrapper] with the given list of [TrackerOption].
+func NewProgressWriterWrapper(trackerOpts ...TrackerOption) func(io.WriteCloser) io.WriteCloser {
+	tracker := NewProgressTracker(trackerOpts...)
+	return func(writeCloser io.WriteCloser) io.WriteCloser {
+		// If the caller did not set a handler via any options then there is nothing to report to, so avoid the wrapper
+		// and have the caller write directly to the input writer.
+		if tracker.Handler == nil {
+			return writeCloser
+		}
+
+		return &ProgressWriter{
+			WriteCloser: writeCloser,
+			Tracker:     tracker,
+		}
+	}
+}
+
+// ProgressWriter is a wrapper around an [io.WriteCloser] which allows for progress tracking.
 type ProgressWriter struct {
 	io.WriteCloser
 	Tracker *ProgressTracker

--- a/shared/util.go
+++ b/shared/util.go
@@ -35,7 +35,6 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
-	"github.com/canonical/lxd/shared/units"
 )
 
 // SnapshotDelimiter is the character used to delimit instance and snapshot names.
@@ -1232,22 +1231,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 	}
 
 	// Handle the data
-	body := r.Body
-	if progress != nil {
-		body = &ioprogress.ProgressReader{
-			ReadCloser: r.Body,
-			Tracker: &ioprogress.ProgressTracker{
-				Length: r.ContentLength,
-				Handler: func(percent int64, speed int64) {
-					if filename != "" {
-						progress(ioprogress.ProgressData{Text: fmt.Sprintf("%s: %d%% (%s/s)", filename, percent, units.GetByteSizeString(speed, 2))})
-					} else {
-						progress(ioprogress.ProgressData{Text: fmt.Sprintf("%d%% (%s/s)", percent, units.GetByteSizeString(speed, 2))})
-					}
-				},
-			},
-		}
-	}
+	body := ioprogress.NewProgressReader(r.Body, ioprogress.WithLength(r.ContentLength), ioprogress.WithDescriptiveProgressHandler(filename, progress))
 
 	var size int64
 


### PR DESCRIPTION
This PR updates the `shared/ioprogress` package and cleans up all usage via common instantiation options. It adds interfaces so that we can remove operations from storage and instance driver interfaces when auditing is performed via context instead.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
