### PR TITLE
Network: Dynamic OVN address updates

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1352,7 +1352,7 @@ func (d *disk) postStart() error {
 	return nil
 }
 
-// Update applies configuration changes to a started device.
+// Update applies configuration changes to a device.
 func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	if filters.IsRootDisk(d.config) {
 		// Make sure we have a valid root disk device (and only one).

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -695,7 +695,7 @@ func (d *nicBridged) postStart() error {
 	return nil
 }
 
-// Update applies configuration changes to a started device.
+// Update applies configuration changes to a device.
 func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
 	v := d.volatileGet()

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -866,22 +866,6 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 		}
 	}
 
-	// If an IPv6 address has changed, if the instance is running we should bounce the host-side
-	// veth interface to give the instance a chance to detect the change and re-apply for an
-	// updated lease with new IP address.
-	if d.config["ipv6.address"] != oldConfig["ipv6.address"] && d.config["host_name"] != "" && network.InterfaceExists(d.config["host_name"]) {
-		link := &ip.Link{Name: d.config["host_name"]}
-		err := link.SetDown()
-		if err != nil {
-			return err
-		}
-
-		err = link.SetUp()
-		if err != nil {
-			return err
-		}
-	}
-
 	// If IP addresses or ACLs changed, update the OVN logical switch port.
 	if ipv4Changed || ipv6Changed || aclsChanged {
 		newACLs := shared.SplitNTrimSpace(d.config["security.acls"], ",", -1, true)

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -846,7 +846,7 @@ func (d *nicOVN) postStart() error {
 	return nil
 }
 
-// Update applies configuration changes to a started device.
+// Update applies configuration changes to a device.
 // The underlying switch port gets removed and re-added.
 func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -894,35 +894,35 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 		}
 
+		// Load uplink network config.
+		uplinkNetworkName := d.network.Config()["network"]
+
+		var uplink *api.Network
+
+		err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkNetworkName)
+
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("Failed loading uplink network %q: %w", uplinkNetworkName, err)
+		}
+
+		// Update OVN logical switch port for instance.
+		_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
+			DNSName:      d.inst.Name(),
+			DeviceName:   d.name,
+			DeviceConfig: d.config,
+			UplinkConfig: uplink.Config,
+		}, removedACLs)
+		if err != nil {
+			return fmt.Errorf("Failed updating OVN port: %w", err)
+		}
+
 		if isRunning {
-			// Load uplink network config.
-			uplinkNetworkName := d.network.Config()["network"]
-
-			var uplink *api.Network
-
-			err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				var err error
-
-				_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkNetworkName)
-
-				return err
-			})
-			if err != nil {
-				return fmt.Errorf("Failed loading uplink network %q: %w", uplinkNetworkName, err)
-			}
-
-			// Update OVN logical switch port for instance.
-			_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
-				InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
-				DNSName:      d.inst.Name(),
-				DeviceName:   d.name,
-				DeviceConfig: d.config,
-				UplinkConfig: uplink.Config,
-			}, removedACLs)
-			if err != nil {
-				return fmt.Errorf("Failed updating OVN port: %w", err)
-			}
-
 			// If an address has changed and if the instance is running, we should bounce the host-side
 			// veth interface to give the instance a chance to detect the change and re-apply for an
 			// updated lease with new IP address.

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -68,7 +68,7 @@ func (d *nicOVN) UpdatableFields(oldDevice Type) []string {
 		return []string{}
 	}
 
-	return []string{"security.acls"}
+	return []string{"security.acls", "ipv4.address", "ipv6.address"}
 }
 
 // validateConfig checks the supplied config for correctness.

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -847,11 +847,24 @@ func (d *nicOVN) postStart() error {
 }
 
 // Update applies configuration changes to a started device.
+// The underlying switch port gets removed and re-added.
 func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, d.volatileGet())
