### PR TITLE
Network: Set veth/vtap host interface MTU to the larger of parent bridge or instance MTU

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -207,6 +207,45 @@ func networkRestorePhysicalNIC(hostName string, volatile map[string]string) erro
 	return nil
 }
 
+// networkCalculatePairMTU calculates the MTU to use on both ends of the VETH/TAP pair.
+// This returns the hostMTU set to the larger of m's mtu (if specified) or m's "parent" (if specified) MTU.
+// The hostMTU will never be smaller than m's "parent" (if specified) MTU to avoid lowering the parent bridge.
+func networkCalculatePairMTU(m deviceConfig.Device) (hostMTU uint32, instanceMTU uint32, err error) {
+	if m["parent"] != "" {
+		mtu, err := network.GetDevMTU(m["parent"])
+		if err != nil {
+			return 0, 0, fmt.Errorf("Failed getting the parent MTU from %q: %w", m["parent"], err)
+		}
+
+		hostMTU = uint32(mtu)
+	}
+
+	if m["mtu"] != "" {
+		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
+		if err != nil {
+			return 0, 0, fmt.Errorf("Invalid MTU specified %q: %w", m["mtu"], err)
+		}
+
+		instanceMTU = uint32(mtu)
+	}
+
+	// If instance MTU is not specified, but host MTU is, then use the host MTU for the instance side to avoid
+	// accidentally lowering the MTU of the parent bridge.
+	if instanceMTU == 0 && hostMTU > 0 {
+		instanceMTU = hostMTU
+	}
+
+	// If host MTU is less than instance MTU then the parent bridge is likely to drop packets from the instance,
+	// so use the instance MTU for the host side to avoid this. This should increase the parent bridge MTU
+	// if needed (for the duration that the instance is connected to the bridge) and if the bridge has not got
+	// an MTU explicitly set.
+	if hostMTU < instanceMTU {
+		hostMTU = instanceMTU
+	}
+
+	return hostMTU, instanceMTU, nil
+}
+
 // networkCreateVethPair creates and configures a veth pair. It will set the hwaddr and mtu settings
 // in the supplied config to the newly created peer interface. If mtu is not specified, but parent
 // is supplied in config, then the MTU of the new peer interface will inherit the parent MTU.

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -263,44 +263,9 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint
 		},
 	}
 
