### PR TITLE
lxd/security: Emit authn security events at authentication boundary points

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -29,6 +29,7 @@ import (
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
@@ -963,6 +964,8 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, cert dbCluster.Certific
 	}
 
 	networkCert := d.endpoints.NetworkCert()
+	oldFingerprint := cert.Fingerprint
+	certChanged := false
 	if req.Certificate != "" && cert.Certificate != req.Certificate {
 		// Add supplied certificate.
 		block, _ := pem.Decode([]byte(req.Certificate))
@@ -977,6 +980,7 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, cert dbCluster.Certific
 
 		cert.Certificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x509Cert.Raw}))
 		cert.Fingerprint = shared.CertFingerprint(x509Cert)
+		certChanged = true
 
 		// Check validity.
 		err = certificateValidate(networkCert, x509Cert)
@@ -1025,6 +1029,16 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, cert dbCluster.Certific
 
 	s.Events.SendLifecycle("", lifecycle.CertificateUpdated.Event(cert.Fingerprint, request.CreateRequestor(r.Context()), nil))
 
+	// Only emit when the certificate material actually changed; name,
+	// restricted, or projects edits are not a credential change. The old
+	// fingerprint is the event suffix so audit consumers can correlate the
+	// event with the previous credential.
+	if certChanged {
+		ev := security.AuthnCertificateChange.WithSuffix(oldFingerprint).
+			UserEvent(r.Context(), security.LevelInfo, "TLS client certificate changed")
+		s.Events.SendSecurity(ev)
+	}
+
 	return response.EmptySyncResponse
 }
 
@@ -1069,6 +1083,7 @@ func doCertificateUpdateUnprivileged(ctx context.Context, s *state.State, cert d
 		return response.BadRequest(err)
 	}
 
+	oldFingerprint := cert.Fingerprint
 	cert.Certificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x509Cert.Raw}))
 	cert.Fingerprint = shared.CertFingerprint(x509Cert)
 