+
+	ipv4Changed := d.config["ipv4.address"] != oldConfig["ipv4.address"]
+	ipv6Changed := d.config["ipv6.address"] != oldConfig["ipv6.address"]
+	aclsChanged := d.config["security.acls"] != oldConfig["security.acls"]
+
+	// If an IP address has changed, re-check for address conflicts.
+	if ipv4Changed || ipv6Changed {
+		err := d.checkAddressConflict()
+		if err != nil {
+			return err
+		}
+	}
 
 	// If an IPv6 address has changed, if the instance is running we should bounce the host-side
 	// veth interface to give the instance a chance to detect the change and re-apply for an
@@ -869,19 +882,34 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 		}
 	}
 
-	// Apply any changes needed when assigned ACLs change.
-	if d.config["security.acls"] != oldConfig["security.acls"] {
-		// Work out which ACLs have been removed and remove logical port from those groups.
-		oldACLs := shared.SplitNTrimSpace(oldConfig["security.acls"], ",", -1, true)
+	// If IP addresses or ACLs changed, update the OVN logical switch port.
+	if ipv4Changed || ipv6Changed || aclsChanged {
 		newACLs := shared.SplitNTrimSpace(d.config["security.acls"], ",", -1, true)
-		removedACLs := []string{}
-		for _, oldACL := range oldACLs {
-			if !slices.Contains(newACLs, oldACL) {
-				removedACLs = append(removedACLs, oldACL)
+
+		// Work out which ACLs have been removed.
+		var removedACLs []string
+		if aclsChanged {
+			oldACLs := shared.SplitNTrimSpace(oldConfig["security.acls"], ",", -1, true)
+			for _, oldACL := range oldACLs {
+				if !slices.Contains(newACLs, oldACL) {
+					removedACLs = append(removedACLs, oldACL)
+				}
 			}
 		}
 
-		// Setup the logical port with new ACLs if running.
+		// Remove old DHCP reservations and DNS records before re-adding with new IPs.
+		if ipv4Changed || ipv6Changed {
+			err := d.network.InstanceDevicePortRemove(d.inst.LocalConfig()["volatile.uuid"], d.name, oldConfig)
+			if err != nil {
+				return fmt.Errorf("Failed removing old instance device port config: %w", err)
+			}
+
+			err = d.network.InstanceDevicePortAdd(d.inst.LocalConfig()["volatile.uuid"], d.name, d.config)
+			if err != nil {
+				return fmt.Errorf("Failed adding updated instance device port config: %w", err)
+			}
+		}
+
 		if isRunning {
 			// Load uplink network config.
 			uplinkNetworkName := d.network.Config()["network"]
@@ -912,6 +940,7 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 		}
 
+		// Clean up unused ACL port groups.
 		if len(removedACLs) > 0 {
 			client, err := openvswitch.NewOVN(d.state.GlobalConfig.NetworkOVNNorthboundConnection(), d.state.GlobalConfig.NetworkOVNSSL)
 			if err != nil {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -922,6 +922,22 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			if err != nil {
 				return fmt.Errorf("Failed updating OVN port: %w", err)
 			}
+
+			// If an address has changed and if the instance is running, we should bounce the host-side
+			// veth interface to give the instance a chance to detect the change and re-apply for an
+			// updated lease with new IP address.
+			if (ipv4Changed || ipv6Changed) && d.config["host_name"] != "" && network.InterfaceExists(d.config["host_name"]) {
+				link := &ip.Link{Name: d.config["host_name"]}
+				err := link.SetDown()
+				if err != nil {
+					return err
+				}
+
+				err = link.SetUp()
+				if err != nil {
+					return err
+				}
+			}
 		}
 
 		// Clean up unused ACL port groups.

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -166,7 +166,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 	return &runConf, nil
 }
 
-// Update applies configuration changes to a started device.
+// Update applies configuration changes to a device.
 func (d *nicP2P) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	if !isRunning {
 		return nil


### PR DESCRIPTION
In preparation for dynamic OVN NIC address changes to be applied for load balancers, this PR makes the `ipv(4|6).address` config settings for OVN NICs updatable. 

In addition the bouncing of host side interfaces is moved to make it working for both IPv4 and IPv6.

Test update in https://github.com/canonical/lxd-ci/pull/744.
