### PR TITLE
Cluster: Fix cluster healing functionality

### DIFF
--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -164,7 +164,7 @@ To enable cluster healing, set the {config:option}`server-cluster:cluster.healin
 Syntax:
 
 ```bash
-lxc cluster set cluster.healing_threshold <value in seconds>
+lxc config set cluster.healing_threshold <value in seconds>
 ```
 
 When the healed cluster member is available again, you must manually {ref}`restore <cluster-restore>` it to remove its "evacuated" state and return instances to it.

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1628,6 +1628,8 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 		// Apply overrides.
 		if opts.mode != "" {
 			switch opts.mode {
+			case api.ClusterEvacuateModeHeal:
+				live = false // The source member is offline when healing.
 			case api.ClusterEvacuateModeStop:
 				migrate = false
 				live = false

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1640,7 +1640,7 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 				migrate = true
 				live = true
 			default:
-				return fmt.Errorf("Invalid mode: %q", opts.mode)
+				return fmt.Errorf("Invalid evacuation mode: %q", opts.mode)
 			}
 		}
 


### PR DESCRIPTION
1. Documented command didn't exist.
2. Healing evacuation mode wasn't recognised by evacuation function - now disables live migration, but respects the instance level migration preference.