### PR TITLE
lxd: remove legacy ZFS bucket datasets at startup and pool deletion

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -124,6 +124,7 @@ var patches = []patch{
 	{name: "config_remove_maas_keys", stage: patchPreLoadClusterConfig, run: patchRemoveMAASConfigKeys},
 	{name: "storage_unset_ceph_source_setting", stage: patchPostDaemonStorage, run: patchUnsetCephSourceSetting},
 	{name: "clustering_event_hub_role_to_control_plane", stage: patchPreLoadClusterConfig, run: patchClusteringEventHubRoleToControlPlane},
+	{name: "storage_zfs_remove_local_bucket_datasets", stage: patchPostDaemonStorage, run: patchGenericStorage},
 }
 
 type patch struct {

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -40,6 +40,7 @@ func (d *btrfs) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -46,6 +46,7 @@ func (d *ceph) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -36,6 +36,7 @@ func (d *cephfs) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -34,6 +34,7 @@ func (d *cephobject) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -29,6 +29,7 @@ func (d *dir) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -40,6 +40,7 @@ func (d *lvm) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": nil,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -54,6 +54,7 @@ func (d *zfs) load() error {
 		"storage_delete_old_snapshot_records":                nil,
 		"storage_zfs_drop_block_volume_filesystem_extension": d.patchDropBlockVolumeFilesystemExtension,
 		"storage_prefix_bucket_names_with_project":           nil,
+		"storage_zfs_remove_local_bucket_datasets":           d.patchRemoveLocalBucketDatasets,
 	}
 
 	// Done if previously loaded.
@@ -780,6 +781,31 @@ func (d *zfs) patchDropBlockVolumeFilesystemExtension() error {
 		_, err = shared.RunCommand(context.TODO(), "zfs", "rename", volume, newName)
 		if err != nil {
 			return fmt.Errorf("Failed renaming zfs dataset: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// patchRemoveLocalBucketDatasets removes orphaned ZFS datasets left over from before local storage bucket support was
+// dropped. Affected datasets are "<pool>/buckets" and "<pool>/deleted/buckets".
+func (d *zfs) patchRemoveLocalBucketDatasets() error {
+	poolName, ok := d.config["zfs.pool_name"]
+	if !ok {
+		poolName = d.name
+	}
+
+	// Remove deepest-first to avoid dependency conflicts.
+	for _, dataset := range []string{poolName + "/deleted/buckets", poolName + "/buckets"} {
+		_, err := shared.RunCommand(d.state.ShutdownCtx, "zfs", "list", "-H", "-o", "name", dataset)
+		if err != nil {
+			// Dataset does not exist; nothing to do.
+			continue
+		}
+
+		_, err = shared.RunCommand(d.state.ShutdownCtx, "zfs", "destroy", "-r", dataset)
+		if err != nil {
+			return fmt.Errorf("Failed removing ZFS bucket dataset %q: %w", dataset, err)
 		}
 	}
 

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -15,6 +15,7 @@ test_storage_driver_zfs() {
   do_zfs_delegate
   do_zfs_rebase
   do_recursive_copy_snapshot_cleanup
+  do_zfs_bucket_dataset_cleanup
 }
 
 do_zfs_delegate() {
@@ -462,4 +463,41 @@ do_recursive_copy_snapshot_cleanup() {
 
   echo "Verify no snapshots remain in deleted pool."
   [ "$(zfs list -rt snapshot "${storage_pool}/deleted/containers" 2>&1)" = "no datasets available" ]
+}
+
+do_zfs_bucket_dataset_cleanup() {
+  local storage_pool
+  storage_pool="lxdtest-$(basename "${LXD_DIR}")"
+
+  sub_test "Verify startup patch removes legacy bucket datasets"
+
+  lxc storage create "${storage_pool}-buckets-patch-test" zfs
+
+  local zfs_pool
+  zfs_pool="$(lxc storage get "${storage_pool}-buckets-patch-test" zfs.pool_name)"
+
+  # Inject the orphaned datasets again to simulate an existing pool that predates the patch that removes them on startup.
+  zfs create "${zfs_pool}/buckets"
+  zfs create "${zfs_pool}/deleted/buckets"
+
+  # Restart LXD to trigger the storage_zfs_remove_local_bucket_datasets patch.
+  # The patch is idempotent but won't re-run on subsequent starts; the datasets
+  # were injected directly bypassing LXD, so clear the patch record from the
+  # local DB to force re-execution on the next startup.
+  lxd sql local "DELETE FROM patches WHERE name = 'storage_zfs_remove_local_bucket_datasets'"
+  shutdown_lxd "${LXD_DIR}"
+  respawn_lxd "${LXD_DIR}" true
+
+  # Both datasets must be gone after LXD applies the startup patch.
+  if zfs list -H -o name "${zfs_pool}/buckets" > /dev/null 2>&1; then
+    echo "ERROR: ${zfs_pool}/buckets still exists after startup patch, aborting" >&2
+    exit 1
+  fi
+
+  if zfs list -H -o name "${zfs_pool}/deleted/buckets" > /dev/null 2>&1; then
+    echo "ERROR: ${zfs_pool}/deleted/buckets still exists after startup patch, aborting" >&2
+    exit 1
+  fi
+
+  lxc storage delete "${storage_pool}-buckets-patch-test"
 }


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/18136 and add system tests.