-	// Set the MTU on both ends.
-	// The host side should always line up with the bridge to avoid accidentally lowering the bridge MTU.
-	// The instance side should use the configured MTU (if any), if not, it should match the host side.
-	var instanceMTU uint32
-	var parentMTU uint32
-
-	if m["parent"] != "" {
-		mtu, err := network.GetDevMTU(m["parent"])
-		if err != nil {
-			return "", 0, fmt.Errorf("Failed getting the parent MTU: %w", err)
-		}
-
-		parentMTU = uint32(mtu)
-	}
-
-	if m["mtu"] != "" {
-		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
-		if err != nil {
-			return "", 0, fmt.Errorf("Invalid MTU specified: %w", err)
-		}
-
-		instanceMTU = uint32(mtu)
-	}
-
-	if instanceMTU == 0 && parentMTU > 0 {
-		instanceMTU = parentMTU
-	}
-
-	if parentMTU == 0 && instanceMTU > 0 {
-		parentMTU = instanceMTU
-	}
-
-	if instanceMTU > 0 {
-		veth.Peer.MTU = instanceMTU
-	}
-
-	if parentMTU > 0 {
-		veth.MTU = parentMTU
+	veth.MTU, veth.Peer.MTU, err = networkCalculatePairMTU(m)
+	if err != nil {
+		return "", 0, err
 	}
 
 	// Set the MAC address on peer.

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -308,13 +308,18 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint
 // networkCreateTap creates and configures a TAP device.
 // Returns the MTU used.
 func networkCreateTap(hostName string, m deviceConfig.Device) (uint32, error) {
+	hostMTU, instanceMTU, err := networkCalculatePairMTU(m)
+	if err != nil {
+		return 0, err
+	}
+
 	tuntap := &ip.Tuntap{
 		Name:       hostName,
 		Mode:       "tap",
 		MultiQueue: true,
 	}
 
-	err := tuntap.Add()
+	err = tuntap.Add()
 	if err != nil {
 		return 0, fmt.Errorf("Failed creating the tap interfaces %q: %w", hostName, err)
 	}
@@ -330,32 +335,10 @@ func networkCreateTap(hostName string, m deviceConfig.Device) (uint32, error) {
 
 	revert.Add(func() { _ = network.InterfaceRemove(hostName) })
 
-	// Set the MTU on both ends.
-	// The host side should always line up with the bridge to avoid accidentally lowering the bridge MTU.
-	// The instance side should use the configured MTU (if any), if not, it should match the host side.
-	var mtu uint32
-	if m["mtu"] != "" {
-		nicMTU, err := strconv.ParseUint(m["mtu"], 10, 32)
+	if hostMTU > 0 {
+		err = NetworkSetDevMTU(hostName, hostMTU)
 		if err != nil {
-			return 0, fmt.Errorf("Invalid MTU specified: %w", err)
-		}
-
-		mtu = uint32(nicMTU)
-	}
-
-	if m["parent"] != "" {
-		parentMTU, err := network.GetDevMTU(m["parent"])
-		if err != nil {
-			return 0, fmt.Errorf("Failed getting the parent MTU: %w", err)
-		}
-
-		err = NetworkSetDevMTU(hostName, parentMTU)
-		if err != nil {
-			return 0, fmt.Errorf("Failed setting the MTU %d: %w", mtu, err)
-		}
-
-		if mtu == 0 {
-			mtu = parentMTU
+			return 0, fmt.Errorf("Failed setting the MTU %d: %w", hostMTU, err)
 		}
 	}
 
@@ -383,7 +366,7 @@ func networkCreateTap(hostName string, m deviceConfig.Device) (uint32, error) {
 	}
 
 	revert.Success()
-	return mtu, nil
+	return instanceMTU, nil
 }
 
 // networkVethFillFromVolatile fills veth host_name and hwaddr fields from volatile if not set in device config.

--- a/lxd/device/device_utils_network_test.go
+++ b/lxd/device/device_utils_network_test.go
@@ -1,0 +1,123 @@
+package device
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
+	"github.com/canonical/lxd/lxd/ip"
+	"github.com/canonical/lxd/lxd/network"
+)
+
+func TestNetworkCalculatePairMTUWithoutParent(t *testing.T) {
+	tests := []struct {
+		name            string
+		deviceConfig    deviceConfig.Device
+		expectedHostMTU uint32
+		expectedInstMTU uint32
+		expectedErr     string
+	}{
+		{
+			name:            "No parent and no MTU",
+			deviceConfig:    deviceConfig.Device{},
+			expectedHostMTU: 0,
+			expectedInstMTU: 0,
+		},
+		{
+			name: "MTU set without parent",
+			deviceConfig: deviceConfig.Device{
+				"mtu": "1400",
+			},
+			expectedHostMTU: 1400,
+			expectedInstMTU: 1400,
+		},
+		{
+			name: "Invalid MTU",
+			deviceConfig: deviceConfig.Device{
+				"mtu": "not-an-int",
+			},
+			expectedErr: "Invalid MTU specified \"not-an-int\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostMTU, instanceMTU, err := networkCalculatePairMTU(tt.deviceConfig)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedHostMTU, hostMTU)
+			assert.Equal(t, tt.expectedInstMTU, instanceMTU)
+		})
+	}
+}
+
+func TestNetworkCalculatePairMTUWithParent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root privileges to create network interfaces")
+	}
+
+	parentName := network.RandomDevName("dmy")
+	require.NotEmpty(t, parentName)
+
+	dummy := ip.Dummy{Link: ip.Link{Name: parentName}}
+	err := dummy.Add()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = network.InterfaceRemove(parentName)
+	})
+
+	err = (&ip.Link{Name: parentName}).SetMTU(1300)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		deviceConfig    deviceConfig.Device
+		expectedHostMTU uint32
+		expectedInstMTU uint32
+	}{
+		{
+			name: "Inherit parent MTU when mtu not set",
+			deviceConfig: deviceConfig.Device{
+				"parent": parentName,
+			},
+			expectedHostMTU: 1300,
+			expectedInstMTU: 1300,
+		},
+		{
+			name: "Keep larger parent MTU when mtu is lower",
+			deviceConfig: deviceConfig.Device{
+				"parent": parentName,
+				"mtu":    "1200",
+			},
+			expectedHostMTU: 1300,
+			expectedInstMTU: 1200,
+		},
+		{
+			name: "Raise host MTU when mtu is higher",
+			deviceConfig: deviceConfig.Device{
+				"parent": parentName,
+				"mtu":    "1400",
+			},
+			expectedHostMTU: 1400,
+			expectedInstMTU: 1400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostMTU, instanceMTU, err := networkCalculatePairMTU(tt.deviceConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedHostMTU, hostMTU)
+			assert.Equal(t, tt.expectedInstMTU, instanceMTU)
+		})
+	}
+}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -564,6 +564,10 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 			reverter.Add(cleanup)
 		default:
