### PR TITLE
Add backport-changes agent skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -271,3 +271,26 @@ For error message assertions, prefer single-quoted strings so error text with `"
 - **Database code**: `lxd/db/`
 - **Tests**: `*_test.go` alongside source files
 - **Integration tests**: `test/suites/*.sh`
+
+## Skills
+
+The `.github/skills/` directory contains [agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) — folders of instructions, scripts, and resources that Copilot can load when relevant to improve its performance in specialized tasks. Each skill lives in its own subdirectory with a `SKILL.md` file.
+
+### Available skills
+
+| Skill | Directory | Purpose | Example trigger phrases |
+|-------|-----------|---------|------------------------|
+| **pre-commit-checks** | `.github/skills/pre-commit-checks/` | Runs linting, unit tests, and build validation before committing. | `run pre-commit checks`, `validate my changes`, `lint and test` |
+| **backport-changes** | `.github/skills/backport-changes/` | Cherry-picks commits from a newer branch to an older stable release branch. | `backport this fix to stable-5.0`, `cherry-pick to stable-X.X`, `backport this PR` |
+
+### Using a skill
+
+Skills are invoked automatically when Copilot detects a matching context in your prompt. You can also invoke a skill directly on the GitHub Copilot CLI with the slash command:
+
+```
+/backport-changes
+```
+
+### Adding a new skill
+
+Create a subdirectory under `.github/skills/` and add a `SKILL.md` file with a YAML front-matter block (`name`, `description`) followed by the procedure in Markdown. The `description` field controls when Copilot auto-invokes the skill.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -331,3 +331,26 @@ OK (counting genuinely matters):
 - **Database code**: `lxd/db/`
 - **Tests**: `*_test.go` alongside source files
 - **Integration tests**: `test/suites/*.sh`
+
+## Skills
+
+The `.github/skills/` directory contains [agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) — folders of instructions, scripts, and resources that Copilot can load when relevant to improve its performance in specialized tasks. Each skill lives in its own subdirectory with a `SKILL.md` file.
+
+### Available skills
+
+| Skill | Directory | Purpose | Example trigger phrases |
+|-------|-----------|---------|------------------------|
+| **pre-commit-checks** | `.github/skills/pre-commit-checks/` | Runs linting, unit tests, and build validation before committing. | `run pre-commit checks`, `validate my changes`, `lint and test` |
+| **backport-changes** | `.github/skills/backport-changes/` | Cherry-picks commits from a newer branch to an older stable release branch. | `backport this fix to stable-5.0`, `cherry-pick to stable-X.X`, `backport this PR` |
+
+### Using a skill
+
+Skills are invoked automatically when Copilot detects a matching context in your prompt. You can also invoke a skill directly on the GitHub Copilot CLI with the slash command:
+
+```
+/backport-changes
+```
+
+### Adding a new skill
+
+Create a subdirectory under `.github/skills/` and add a `SKILL.md` file with a YAML front-matter block (`name`, `description`) followed by the procedure in Markdown. The `description` field controls when Copilot auto-invokes the skill.

--- a/.github/skills/backport-changes/SKILL.md
+++ b/.github/skills/backport-changes/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: backport-changes
+description: >
+  Use this skill when the user asks to backport commits or a PR from a newer
+  branch to an older stable release branch (e.g. "backport this fix to
+  stable-5.0"). Triggers on phrases like: "backport this PR", "cherry-pick to
+  stable-X.X", "backport PR #1234 to stable-5.21".
+---
+
+## Overview
+
+Backporting carries a fix or feature from a newer branch (e.g. `main` or `stable-5.21`) to an older release branch (e.g. `stable-5.0`) using `git cherry-pick -x`. The `-x` flag appends the source commit SHA to the cherry-pick commit message, preserving provenance.
+
+## Steps
+
+### 1. Identify the commits
+
+If the user provides a PR number or URL, resolve it to commits using the `gh` CLI:
+
+```bash
+# Get the list of commit SHAs in a PR in chronological order
+gh pr view <pr-number> --json commits --jq '.commits[].oid'
+```
+
+If `gh` is not available, fall back to searching the git history for the merge commit:
+
+```bash
+git log --all --grep="(#<pr-number>)" --oneline
+```
+
+If the user provides commit hashes directly, use those instead.
+
+Collect the commit hashes to backport in topological order (parent before child).
+
+```bash
+# List commits in a PR in topological order (parent first), ready to cherry-pick
+git --no-pager log --oneline --reverse --topo-order <base>..<head>
+```
+
+### 2. Prepare the target branch
+
+```bash
+git fetch origin
+git checkout <target-branch>
+git pull origin <target-branch>
+git status -s  # must output nothing before proceeding
+```
+
+### 3. Apply the commits
+
+The simplest approach is `git cherry-pick -x`, which automatically appends the `(cherry picked from commit ...)` marker:
+
+```bash
+git cherry-pick -x <commit-hash>
+```
+
+Multiple commits can be applied in a single invocation:
+
+```bash
+git cherry-pick -x <commit-hash-1> <commit-hash-2> ...
+```
+
+Any other method is also acceptable as long as each resulting commit includes the `(cherry picked from commit <original-sha>)` trailer in its message.
+
+### 4. Resolve conflicts (if any)
+
+When `git cherry-pick` reports conflicts:
+
+1. Inspect the conflicting files: `git status` and `git diff`
+2. Edit each file to resolve, preserving the **intent** of the original
+   commit while respecting patterns already in the target branch (e.g.
+   keep the target branch's dependency versions unless the backport
+   explicitly updates them)
+3. Stage the resolved files: `git add <file>`
+4. Complete the cherry-pick: `git cherry-pick --continue`
+
+If a conflict cannot be resolved cleanly, abort and report:
+
+```bash
+git cherry-pick --abort
+```
+
+Then explain what blocked the backport and what manual intervention is needed.
+
+### 5. Verify
+
+```bash
+git log --oneline -10   # confirm cherry-picked commits are present
+git status -s           # must output nothing (clean working tree)
+```
+
+## Key rules
+
+- Every backported commit **must** include a `(cherry picked from commit <sha>)` trailer — `git cherry-pick -x` adds this automatically
+- **Never** force-push or rewrite history on release branches
+- **Stop and report** if a conflict cannot be resolved; do not skip ahead

--- a/.github/skills/backport-changes/SKILL.md
+++ b/.github/skills/backport-changes/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: backport-changes
+description: >
+  Use this skill when the user asks to backport commits or a PR from a newer
+  branch to an older stable release branch (e.g. "backport this fix to
+  stable-5.0"). Triggers on phrases like: "backport this PR", "cherry-pick to
+  stable-X.X", "backport PR #1234 to stable-5.21".
+---
+
+## Overview
+
+Backporting carries a fix or feature from a newer branch (e.g. `main` or `stable-5.21`) to an older release branch (e.g. `stable-5.0`) using `git cherry-pick -x`. The `-x` flag appends the source commit SHA to the cherry-pick commit message, preserving provenance.
+
+## Steps
+
+### 1. Identify the commits
+
+If the user provides a PR number or URL, resolve it to commits using the `gh` CLI:
+
+```bash
+# Get the list of commit SHAs in a PR in chronological order
+gh pr view <pr-number> --json commits --jq '.commits[].oid'
+```
+
+If `gh` is not available, fall back to searching the git history for the merge commit:
+
+```bash
+git log --all --grep="(#<pr-number>)" --oneline
+```
+
+If the user provides commit hashes directly, use those instead.
+
+Collect the commit hashes to backport in topological order (parent before child).
+
+```bash
+# List commits in a PR in topological order (parent first), ready to cherry-pick
+git --no-pager log --oneline --reverse --topo-order <base>..<head>
+```
+
+### 2. Prepare the target branch
+
+```bash
+git fetch origin
+git checkout <target-branch>
+git pull origin <target-branch>
+git status -s  # must output nothing before proceeding
+```
+
+### 3. Triage the commits (for multi-commit PRs)
+
+Before applying anything, scan the commit list and classify each commit:
+
+- **Essential** — functional changes that directly implement the fix or feature (logic changes, new behaviour, bug fixes)
+- **Cosmetic / optional** — pure rename/rewording of error messages, whitespace fixes, comment-only changes, or style cleanups that are independent of the fix
+
+Apply essential commits first. Cosmetic commits can be skipped if they conflict — they carry no semantic value and omitting them keeps the backport minimal and safe. If you skip a commit, note it explicitly in your summary.
+
+### 4. Apply the commits
+
+Apply commits one at a time in topological order so that a conflict on one commit
+does not cascade into subsequent ones:
+
+```bash
+git cherry-pick -x <commit-hash>
+```
+
+### 5. Resolve conflicts (if any)
+
+When `git cherry-pick` reports conflicts:
+
+1. Determine whether the conflicting commit is **essential** or **cosmetic/optional**:
+   - If **cosmetic/optional**: abort immediately and move on — do not read any files.
+     ```bash
+     git cherry-pick --abort
+     ```
+   - If **essential**: read only the conflict markers, not the entire file. Use
+     `git diff` to see just the conflicting hunks, then edit the minimum necessary
+     to preserve the intent of the original commit while respecting the target
+     branch's existing patterns. Stage and continue:
+     ```bash
+     git diff          # read conflict markers only
+     # edit the file to resolve
+     git add <file>
+     git cherry-pick --continue
+     ```
+
+2. **Empty cherry-picks** — if git reports "The previous cherry-pick is now empty",
+   the change was already absorbed by a prior conflict resolution. Skip it:
+   ```bash
+   git cherry-pick --skip
+   ```
+
+3. **Do not attempt the same conflict resolution more than twice.** If an essential
+   commit is still unresolved after a second attempt, abort and stop:
+   ```bash
+   git cherry-pick --abort
+   ```
+   Explain precisely which file/hunk conflicted and what the user must do manually.
+   Stopping early with a clear report is always better than spinning.
+
+### 6. Verify
+
+```bash
+git log --oneline -10   # confirm cherry-picked commits are present
+git status -s           # must output nothing (clean working tree)
+git diff --check        # catch any leftover conflict markers
+```
+
+Do **not** run build or test commands (`go test`, `make`, etc.) unless the user
+explicitly asks for them. Verification ends at a clean working tree.
+
+## Key rules
+
+- Every backported commit **must** include a `(cherry picked from commit <sha>)` trailer — `git cherry-pick -x` adds this automatically
+- **Never** force-push or rewrite history on release branches
+- **Stop and report early** if an essential commit's conflict cannot be resolved in two attempts; do not spin indefinitely
+- **Cosmetic-only commits that conflict may be skipped** — always note any skipped commits in your summary so the user knows exactly what was included

--- a/.github/skills/backport-changes/evals/README.md
+++ b/.github/skills/backport-changes/evals/README.md
@@ -1,0 +1,66 @@
+# Evals for the `backport-changes` skill
+
+These evals were designed using the
+[skill-creator](https://www.skills.sh/anthropics/skills/skill-creator) framework
+from Anthropic, which provides a structured approach to writing, running, and
+grading agent evaluations.
+
+## What the evals test
+
+| # | Name | What it exercises |
+|---|------|-------------------|
+| 1 | Simple backport | Single commit, clean cherry-pick onto a stable branch |
+| 2 | Multi-commit backport | Two commits applied in topological order |
+| 3 | Conflict handling | Conflict that requires abort and clear user explanation |
+| 4 | Mixed PR (cosmetic + essential) | Triage of cosmetic vs essential commits; cosmetic conflict skipped, essential conflict resolved |
+
+## How to run an eval
+
+Each eval is self-contained. The setup scripts create a throwaway git repo
+(or worktree) so there is no risk of corrupting the real repository.
+
+**Step 1 — Set up the test repo:**
+
+```bash
+# Example for eval 4 (mixed commits):
+bash .github/skills/backport-changes/evals/files/setup_mixed_backport.sh
+# Outputs: REPO=... BRANCH=... COMMITS=...
+```
+
+**Step 2 — Run the skill against the eval prompt:**
+
+Use the Copilot CLI and paste the prompt from `evals.json` (substituting the
+values printed by the setup script):
+
+```
+# In the Copilot CLI terminal session, e.g.:
+> Backport these 4 commits onto stable-5.0 in /tmp/backport-eval-mixed: ...
+```
+
+The skill (`SKILL.md`) is automatically loaded by the Copilot CLI when the
+`backport-changes` skill is active.
+
+**Step 3 — Check the result:**
+
+```bash
+cd /tmp/backport-eval-mixed   # or whatever REPO was printed
+git log --oneline -10
+git status -s   # should be empty
+```
+
+Compare against the `expectations` in `evals.json` for that eval.
+
+## Real-world PR test
+
+A separate setup script (`files/setup_real_backport.sh`) creates a worktree
+of the actual LXD repository at the pre-backport stable-5.21 tip (commit
+`9aaba5c`) for testing against PR #18180. This requires the LXD repo to be
+available locally:
+
+```bash
+bash .github/skills/backport-changes/evals/files/setup_real_backport.sh /path/to/lxd-repo
+```
+
+> **Note:** This eval exercises 18 real commits with genuine Go merge conflicts
+> and takes 20–50 minutes. For regular regression testing, eval 4 (synthetic)
+> is a faster equivalent.

--- a/.github/skills/backport-changes/evals/evals.json
+++ b/.github/skills/backport-changes/evals/evals.json
@@ -1,0 +1,58 @@
+{
+  "skill_name": "backport-changes",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need you to backport a bug fix to our stable branch. First, set up the test repo by running: bash evals/files/setup_simple_backport.sh. Parse the REPO and SHA from the output. Then, working inside that repo directory, backport the commit identified by SHA to the stable-5.0 branch.",
+      "expected_output": "The commit is cherry-picked onto stable-5.0, the commit message includes a '(cherry picked from commit <sha>)' trailer, and the working tree is clean.",
+      "files": [],
+      "expectations": [
+        "The agent checks out the stable-5.0 branch before cherry-picking",
+        "The agent runs git cherry-pick -x <sha> (or equivalent that adds the cherry-picked-from trailer)",
+        "The resulting commit on stable-5.0 contains the line 'fmt.Println(\"hello, world\")' in buggy.go",
+        "The commit message on stable-5.0 includes '(cherry picked from commit' followed by the original SHA",
+        "The working tree is clean (git status -s outputs nothing) at the end"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "We have two commits from a feature branch that need to go into stable-5.0. Please run bash evals/files/setup_multicommit_backport.sh first to set up the repo. Parse REPO, SHA1, and SHA2 from its output. Then backport both commits (SHA1 first, then SHA2) to the stable-5.0 branch in the repo at REPO.",
+      "expected_output": "Both commits appear on stable-5.0 in topological order (SHA1's change before SHA2's change), each with a '(cherry picked from commit ...)' trailer, and the working tree is clean.",
+      "files": [],
+      "expectations": [
+        "The agent applies SHA1 before SHA2 (topological order preserved)",
+        "Both commits on stable-5.0 include a '(cherry picked from commit' trailer",
+        "After the backport, stable-5.0 contains api.go with 'return \"1.1\"'",
+        "After the backport, stable-5.0 contains changelog.md with the v1.1 entry",
+        "The working tree is clean at the end"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Run bash evals/files/setup_conflict_backport.sh to set up the test repo. Parse REPO and SHA from the output. Try to backport the commit SHA to the stable-5.0 branch in that repo. There will be a merge conflict — handle it appropriately.",
+      "expected_output": "The agent detects the conflict, aborts the cherry-pick (or resolves it with preserved intent), and clearly explains what blocked the backport and what manual steps are needed.",
+      "files": [],
+      "expectations": [
+        "The agent detects that git cherry-pick results in a conflict",
+        "The agent does NOT silently skip the conflict or leave the repo in a mid-cherry-pick state",
+        "If the agent aborts (git cherry-pick --abort), it explains what file conflicted and why",
+        "The working tree is clean at the end (either conflict was resolved and committed, or cherry-pick was aborted)",
+        "The agent clearly communicates to the user what manual intervention is needed"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Run bash evals/files/setup_mixed_backport.sh to set up the test repo. Parse REPO, BRANCH, and COMMITS from the output (COMMITS is a space-separated list of 4 SHAs in topological order). Then, working inside REPO, backport those 4 commits onto BRANCH. The commits include a mix of cosmetic changes (renames, comment fixes) and essential bug fixes. Some will conflict — use your judgment about which to skip vs resolve. Clearly state which commits were applied, which were skipped, and why.",
+      "expected_output": "The two essential commits (bug fix and new feature) land on the target branch. The cosmetic commit that conflicts is skipped with an explanation. The cosmetic comment-fix commit that applies cleanly may or may not be included. Every applied commit has a '(cherry picked from commit ...)' trailer. The working tree is clean at the end.",
+      "files": [],
+      "expectations": [
+        "The essential bug-fix commit ('fix: restore original address on revert instead of wiping cfg') is present on the target branch",
+        "The essential feature commit ('feat: reinstate cluster.https_address listener') is present on the target branch",
+        "Each applied commit includes a '(cherry picked from commit' trailer",
+        "The cosmetic rename commit that conflicts is skipped with an explicit explanation",
+        "The agent does not attempt conflict resolution indefinitely — it aborts and reports if a conflict cannot be resolved cleanly",
+        "The working tree is clean (git status -s outputs nothing) at the end"
+      ]
+    }
+  ]
+}

--- a/.github/skills/backport-changes/evals/files/setup_conflict_backport.sh
+++ b/.github/skills/backport-changes/evals/files/setup_conflict_backport.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Sets up a minimal git repo for eval 3: backport that results in a conflict.
+# The same file is modified in both main and stable-5.0, so cherry-pick will conflict.
+# Usage: bash setup_conflict_backport.sh [target-dir]
+# Prints:
+#   REPO=<path>
+#   SHA=<sha of commit to backport>
+
+set -euo pipefail
+
+REPO="${1:-/tmp/backport-eval-conflict}"
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+
+# Shared base
+cat > config.go <<'EOF'
+package main
+
+const Timeout = 30
+EOF
+git add config.go
+git commit -q -m "initial commit"
+
+# stable-5.0 diverges: changes Timeout to 60
+git checkout -q -b stable-5.0
+cat > config.go <<'EOF'
+package main
+
+const Timeout = 60
+EOF
+git add config.go
+git commit -q -m "chore: increase default timeout to 60s on stable"
+
+# Back to main: changes Timeout to 45 (will conflict with stable's 60)
+git checkout -q main 2>/dev/null || git checkout -q -b main
+cat > config.go <<'EOF'
+package main
+
+const Timeout = 45
+EOF
+git add config.go
+git commit -q -m "fix: set timeout to 45s"
+SHA=$(git rev-parse HEAD)
+
+echo "REPO=$REPO"
+echo "SHA=$SHA"

--- a/.github/skills/backport-changes/evals/files/setup_mixed_backport.sh
+++ b/.github/skills/backport-changes/evals/files/setup_mixed_backport.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Sets up a synthetic git repo for eval 4: multi-commit PR with a mix of
+# essential and cosmetic commits, some of which conflict on the target branch.
+# Designed to be fast to execute (small files) while exercising the same
+# decision-making as a real-world backport.
+# Usage: bash setup_mixed_backport.sh [target-dir]
+# Prints:
+#   REPO=<path>
+#   BRANCH=<target branch>
+#   COMMITS=<space-separated SHAs in topological order>
+
+set -euo pipefail
+
+REPO="${1:-/tmp/backport-eval-mixed}"
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+git config rerere.enabled false
+
+# ---- shared base on main ----
+cat > server.go <<'EOF'
+package main
+
+import "fmt"
+
+func handleRequest(cfg map[string]string) error {
+addr := cfg["core.https_address"]
+if addr == "" {
+return fmt.Errorf("node config missing address")
+}
+return listen(addr)
+}
+
+func listen(addr string) error {
+fmt.Printf("listening on %s\n", addr)
+return nil
+}
+EOF
+
+cat > errors.go <<'EOF'
+package main
+
+const errNodeConfig = "node config error"
+EOF
+
+git add server.go errors.go
+git commit -q -m "initial commit"
+
+# ---- stable-5.0 diverges: different server.go structure ----
+git checkout -q -b stable-5.0
+
+cat > server.go <<'EOF'
+package main
+
+import "fmt"
+
+func handleRequest(cfg map[string]string) error {
+addr := cfg["core.https_address"]
+if addr == "" {
+return fmt.Errorf("node config missing address")
+}
+// stable-5.0 uses a legacy listener
+return legacyListen(addr)
+}
+
+func legacyListen(addr string) error {
+fmt.Printf("[legacy] listening on %s\n", addr)
+return nil
+}
+EOF
+git add server.go
+git commit -q -m "stable-5.0: use legacyListen"
+
+# ---- back to main: add the feature branch commits ----
+git checkout -q main 2>/dev/null || git checkout -q -b main
+
+# Commit A (cosmetic): rename error string (will conflict on stable because
+# errors.go on stable still has the old string referenced elsewhere)
+cat > errors.go <<'EOF'
+package main
+
+const errNodeConfig = "member config error"
+EOF
+git add errors.go
+git commit -q -m "rename: node config -> member config in error strings"
+SHA_A=$(git rev-parse HEAD)
+
+# Commit B (essential): fix the bug — don't overwrite cfg on revert
+cat > server.go <<'EOF'
+package main
+
+import "fmt"
+
+func handleRequest(cfg map[string]string) error {
+addr := cfg["core.https_address"]
+if addr == "" {
+return fmt.Errorf("node config missing address")
+}
+oldAddr := addr
+if err := listen(addr); err != nil {
+// BUG FIX: restore original address instead of wiping cfg
+cfg["core.https_address"] = oldAddr
+return err
+}
+return nil
+}
+
+func listen(addr string) error {
+fmt.Printf("listening on %s\n", addr)
+return nil
+}
+EOF
+git add server.go
+git commit -q -m "fix: restore original address on revert instead of wiping cfg"
+SHA_B=$(git rev-parse HEAD)
+
+# Commit C (cosmetic): fix typo in comment (applies cleanly, no conflict)
+cat > server.go <<'EOF'
+package main
+
+import "fmt"
+
+func handleRequest(cfg map[string]string) error {
+addr := cfg["core.https_address"]
+if addr == "" {
+return fmt.Errorf("node config missing address")
+}
+oldAddr := addr
+if err := listen(addr); err != nil {
+// BUG FIX: restore original address instead of wiping config
+cfg["core.https_address"] = oldAddr
+return err
+}
+return nil
+}
+
+func listen(addr string) error {
+fmt.Printf("listening on %s\n", addr)
+return nil
+}
+EOF
+git add server.go
+git commit -q -m "comment: fix typo cfg -> config"
+SHA_C=$(git rev-parse HEAD)
+
+# Commit D (essential): add reinstate logic for cluster address (new function, no conflict)
+cat >> server.go <<'EOF'
+
+func reinstateClusterAddr(cfg map[string]string) {
+if cfg["cluster.https_address"] != "" && cfg["core.https_address"] == "" {
+// Reinstate cluster address when core address is unset
+_ = listen(cfg["cluster.https_address"])
+}
+}
+EOF
+git add server.go
+git commit -q -m "feat: reinstate cluster.https_address listener when core.https_address is unset"
+SHA_D=$(git rev-parse HEAD)
+
+git checkout -q stable-5.0
+
+echo "REPO=$REPO"
+echo "BRANCH=stable-5.0"
+echo "COMMITS=$SHA_A $SHA_B $SHA_C $SHA_D"
+echo ""
+echo "Commit summary:"
+echo "  SHA_A=$SHA_A  (cosmetic rename — will conflict)"
+echo "  SHA_B=$SHA_B  (essential bug fix — will conflict due to legacyListen)"
+echo "  SHA_C=$SHA_C  (cosmetic comment fix — will apply cleanly after B)"
+echo "  SHA_D=$SHA_D  (essential new feature — applies cleanly)"

--- a/.github/skills/backport-changes/evals/files/setup_multicommit_backport.sh
+++ b/.github/skills/backport-changes/evals/files/setup_multicommit_backport.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Sets up a minimal git repo for eval 2: multi-commit PR-style backport.
+# Simulates two commits that together constitute a logical change, like a PR.
+# Usage: bash setup_multicommit_backport.sh [target-dir]
+# Prints:
+#   REPO=<path>
+#   SHA1=<first commit sha>
+#   SHA2=<second commit sha>
+
+set -euo pipefail
+
+REPO="${1:-/tmp/backport-eval-multi}"
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+
+# Shared base
+cat > api.go <<'EOF'
+package main
+
+func GetVersion() string {
+    return "1.0"
+}
+EOF
+git add api.go
+git commit -q -m "initial commit"
+
+# stable-5.0 branches from here
+git checkout -q -b stable-5.0
+git checkout -q main 2>/dev/null || git checkout -q -b main
+
+# First commit of the "PR" on main
+cat > api.go <<'EOF'
+package main
+
+func GetVersion() string {
+    return "1.1"
+}
+EOF
+git add api.go
+git commit -q -m "feat: bump version to 1.1"
+SHA1=$(git rev-parse HEAD)
+
+# Second commit of the "PR" on main
+cat > changelog.md <<'EOF'
+# Changelog
+
+## v1.1
+- Bumped version to 1.1
+EOF
+git add changelog.md
+git commit -q -m "docs: add changelog entry for v1.1"
+SHA2=$(git rev-parse HEAD)
+
+echo "REPO=$REPO"
+echo "SHA1=$SHA1"
+echo "SHA2=$SHA2"

--- a/.github/skills/backport-changes/evals/files/setup_simple_backport.sh
+++ b/.github/skills/backport-changes/evals/files/setup_simple_backport.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Sets up a minimal git repo for eval 1: single-commit backport.
+# Usage: bash setup_simple_backport.sh [target-dir]
+# Prints the repo path and commit SHA to stdout as:
+#   REPO=<path>
+#   SHA=<sha>
+
+set -euo pipefail
+
+REPO="${1:-/tmp/backport-eval-simple}"
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+
+# Shared base on main
+cat > buggy.go <<'EOF'
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello")
+}
+EOF
+git add buggy.go
+git commit -q -m "initial commit"
+
+# Create stable-5.0 from the base
+git checkout -q -b stable-5.0
+
+git checkout -q main 2>/dev/null || git checkout -q -b main
+
+# Add a bug-fix commit on main
+cat > buggy.go <<'EOF'
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello, world")
+}
+EOF
+git add buggy.go
+git commit -q -m "fix: correct greeting message"
+
+SHA=$(git rev-parse HEAD)
+
+echo "REPO=$REPO"
+echo "SHA=$SHA"


### PR DESCRIPTION
This PR adds a backport-changes agent skill and updates the Copilot instructions to document skill usage.

Example trigger phrases:

 - backport PR #123456 to stable-5.21
 - backport these changes to stable-5.0 and stable-5.21
 - cherry-pick this commit to the release branch

The skill is invoked automatically when Copilot detects a matching context, or you can reference it explicitly in a prompt. You can also invoke a skill directly on the GitHub Copilot CLI with the slash command:

```
/backport-changes
```