@@ -1097,6 +1112,17 @@ func doCertificateUpdateUnprivileged(ctx context.Context, s *state.State, cert d
 	s.UpdateIdentityCache()
 
 	s.Events.SendLifecycle("", lifecycle.CertificateUpdated.Event(cert.Fingerprint, request.CreateRequestor(ctx), nil))
+
+	// Emit the same event as the privileged path so certificate replacements
+	// are auditable regardless of who triggered them. The fingerprint changes
+	// whenever the certificate material does, and the helpers above already
+	// require Certificate to be supplied in the request, so the gate exists
+	// purely as a safety net against accidental no-op updates.
+	if cert.Fingerprint != oldFingerprint {
+		ev := security.AuthnCertificateChange.WithSuffix(oldFingerprint).
+			UserEvent(ctx, security.LevelInfo, "TLS client certificate changed (self-update)")
+		s.Events.SendSecurity(ev)
+	}
 
 	return response.EmptySyncResponse
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -491,7 +491,14 @@ func extractEntitlementsFromQuery(r *http.Request, entityType entity.Type, allow
 // This does not perform authorization, only validates authentication.
 // Returns whether trusted or not, the username (or certificate fingerprint) of the trusted client, and the type of
 // client that has been authenticated (cluster, unix, oidc or tls).
-func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (*request.RequestorArgs, error) {
+//
+// allowUntrusted is the AllowUntrusted flag of the endpoint action being
+// dispatched. It gates emission of authn_login_fail: the event is raised
+// only when no auth method recognised the caller and the endpoint required
+// authentication. Errors returned from this function never trigger the
+// event because they may originate from a server-side fault (e.g. an
+// unreachable IdP).
+func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request, allowUntrusted bool) (*request.RequestorArgs, error) {
 	if r.TLS == nil {
 		// For a socket, the server is listening on a file, but the client does not have an address.
 		// Since there is no address, the kernel uses an unnamed unix socket address.
@@ -636,7 +643,6 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (*request.
 
 		bearerRequestor, err := bearer.Authenticate(r.Context(), subject, token, tokenLocation, d.identityCache, d.events.SendSecurity)
 		if err != nil {
-			// Deny access if the provided token is not verifiable.
 			return nil, fmt.Errorf("Failed verifying bearer token: %w", err)
 		}
 
@@ -659,7 +665,16 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (*request.
 		}, nil
 	}
 
-	// Reject unauthorized.
+	// Peer presented a client certificate but no auth method recognised the
+	// caller. Emit only when the endpoint requires authentication; anonymous
+	// requests (no peer cert, no bearer, no OIDC header) also reach this
+	// point and intentionally do not emit.
+	if !allowUntrusted && len(r.TLS.PeerCertificates) > 0 {
+		loginFail := security.AuthnLoginFail.WithSuffix(string(api.AuthenticationMethodTLS)).
+			UserEvent(r.Context(), security.LevelWarning, "TLS authentication failure")
+		d.events.SendSecurity(loginFail)
+	}
+
 	return &request.RequestorArgs{Trusted: false}, nil
 }
 
@@ -839,8 +854,36 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 		}
 
+		// Resolve the endpoint action up front so authentication knows
+		// whether the endpoint requires authentication. This drives whether
+		// authn_login_fail is emitted on a fallthrough (no auth method
+		// recognised the caller).
+		var endpointAction APIEndpointAction
+		switch r.Method {
+		case http.MethodGet:
+			endpointAction = c.Get
+		case http.MethodHead:
+			endpointAction = c.Head
+		case http.MethodPut:
+			endpointAction = c.Put
+		case http.MethodPost:
+			endpointAction = c.Post
+		case http.MethodDelete:
+			endpointAction = c.Delete
+		case http.MethodPatch:
+			endpointAction = c.Patch
+		default:
+			_ = response.NotFound(fmt.Errorf("Method %q not found", r.Method)).Render(w, r)
+			return
+		}
+
+		if endpointAction.Handler == nil {
+			_ = response.NotImplemented(nil).Render(w, r)
+			return
+		}
+
 		// Authentication
-		requestor, err := d.Authenticate(w, r)
+		requestor, err := d.Authenticate(w, r, endpointAction.AllowUntrusted)
 		if err != nil {
 			var authError oidc.AuthError
 			if errors.As(err, &authError) {
@@ -948,10 +991,6 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		}
 
 		handleRequest := func(action APIEndpointAction) response.Response {
-			if action.Handler == nil {
-				return response.NotImplemented(nil)
-			}
-
 			// Protect against CSRF when using LXD-UI with browser that supports Fetch metadata.
 			// Deny Sec-Fetch-Site when set to cross-site or same-site.
 			if http.NewCrossOriginProtection().Check(r) != nil {
@@ -994,22 +1033,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			return action.Handler(d, r)
 		}
 
-		switch r.Method {
-		case "GET":
-			resp = handleRequest(c.Get)
-		case "HEAD":
-			resp = handleRequest(c.Head)
-		case "PUT":
-			resp = handleRequest(c.Put)
-		case "POST":
-			resp = handleRequest(c.Post)
-		case "DELETE":
-			resp = handleRequest(c.Delete)
-		case "PATCH":
-			resp = handleRequest(c.Patch)
-		default:
-			resp = response.NotFound(fmt.Errorf("Method %q not found", r.Method))
-		}
+		resp = handleRequest(endpointAction)
 
 		// Handle errors
 		err = resp.Render(w, r)

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -26,6 +26,7 @@ import (
 	"github.com/canonical/lxd/lxd/identity"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
@@ -575,6 +576,12 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// The identity identifier is appended to the event name so operators can
+	// correlate token issuance events with a specific identity.
+	ev := security.AuthnTokenCreated.WithSuffix(id.Identifier).
+		UserEvent(r.Context(), security.LevelInfo, "Bearer token created")
+	s.Events.SendSecurity(ev)
+
 	return response.SyncResponse(true, api.IdentityBearerToken{Token: token})
 }
 
@@ -623,6 +630,12 @@ func identityBearerTokenDelete(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	// The identity identifier is appended to the event name so operators can
+	// correlate revocation events with a specific identity.
+	ev := security.AuthnTokenRevoked.WithSuffix(id.Identifier).
+		UserEvent(r.Context(), security.LevelInfo, "Bearer token revoked")
+	s.Events.SendSecurity(ev)
 
 	return response.EmptySyncResponse
 }

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -133,6 +133,7 @@ readonly test_group_standalone=(
     "acme"
     "alias"
     "apparmor"
+    "authn_events"
     "authorization"
     "ui_initial_access_link"
     "basic_usage"

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -292,3 +292,145 @@ test_security_events_bearer_authn() {
 
   lxc auth identity delete bearer/security-events-bearer
 }
+
+test_authn_events() {
+  ensure_has_localhost_remote "${LXD_ADDR}"
+
+  # Helper: poll the JSONL monitor file (up to 10 s) for jq_filter, then kill
+  # the monitor, assert one final time, and remove the file.
+  _wait_authn_event() {
+    local monfile="${1}" mon_pid="${2}" jq_filter="${3}"
+    for _ in $(seq 10); do
+      jq --exit-status --slurp "${jq_filter}" "${monfile}" && break
+      sleep 1
+    done
+    kill_go_proc "${mon_pid}" || true
+    jq --exit-status --slurp "${jq_filter}" "${monfile}"
+    rm -f "${monfile}"
+  }
+
+  sub_test "Verify authn_login_fail does not fire on public unauthenticated endpoints"
+  local monfile="${TEST_DIR}/authn-no-event.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  sleep 0.2
+
+  # GET /1.0 has AllowUntrusted=true so daemon.Authenticate is not reached
+  # with a failing auth method.
+  curl --insecure --silent "https://${LXD_ADDR}/1.0" \
+    | jq --exit-status '.metadata.auth == "untrusted"'
+
+  sleep 3
+  kill_go_proc "${mon_pid}" || true
+  jq --exit-status --slurp \
+    'map(select(.type == "security" and (.metadata.name // "" | startswith("authn_login_fail")))) | length == 0' \
+    "${monfile}"
+  rm -f "${monfile}"
+
+  sub_test "Verify authn_login_fail:tls fires when an untrusted client cert is presented"
+  gen_cert_and_key "authn-untrusted-cert"
+
+  monfile="${TEST_DIR}/authn-login-fail-tls.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  mon_pid=$!
+  sleep 0.2
+
+  curl --insecure --silent \
+    --cert "${LXD_CONF}/authn-untrusted-cert.crt" \
+    --key "${LXD_CONF}/authn-untrusted-cert.key" \
+    "https://${LXD_ADDR}/1.0/instances" \
+    | jq --exit-status '.error_code == 403'
+
+  _wait_authn_event "${monfile}" "${mon_pid}" \
+    'map(select(.type == "security" and .metadata.name == "authn_login_fail:tls" and .metadata.level == "warning" and (.metadata.requestor.address // "") != "")) | length >= 1'
+
+  sub_test "Verify authn_token_created fires when a bearer token is issued"
+  lxc auth identity create bearer/authn-bearer-test
+  local bearer_id
+  bearer_id="$(lxc auth identity list bearer --format json | jq --raw-output '.[] | select(.name == "authn-bearer-test") | .id')"
+
+  monfile="${TEST_DIR}/authn-token-created.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  mon_pid=$!
+  sleep 0.2
+
+  local issued_token
+  issued_token="$(lxc auth identity token issue bearer/authn-bearer-test --quiet)"
+  [ -n "${issued_token}" ]
+
+  _wait_authn_event "${monfile}" "${mon_pid}" \
+    "map(select(.type == \"security\" and .metadata.name == \"authn_token_created:${bearer_id}\" and .metadata.level == \"info\")) | length >= 1"
+
+  sub_test "Verify authn_token_revoked fires when a bearer token is revoked"
+  monfile="${TEST_DIR}/authn-token-revoked.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  mon_pid=$!
+  sleep 0.2
+
+  lxc auth identity token revoke bearer/authn-bearer-test
+
+  _wait_authn_event "${monfile}" "${mon_pid}" \
+    "map(select(.type == \"security\" and .metadata.name == \"authn_token_revoked:${bearer_id}\" and .metadata.level == \"info\")) | length >= 1"
+
+  lxc auth identity delete bearer/authn-bearer-test
+
+  sub_test "Verify authn_certificate_change fires when TLS certificate material is replaced (admin)"
+  gen_cert_and_key "authn-orig-cert"
+  lxc config trust add "${LXD_CONF}/authn-orig-cert.crt" --name authn-test-cert
+  local old_fp
+  old_fp="$(cert_fingerprint "${LXD_CONF}/authn-orig-cert.crt")"
+  gen_cert_and_key "authn-new-cert"
+
+  monfile="${TEST_DIR}/authn-cert-change.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  mon_pid=$!
+  sleep 0.2
+
+  lxc query --request PUT \
+    --data "$(jq --null-input \
+      --argjson cert "$(cert_to_json "${LXD_CONF}/authn-new-cert.crt")" \
+      --arg name "authn-test-cert" \
+      '{certificate: $cert, name: $name, restricted: false, projects: [], type: "client"}')" \
+    "/1.0/certificates/${old_fp}"
+
+  _wait_authn_event "${monfile}" "${mon_pid}" \
+    "map(select(.type == \"security\" and .metadata.name == \"authn_certificate_change:${old_fp}\" and .metadata.level == \"info\")) | length >= 1"
+
+  local new_fp
+  new_fp="$(cert_fingerprint "${LXD_CONF}/authn-new-cert.crt")"
+  lxc config trust remove "${new_fp}"
+
+  sub_test "Verify authn_certificate_change fires on self-update (old fingerprint in event name)"
+  gen_cert_and_key "authn-self-cert"
+  lxc config trust add "${LXD_CONF}/authn-self-cert.crt" --name authn-self-cert
+  local self_old_fp
+  self_old_fp="$(cert_fingerprint "${LXD_CONF}/authn-self-cert.crt")"
+
+  # Mark as restricted so the PUT goes through doCertificateUpdateUnprivileged.
+  lxc config trust show "${self_old_fp}" \
+    | sed "s/restricted: false/restricted: true/" \
+    | lxc config trust edit "${self_old_fp}"
+
+  gen_cert_and_key "authn-self-new-cert"
+
+  monfile="${TEST_DIR}/authn-cert-selfchange.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  mon_pid=$!
+  sleep 0.2
+
+  CERTNAME="authn-self-cert" my_curl --request PUT \
+    --data "$(jq --null-input \
+      --argjson cert "$(cert_to_json "${LXD_CONF}/authn-self-new-cert.crt")" \
+      --arg name "authn-self-cert" \
+      '{certificate: $cert, name: $name, restricted: true, projects: [], type: "client"}')" \
+    "https://${LXD_ADDR}/1.0/certificates/${self_old_fp}"
+
+  # Caller authenticated with the old cert, so the requestor username equals
+  # the old fingerprint.
+  _wait_authn_event "${monfile}" "${mon_pid}" \
+    "map(select(.type == \"security\" and .metadata.name == \"authn_certificate_change:${self_old_fp}\" and .metadata.requestor.username == \"${self_old_fp}\")) | length >= 1"
+
+  local self_new_fp
+  self_new_fp="$(cert_fingerprint "${LXD_CONF}/authn-self-new-cert.crt")"
+  lxc config trust remove "${self_new_fp}"
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Changes

### `lxd/daemon`: `authn_login_fail`

Emits `authn_login_fail:tls` at the catch-all fallthrough in `Daemon.Authenticate` , when no auth method recognised the caller, the endpoint requires authentication, and a TLS client certificate was presented. The design follows the principle that audit events should fire only at unambiguous outcome paths, so:

- `Daemon.Authenticate` now takes an `allowUntrusted` argument (the `AllowUntrusted` flag of the endpoint action being dispatched).
- The HTTP method dispatch in `createCmd` has been moved to before authentication so the endpoint action (and its `AllowUntrusted` flag) is known at auth time.
- The fallthrough emission is gated on `!allowUntrusted && len(r.TLS.PeerCertificates) > 0`.

Errors returned from `Authenticate` (e.g. bearer-token verification failures, OIDC verifier rejections) deliberately do not trigger the event because they may originate from server-side faults; an unreachable IdP, a misconfigured OIDC client, or a transient session-store error. The 401/403 access-log entry is the only audit trail for those cases.

`authn_token_reuse` is unchanged on this PR it is emitted from inside `bearer.Authenticate` for bearer-specific misuse patterns (initial-UI token presented in the Authorization header; bearer token presented as a query parameter or cookie). That emission was added in #18027.

### `lxd/identities`: `authn_token_created` and `authn_token_revoked`

Emits `authn_token_created:<identity_id>` from `identityBearerTokenPost` after the signing key has been rotated and the lifecycle event sent. Emits `authn_token_revoked:<identity_id>` from `identityBearerTokenDelete` after the signing key has been deleted. The identity UUID is appended as the event suffix for correlation.

### `lxd/certificates`: `authn_certificate_change`

Emits `authn_certificate_change:<old_fingerprint>` when TLS certificate material is replaced, in both the privileged path (`doCertificateUpdate`, with HTTP request context) and the unprivileged self-update path (`doCertificateUpdateUnprivileged`, where the requestor comes from context rather than a request parameter). The old fingerprint in the event suffix and the `user_id` field together let auditors determine whether a user changed their own certificate (`user_id == "tls/<old_fingerprint>"`) or an administrator changed another user's certificate (`user_id != "tls/<old_fingerprint>"`).

## Tests

`test/suites/security.sh`, `test_authn_events`:

| Sub-test | What is verified |
|---|---|
| `authn_login_fail` (no-fire) | Does not fire on `AllowUntrusted` endpoints |
| `authn_login_fail:tls` | Fires when an untrusted client certificate is presented to a protected endpoint |
| `authn_token_created` | Event fires with exact `authn_token_created:<uuid>` suffix |
| `authn_token_revoked` | Event fires with matching `authn_token_revoked:<uuid>` suffix |
| `authn_certificate_change` (admin) | Event fires; `user_id=unix/root` (differs from old fingerprint) |
| `authn_certificate_change` (self) | Event fires with `user_id=tls/<old_fingerprint>` (matches old fingerprint) |

Each sub-test also validates that all OWASP required fields are non-empty, with `port` required only when `protocol=https` (unix-socket requests legitimately have no port).
