### PR TITLE
Unidirectional cluster links

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -377,6 +377,7 @@ type InstanceServer interface {
 	GetClusterLinkNames() (clusterLinkNames []string, err error)
 	GetClusterLinks() (clusterLinks []api.ClusterLink, err error)
 	GetClusterLinkState(name string) (clusterLinkState *api.ClusterLinkState, ETag string, err error)
+	GetClusterLinkCertificate(address string) (fingerprint string, pemCert string, err error)
 	CreateClusterLink(clusterLink api.ClusterLinksPost) (err error)
 	CreateIdentityClusterLinkToken(clusterLink api.ClusterLinksPost) (certificateAddToken *api.CertificateAddToken, err error)
 	UpdateClusterLink(name string, clusterLink api.ClusterLinkPut, ETag string) (err error)

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -437,6 +437,25 @@ func (r *ProtocolLXD) CreateIdentityClusterLinkToken(clusterLink api.ClusterLink
 	return &token, nil
 }
 
+// GetClusterLinkCertificate fetches the TLS certificate from the given address via the server.
+// It returns the certificate fingerprint and PEM-encoded certificate for user verification.
+func (r *ProtocolLXD) GetClusterLinkCertificate(address string) (fingerprint string, certificate string, err error) {
+	err = r.CheckExtension("cluster_links_unidirectional")
+	if err != nil {
+		return "", "", err
+	}
+
+	var resp api.ClusterLinkCertificate
+	_, err = r.queryStruct(http.MethodGet,
+		api.NewURL().Path("cluster", "links", "certificate").WithQuery("address", address).String(),
+		nil, "", &resp)
+	if err != nil {
+		return "", "", err
+	}
+
+	return resp.Fingerprint, resp.Certificate, nil
+}
+
 // UpdateClusterLink updates a cluster link.
 func (r *ProtocolLXD) UpdateClusterLink(name string, clusterLink api.ClusterLinkPut, ETag string) error {
 	err := r.CheckExtension("cluster_links")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3081,3 +3081,17 @@ This includes the following new endpoints (see {ref}`rest-api` for details):
 * [`POST /1.0/replicators/<name>`](swagger:/replicators/replicator_post)
 * [`DELETE /1.0/replicators/<name>`](swagger:/replicators/replicator_delete)
 * [`GET /1.0/replicators/<name>/state`](swagger:/replicators/replicator_state_get)
+
+(extension-cluster_links_unidirectional)=
+## cluster_links_unidirectional
+
+This extends the cluster links API with support for unidirectional cluster links.
+
+Two new link types are introduced:
+
+- `unidirectional`: The local cluster consumes a trust token issued by the remote to establish the link and pin the remote's certificate. The remote cluster creates a dedicated identity for the local cluster and can authenticate its incoming requests, but holds no addresses for the local cluster and cannot initiate requests to it.
+- `unidirectional-unauthenticated`: The local cluster can reach the remote cluster without presenting a client certificate. The remote cluster has no knowledge of the link.
+
+This includes the following new endpoint (see {ref}`rest-api` for details):
+
+* [`GET /1.0/cluster/links/certificate`](swagger:/cluster-links/cluster_links_certificate_get)

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -158,35 +158,60 @@ See {ref}`howto-cluster-groups` and {ref}`cluster-target-instance` for more info
 (exp-cluster-links)=
 ## Cluster links
 
-Cluster links enable authenticated communication between separate LXD clusters by establishing a bidirectional trust relationship using mutual TLS certificates.
+Cluster links enable secure communication between separate LXD clusters by pinning the remote cluster's TLS certificate and optionally establishing mutual trust.
+
+Cluster links are the foundation for {ref}`replicators <exp-replicators>`, which use bidirectional links to sync instances across clusters for active-passive disaster recovery. Unidirectional links are suited to scenarios where one cluster needs to read from another without granting reciprocal access, or for anonymous access to a cluster that exposes resources publicly.
+
+### Link types
+
+There are three link types, each suited to different trust and access requirements:
+
+`bidirectional`
+: Both clusters authenticate each other using mutual TLS. Each side creates an identity for the other and can initiate requests to the other. This is the default type.
+
+`unidirectional`
+: A pins B's certificate and uses a token to activate a pending identity that B created for A. B stores a corresponding link entry and can authenticate incoming requests from A, but holds no address for A and cannot initiate requests to it.
+
+`unidirectional-unauthenticated`
+: Only the initiating cluster (A) stores a link to B. A connects to B without presenting a client certificate, relying solely on certificate pinning for server authentication. B is completely unaware of the link and no identity is created on either side. Use this type when B exposes resources publicly or when you want read-only, anonymous-style access to B.
 
 ### How cluster links work
 
-1. **Trust establishment**: Each cluster presents its certificate to the other, establishing mutual trust.
-1. **Identity creation**: LXD automatically creates a special identity for each linked cluster with type `Cluster link certificate`.
-1. **Permission control**: The linked cluster's permissions are managed through LXD's {ref}`fine-grained-authorization` system.
-1. **Secure communication**: All communication between clusters uses TLS encryption with certificate verification.
+All link types rely on TLS certificate pinning: A fetches and pins B's certificate before making any connection. The link type determines what trust is established on B's side.
 
-#### Connection process
-
-Both clusters coordinate to create a link.
+#### Bidirectional connection process
 
 1. **Cluster A** creates a pending cluster link and generates a trust token.
 1. **Cluster B** uses this token to establish the connection and send its certificate back.
 1. Both clusters validate certificates and activate the bidirectional link.
 1. The link becomes active and both clusters can communicate.
 
+#### Unidirectional connection process
+
+1. **Cluster B** issues a pending identity token using `lxc auth identity create cluster-link/<name>`.
+1. **Cluster A** consumes the token with `lxc cluster link create <name> --token <token> --unidirectional`, pins B's certificate, and calls back to B to activate the pending identity.
+1. A has an active link to B with no associated identity. B has an active identity for A and a corresponding link row.
+
+#### Unauthenticated unidirectional connection process
+
+1. **Cluster A** runs `lxc cluster link create <name> --unauthenticated --remote-address <addr>`.
+1. The CLI fetches B's certificate and displays the fingerprint for the user to confirm.
+1. A stores the link locally with B's pinned certificate. B is not contacted and remains unaware of the link.
+
 For more information, see: {ref}`howto-cluster-links-create`.
 
 (exp-clusters-links-identity)=
 ### Identity management for cluster links
 
-When you create a cluster link, LXD automatically creates an identity for the linked cluster. This identity is of type `Cluster link certificate` and is used to authenticate that cluster. These identities are managed using {ref}`fine-grained-authorization`.
+The identities created depend on the link type:
 
-The identity can be in one of two states:
+- **Bidirectional**: LXD creates a `Cluster link certificate` identity on each side. The identity can be in one of two states:
+  - **Pending**: A trust token has been generated but the link has not been activated yet.
+  - **Active**: Both clusters have exchanged certificates and the link is operational.
+- **Unidirectional (authenticated)**: B creates an identity for A and a corresponding link entry (no addresses, so B cannot reach A, but can manage A's access via `lxc cluster link delete`). A stores B's certificate directly without an associated identity.
+- **Unidirectional unauthenticated**: No identity is created on either side.
 
-- **Pending**: When a trust token is generated but the link hasn't been activated yet.
-- **Active**: When both clusters have exchanged certificates and the link is operational.
+Identities are managed using {ref}`fine-grained-authorization`.
 
 #### Security considerations
 
@@ -195,7 +220,15 @@ The identity can be in one of two states:
 - **Identity isolation**: Each cluster link gets its own identity that can be managed independently.
 - **Group membership**: Cluster link identities can be assigned to authentication groups for bulk permission management.
 
-Together, these controls limit the blast radius of a compromised link by enforcing mutual authentication and least-privilege access. They also make it possible to revoke a single link’s access without impacting other cluster-to-cluster trust relationships.
+Together, these controls limit the blast radius of a compromised link by enforcing certificate-based trust and least-privilege access. They also make it possible to revoke a single link's access without impacting other cluster-to-cluster trust relationships.
+
+#### Cluster link deletion
+
+Deletion behavior depends on the link type:
+
+- **Bidirectional**: Run `lxc cluster link delete` on both clusters to fully remove the trust relationship.
+- **Unidirectional (authenticated)**: Deleting on A removes only A's link. B's identity and link row remain until B explicitly deletes its link.
+- **Unidirectional unauthenticated**: Only A has a link. Run `lxc cluster link delete` on A; B is unaffected.
 
 #### Cluster link member status
 

--- a/doc/howto/cluster_links_create.md
+++ b/doc/howto/cluster_links_create.md
@@ -166,3 +166,8 @@ lxc auth identity show tls/<cluster-link-name>
 ```
 
 The output shows the identity of your cluster link, with the type `Cluster link certificate`.
+
+## Next steps
+
+- {ref}`howto-replicators-setup` — set up replicators to sync instances across this link for active-passive disaster recovery.
+- {ref}`howto-cluster-links-manage` — view, configure, and delete existing cluster links.

--- a/doc/howto/cluster_links_create.md
+++ b/doc/howto/cluster_links_create.md
@@ -1,18 +1,18 @@
 ---
 myst:
   html_meta:
-    description: Create cluster links between LXD clusters using trust tokens and mutual TLS.
+    description: Create bidirectional and unidirectional cluster links between LXD clusters.
 ---
 
 (howto-cluster-links-create)=
 # How to create cluster links
 
-{ref}`Cluster links <exp-cluster-links>` can connect separate LXD clusters by establishing a trust relationship using mutual TLS with certificates, ensuring secure communication.
+{ref}`Cluster links <exp-cluster-links>` connect separate LXD clusters. There are three link types — bidirectional, unidirectional (authenticated), and unidirectional unauthenticated — each with a different creation flow.
 
 (howto-cluster-links-auth)=
 ## Prepare authentication
 
-Before creating cluster links, set up proper authentication groups and {ref}`manage-permissions`:
+Before creating bidirectional or authenticated unidirectional cluster links, set up proper authentication groups and {ref}`manage-permissions`:
 
 ```bash
 lxc auth group create <group-name>
@@ -42,9 +42,10 @@ lxc auth group create backup
 lxc auth group permission add backup instance can_manage_backups
 ```
 
-## Create a cluster link
+(howto-cluster-links-create-bidirectional)=
+## Create a bidirectional cluster link
 
-To create a new cluster link between two clusters (Cluster A and Cluster B), you must create the link on both sides. Follow these steps:
+To create a bidirectional cluster link between two clusters (Cluster A and Cluster B), you must create the link on both sides. Follow these steps:
 
 1. On Cluster A, create a new cluster link to Cluster B and receive a trust token:
 
@@ -83,10 +84,82 @@ To create a new cluster link between two clusters (Cluster A and Cluster B), you
    lxc cluster link create cluster_a --token <token-from-A> --auth-group clusters
    ```
 
+(howto-cluster-links-create-unidirectional)=
+## Create an authenticated unidirectional cluster link
+
+An authenticated unidirectional link lets Cluster A access Cluster B's resources. B creates an identity for A, but A does not create an identity for B — B cannot initiate requests to A via a cluster link.
+
+Follow these steps:
+
+1. On Cluster B (the target), issue a pending identity token:
+
+   ```bash
+   lxc auth identity create cluster-link/<name-for-cluster-a> --auth-group <auth-group-name>
+   ```
+
+   This command creates a pending `Cluster link certificate` identity on B and returns a trust token.
+
+   Example:
+
+   ```bash
+   lxc auth identity create cluster-link/cluster_a --auth-group clusters
+   ```
+
+1. On Cluster A (the initiator), create the cluster link using the token from Cluster B:
+
+   ```bash
+   lxc cluster link create <name-for-cluster-b> --token <token-from-B> --unidirectional
+   ```
+
+   This command:
+   - Pins Cluster B's certificate on Cluster A.
+   - Calls back to Cluster B to activate B's pending identity for A.
+   - Stores B's addresses in `volatile.addresses` so A can reach B.
+
+   Example:
+
+   ```bash
+   lxc cluster link create cluster_b --token <token-from-B> --unidirectional
+   ```
+
+After these steps, Cluster A has a link with `type: unidirectional` and no associated identity. Cluster B has an active `Cluster link certificate` identity for A and a corresponding link row.
+
+(howto-cluster-links-create-unauthenticated)=
+## Create an unauthenticated unidirectional cluster link
+
+An unauthenticated unidirectional link lets Cluster A connect to Cluster B without presenting a client certificate. B remains completely unaware of the link. Use this type for anonymous or public access to B.
+
+On Cluster A, run:
+
+```bash
+lxc cluster link create <name-for-cluster-b> --unauthenticated --remote-address <cluster-b-address>
+```
+
+The CLI fetches Cluster B's certificate and displays its fingerprint:
+
+```
+Certificate fingerprint: <fingerprint>
+ok (y/n/[fingerprint])?
+```
+
+Confirm by typing `y` or the full fingerprint. The link is then stored locally on A with `type: unidirectional-unauthenticated`.
+
+Example:
+
+```bash
+lxc cluster link create cluster_b --unauthenticated --remote-address 10.0.0.1:8443
+```
+
+```{admonition} No identity is created
+:class: note
+
+For unauthenticated unidirectional links, no identity is created on either cluster. Cluster B is not contacted during link creation.
+```
+
 (howto-cluster-links-identities)=
 ## View the underlying identities
 
-When you create a cluster link, LXD automatically creates an identity for authentication. You can view this identity with:
+For bidirectional and authenticated unidirectional links, LXD automatically creates an identity for authentication. You can view this identity with:
 
 ```bash
 lxc auth identity show tls/<cluster-link-name>

--- a/doc/howto/cluster_links_manage.md
+++ b/doc/howto/cluster_links_manage.md
@@ -170,10 +170,12 @@ See [`DELETE /1.0/cluster/links/{name}`](swagger:/cluster-links/{name}/cluster_l
 ```
 ````
 
-```{admonition} To fully disconnect the cluster link on both sides
+```{admonition} Deletion behavior depends on link type
 :class: note
 
-To fully disconnect the clusters, run the command on both clusters.
+The effect of deleting a cluster link varies by type:
 
-Deleting a cluster link removes the established trust and deletes the associated identity on the local cluster. If you only run the command on one cluster, the other cluster still has the cluster link identity and trust established (still allowing requests from the linked cluster).
+- **Bidirectional**: Deleting on one cluster removes the trust and identity only on that cluster. The other cluster retains its identity and trust until you also delete the link there. To fully disconnect, run the command on both clusters.
+- **Unidirectional (authenticated)**: Deleting on Cluster A removes only A's link row. Cluster B retains its identity and link row until B explicitly deletes its link.
+- **Unidirectional unauthenticated**: Only Cluster A has a link. Run the delete command on A; Cluster B is unaffected.
 ```

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -429,6 +429,21 @@ definitions:
         title: ClusterLink represents high-level information about a cluster link.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    ClusterLinkCertificate:
+        properties:
+            certificate:
+                description: PEM-encoded X.509 certificate.
+                example: '-----BEGIN CERTIFICATE-----\n...'
+                type: string
+                x-go-name: Certificate
+            fingerprint:
+                description: SHA-256 fingerprint of the certificate.
+                example: a1b2c3d4...
+                type: string
+                x-go-name: Fingerprint
+        title: ClusterLinkCertificate represents a remote cluster certificate fetched for user verification.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     ClusterLinkMemberState:
         properties:
             address:
@@ -529,6 +544,11 @@ definitions:
                 example: lxd02
                 type: string
                 x-go-name: Name
+            remote_address:
+                description: RemoteAddress is the address of the remote cluster, used for unauthenticated unidirectional links.
+                example: 10.0.0.1:8443
+                type: string
+                x-go-name: RemoteAddress
             trust_token:
                 description: |-
                     TrustToken for creating a cluster link. This is included in requests to create an active cluster link on the local cluster and activate a pending cluster link on the linked cluster.
@@ -10135,6 +10155,50 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Get the cluster link state
+            tags:
+                - cluster-links
+    /1.0/cluster/links/certificate:
+        get:
+            description: |-
+                Fetches the TLS certificate from the given remote address for user verification.
+                This is used as the first step of the unauthenticated unidirectional cluster link creation flow.
+            operationId: cluster_links_certificate_get
+            parameters:
+                - description: Address of the remote cluster
+                  example: 10.0.0.1:8443
+                  in: query
+                  name: address
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Remote cluster certificate
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/ClusterLinkCertificate'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the remote cluster certificate
             tags:
                 - cluster-links
     /1.0/cluster/links?recursion=1:

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -752,6 +752,8 @@ func resolveIdentityTypeShorthand(identityArg string) (method string, identityTy
 		return api.AuthenticationMethodBearer, api.IdentityTypeBearerTokenDevLXD, idName, nil
 	case "bearer":
 		return api.AuthenticationMethodBearer, "", idName, nil
+	case "cluster-link":
+		return api.AuthenticationMethodTLS, api.IdentityTypeCertificateClusterLink, idName, nil
 	}
 
 	return "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
@@ -843,6 +845,10 @@ func (c *cmdIdentityCreate) run(cmd *cobra.Command, args []string) error {
 
 	switch method {
 	case api.AuthenticationMethodTLS:
+		if idType == api.IdentityTypeCertificateClusterLink {
+			return c.createClusterLinkIdentity(remoteName, name)
+		}
+
 		var certFilePath string
 		if len(args) == 2 {
 			certFilePath = args[1]
@@ -962,6 +968,58 @@ func (c *cmdIdentityCreate) createTLSIdentity(remote string, name string, certFi
 		fmt.Printf("TLS identity %q created with fingerprint %q\n", name, fingerprint)
 	}
 
+	return nil
+}
+
+// createClusterLinkIdentity is called via `lxc auth identity create cluster-link/<name>`.
+// It creates a pending unidirectional cluster link identity on B (the image host).
+// Returns a token that A (the image client) can use with `lxc cluster link create --token --unidirectional`.
+func (c *cmdIdentityCreate) createClusterLinkIdentity(remote string, name string) error {
+	transporter, wrapper := newLocationHeaderTransportWrapper()
+	client, err := c.global.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{TransportWrapper: wrapper})
+	if err != nil {
+		return err
+	}
+
+	clusterLink := api.ClusterLinksPost{
+		Name: name,
+		Type: api.ClusterLinkTypeUnidirectional,
+	}
+
+	clusterLink.AuthGroups = append(clusterLink.AuthGroups, c.flagGroups...)
+
+	token, err := client.CreateIdentityClusterLinkToken(clusterLink)
+	if err != nil {
+		return err
+	}
+
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("Failed encoding identity token: %w", err)
+	}
+
+	if !c.identity.global.flagQuiet {
+		pendingIdentityURL, err := url.Parse(transporter.location)
+		if err != nil {
+			return fmt.Errorf("Received invalid location header %q: %w", transporter.location, err)
+		}
+
+		var pendingIdentityUUIDStr string
+		identityURLPrefix := api.NewURL().Path(version.APIVersion, "auth", "identities", api.AuthenticationMethodTLS).String()
+		_, err = fmt.Sscanf(pendingIdentityURL.Path, identityURLPrefix+"/%s", &pendingIdentityUUIDStr)
+		if err != nil {
+			return fmt.Errorf("Received unexpected location header %q: %w", transporter.location, err)
+		}
+
+		pendingIdentityUUID, err := uuid.Parse(pendingIdentityUUIDStr)
+		if err != nil {
+			return fmt.Errorf("Received invalid pending identity UUID %q: %w", pendingIdentityUUIDStr, err)
+		}
+
+		fmt.Printf("Cluster link %q (%s) pending identity token:\n", name, pendingIdentityUUID.String())
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString(tokenJSON))
 	return nil
 }
 

--- a/lxc/cluster_link.go
+++ b/lxc/cluster_link.go
@@ -86,9 +86,12 @@ type cmdClusterLinkCreate struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
 
-	flagToken       string
-	flagAuthGroups  []string
-	flagDescription string
+	flagToken           string
+	flagAuthGroups      []string
+	flagDescription     string
+	flagUnidirectional  bool
+	flagUnauthenticated bool
+	flagRemoteAddress   string
 }
 
 func (c *cmdClusterLinkCreate) command() *cobra.Command {
@@ -97,19 +100,26 @@ func (c *cmdClusterLinkCreate) command() *cobra.Command {
 	cmd.Short = "Create cluster links"
 	cmd.Long = cli.FormatSection("Description", `Create cluster links
 
-When run with the --token flag, creates an active cluster link.
-When run without a token, creates a pending cluster link that must be activated by creating a cluster link on the remote cluster.`)
+Bidirectional (default): run without --token on cluster A to get a token, then run with --token on cluster B.
+Unidirectional authenticated: run "lxc auth identity create cluster-link/<name>" on B to get a token, then run with --token --unidirectional on A.
+Unidirectional unauthenticated: run with --unauthenticated --remote-address on A; the certificate fingerprint is shown for confirmation before the link is created.`)
 	cmd.Example = cli.FormatSection("", `lxc cluster link create backup-cluster --auth-group backups
-    Create a pending cluster link reachable at "192.0.2.1:8443" and "192.0.2.2:8443" called "backup-cluster", belonging to the authentication group "backups".
+    Create a pending bidirectional cluster link called "backup-cluster".
 
-lxc cluster link create main-cluster --token <token from backup-cluster> --auth-group backups
-    Create a cluster link with "backup-cluster" called "main-cluster", belonging to the auth group "backups".
+lxc cluster link create main-cluster --token <token> --auth-group backups
+    Create an active bidirectional cluster link called "main-cluster" using a token from "backup-cluster".
 
-lxc cluster link create backup-cluster < config.yaml
-    Create a pending cluster link with the configuration from "config.yaml" called "backup-cluster".`)
+lxc cluster link create image-host --token <token> --unidirectional
+    Create an authenticated unidirectional cluster link called "image-host" using a token issued by the remote cluster.
+
+lxc cluster link create image-host --unauthenticated --remote-address 10.0.0.1:8443
+    Create an unauthenticated unidirectional cluster link called "image-host" by pinning the remote certificate.`)
 	cmd.Flags().StringVarP(&c.flagToken, "token", "t", "", cli.FormatStringFlagLabel("Trust token to use when creating cluster link"))
 	cmd.Flags().StringSliceVarP(&c.flagAuthGroups, "auth-group", "g", []string{}, cli.FormatStringFlagLabel("Authentication groups to add the newly created cluster link identity to"))
 	cmd.Flags().StringVarP(&c.flagDescription, "description", "d", "", cli.FormatStringFlagLabel("Cluster link description"))
+	cmd.Flags().BoolVar(&c.flagUnidirectional, "unidirectional", false, cli.FormatStringFlagLabel("Create a unidirectional cluster link (requires --token)"))
+	cmd.Flags().BoolVar(&c.flagUnauthenticated, "unauthenticated", false, cli.FormatStringFlagLabel("Create a link without presenting a client certificate (requires --remote-address)"))
+	cmd.Flags().StringVar(&c.flagRemoteAddress, "remote-address", "", cli.FormatStringFlagLabel("Address of the remote cluster for unauthenticated unidirectional links"))
 
 	cmd.RunE = c.run
 
@@ -133,8 +143,9 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If stdin isn't a terminal, read text from it
-	if !termios.IsTerminal(getStdinFd()) {
+	// If stdin isn't a terminal, read text from it.
+	// Skip this for unauthenticated unidirectional links: stdin is reserved for the interactive certificate confirmation prompt.
+	if !termios.IsTerminal(getStdinFd()) && !c.flagUnauthenticated {
 		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
@@ -158,11 +169,30 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if c.flagUnidirectional && c.flagUnauthenticated {
+		return errors.New("--unidirectional and --unauthenticated cannot be used together")
+	}
+
+	if c.flagUnauthenticated && c.flagRemoteAddress == "" {
+		return errors.New("--unauthenticated requires --remote-address")
+	}
+
+	if !c.flagUnauthenticated && c.flagRemoteAddress != "" {
+		return errors.New("--remote-address requires --unauthenticated")
+	}
+
+	if c.flagUnidirectional && c.flagToken == "" {
+		return errors.New("--unidirectional requires --token")
+	}
+
+	if (c.flagUnidirectional || c.flagUnauthenticated) && len(c.flagAuthGroups) > 0 {
+		return errors.New("--auth-group cannot be used with unidirectional cluster links")
+	}
+
 	clusterLink := api.ClusterLinksPost{
 		Name:           clusterLinkName,
 		ClusterLinkPut: stdinData,
-		// Bidirectional is the only supported cluster link type for now.
-		Type: api.ClusterLinkTypeBidirectional,
+		Type:           api.ClusterLinkTypeBidirectional,
 	}
 
 	if c.flagDescription != "" {
@@ -187,6 +217,68 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		clusterLink.AuthGroups = c.flagAuthGroups
 	}
 
+	// Unauthenticated unidirectional: fetch cert, prompt user, then create.
+	if c.flagUnauthenticated {
+		fingerprint, pemCert, err := client.GetClusterLinkCertificate(c.flagRemoteAddress)
+		if err != nil {
+			return fmt.Errorf("Failed retrieving remote certificate: %w", err)
+		}
+
+		fmt.Printf("Certificate fingerprint: %s\n", fingerprint)
+		fmt.Print("ok (y/n/[fingerprint])? ")
+		for {
+			line, err := shared.ReadStdin()
+			if err != nil {
+				return err
+			}
+
+			if string(line) == fingerprint || (len(line) > 0 && strings.ToLower(string(line[0])) == "y") {
+				break
+			}
+
+			if len(line) == len(fingerprint) {
+				return errors.New("The provided fingerprint does not match the remote cluster certificate fingerprint")
+			}
+
+			if len(line) == 0 || strings.ToLower(string(line[0])) == "n" {
+				return errors.New("Remote cluster certificate NACKed by user")
+			}
+
+			fmt.Print("Please type 'y', 'n' or the fingerprint: ")
+		}
+
+		clusterLink.Type = api.ClusterLinkTypeUnidirectionalUnauthenticated
+		clusterLink.RemoteAddress = c.flagRemoteAddress
+		clusterLink.ClusterCertificate = pemCert
+		err = client.CreateClusterLink(clusterLink)
+		if err != nil {
+			return err
+		}
+
+		if !c.global.flagQuiet {
+			fmt.Printf("Cluster link %s created\n", clusterLinkName)
+		}
+
+		return nil
+	}
+
+	// Authenticated unidirectional: consume B's token, pin B's cert on A, activate B's identity.
+	if c.flagUnidirectional {
+		clusterLink.Type = api.ClusterLinkTypeUnidirectional
+		clusterLink.TrustToken = c.flagToken
+		err = client.CreateClusterLink(clusterLink)
+		if err != nil {
+			return err
+		}
+
+		if !c.global.flagQuiet {
+			fmt.Printf("Cluster link %s created\n", clusterLinkName)
+		}
+
+		return nil
+	}
+
+	// Bidirectional pending: no token; create pending identity and return token.
 	if c.flagToken == "" {
 		token, err := client.CreateIdentityClusterLinkToken(clusterLink)
 		if err != nil {
@@ -219,21 +311,23 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Received invalid pending identity UUID %q: %w", pendingIdentityUUIDStr, err)
 			}
 
-			fmt.Printf("Cluster link %q (%s) pending identity token:"+"\n", clusterLinkName, pendingIdentityUUID.String())
+			fmt.Printf("Cluster link %q (%s) pending identity token:\n", clusterLinkName, pendingIdentityUUID.String())
 		}
 
 		// Print the base64 encoded token.
 		fmt.Println(base64.StdEncoding.EncodeToString(tokenJSON))
-	} else {
-		clusterLink.TrustToken = c.flagToken
-		err = client.CreateClusterLink(clusterLink)
-		if err != nil {
-			return err
-		}
+		return nil
+	}
 
-		if !c.global.flagQuiet {
-			fmt.Printf("Cluster link %s created"+"\n", clusterLinkName)
-		}
+	// Bidirectional active: token provided; create active cluster link.
+	clusterLink.TrustToken = c.flagToken
+	err = client.CreateClusterLink(clusterLink)
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf("Cluster link %s created\n", clusterLinkName)
 	}
 
 	return nil

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -61,6 +61,7 @@ var api10 = []APIEndpoint{
 	clusterMemberCmd,
 	clusterMemberStateCmd,
 	clusterMembersCmd,
+	clusterLinksCertificateCmd,
 	clusterLinkCmd,
 	clusterLinksCmd,
 	clusterLinkStateCmd,

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -66,6 +66,13 @@ var clusterLinkStateCmd = APIEndpoint{
 	Get: APIEndpointAction{Handler: clusterLinkStateGet, AccessHandler: allowPermission(entity.TypeClusterLink, auth.EntitlementCanView, "name")},
 }
 
+var clusterLinksCertificateCmd = APIEndpoint{
+	Path:        "cluster/links/certificate",
+	MetricsType: entity.TypeClusterLink,
+
+	Get: APIEndpointAction{Handler: clusterLinkCertificateGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanCreateClusterLinks)},
+}
+
 // swagger:operation GET /1.0/cluster/links cluster-links cluster_links_get
 //
 //		Get the cluster links
@@ -1495,4 +1502,66 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 	wg.Wait()
 
 	return response.SyncResponse(true, clusterLinkState)
+}
+
+// swagger:operation GET /1.0/cluster/links/certificate cluster-links cluster_links_certificate_get
+//
+//	Get the remote cluster certificate
+//
+//	Fetches the TLS certificate from the given remote address for user verification.
+//	This is used as the first step of the unauthenticated unidirectional cluster link creation flow.
+//
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: address
+//	    description: Address of the remote cluster
+//	    type: string
+//	    example: 10.0.0.1:8443
+//	responses:
+//	  "200":
+//	    description: Remote cluster certificate
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ClusterLinkCertificate"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func clusterLinkCertificateGet(d *Daemon, r *http.Request) response.Response {
+	address := r.URL.Query().Get("address")
+	if address == "" {
+		return response.BadRequest(errors.New("Address query parameter is required"))
+	}
+
+	canonicalAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
+	cert, err := shared.GetRemoteCertificate(r.Context(), "https://"+canonicalAddress, version.UserAgent)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed retrieving certificate from %q: %w", address, err))
+	}
+
+	pemCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+	return response.SyncResponse(true, api.ClusterLinkCertificate{
+		Fingerprint: shared.CertFingerprint(cert),
+		Certificate: pemCert,
+	})
 }

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -527,19 +527,21 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading cluster link: %w", err)
 		}
 
-		// Get identity for notification and lifecycle event.
-		identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), clusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed getting identity with ID %d: %w", clusterLink.IdentityID, err)
-		}
+		// Get identity for notification and lifecycle event (bidirectional links only).
+		if clusterLink.IdentityID != nil {
+			identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), *clusterLink.IdentityID)
+			if err != nil {
+				return fmt.Errorf("Failed getting identity with ID %d: %w", *clusterLink.IdentityID, err)
+			}
 
-		identityIdentifier = identity.Identifier
+			identityIdentifier = identity.Identifier
 
-		// Rename identity.
-		identity.Name = req.Name
-		err = query.UpdateByPrimaryKey(ctx, tx.Tx(), *identity)
-		if err != nil {
-			return err
+			// Rename identity.
+			identity.Name = req.Name
+			err = query.UpdateByPrimaryKey(ctx, tx.Tx(), *identity)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Rename cluster link.
@@ -598,7 +600,7 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
 
 	// Update DB entry.
-	var identity *dbCluster.IdentitiesRow
+	var identityIdentifier string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get cluster link.
 		clusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), name)
@@ -606,16 +608,24 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Get identity for notification and lifecycle event.
-		identity, err = dbCluster.GetIdentityByID(ctx, tx.Tx(), clusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed getting identity with ID %d: %w", clusterLink.IdentityID, err)
-		}
+		if clusterLink.IdentityID != nil {
+			// For bidirectional links, deleting the identity cascades to delete the cluster link.
+			identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), *clusterLink.IdentityID)
+			if err != nil {
+				return fmt.Errorf("Failed getting identity with ID %d: %w", *clusterLink.IdentityID, err)
+			}
 
-		// Deleting the identity also deletes the cluster link.
-		err = dbCluster.DeleteIdentityByAuthenticationMethodAndIdentifier(ctx, tx.Tx(), api.AuthenticationMethodTLS, identity.Identifier)
-		if err != nil {
-			return err
+			identityIdentifier = identity.Identifier
+			err = dbCluster.DeleteIdentityByAuthenticationMethodAndIdentifier(ctx, tx.Tx(), api.AuthenticationMethodTLS, identity.Identifier)
+			if err != nil {
+				return err
+			}
+		} else {
+			// For unidirectional links, delete the cluster link directly.
+			err = dbCluster.DeleteClusterLink(ctx, tx.Tx(), name)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -628,10 +638,12 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r.Context())
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkDeleted.Event(name, requestor, nil))
 
-	// Notify other members, update the cache, and send an identity lifecycle event.
-	_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identity.Identifier, true)
-	if err != nil {
-		return response.SmartError(err)
+	// Notify other members, update the cache, and send an identity lifecycle event (bidirectional links only).
+	if identityIdentifier != "" {
+		_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identityIdentifier, true)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.EmptySyncResponse
@@ -779,7 +791,7 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 		}
 
 		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
-			IdentityID:  id,
+			IdentityID:  &id,
 			Name:        req.Name,
 			Description: req.Description,
 			Type:        clusterLinkType,
@@ -859,7 +871,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 
 		// Create cluster link DB entry.
 		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
-			IdentityID:  id,
+			IdentityID:  &id,
 			Name:        req.Name,
 			Description: req.Description,
 			Type:        clusterLinkType,
@@ -1378,23 +1390,39 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 
 		clusterLink = dbClusterLink.ToAPI(config)
 
-		identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), dbClusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link identity: %w", err)
+		var pemCert string
+		if dbClusterLink.IdentityID != nil {
+			// Bidirectional: cert is stored via the identity.
+			identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), *dbClusterLink.IdentityID)
+			if err != nil {
+				return fmt.Errorf("Failed loading cluster link identity: %w", err)
+			}
+
+			certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx.Tx(), &identity.ID)
+			if err != nil {
+				return fmt.Errorf("Failed loading cluster link certificate: %w", err)
+			}
+
+			if len(certs[identity.ID]) == 0 {
+				return fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
+			}
+
+			pemCert = certs[identity.ID][0]
+		} else {
+			// Unidirectional: cert is stored directly in cluster_links_certificates.
+			pemCert, err = dbCluster.GetClusterLinkPEMCertificate(ctx, tx.Tx(), dbClusterLink.ID)
+			if err != nil {
+				return fmt.Errorf("Failed loading cluster link certificate: %w", err)
+			}
+
+			if pemCert == "" {
+				return fmt.Errorf("No certificate found for cluster link %q", dbClusterLink.Name)
+			}
 		}
 
-		certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx.Tx(), &identity.ID)
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link certificate: %w", err)
-		}
-
-		if len(certs[identity.ID]) == 0 {
-			return fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
-		}
-
-		certBlock, _ := pem.Decode([]byte(certs[identity.ID][0]))
+		certBlock, _ := pem.Decode([]byte(pemCert))
 		if certBlock == nil {
-			return fmt.Errorf("Failed decoding certificate for cluster link identity %q", identity.Name)
+			return fmt.Errorf("Failed decoding certificate for cluster link %q", dbClusterLink.Name)
 		}
 
 		targetCert, err = x509.ParseCertificate(certBlock.Bytes)
@@ -1404,7 +1432,13 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed loading cluster link %q: %w", name, err))
 	}
 
-	args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	var args *lxd.ConnectionArgs
+	if clusterLink.Type == api.ClusterLinkTypeUnidirectionalUnauthenticated {
+		args = cluster.GetUnauthenticatedClusterLinkConnectionArgs(targetCert)
+	} else {
+		args = cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	}
+
 	args.SkipGetServer = true
 
 	// Determine cluster link member status by establishing a connection to each member's address.

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1435,10 +1435,7 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 	l := logger.AddContext(logger.Ctx{"clusterLinkName": name})
 
 	var clusterLink *api.ClusterLink
-	clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-	if err != nil {
-		return response.InternalError(err)
-	}
+	clusterCert := s.Endpoints.NetworkCert()
 
 	var targetCert *x509.Certificate
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -712,7 +712,24 @@ func clusterLinksPost(d *Daemon, r *http.Request) response.Response {
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
 	requestor := request.CreateRequestor(r.Context())
 
+	// Unauthenticated unidirectional: name + remote_address, no token or identity-related settings.
+	if req.Name != "" && req.RemoteAddress != "" && clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated) {
+		if req.TrustToken != "" {
+			return response.BadRequest(errors.New("Trust token cannot be set for unauthenticated unidirectional cluster links"))
+		}
+
+		if len(req.AuthGroups) > 0 {
+			return response.BadRequest(errors.New("Auth groups cannot be set for unauthenticated unidirectional cluster links"))
+		}
+
+		return clusterLinkCreateUnidirectionalUnauthenticated(s, r, req, requestor)
+	}
+
 	if req.Name != "" && req.TrustToken == "" {
+		if clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated) {
+			return response.BadRequest(errors.New("Unauthenticated unidirectional cluster links require remote_address and cluster_certificate"))
+		}
+
 		return clusterLinkCreatePending(s, r, req, clusterLinkType, notify, requestor)
 	}
 
@@ -724,6 +741,10 @@ func clusterLinksPost(d *Daemon, r *http.Request) response.Response {
 	trustToken, err := shared.CertificateTokenDecode(req.TrustToken)
 	if err != nil {
 		return response.Forbidden(fmt.Errorf("Invalid trust token: %w", err))
+	}
+
+	if req.Name != "" && clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectional) {
+		return clusterLinkCreateUnidirectionalAuthenticated(s, r, req, requestor, trustToken)
 	}
 
 	if req.Name != "" {
@@ -1045,7 +1066,38 @@ func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPo
 
 		// Get cluster link by name.
 		clusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), identity.Name)
-		if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			// No cluster link row exists yet; this happens when B used
+			// `lxc auth identity create cluster-link/<name>` rather than
+			// `lxc cluster link create <name>`. Create the cluster link now,
+			// linked to the now-active identity.
+			clusterLinkType, typeErr := validateClusterLinkType(req.Type)
+			if typeErr != nil {
+				return fmt.Errorf("Invalid cluster link type %q: %w", req.Type, typeErr)
+			}
+
+			id, createErr := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
+				IdentityID: &identity.ID,
+				Name:       identity.Name,
+				Type:       clusterLinkType,
+			})
+			if createErr != nil {
+				return fmt.Errorf("Failed creating cluster link %q: %w", identity.Name, createErr)
+			}
+
+			persistedConfig := mergeClusterLinkActivationConfig(map[string]string{}, req.Config)
+			if req.Type == api.ClusterLinkTypeUnidirectional {
+				delete(persistedConfig, "volatile.addresses")
+			}
+
+			createErr = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), id, persistedConfig)
+			if createErr != nil {
+				return fmt.Errorf("Failed creating cluster link config for %q: %w", identity.Name, createErr)
+			}
+
+			clusterLinkName = identity.Name
+			return nil
+		} else if err != nil {
 			return fmt.Errorf("Failed loading cluster link: %w", err)
 		}
 
@@ -1063,7 +1115,12 @@ func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPo
 
 		// Activate the pending cluster link by updating only volatile keys from the request.
 		// This preserves any user.* configuration set while the link was pending.
-		err = dbCluster.UpdateClusterLinkConfig(ctx, tx.Tx(), clusterLink.ID, mergeClusterLinkActivationConfig(currentConfig, req.Config))
+		mergedConfig := mergeClusterLinkActivationConfig(currentConfig, req.Config)
+		if req.Type == api.ClusterLinkTypeUnidirectional {
+			delete(mergedConfig, "volatile.addresses")
+		}
+
+		err = dbCluster.UpdateClusterLinkConfig(ctx, tx.Tx(), clusterLink.ID, mergedConfig)
 		if err != nil {
 			return fmt.Errorf("Failed activating cluster link %q: %w", clusterLink.Name, err)
 		}
@@ -1564,4 +1621,198 @@ func clusterLinkCertificateGet(d *Daemon, r *http.Request) response.Response {
 		Fingerprint: shared.CertFingerprint(cert),
 		Certificate: pemCert,
 	})
+}
+
+// clusterLinkCreateUnidirectionalAuthenticated handles creation of an authenticated unidirectional cluster link.
+// A (image client) consumes a token issued by B (image host) to create a one-way link.
+// A pins B's certificate locally and calls back to B to activate B's pending identity for A.
+func clusterLinkCreateUnidirectionalAuthenticated(s *state.State, r *http.Request, req api.ClusterLinksPost, requestor *api.EventLifecycleRequestor, trustToken *api.CertificateAddToken) response.Response {
+	// Check if the caller has permission to create cluster links.
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanCreateClusterLinks)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if len(trustToken.Addresses) == 0 {
+		return response.BadRequest(errors.New("No cluster addresses provided in trust token"))
+	}
+
+	// Retrieve and verify B's certificate.
+	remoteCert, _, err := cluster.CheckClusterLinkCertificate(r.Context(), trustToken.Addresses, trustToken.Fingerprint, version.UserAgent)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed validating cluster certificate: %w", err))
+	}
+
+	remotePEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: remoteCert.Raw}))
+	fingerprint := shared.CertFingerprint(remoteCert)
+
+	networkCert := s.Endpoints.NetworkCert()
+
+	// Determine local listen addresses to send to B for certificate verification during activation.
+	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
+	listenAddresses, err := util.ListenAddresses(localHTTPSAddress)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// Store the cluster link and B's certificate locally. No identity for B; B never connects here.
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
+			IdentityID:  nil,
+			Name:        req.Name,
+			Description: req.Description,
+			Type:        dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectional),
+		})
+		if err != nil {
+			return fmt.Errorf("Failed creating cluster link %q: %w", req.Name, err)
+		}
+
+		if req.Config == nil {
+			req.Config = map[string]string{}
+		}
+
+		err = clusterLinkValidateConfig(req.Config)
+		if err != nil {
+			return err
+		}
+
+		req.Config["volatile.addresses"] = strings.Join(trustToken.Addresses, ",")
+		err = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, req.Config)
+		if err != nil {
+			return err
+		}
+
+		return dbCluster.SetClusterLinkCertificate(ctx, tx.Tx(), clusterLinkID, fingerprint, remotePEM)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() {
+		err := s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+			return dbCluster.DeleteClusterLink(ctx, tx.Tx(), req.Name)
+		})
+		if err != nil {
+			logger.Warn("Failed cleaning up unidirectional cluster link after activation failure", logger.Ctx{"err": err, "clusterLinkName": req.Name})
+		}
+	})
+
+	// Call B to activate B's pending identity for A.
+	// Send volatile.addresses for certificate verification; the activation path on B
+	// will not persist them for unidirectional links.
+	clusterLinkPut := api.ClusterLinkPut{
+		Config: map[string]string{"volatile.addresses": strings.Join(listenAddresses, ",")},
+	}
+
+	activationErrs := make([]error, 0, len(trustToken.Addresses))
+
+	for _, address := range trustToken.Addresses {
+		args := &lxd.ConnectionArgs{
+			TLSServerCert: remotePEM,
+			UserAgent:     version.UserAgent,
+		}
+
+		clusterAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
+		client, err := lxd.ConnectLXD("https://"+clusterAddress, args)
+		if err != nil {
+			activationErrs = append(activationErrs, fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err))
+			continue
+		}
+
+		_, _, err = client.RawQuery(http.MethodPost, "/1.0/cluster/links", api.ClusterLinksPost{TrustToken: trustToken.String(), Type: req.Type, ClusterLinkPut: clusterLinkPut, ClusterCertificate: string(networkCert.PublicKey())}, "")
+		if err != nil {
+			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
+			continue
+		}
+
+		reverter.Success()
+
+		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+
+		err = cluster.RefreshClusterLinkVolatileAddresses(r.Context(), s, req.Name)
+		if err != nil {
+			logger.Warn("Failed refreshing cluster link addresses after link creation", logger.Ctx{"err": err, "clusterLinkName": req.Name})
+		}
+
+		return response.EmptySyncResponse
+	}
+
+	errStrings := make([]string, 0, len(activationErrs))
+	for _, err := range activationErrs {
+		errStrings = append(errStrings, err.Error())
+	}
+
+	return response.SmartError(api.StatusErrorf(http.StatusBadGateway, "Failed activating unidirectional cluster link %q: %s", req.Name, strings.Join(errStrings, "; ")))
+}
+
+// clusterLinkCreateUnidirectionalUnauthenticated handles creation of an unauthenticated unidirectional cluster link.
+// A (image client) downloads and pins B's certificate using only the remote address. No identity is created on either side.
+// The ClusterCertificate field must contain the PEM certificate for B, already confirmed by the caller.
+func clusterLinkCreateUnidirectionalUnauthenticated(s *state.State, r *http.Request, req api.ClusterLinksPost, requestor *api.EventLifecycleRequestor) response.Response {
+	// Check if the caller has permission to create cluster links.
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanCreateClusterLinks)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if req.ClusterCertificate == "" {
+		return response.BadRequest(errors.New("Cluster certificate required"))
+	}
+
+	block, _ := pem.Decode([]byte(req.ClusterCertificate))
+	if block == nil {
+		return response.BadRequest(errors.New("Failed decoding cluster certificate"))
+	}
+
+	remoteCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed parsing cluster certificate: %w", err))
+	}
+
+	fingerprint := shared.CertFingerprint(remoteCert)
+
+	// Verify the remote address presents the expected certificate.
+	_, _, err = cluster.CheckClusterLinkCertificate(r.Context(), []string{req.RemoteAddress}, fingerprint, version.UserAgent)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed validating cluster certificate: %w", err))
+	}
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
+			IdentityID:  nil,
+			Name:        req.Name,
+			Description: req.Description,
+			Type:        dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated),
+		})
+		if err != nil {
+			return fmt.Errorf("Failed creating cluster link %q: %w", req.Name, err)
+		}
+
+		if req.Config == nil {
+			req.Config = map[string]string{}
+		}
+
+		err = clusterLinkValidateConfig(req.Config)
+		if err != nil {
+			return err
+		}
+
+		req.Config["volatile.addresses"] = req.RemoteAddress
+		err = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, req.Config)
+		if err != nil {
+			return err
+		}
+
+		return dbCluster.SetClusterLinkCertificate(ctx, tx.Tx(), clusterLinkID, fingerprint, req.ClusterCertificate)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+
+	return response.EmptySyncResponse
 }

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -114,7 +114,8 @@ func GetClusterLinkConnectionArgs(clusterCert *shared.CertInfo, targetCert *x509
 	}
 }
 
-// LoadClusterLinkAndCert loads a cluster link by name and returns its database ID, API representation, and the parsed TLS certificate associated with its identity.
+// LoadClusterLinkAndCert loads a cluster link by name and returns its database ID, API representation, and the parsed TLS certificate.
+// For bidirectional links the certificate is loaded via the associated identity; for unidirectional links it is loaded from cluster_links_certificates.
 func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id int64, clusterLink *api.ClusterLink, cert *x509.Certificate, err error) {
 	dbLink, err := dbCluster.GetClusterLink(ctx, tx, name)
 	if err != nil {
@@ -128,31 +129,58 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 
 	clusterLink = dbLink.ToAPI(config)
 
-	identity, err := dbCluster.GetIdentityByID(ctx, tx, dbLink.IdentityID)
-	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed loading cluster link identity: %w", err)
+	var pemCert string
+	if dbLink.IdentityID != nil {
+		// Bidirectional: cert is stored via the identity.
+		identity, err := dbCluster.GetIdentityByID(ctx, tx, *dbLink.IdentityID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link identity: %w", err)
+		}
+
+		certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx, &identity.ID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
+		}
+
+		if len(certs[identity.ID]) == 0 {
+			return 0, nil, nil, fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
+		}
+
+		pemCert = certs[identity.ID][0]
+	} else {
+		// Unidirectional: cert is stored directly in cluster_links_certificates.
+		pemCert, err = dbCluster.GetClusterLinkPEMCertificate(ctx, tx, dbLink.ID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
+		}
+
+		if pemCert == "" {
+			return 0, nil, nil, fmt.Errorf("No certificate found for cluster link %q", dbLink.Name)
+		}
 	}
 
-	certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx, &identity.ID)
-	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
-	}
-
-	if len(certs[identity.ID]) == 0 {
-		return 0, nil, nil, fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
-	}
-
-	certBlock, _ := pem.Decode([]byte(certs[identity.ID][0]))
+	certBlock, _ := pem.Decode([]byte(pemCert))
 	if certBlock == nil {
-		return 0, nil, nil, fmt.Errorf("Failed decoding certificate for cluster link identity %q", identity.Name)
+		return 0, nil, nil, fmt.Errorf("Failed decoding certificate for cluster link %q", dbLink.Name)
 	}
 
 	cert, err = x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed extracting certificate from cluster link identity: %w", err)
+		return 0, nil, nil, fmt.Errorf("Failed extracting certificate from cluster link: %w", err)
 	}
 
 	return dbLink.ID, clusterLink, cert, nil
+}
+
+// GetUnauthenticatedClusterLinkConnectionArgs builds connection args for unauthenticated unidirectional cluster links.
+// No client certificate is presented; only the server certificate is pinned.
+func GetUnauthenticatedClusterLinkConnectionArgs(targetCert *x509.Certificate) *lxd.ConnectionArgs {
+	targetCertStr := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: targetCert.Raw}))
+
+	return &lxd.ConnectionArgs{
+		TLSServerCert: targetCertStr,
+		UserAgent:     version.UserAgent,
+	}
 }
 
 // ConnectCluster connects to a linked cluster using the provided connection args, trying each address until one succeeds.
@@ -176,7 +204,7 @@ func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.
 // It connects to the linked cluster and retrieves its current cluster members. If the addresses
 // have changed, [CheckClusterLinkCertificate] is called to ensure the cluster certificate remains valid.
 func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, name string) error {
-	// Fetch the cluster link and identity cert in a single transaction so we have everything needed
+	// Fetch the cluster link and cert in a single transaction so we have everything needed
 	// for connecting and cert validation without any further DB queries.
 	var clusterLink *api.ClusterLink
 	var clusterLinkID int64
@@ -197,12 +225,19 @@ func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, na
 		return nil
 	}
 
-	clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-	if err != nil {
-		return err
+	var args *lxd.ConnectionArgs
+	if clusterLink.Type == api.ClusterLinkTypeUnidirectionalUnauthenticated {
+		args = GetUnauthenticatedClusterLinkConnectionArgs(targetCert)
+	} else {
+		clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
+		if err != nil {
+			return err
+		}
+
+		args = GetClusterLinkConnectionArgs(clusterCert, targetCert)
 	}
 
-	targetClient, err := ConnectCluster(ctx, *clusterLink, GetClusterLinkConnectionArgs(clusterCert, targetCert))
+	targetClient, err := ConnectCluster(ctx, *clusterLink, args)
 	if err != nil {
 		return fmt.Errorf("Failed connecting to target cluster link: %w", err)
 	}

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -229,12 +229,7 @@ func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, na
 	if clusterLink.Type == api.ClusterLinkTypeUnidirectionalUnauthenticated {
 		args = GetUnauthenticatedClusterLinkConnectionArgs(targetCert)
 	} else {
-		clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-		if err != nil {
-			return err
-		}
-
-		args = GetClusterLinkConnectionArgs(clusterCert, targetCert)
+		args = GetClusterLinkConnectionArgs(s.Endpoints.NetworkCert(), targetCert)
 	}
 
 	targetClient, err := ConnectCluster(ctx, *clusterLink, args)

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -28,7 +28,7 @@ const (
 // db:model cluster_links
 type ClusterLinkRow struct {
 	ID          int64           `db:"id"`
-	IdentityID  int64           `db:"identity_id"`
+	IdentityID  *int64          `db:"identity_id"`
 	Name        string          `db:"name"`
 	Description string          `db:"description"`
 	Type        ClusterLinkType `db:"type"`

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -19,7 +19,9 @@ import (
 type ClusterLinkType string
 
 const (
-	clusterLinkTypeBidirectional int64 = 0
+	clusterLinkTypeBidirectional                 int64 = 0
+	clusterLinkTypeUnidirectional                int64 = 1
+	clusterLinkTypeUnidirectionalUnauthenticated int64 = 2
 )
 
 // ClusterLinkRow represents a single row of the cluster_links table.
@@ -42,6 +44,10 @@ func (c *ClusterLinkType) ScanInteger(clusterLinkTypeCode int64) error {
 	switch clusterLinkTypeCode {
 	case clusterLinkTypeBidirectional:
 		*c = api.ClusterLinkTypeBidirectional
+	case clusterLinkTypeUnidirectional:
+		*c = api.ClusterLinkTypeUnidirectional
+	case clusterLinkTypeUnidirectionalUnauthenticated:
+		*c = api.ClusterLinkTypeUnidirectionalUnauthenticated
 	default:
 		return fmt.Errorf("Unknown cluster link type %d", clusterLinkTypeCode)
 	}
@@ -59,6 +65,10 @@ func (c ClusterLinkType) Value() (driver.Value, error) {
 	switch c {
 	case api.ClusterLinkTypeBidirectional:
 		return clusterLinkTypeBidirectional, nil
+	case api.ClusterLinkTypeUnidirectional:
+		return clusterLinkTypeUnidirectional, nil
+	case api.ClusterLinkTypeUnidirectionalUnauthenticated:
+		return clusterLinkTypeUnidirectionalUnauthenticated, nil
 	}
 
 	return nil, fmt.Errorf("Invalid cluster link type %q", c)

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"net/http"
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
@@ -179,6 +180,63 @@ func UpdateClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID int6
 	}
 
 	return CreateClusterLinkConfig(ctx, tx, clusterLinkID, config)
+}
+
+// SetClusterLinkCertificate stores the certificate for a unidirectional cluster link.
+// Any existing certificate for the link is replaced.
+func SetClusterLinkCertificate(ctx context.Context, tx *sql.Tx, clusterLinkID int64, fingerprint string, pemCert string) error {
+	// Check whether this fingerprint is already in use. The certificates table enforces UNIQUE(fingerprint),
+	// so inserting a duplicate would produce an opaque constraint error. Return a clear error instead.
+	_, err := query.SelectOne[CertificatesRow](ctx, tx, "WHERE fingerprint = ?", fingerprint)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return fmt.Errorf("Failed checking for existing certificate with fingerprint %q: %w", fingerprint, err)
+	}
+
+	if err == nil {
+		return fmt.Errorf("A cluster link certificate with fingerprint %q already exists; the remote cluster may already be linked", fingerprint)
+	}
+
+	// Delete any existing certificate for this link. The trigger deletes the corresponding certificates row.
+	_, err = tx.ExecContext(ctx, "DELETE FROM cluster_links_certificates WHERE cluster_link_id = ?", clusterLinkID)
+	if err != nil {
+		return fmt.Errorf("Failed deleting existing cluster link certificate: %w", err)
+	}
+
+	cert := CertificatesRow{
+		Fingerprint: fingerprint,
+		Certificate: pemCert,
+	}
+
+	certificateID, err := query.Create(ctx, tx, cert)
+	if err != nil {
+		return fmt.Errorf("Failed creating certificate: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, "INSERT INTO cluster_links_certificates (cluster_link_id, certificate_id) VALUES (?, ?)", clusterLinkID, certificateID)
+	if err != nil {
+		return fmt.Errorf("Failed associating cluster link with certificate: %w", err)
+	}
+
+	return nil
+}
+
+// GetClusterLinkPEMCertificate returns the PEM-encoded certificate stored for a unidirectional cluster link, or an empty string if none is stored.
+func GetClusterLinkPEMCertificate(ctx context.Context, tx *sql.Tx, clusterLinkID int64) (string, error) {
+	var pemCert string
+	err := query.Scan(ctx, tx,
+		`SELECT certificates.certificate FROM certificates
+		 JOIN cluster_links_certificates ON certificates.id = cluster_links_certificates.certificate_id
+		 WHERE cluster_links_certificates.cluster_link_id = ?`,
+		func(scan func(dest ...any) error) error {
+			return scan(&pemCert)
+		},
+		clusterLinkID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("Failed loading cluster link certificate: %w", err)
+	}
+
+	return pemCert, nil
 }
 
 // GetClusterLinksAndURLs returns all cluster links that pass the given filter, along with their entity URLs.

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -44,7 +44,7 @@ CREATE TABLE "cluster_groups" (
 );
 CREATE TABLE cluster_links (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-	identity_id INTEGER NOT NULL,
+	identity_id INTEGER,
 	description TEXT NOT NULL,
 	name TEXT NOT NULL,
 	type INTEGER NOT NULL DEFAULT 0,
@@ -52,7 +52,22 @@ CREATE TABLE cluster_links (
 	UNIQUE(name),
 	FOREIGN KEY (identity_id) REFERENCES identities (id) ON DELETE CASCADE
 );
-CREATE TABLE cluster_links_config (
+CREATE TABLE cluster_links_certificates (
+	cluster_link_id INTEGER NOT NULL,
+	certificate_id INTEGER NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	FOREIGN KEY (certificate_id) REFERENCES certificates (id) ON DELETE CASCADE,
+	UNIQUE (certificate_id),
+	PRIMARY KEY (cluster_link_id,
+    certificate_id)
+) WITHOUT ROWID;
+CREATE TRIGGER cluster_links_certificates_after_delete
+	AFTER DELETE ON cluster_links_certificates
+	BEGIN
+	DELETE FROM certificates
+		WHERE certificates.id = OLD.certificate_id;
+	END;
+CREATE TABLE "cluster_links_config" (
 	cluster_link_id INTEGER NOT NULL,
 	key TEXT NOT NULL,
 	value TEXT NOT NULL,
@@ -795,5 +810,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (84, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (85, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -128,6 +128,64 @@ var updates = map[int]schema.Update{
 	82: updateFromV81,
 	83: updateFromV82,
 	84: updateFromV83,
+	85: updateFromV84,
+}
+
+func updateFromV84(ctx context.Context, tx *sql.Tx) error {
+	// Recreate cluster_links with nullable identity_id to support unidirectional links.
+	// Add cluster_links_certificates to store the remote cert for unidirectional links.
+	//
+	// Renaming cluster_links to cluster_links_old causes cluster_links_config's
+	// FK to be rewritten to reference "cluster_links_old". We must recreate
+	// cluster_links_config to restore the correct FK reference to cluster_links.
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE cluster_links RENAME TO cluster_links_old;
+
+CREATE TABLE cluster_links (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	identity_id INTEGER,
+	description TEXT NOT NULL,
+	name TEXT NOT NULL,
+	type INTEGER NOT NULL DEFAULT 0,
+	UNIQUE(identity_id),
+	UNIQUE(name),
+	FOREIGN KEY (identity_id) REFERENCES identities (id) ON DELETE CASCADE
+);
+
+INSERT INTO cluster_links SELECT * FROM cluster_links_old;
+
+CREATE TABLE cluster_links_config_new (
+	cluster_link_id INTEGER NOT NULL,
+	key TEXT NOT NULL,
+	value TEXT NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	PRIMARY KEY (cluster_link_id, key)
+) WITHOUT ROWID;
+
+INSERT INTO cluster_links_config_new SELECT * FROM cluster_links_config;
+DROP TABLE cluster_links_config;
+ALTER TABLE cluster_links_config_new RENAME TO cluster_links_config;
+
+DROP TABLE cluster_links_old;
+
+CREATE TABLE cluster_links_certificates (
+	cluster_link_id INTEGER NOT NULL,
+	certificate_id INTEGER NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	FOREIGN KEY (certificate_id) REFERENCES certificates (id) ON DELETE CASCADE,
+	UNIQUE (certificate_id),
+	PRIMARY KEY (cluster_link_id, certificate_id)
+) WITHOUT ROWID;
+
+CREATE TRIGGER cluster_links_certificates_after_delete
+	AFTER DELETE ON cluster_links_certificates
+	BEGIN
+	DELETE FROM certificates
+		WHERE certificates.id = OLD.certificate_id;
+	END;
+`)
+
+	return err
 }
 
 func updateFromV83(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1379,7 +1379,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			// connections always authenticate via a named TLS identity in the DB, so they have a
 			// non-zero ID. A zero ID here means the caller is not a named identity (e.g. a PKI
 			// admin cert), which must not be allowed to write to a standby project.
-			if requestor.CallerIdentityID() == 0 || requestor.CallerIdentityID() != clusterLink.IdentityID {
+			if requestor.CallerIdentityID() == 0 || clusterLink.IdentityID == nil || requestor.CallerIdentityID() != *clusterLink.IdentityID {
 				return api.StatusErrorf(http.StatusForbidden, "Cannot create instances in a standby replica project")
 			}
 		}

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -9,6 +9,16 @@ import (
 const (
 	// ClusterLinkTypeBidirectional indicates that the cluster link can be used by both clusters.
 	ClusterLinkTypeBidirectional = "bidirectional"
+
+	// ClusterLinkTypeUnidirectional indicates that only the local cluster can use the link (authenticated).
+	//
+	// API extension: cluster_links_unidirectional.
+	ClusterLinkTypeUnidirectional = "unidirectional"
+
+	// ClusterLinkTypeUnidirectionalUnauthenticated indicates that only the local cluster can use the link and no client certificate is presented.
+	//
+	// API extension: cluster_links_unidirectional.
+	ClusterLinkTypeUnidirectionalUnauthenticated = "unidirectional-unauthenticated"
 )
 
 // Cluster represents high-level information about a LXD cluster.

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -501,6 +501,25 @@ type ClusterLinksPost struct {
 	// The certificate (X509 PEM encoded) for the linked cluster. This is included in server-side POST requests to activate the pending cluster link on the linked cluster that generated the trust token.
 	// Example: X509 PEM certificate
 	ClusterCertificate string `json:"cluster_certificate" yaml:"cluster_certificate"`
+
+	// RemoteAddress is the address of the remote cluster, used for unauthenticated unidirectional links.
+	// Example: 10.0.0.1:8443
+	RemoteAddress string `json:"remote_address,omitempty" yaml:"remote_address,omitempty"`
+}
+
+// ClusterLinkCertificate represents a remote cluster certificate fetched for user verification.
+//
+// swagger:model
+//
+// API extension: cluster_links_unidirectional.
+type ClusterLinkCertificate struct {
+	// SHA-256 fingerprint of the certificate.
+	// Example: a1b2c3d4...
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+
+	// PEM-encoded X.509 certificate.
+	// Example: -----BEGIN CERTIFICATE-----\n...
+	Certificate string `json:"certificate" yaml:"certificate"`
 }
 
 // ClusterLinkPost represents the fields available for renaming a cluster link.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -488,6 +488,7 @@ var APIExtensions = []string{
 	"image_extended_metadata",
 	"cluster_links",
 	"replicators",
+	"cluster_links_unidirectional",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -53,6 +53,7 @@ readonly test_group_cluster=(
     "clustering_replicator_scheduled"
     "clustering_replicator_dr"
     "clustering_replicator_snapshot"
+    "clustering_link_unidirectional"
 )
 
 readonly test_group_cluster_storage=(

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6143,6 +6143,20 @@ test_clustering_link_unidirectional() {
   # B must not store A's listen addresses for unidirectional links; this preserves the one-way property.
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster link get lxd_one volatile.addresses || echo fail)" = "" ]
 
+  sub_test "Check standalone bidirectional link state reports ACTIVE"
+
+  # In standalone mode there is no cluster.crt; the server uses server.crt.
+  # The state endpoint must use the correct network cert so links show ACTIVE, not UNAUTHENTICATED.
+  BIDIR_TOKEN="$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one_bidir --quiet)"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two_bidir --token "${BIDIR_TOKEN}"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link info lxd_two_bidir | grep -F 'ACTIVE'
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link info lxd_one_bidir | grep -F 'ACTIVE'
+
+  # Clean up the bidirectional link.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two_bidir
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link delete lxd_one_bidir
+
   sub_test "Check authenticated unidirectional link deletion"
 
   # Delete from A; only A's link row is removed; B retains its identity and link row.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6060,3 +6060,163 @@ test_clustering_replicator_snapshot() {
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_ONE_DIR}"
 }
+
+test_clustering_link_unidirectional() {
+  # Create two standalone clustered LXD daemons (single member each) to simulate two separate clusters.
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_ONE_DIR}" false
+
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_TWO_DIR}" false
+
+  LXD_ONE_ADDR="$(LXD_DIR="${LXD_ONE_DIR}" lxc config get core.https_address)"
+  LXD_TWO_ADDR="$(LXD_DIR="${LXD_TWO_DIR}" lxc config get core.https_address)"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster enable node2
+
+  sub_test "Check CLI validation for unidirectional flags"
+
+  # --unidirectional and --unauthenticated are mutually exclusive.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional --unauthenticated 2>&1)" = 'Error: --unidirectional and --unauthenticated cannot be used together' ]
+
+  # --unidirectional without --token must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional 2>&1)" = 'Error: --unidirectional requires --token' ]
+
+  # --unauthenticated without --remote-address must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unauthenticated 2>&1)" = 'Error: --unauthenticated requires --remote-address' ]
+
+  # --remote-address without --unauthenticated must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --remote-address "${LXD_TWO_ADDR}" 2>&1)" = 'Error: --remote-address requires --unauthenticated' ]
+
+  # --auth-group cannot be used with unidirectional or unauthenticated links.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional --token fake --auth-group mygroup 2>&1)" = 'Error: --auth-group cannot be used with unidirectional cluster links' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unauthenticated --remote-address "${LXD_TWO_ADDR}" --auth-group mygroup 2>&1)" = 'Error: --auth-group cannot be used with unidirectional cluster links' ]
+
+  sub_test "Check pending creation rejected for unauthenticated unidirectional type"
+
+  # Directly calling the API with type=unidirectional-unauthenticated and a name but no
+  # remote_address must be rejected; pending creation is not valid for this type.
+  resp="$(LXD_DIR="${LXD_ONE_DIR}" lxc query --request POST /1.0/cluster/links --data '{"name":"bad-link","type":"unidirectional-unauthenticated"}' 2>&1)" || true
+  echo "${resp}" | grep -qF 'Unauthenticated unidirectional cluster links require remote_address and cluster_certificate'
+
+  # Ensure no link was created.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'bad-link'; then
+    echo "ERROR: cluster link 'bad-link' unexpectedly created for pending unauthenticated request" >&2
+    exit 1
+  fi
+
+  sub_test "Check certificate endpoint returns fingerprint and certificate"
+
+  cert_resp="$(LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/cluster/links/certificate?address=${LXD_TWO_ADDR}")"
+  echo "${cert_resp}" | jq --exit-status '.fingerprint != null and .fingerprint != ""' > /dev/null
+  echo "${cert_resp}" | jq --exit-status '.certificate != null and .certificate != ""' > /dev/null
+
+  sub_test "Check authenticated unidirectional link creation"
+
+  # B issues a pending identity token via auth identity create.
+  UNIDIRECTIONAL_TOKEN="$(LXD_DIR="${LXD_TWO_DIR}" lxc auth identity create cluster-link/lxd_one --quiet)"
+
+  # A consumes the token and creates a unidirectional link to B.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --token "${UNIDIRECTIONAL_TOKEN}" --unidirectional
+
+  # A should have the cluster link with no associated identity (unidirectional; A never authenticates to B).
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link show lxd_two | grep -F 'type: unidirectional'
+  if LXD_DIR="${LXD_ONE_DIR}" lxc auth identity list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: identity 'lxd_two' unexpectedly found on A" >&2
+    exit 1
+  fi
+
+  # B should have an active identity for A plus a matching cluster link row.
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -vF '(pending)' | grep -cF 'Cluster link certificate')" = 1 ]
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link list --format csv | grep -F 'lxd_one'
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link show lxd_one | grep -F 'type: unidirectional'
+
+  sub_test "Check authenticated unidirectional link: volatile.addresses populated on A"
+
+  # A stores B's address in volatile.addresses so it can reach B.
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link get lxd_two volatile.addresses)" != "" ]
+
+  sub_test "Check authenticated unidirectional link: volatile.addresses not stored on B"
+
+  # B must not store A's listen addresses for unidirectional links; this preserves the one-way property.
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster link get lxd_one volatile.addresses || echo fail)" = "" ]
+
+  sub_test "Check authenticated unidirectional link deletion"
+
+  # Delete from A; only A's link row is removed; B retains its identity and link row.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: cluster link 'lxd_two' unexpectedly found on A after deletion" >&2
+    exit 1
+  fi
+
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -vF '(pending)' | grep -cF 'Cluster link certificate')" = 1 ]
+
+  # Delete from B; removes B's identity and link row.
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link delete lxd_one
+  if LXD_DIR="${LXD_TWO_DIR}" lxc cluster link list --format csv | grep -F 'lxd_one'; then
+    echo "ERROR: cluster link 'lxd_one' unexpectedly found on B after deletion" >&2
+    exit 1
+  fi
+
+  if LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on B after deletion" >&2
+    exit 1
+  fi
+
+  sub_test "Check unauthenticated unidirectional link: certificate rejection"
+
+  # Responding 'n' to the fingerprint prompt must abort link creation.
+  # Use 2>&1 >/dev/null to capture only stderr (the error message), discarding the interactive prompt on stdout.
+  [ "$(printf 'n\n' | CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --unauthenticated --remote-address "${LXD_TWO_ADDR}" 2>&1 >/dev/null)" = 'Error: Remote cluster certificate NACKed by user' ]
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: cluster link 'lxd_two' unexpectedly found on A after certificate rejection" >&2
+    exit 1
+  fi
+
+  sub_test "Check unauthenticated unidirectional link creation"
+
+  # Responding 'y' to the fingerprint prompt creates the link on A only.
+  printf 'y\n' | LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --unauthenticated --remote-address "${LXD_TWO_ADDR}"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link show lxd_two | grep -F 'type: unidirectional-unauthenticated'
+
+  # B must have no knowledge of this link.
+  if LXD_DIR="${LXD_TWO_DIR}" lxc cluster link list --format csv | grep -F 'lxd_one'; then
+    echo "ERROR: cluster link 'lxd_one' unexpectedly found on B" >&2
+    exit 1
+  fi
+
+  if LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on B" >&2
+    exit 1
+  fi
+
+  # No identity should exist on A either.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on A" >&2
+    exit 1
+  fi
+
+  sub_test "Check unauthenticated unidirectional link: link state reachable"
+
+  # Unauthenticated links present no client certificate, so the remote sees an untrusted connection.
+  # The expected state is UNAUTHENTICATED (reachable but not trusted), not ACTIVE.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link info lxd_two | grep -F 'UNAUTHENTICATED'
+
+  sub_test "Check unauthenticated unidirectional link deletion"
+
+  # Deleting the link on A should succeed without any identity cleanup.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: cluster link 'lxd_two' unexpectedly found on A after deletion" >&2
+    exit 1
+  fi
+
+  # Cleanup.
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+}


### PR DESCRIPTION
Adds unidirectional and unidirectional-unauthenticated cluster links.

unidirectional (authenticated) — cluster A consumes a token issued by B to create a one-way link. A pins B's certificate locally; B gets a cluster-link identity for A so it can authenticate inbound connections from A.

unidirectional-unauthenticated — cluster A fetches B's TLS certificate by address alone (TOFU with interactive fingerprint confirmation), pins it, and stores no identity on either side. B never learns about A.
