### PR TITLE
Migration: Check that moving an instance to its existing member fails with a proper error 

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -354,6 +354,10 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			needsLocalCopy = targetProjectName != inst.Project().Name
 		}
 
+		if targetMemberInfo != nil && !needsClusterMove {
+			return response.BadRequest(errors.New("Target must be different than instance's current location"))
+		}
+
 		// Validate offline source member constraints.
 		if needsClusterMove && sourceNodeOffline {
 			srcPool, err := storagePools.LoadByInstance(s, inst)

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -58,6 +58,7 @@ test_clustering_move() {
   echo "==> Move tests"
   echo "c1 can be moved to a new target location."
   lxc move cluster:c1 --target node2
+  [ "$(! "${_LXC}" move cluster:c1 --target node2 2>&1 1>/dev/null)" = "Error: Migration API failure: Target must be different than instance's current location" ]
 
   echo "c1 can be moved to a new target project."
   lxc move cluster:c1 --target-project test-project


### PR DESCRIPTION
Rather than a migration timeout failure.