### PR TITLE
lxd/daemon: Do not prune leftover images when running in Mock mode

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1847,12 +1847,12 @@ func (d *Daemon) init() error {
 		return err
 	}
 
-	// Cleanup leftover images.
-	pruneLeftoverImages(d.State())
-
 	var instances []instance.Instance
 
 	if !d.os.MockMode {
+		// Cleanup leftover images.
+		pruneLeftoverImages(d.State())
+
 		// Start the scheduler
 		go deviceEventListener(d.State)
 


### PR DESCRIPTION
This is needed to avoid the image prunning triggered by the `TestIntegration_UnixSocket()` test when running on the same host where LXD is installed.

The `TestIntegration_UnixSocket()` test is using an empty mock database for LXD daemon, so when `pruneLeftoverImages()` is running, it finds image files stored on the host without database records and removes them. This effectively leaves the host installed LXD's images in a broken state.