### PR TITLE
github: add US English check to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -208,6 +208,17 @@ For error message assertions, prefer single-quoted strings so error text with `"
 
 <!-- END COMMIT STRUCTURE -->
 
+### Language and Spelling
+
+- Use **US English spelling** throughout all user-facing text, including documentation, CLI output, and error messages. Common examples:
+  - `behavior` not `behaviour`
+  - `color` not `colour`
+  - `center` not `centre`
+  - `license` not `licence`
+  - `initialize` not `initialise`
+  - `analyze` not `analyse`
+  - `canceled` not `cancelled`
+
 ### Code Style
 
 - Follow `golangci-lint` rules (see `.golangci.yaml`)


### PR DESCRIPTION
Per Canonical style guidelines, all user-facing copy should use US English instead of UK English. This should be reflected not only in documentation but in CLI output and any other text shown to users. This PR adds reinforcement of this to `copilot-instructions.md` for future PR reviews.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