+			// Specify the OVN integration bridge as parent so that the veth/tap pair setup can take
+			// its MTU into account to avoid lowering it.
+			d.config["parent"] = d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+
 			// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 			if d.inst.Type() == instancetype.Container {
 				if saveData["host_name"] == "" {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1280,7 +1280,7 @@ func (d *lxc) IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 	if bindMount {
 		err := unix.Statfs(path, buf)
 		if err != nil {
-			d.logger.Warn("Failed statfsing", logger.Ctx{"path": path, "err": err})
+			d.logger.Warn("Could not statfs", logger.Ctx{"path": path, "err": err})
 			return mode
 		}
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4729,6 +4729,17 @@ func (d *qemu) addNetDevConfig(busName string, busAllocate busAllocator, bootInd
 			qemuDev["netdev"] = qemuNetDevID
 			qemuDev["mac"] = devHwaddr
 
+			if mtu != "" {
+				mtuUint, err := strconv.ParseUint(mtu, 10, 32)
+				if err != nil {
+					return fmt.Errorf("Failed parsing MTU %q: %w", mtu, err)
+				}
+
+				if mtuUint > 0 {
+					qemuDev["host_mtu"] = mtuUint
+				}
+			}
+
 			err = m.AddNIC(qemuNetDev, qemuDev)
 			if err != nil {
 				return fmt.Errorf("Failed setting up device %q: %w", devName, err)

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -460,17 +460,17 @@ func IsNetworkVLAN(value string) error {
 	return nil
 }
 
-// IsNetworkMTU validates MTU number >= 1280 and <= 16384.
+// IsNetworkMTU validates MTU number >= 68 and <= 16384.
 // Anything below 68 and the kernel doesn't allow IPv4, anything below 1280 and the kernel doesn't allow IPv6.
-// So require an IPv6-compatible MTU as the low value and cap at the max ethernet jumbo frame size.
+// So require an IPv4-compatible MTU as the low value and cap at the max ethernet jumbo frame size.
 func IsNetworkMTU(value string) error {
 	mtu, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
 		return fmt.Errorf("Invalid MTU %q", value)
 	}
 
-	if mtu < 1280 || mtu > 16384 {
-		return fmt.Errorf("Out of MTU range (1280-16384) %q", value)
+	if mtu < 68 || mtu > 16384 {
+		return fmt.Errorf("Out of MTU range (68-16384) %q", value)
 	}
 
 	return nil

--- a/shared/validate/validate_test.go
+++ b/shared/validate/validate_test.go
@@ -964,3 +964,33 @@ func TestIsHTTPSURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNetworkMTU(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"minimum valid MTU", "68", false},
+		{"maximum valid MTU", "16384", false},
+		{"typical Ethernet MTU", "1500", false},
+		{"jumbo frame MTU", "9000", false},
+		{"minimum IPv6 MTU", "1280", false},
+		{"below minimum", "67", true},
+		{"zero", "0", true},
+		{"above maximum", "16385", true},
+		{"negative number", "-1", true},
+		{"non-numeric", "abc", true},
+		{"empty string", "", true},
+		{"float value", "1500.5", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate.IsNetworkMTU(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsNetworkMTU(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -129,13 +129,12 @@ test_container_devices_nic_macvlan() {
 
   echo "==> Check that setting MTU config value out of range (1280-16384) is not allowed."
   ! lxc network set "${ctName}net" mtu=0 || false
-  ! lxc network set "${ctName}net" mtu=1000 || false
-  ! lxc network set "${ctName}net" mtu=1279 || false
+  ! lxc network set "${ctName}net" mtu=67 || false
   ! lxc network set "${ctName}net" mtu=16385 || false
   ! lxc network set "${ctName}net" mtu=50000 || false
 
-  echo "==> Check that setting MTU config value to the boundaries of range (1280-16384) is allowed."
-  lxc network set "${ctName}net" mtu=1280
+  echo "==> Check that setting MTU config value to the boundaries of range (68-16384) is allowed."
+  lxc network set "${ctName}net" mtu=68
   lxc network set "${ctName}net" mtu=16384
 
   echo "==> Unset MTU config value for macvlan network."

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -6,6 +6,10 @@ test_network_ovn() {
 
   ensure_import_testimage
 
+  if [ "${LXD_VM_TESTS}" != "0" ]; then
+    ensure_import_ubuntu_vm_image
+  fi
+
   # Create an associative array holding table names and the expected number of rows for that table.
   declare -A tables
 
@@ -76,8 +80,15 @@ test_network_ovn() {
   echo "Set IP routes that include OVN ranges."
   lxc network set "${uplink_network}" ipv4.routes=192.0.2.0/24 ipv6.routes=2001:db8:1:2::/64
 
+  # Check invalid bridge.mtu values
+  [ "$(! "${_LXC}" network create "${ovn_network}" --type ovn network="${uplink_network}" bridge.mtu=67 2>&1 1>/dev/null)" = 'Error: Invalid value for network "'"${ovn_network}"'" option "bridge.mtu": Out of MTU range (68-16384) "67"' ]
+  [ "$(! "${_LXC}" network create "${ovn_network}" --type ovn network="${uplink_network}" bridge.mtu=16385 2>&1 1>/dev/null)" = 'Error: Invalid value for network "'"${ovn_network}"'" option "bridge.mtu": Out of MTU range (68-16384) "16385"' ]
+
   echo "Create an OVN network."
   lxc network create "${ovn_network}" --type ovn network="${uplink_network}"
+  lxc network create "${ovn_network}_jumbo" --type ovn network="${uplink_network}" bridge.mtu=8942
+  [ "$(lxc network get "${ovn_network}" bridge.mtu || echo fail)" = "1442" ] # check auto mtu calculation works.
+  [ "$(lxc network get "${ovn_network}_jumbo" bridge.mtu || echo fail)" = "8942" ]
 
   echo "Check that no forward can be created with a listen address that is not in the uplink's routes."
   ! lxc network forward create "${ovn_network}" 192.0.3.1 || false
@@ -131,8 +142,36 @@ test_network_ovn() {
   echo "Check that instance NIC passthrough with ipv6.routes.external allows using IPs outside of OVN ranges but on the same network."
   lxc launch testimage c2 -n "${ovn_network}" -d eth0,ipv6.routes.external=2001:db8:1:2::10/128
 
+  echo "Check that c1 eth0 MTU is set to bridge.mtu value in container matches br-int on host side to avoid lowering."
+  c1Eth0Hostname="$(lxc config get c1 volatile.eth0.host_name)"
+  [ "$(< "/sys/class/net/${c1Eth0Hostname}/mtu")" = "1500" ]
+  [ "$(lxc exec c1 -- cat /sys/class/net/eth0/mtu)" = "1442" ]
+
+  lxc launch testimage c3 -n "${ovn_network}_jumbo"
+  c3Eth0Hostname="$(lxc config get c3 volatile.eth0.host_name)"
+  [ "$(< "/sys/class/net/${c3Eth0Hostname}/mtu")" = "8942" ]
+  [ "$(lxc exec c3 -- cat /sys/class/net/eth0/mtu)" = "8942" ]
+
+  if [ "${LXD_VM_TESTS}" != "0" ]; then
+    lxc launch ubuntu-vm v1 --vm --config limits.memory=384MiB --device "${SMALL_VM_ROOT_DISK}" -n "${ovn_network}"
+    v1Eth0Hostname="$(lxc config get v1 volatile.eth0.host_name)"
+    [ "$(< "/sys/class/net/${v1Eth0Hostname}/mtu")" = "1500" ]
+    waitInstanceReady v1
+    [ "$(lxc exec v1 -- cat /sys/class/net/enp5s0/mtu)" = "1442" ]
+    lxc delete --force v1
+
+    lxc launch ubuntu-vm v2 --vm --config limits.memory=384MiB --device "${SMALL_VM_ROOT_DISK}" -n "${ovn_network}_jumbo"
+    v2Eth0Hostname="$(lxc config get v2 volatile.eth0.host_name)"
+    [ "$(< "/sys/class/net/${v2Eth0Hostname}/mtu")" = "8942" ]
+    waitInstanceReady v2
+    [ "$(lxc exec v2 -- cat /sys/class/net/enp5s0/mtu)" = "8942" ]
+    lxc delete --force v2
+  fi
+
   echo "Clean up instances."
-  lxc delete --force c1 c2
+  lxc delete --force c1 c2 c3
+
+  lxc network delete "${ovn_network}_jumbo"
 
   echo "Check that removing IP routes on uplink works when there are no dependent OVN forwards."
   lxc network set "${uplink_network}" ipv4.routes= ipv6.routes=


### PR DESCRIPTION
- De-dupes veth/tap pair MTU logic into `networkCalculatePairMTU` and adds logic to ensure that when devices are attached to a bridge that may do not reduce the bridge's MTU, but only allow a possible increase in the bridge's MTU.
- Use OVN integration bridge interface as `parent` when calculating veth/tap pair MTU.
- Applies the calculated instance NIC MTU value to QEMU's netdev so that even if the host interface's MTU has been set larger that the instance's NIC (to allow it to be safely attached to the bridge) that the instance guest only sees the instance MTU specified.
- Allows using MTUs down to IPv4 minimum (68 bytes).


Fixes https://github.com/canonical/lxd/issues/18006
Fixes https://github.com/canonical/lxd/issues/18068