### PR TITLE
Locking: Fix deadlock by only taking storage pool and network creation lock for external API requests

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -592,24 +592,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return operations.OperationResponse(op)
 	}
 
-	var netInfo *api.Network
-
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// Load existing network if exists, if not don't fail.
-		_, netInfo, _, err = tx.GetNetworkInAnyState(ctx, projectName, req.Name)
-
-		return err
-	})
-	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
-		return response.InternalError(err)
-	}
-
-	// Check if we're clustered.
-	count, err := cluster.Count(s)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	run := func(ctx context.Context, op *operations.Operation) error {
 		// Don't allow concurrent ongoing network creation requests from external API requests.
 		// This isn't perfect as concurrent requests can come into other cluster members, but we do not yet
@@ -620,6 +602,24 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		defer unlock()
+
+		var netInfo *api.Network
+
+		err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			// Load existing network if exists, if not don't fail.
+			_, netInfo, _, err = tx.GetNetworkInAnyState(ctx, projectName, req.Name)
+
+			return err
+		})
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return err
+		}
+
+		// Check if we're clustered.
+		count, err := cluster.Count(s)
+		if err != nil {
+			return err
+		}
 
 		// No targetNode was specified and we're clustered or there is an existing partially created single node
 		// network, either way finalize the config in the db and actually create the network on all cluster nodes.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -27,6 +26,7 @@ import (
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
+	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/network"
 	"github.com/canonical/lxd/lxd/network/openvswitch"
 	"github.com/canonical/lxd/lxd/operations"
@@ -44,9 +44,6 @@ import (
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/version"
 )
-
-// Lock to prevent concurent networks creation.
-var networkCreateLock sync.Mutex
 
 var networksCmd = APIEndpoint{
 	Path:        "networks",
@@ -455,9 +452,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	networkCreateLock.Lock()
-	defer networkCreateLock.Unlock()
-
 	req := api.NetworksPost{}
 
 	// Parse the request.
@@ -617,6 +611,16 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	run := func(ctx context.Context, op *operations.Operation) error {
+		// Don't allow concurrent ongoing network creation requests from external API requests.
+		// This isn't perfect as concurrent requests can come into other cluster members, but we do not yet
+		// have cluster wide locking semantics.
+		unlock, err := locking.Lock(ctx, "networkCreateLock")
+		if err != nil {
+			return fmt.Errorf("Failed acquiring network create lock: %w", err)
+		}
+
+		defer unlock()
+
 		// No targetNode was specified and we're clustered or there is an existing partially created single node
 		// network, either way finalize the config in the db and actually create the network on all cluster nodes.
 		if count > 1 || (netInfo != nil && netInfo.Status != api.NetworkStatusCreated) {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/mux"
 
@@ -21,6 +20,7 @@ import (
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/lifecycle"
+	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/project/limits"
@@ -35,9 +35,6 @@ import (
 	"github.com/canonical/lxd/shared/validate"
 	"github.com/canonical/lxd/shared/version"
 )
-
-// Lock to prevent concurent storage pools creation.
-var storagePoolCreateLock sync.Mutex
 
 var storagePoolsCmd = APIEndpoint{
 	Path:        "storage-pools",
@@ -288,9 +285,6 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	storagePoolCreateLock.Lock()
-	defer storagePoolCreateLock.Unlock()
-
 	req := api.StoragePoolsPost{}
 
 	// Parse the request.
@@ -432,6 +426,16 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.StoragePoolCreated.Event(req.Name, requestor.EventLifecycleRequestor(), ctx)
 
 	run := func(ctx context.Context, op *operations.Operation) error {
+		// Don't allow concurrent ongoing storage pool creation requests from external API requests.
+		// This isn't perfect as concurrent requests can come into other cluster members, but we do not yet
+		// have cluster wide locking semantics.
+		unlock, err := locking.Lock(ctx, "storagePoolCreateLock")
+		if err != nil {
+			return fmt.Errorf("Failed acquiring storage pool create lock: %w", err)
+		}
+
+		defer unlock()
+
 		// No targetNode was specified and we're clustered or there is an existing partially created single node
 		// pool, either way finalize the config in the db and actually create the pool on all nodes in the cluster.
 		if count > 1 || (pool != nil && pool.Status != api.StoragePoolStatusCreated) {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -316,12 +316,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		req.Config = map[string]string{}
 	}
 
-	ctx := logger.Ctx{}
-
 	targetNode := request.QueryParam(r, "target")
-	if targetNode != "" {
-		ctx["target"] = targetNode
-	}
 
 	requestor, err := request.GetRequestor(r.Context())
 	if err != nil {
@@ -403,28 +398,6 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		return operations.OperationResponse(op)
 	}
 
-	var pool *api.StoragePool
-
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
-
-		// Load existing pool if exists, if not don't fail.
-		_, pool, _, err = tx.GetStoragePoolInAnyState(ctx, req.Name)
-
-		return err
-	})
-	if err != nil && !response.IsNotFoundError(err) {
-		return response.InternalError(err)
-	}
-
-	// Check if we're clustered.
-	count, err := cluster.Count(s)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	lc := lifecycle.StoragePoolCreated.Event(req.Name, requestor.EventLifecycleRequestor(), ctx)
-
 	run := func(ctx context.Context, op *operations.Operation) error {
 		// Don't allow concurrent ongoing storage pool creation requests from external API requests.
 		// This isn't perfect as concurrent requests can come into other cluster members, but we do not yet
@@ -435,6 +408,26 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		defer unlock()
+
+		var pool *api.StoragePool
+
+		err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			// Load existing pool if exists, if not don't fail.
+			_, pool, _, err = tx.GetStoragePoolInAnyState(ctx, req.Name)
+
+			return err
+		})
+		if err != nil && !response.IsNotFoundError(err) {
+			return err
+		}
+
+		// Check if we're clustered.
+		count, err := cluster.Count(s)
+		if err != nil {
+			return err
+		}
 
 		// No targetNode was specified and we're clustered or there is an existing partially created single node
 		// pool, either way finalize the config in the db and actually create the pool on all nodes in the cluster.
@@ -451,6 +444,12 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
+		loggingCtx := logger.Ctx{}
+		if targetNode != "" {
+			loggingCtx["target"] = targetNode
+		}
+
+		lc := lifecycle.StoragePoolCreated.Event(req.Name, requestor.EventLifecycleRequestor(), loggingCtx)
 		s.Events.SendLifecycle("", lc)
 
 		return nil

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1261,6 +1261,32 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
   LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net1}"
 
+  echo "Test concurrent creation of different bridge networks."
+  net1="${net}"
+  net2="${net}2"
+
+  # Define both networks on both members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" --target node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --target node2
+
+  # Finalize both networks at the same time but routing request to different cluster members.
+  # Tests that locking logic doesn't deadlock for operatio notification requests.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" ipv4.address=none ipv6.address=none &
+  pid1=$!
+  LXD_DIR="${LXD_TWO_DIR}" lxc network create "${net2}" ipv4.address=none ipv6.address=none &
+  pid2=$!
+  wait "${pid1}"
+  wait "${pid2}"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net1}" | grep -xF 'status: Created'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Created'
+
+  # Clean up concurrently created networks.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net1}"
+
   echo "Delete dummy interfaces."
   nsenter -n -t "${LXD_PID1}" -- ip link delete i2
   nsenter -n -t "${LXD_PID1}" -- ip link delete i1


### PR DESCRIPTION
And don't take the lock for cluster operation notification requests.

Fixes https://github.com/canonical/lxd/issues/18023