### PR TITLE
Add helper for compressing JSON responses

### DIFF
--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -204,6 +204,11 @@ func SyncResponse(success bool, metadata any) Response {
 	return &syncResponse{success: success, metadata: metadata}
 }
 
+// SyncResponseCompressed returns a new syncResponse with gzip compressed JSON output.
+func SyncResponseCompressed(success bool, metadata any) Response {
+	return &syncResponse{success: success, metadata: metadata, compress: true}
+}
+
 // SyncResponseETag returns a new syncResponse with an etag.
 func SyncResponseETag(success bool, metadata any, etag any) Response {
 	return &syncResponse{success: success, metadata: metadata, etag: etag}
@@ -329,6 +334,14 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	var debugLogger logger.Logger
 	if debug {
 		debugLogger = logger.AddContext(logger.Ctx{"http_code": code})
+	}
+
+	// Handle JSON compression to gzip if needed.
+	if r.compress {
+		comp := gzip.NewWriter(w)
+		defer comp.Close()
+
+		return util.WriteJSON(comp, resp, debugLogger)
 	}
 
 	return util.WriteJSON(w, resp, debugLogger)

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -261,6 +261,19 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		}
 	}
 
+	// Prepare the JSON response
+	status := api.Success
+	if !r.success {
+		status = api.Failure
+
+		// If the metadata is an error, consider the response a SmartError
+		// to propagate the data and preserve the status code.
+		err, ok := r.metadata.(error)
+		if ok {
+			return SmartError(err).Render(w, req)
+		}
+	}
+
 	// Handle plain text headers.
 	if r.plaintext {
 		w.Header().Set("Content-Type", "text/plain")
@@ -282,19 +295,6 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 
 	if w.Header().Get("Connection") != "keep-alive" {
 		w.WriteHeader(code)
-	}
-
-	// Prepare the JSON response
-	status := api.Success
-	if !r.success {
-		status = api.Failure
-
-		// If the metadata is an error, consider the response a SmartError
-		// to propagate the data and preserve the status code.
-		err, ok := r.metadata.(error)
-		if ok {
-			return SmartError(err).Render(w, req)
-		}
 	}
 
 	// defer calling the callback function after possibly considering the response a SmartError.

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -263,6 +263,9 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Handle plain text headers.
 	if r.plaintext {
 		w.Header().Set("Content-Type", "text/plain")
+	} else if w.Header().Get("Content-Type") == "" {
+		// If Content-Type is not set, default to "application/json".
+		w.Header().Set("Content-Type", "application/json")
 	}
 
 	// Handle compression.

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -311,11 +311,11 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		if r.metadata != nil {
 			if r.compress {
 				comp := gzip.NewWriter(w)
-				defer comp.Close()
+				_, writeErr := comp.Write([]byte(r.metadata.(string)))
+				closeErr := comp.Close()
 
-				_, err := comp.Write([]byte(r.metadata.(string)))
-				if err != nil {
-					return err
+				if writeErr != nil || closeErr != nil {
+					return errors.Join(writeErr, closeErr)
 				}
 			} else {
 				_, err := w.Write([]byte(r.metadata.(string)))
@@ -344,9 +344,14 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Handle JSON compression to gzip if needed.
 	if r.compress {
 		comp := gzip.NewWriter(w)
-		defer comp.Close()
+		writeErr := util.WriteJSON(comp, resp, debugLogger)
+		closeErr := comp.Close()
 
-		return util.WriteJSON(comp, resp, debugLogger)
+		if writeErr != nil || closeErr != nil {
+			return errors.Join(writeErr, closeErr)
+		}
+
+		return nil
 	}
 
 	return util.WriteJSON(w, resp, debugLogger)

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -272,6 +272,7 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Handle compression.
 	if r.compress {
 		w.Header().Set("Content-Encoding", "gzip")
+		addVaryHeader(w.Header(), "Accept-Encoding")
 	}
 
 	// Write header and status code.

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/canonical/lxd/client"
@@ -703,4 +704,20 @@ func (r *manualResponse) Render(w http.ResponseWriter, req *http.Request) error 
 
 func (r *manualResponse) String() string {
 	return "unknown"
+}
+
+// addVaryHeader adds a value to the Vary header if it is not already present.
+// It matches existing Vary entries case-insensitively, including comma-separated values.
+func addVaryHeader(header http.Header, value string) {
+	for _, vary := range header.Values("Vary") {
+		values := strings.Split(vary, ",")
+
+		for _, varyValue := range values {
+			if strings.EqualFold(strings.TrimSpace(varyValue), value) {
+				return
+			}
+		}
+	}
+
+	header.Add("Vary", value)
 }

--- a/lxd/response/response_test.go
+++ b/lxd/response/response_test.go
@@ -1,0 +1,55 @@
+package response
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+func TestSyncResponseCompressed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/1.0/test", nil)
+	rec := httptest.NewRecorder()
+
+	resp := SyncResponseCompressed(true, map[string]string{"key": "value"})
+	require.NoError(t, resp.Render(rec, req))
+
+	result := rec.Result()
+
+	defer func() { _ = result.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	assert.Equal(t, "gzip", result.Header.Get("Content-Encoding"))
+	assert.Contains(t, strings.ToLower(result.Header.Get("Vary")), "accept-encoding")
+	assert.Contains(t, result.Header.Get("Content-Type"), "application/json")
+
+	reader, err := gzip.NewReader(result.Body)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	require.NoError(t, reader.Close())
+
+	var parsed api.ResponseRaw
+	require.NoError(t, json.Unmarshal(body, &parsed))
+
+	assert.Equal(t, api.SyncResponse, parsed.Type)
+	assert.Equal(t, api.Success.String(), parsed.Status)
+	assert.Equal(t, int(api.Success), parsed.StatusCode)
+
+	metadata, ok := parsed.Metadata.(map[string]any)
+	require.Truef(t, ok, "Expected metadata as map, got %T", parsed.Metadata)
+
+	value, ok := metadata["key"].(string)
+	require.Truef(t, ok, "Expected metadata key %q to be a string, got %T", "key", metadata["key"])
+	assert.Equal(t, "value", value)
+}

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -43,9 +43,9 @@ func DebugJSON(title string, r *bytes.Buffer, l logger.Logger) {
 	l.Debug(fmt.Sprintf("%s\n\t%s", title, str[0:len(str)-1]))
 }
 
-// WriteJSON encodes the body as JSON and sends it back to the client
+// WriteJSON encodes the body as JSON and writes it to [io.Writer].
 // Accepts optional debugLogger that activates debug logging if non-nil.
-func WriteJSON(w http.ResponseWriter, body any, debugLogger logger.Logger) error {
+func WriteJSON(w io.Writer, body any, debugLogger logger.Logger) error {
 	var output io.Writer
 	var captured *bytes.Buffer
 


### PR DESCRIPTION
This PR adds the `SyncResponseCompressed()` helper for compressing JSON response to `gzip`. It also expands the `syncResponse.Render()` to correctly handle compressed responses.

The main reason for this addition is that currently only the `SyncResponsePlain()` function supports compression, but it operates on the content type `text/plain`.

This is needed for the image registries feature https://github.com/canonical/lxd/pull/17680 to provide `gzip` compression for the `GET /1.0/image-registries/<registry>/images` endpoint. With this addition, clients would be able to set the `Accept-Encoding` header with value `gzip` in the request and receive the compressed JSON output. This is the same approach that is currently used in the `metricsGet()` handler. However, `metricsGet()` returns the `text/plain` response and uses the `SyncResponsePlain()`.

Here is an example of how `SyncResponseCompressed()` can be used inside an HTTP handler:

```go
// Determine if the response compression is requested.
compress := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")

if compress {
	return response.SyncResponseCompressed(true, images)
}

return response.SyncResponse(true, images)
```

I've tested this locally and the compression is working correctly for the `GET /1.0/image-registries/<registry>/images` endpoint. I'll also add a test for it in the image registries PR to compare compressed vs non-compressed responses.