### PR TITLE
`ioprogess` follow up

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -1051,7 +1051,7 @@ func validateMetadata(metadata map[string]any) (map[string]any, error) {
 	return metadata, nil
 }
 
-// ProgressHandler implements [ioprogress.ProgressHandlerFactory]. This is used by instance and storage drivers to
+// ProgressHandler implements [ioprogress.ProgressReporter]. This is used by instance and storage drivers to
 // report I/O progress as they perform different actions (migration, download, image unpack, etc.).
 func (op *Operation) ProgressHandler(action string) ioprogress.ProgressHandler {
 	return func(data ioprogress.ProgressData) {

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -306,7 +306,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.
 // Recv sets up the receiving half of the websocket to rsync (the other
 // half set up by rsync.Send), putting the contents in the directory specified
 // by path.
-func Recv(path string, conn io.ReadWriteCloser, readWrapper func(closer io.ReadCloser) io.ReadCloser, features []string) error {
+func Recv(path string, conn io.ReadWriteCloser, readWrapper ioprogress.ReaderWrapper, features []string) error {
 	args := []string{
 		"--server",
 		"-vlogDtpre.iLsfx",

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -1,6 +1,7 @@
 package ioprogress
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -143,7 +144,7 @@ func (pt *ProgressTracker) update(n int) {
 		}
 
 		pt.percentage = percentage
-		percentComplete = min(int64(pt.percentage)+1, 100)
+		percentComplete = int64(math.Round(percentage))
 	} else {
 		// If running in absolute mode, check that at least a second elapsed
 		interval := time.Since(*pt.last).Seconds()

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -134,39 +134,37 @@ func (pt *ProgressTracker) update(n int) {
 	}
 
 	// Update interval handling (this is to prevent the tracker hook from being called too frequently).
-	var percentage float64
+	var percentComplete int64
 	if pt.Length > 0 {
 		// If running in relative mode, check that we increased by at least 1%
-		percentage = float64(pt.total) / float64(pt.Length) * float64(100)
+		percentage := float64(pt.total) / float64(pt.Length) * float64(100)
 		if percentage-pt.percentage < 0.9 {
 			return
 		}
+
+		pt.percentage = percentage
+		percentComplete = min(int64(pt.percentage)+1, 100)
 	} else {
 		// If running in absolute mode, check that at least a second elapsed
 		interval := time.Since(*pt.last).Seconds()
 		if interval < 1 {
 			return
 		}
-	}
 
-	// Determine speed
-	speedInt := int64(0)
-	duration := time.Since(*pt.start).Seconds()
-	if duration > 0 {
-		speed := float64(pt.total) / duration
-		speedInt = int64(speed)
-	}
-
-	// Determine progress
-	if pt.Length > 0 {
-		pt.percentage = percentage
-	} else {
 		// Update timestamp
 		cur := time.Now()
 		pt.last = &cur
 	}
 
-	pt.Handler(min(int64(pt.percentage)+1, 100), pt.total, speedInt)
+	// Determine speed
+	var bytesPerSecond int64
+	duration := time.Since(*pt.start).Seconds()
+	if duration > 0 {
+		speed := float64(pt.total) / duration
+		bytesPerSecond = int64(speed)
+	}
+
+	pt.Handler(percentComplete, pt.total, bytesPerSecond)
 }
 
 func (pt *ProgressTracker) buildProgressData(description string, percentage int64, bytesTransferred int64, bytesPerSecond int64) ProgressData {


### PR DESCRIPTION
This PR fixes an issue with the reworked tracker update function whereby the percentage passed to the update handler was always non-zero, causing reporting errors when the `Length` was not set (because the string representation prioritises percentage over total bytes transferred when non-zero).

It also addresses two comments from #18109 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
