### PR TITLE
Replicators follow-up

### DIFF
--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1148,13 +1148,9 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				}
 
 				remoteOpInfo := remoteMigrateOp.Get()
-
-				remoteSecrets := make(map[string]string, len(remoteOpInfo.Metadata))
-				for k, v := range remoteOpInfo.Metadata {
-					secretVal, ok := v.(string)
-					if ok {
-						remoteSecrets[k] = secretVal
-					}
+				remoteSecrets, err := remoteOpInfo.WebsocketSecrets()
+				if err != nil {
+					return fmt.Errorf("Failed getting websocket secrets for instance %q migration: %w", instName, err)
 				}
 
 				remoteAddresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, false)

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -487,8 +487,7 @@ func replicatorsPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorCreated.Event(req.Name, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorCreated.Event(r.Context(), req.Name, projectName, nil))
 
 	return response.EmptySyncResponse
 }
@@ -556,8 +555,7 @@ func replicatorPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorRenamed.Event(req.Name, projectName, requestor, logger.Ctx{"old_name": name}))
+	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorRenamed.Event(r.Context(), req.Name, projectName, logger.Ctx{"old_name": name}))
 
 	return response.EmptySyncResponse
 }
@@ -678,8 +676,7 @@ func replicatorStatePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorRun.Event(name, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorRun.Event(r.Context(), name, projectName, nil))
 
 	return operations.OperationResponse(op)
 }
@@ -761,8 +758,7 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 		return response.SmartError(err)
 	}
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorUpdated.Event(name, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorUpdated.Event(r.Context(), name, projectName, nil))
 
 	return response.EmptySyncResponse
 }
@@ -887,8 +883,7 @@ func replicatorDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting replicator %q: %w", name, err))
 	}
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorDeleted.Event(name, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ReplicatorDeleted.Event(r.Context(), name, projectName, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1065,9 +1065,9 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	}
 
 	// In restore mode, all local instances must be stopped before proceeding.
-	// The restore operation deletes and recreates each existing local instance using the
-	// remote leader as the source of truth; a running instance cannot be deleted.
-	// Fail fast here to avoid a partial restore where some instances are recreated and
+	// The restore operation refreshes each existing local instance from the remote leader
+	// and creates any that only exist on the leader; a running instance cannot be refreshed.
+	// Fail fast here to avoid a partial restore where some instances are updated and
 	// others are not.
 	if restore {
 		for _, inst := range localInsts {
@@ -1078,7 +1078,8 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	}
 
 	// In restore mode the remote leader is the source of truth: use its instance list so
-	// that instances created on the leader after failover are included.
+	// that instances created on the leader after failover are included. Restore is additive
+	// only: local instances that do not exist on the leader are left in place and not deleted.
 	var iterNames []string
 	if restore {
 		remoteInsts, err := targetClient.GetInstances(lxd.GetInstancesArgs{InstanceType: api.InstanceTypeAny})

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -21,7 +21,6 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
-	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
@@ -35,8 +34,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/osarch"
-	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -1160,150 +1157,52 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 				remoteOpURL := "https://" + remoteAddresses[0] + "/1.0/operations/" + remoteOpInfo.ID
 
-				dialer, err := setupWebsocketDialer(targetCertPEM)
-				if err != nil {
-					return fmt.Errorf("Failed setting up websocket dialer for restore of instance %q: %w", instName, err)
-				}
-
-				if inst != nil {
-					// Instance already exists locally: refresh it from the remote leader.
-					localInst, err := instance.LoadByProjectAndName(s, projectName, instName)
-					if err != nil {
-						return fmt.Errorf("Failed loading local instance %q: %w", instName, err)
-					}
-
-					instOp, err := localInst.LockExclusive()
-					if err != nil {
-						return fmt.Errorf("Failed locking instance %q for restore: %w", instName, err)
-					}
-
-					sink, err := newMigrationSink(&migrationSinkArgs{
-						url:      remoteOpURL,
-						dialer:   dialer,
-						instance: localInst,
-						secrets:  remoteSecrets,
-						refresh:  true,
-					})
-					if err != nil {
-						instOp.Done(err)
-						return fmt.Errorf("Failed setting up migration sink for instance %q: %w", instName, err)
-					}
-
-					err = sink.Do(ctx, instOp, op)
-					if err != nil {
-						instOp.Done(err)
-						return fmt.Errorf("Restore of instance %q failed: %w", instName, err)
-					}
-
-					instOp.Done(nil)
-					return remoteMigrateOp.Wait()
-				}
-
-				// Instance only exists on the remote leader: create it locally from scratch.
-				architecture, err := osarch.ArchitectureId(freshInst.Architecture)
-				if err != nil {
-					return fmt.Errorf("Failed parsing architecture for instance %q: %w", instName, err)
-				}
-
-				dbType, err := instancetype.New(string(freshInst.Type))
-				if err != nil {
-					return fmt.Errorf("Failed parsing instance type for instance %q: %w", instName, err)
-				}
-
+				// Load profiles for the instance to pass to the migration sink.
 				var profiles []api.Profile
 				err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-					profileFilters := make([]dbCluster.ProfileFilter, 0, len(freshInst.Profiles))
-					for _, profileName := range freshInst.Profiles {
-						pName := profileName
-						profileFilters = append(profileFilters, dbCluster.ProfileFilter{
-							Project: &projectName,
-							Name:    &pName,
-						})
-					}
-
-					dbProfiles, err := dbCluster.GetProfiles(ctx, tx.Tx(), profileFilters...)
-					if err != nil {
-						return err
-					}
-
-					dbProfileConfigs, err := dbCluster.GetConfig(ctx, tx.Tx(), "profile")
-					if err != nil {
-						return err
-					}
-
-					dbProfileDevices, err := dbCluster.GetDevices(ctx, tx.Tx(), "profile")
-					if err != nil {
-						return err
-					}
-
-					profilesByName := make(map[string]dbCluster.Profile, len(dbProfiles))
-					for _, dbProfile := range dbProfiles {
-						profilesByName[dbProfile.Name] = dbProfile
-					}
-
-					for _, profileName := range freshInst.Profiles {
-						profile, found := profilesByName[profileName]
-						if !found {
-							return fmt.Errorf("Profile %q not found locally for instance %q", profileName, instName)
-						}
-
-						apiProfile, err := profile.ToAPI(ctx, tx.Tx(), dbProfileConfigs, dbProfileDevices)
-						if err != nil {
-							return err
-						}
-
-						profiles = append(profiles, *apiProfile)
-					}
-
-					return nil
+					profiles, err = instanceProfilesFromNames(ctx, tx, projectName, freshInst.Profiles)
+					return err
 				})
 				if err != nil {
 					return fmt.Errorf("Failed loading profiles for instance %q: %w", instName, err)
 				}
 
-				instArgs := db.InstanceArgs{
-					Project:      projectName,
-					Name:         instName,
-					Type:         dbType,
-					Architecture: architecture,
-					Config:       freshInst.Config,
-					Devices:      deviceConfig.NewDevices(freshInst.Devices),
-					Description:  freshInst.Description,
-					Ephemeral:    freshInst.Ephemeral,
-					Profiles:     profiles,
-					Stateful:     freshInst.Stateful,
+				// Build a migration request that the shared migration-sink core understands.
+				migrateReq := &api.InstancesPost{
+					InstancePut: api.InstancePut{
+						Architecture: freshInst.Architecture,
+						Config:       freshInst.Config,
+						Devices:      freshInst.Devices,
+						Description:  freshInst.Description,
+						Ephemeral:    freshInst.Ephemeral,
+						Profiles:     freshInst.Profiles,
+						Stateful:     freshInst.Stateful,
+					},
+					Name: instName,
+					Type: api.InstanceType(freshInst.Type),
+					Source: api.InstanceSource{
+						Type:        api.SourceTypeMigration,
+						Mode:        "pull",
+						Operation:   remoteOpURL,
+						Websockets:  remoteSecrets,
+						Certificate: targetCertPEM,
+						Refresh:     inst != nil,
+					},
 				}
 
-				rev := revert.New()
-				defer rev.Fail()
-
-				localInst, instOp, cleanup, err := instance.CreateInternal(ctx, s, instArgs, true)
+				result, err := prepareInstanceMigrationSink(ctx, s, projectName, profiles, migrateReq, "")
 				if err != nil {
-					return fmt.Errorf("Failed creating local instance record for %q: %w", instName, err)
+					return fmt.Errorf("Failed preparing migration sink for instance %q: %w", instName, err)
 				}
 
-				rev.Add(cleanup)
+				defer result.revert.Fail()
 
-				sink, err := newMigrationSink(&migrationSinkArgs{
-					url:      remoteOpURL,
-					dialer:   dialer,
-					instance: localInst,
-					secrets:  remoteSecrets,
-					refresh:  false,
-				})
+				err = result.run(ctx, op)
 				if err != nil {
-					instOp.Done(err)
-					return fmt.Errorf("Failed setting up migration sink for new instance %q: %w", instName, err)
+					return fmt.Errorf("Restore of instance %q failed: %w", instName, err)
 				}
 
-				err = sink.Do(ctx, instOp, op)
-				if err != nil {
-					instOp.Done(err)
-					return fmt.Errorf("Restore of new instance %q failed: %w", instName, err)
-				}
-
-				instOp.Done(nil)
-				rev.Success()
+				result.revert.Success()
 				return remoteMigrateOp.Wait()
 			}
 

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -158,26 +158,7 @@ func GetClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID *int64)
 
 // CreateClusterLinkConfig creates config for a new cluster link with the given ID.
 func CreateClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID int64, config map[string]string) error {
-	str := "INSERT INTO cluster_links_config (cluster_link_id, key, value) VALUES(?, ?, ?)"
-	stmt, err := tx.Prepare(str)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = stmt.Close() }()
-
-	for k, v := range config {
-		if v == "" {
-			continue
-		}
-
-		_, err = stmt.ExecContext(ctx, clusterLinkID, k, v)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return CreateEntityConfig(ctx, tx, "cluster_links_config", "cluster_link_id", clusterLinkID, config)
 }
 
 // UpdateClusterLinkConfig updates the cluster link with the given ID, setting its config.

--- a/lxd/db/cluster/config.go
+++ b/lxd/db/cluster/config.go
@@ -2,6 +2,12 @@
 
 package cluster
 
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
 // Code generation directives.
 //
 //go:generate -command mapper lxd-generate db mapper -t config.mapper.go
@@ -30,4 +36,28 @@ type Config struct {
 type ConfigFilter struct {
 	Key   *string
 	Value *string
+}
+
+// CreateEntityConfig inserts config rows for an entity. The table must have columns
+// (<idColumn>, key, value). Empty values are skipped.
+func CreateEntityConfig(ctx context.Context, tx *sql.Tx, table string, idColumn string, entityID int64, config map[string]string) error {
+	stmt, err := tx.Prepare(fmt.Sprintf("INSERT INTO %s (%s, key, value) VALUES(?, ?, ?)", table, idColumn))
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = stmt.Close() }()
+
+	for k, v := range config {
+		if v == "" {
+			continue
+		}
+
+		_, err = stmt.ExecContext(ctx, entityID, k, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/lxd/db/cluster/entity_type_auth_group.go
+++ b/lxd/db/cluster/entity_type_auth_group.go
@@ -31,17 +31,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeAuthGroup) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_auth_group_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON auth_groups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_auth_group_delete", "auth_groups", e.code())
 }

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -31,17 +31,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeClusterGroup) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_cluster_group_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON cluster_groups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_cluster_group_delete", "cluster_groups", e.code())
 }

--- a/lxd/db/cluster/entity_type_cluster_link.go
+++ b/lxd/db/cluster/entity_type_cluster_link.go
@@ -35,17 +35,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeClusterLink) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_cluster_link_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON cluster_links
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings 
-		WHERE entity_type_code = %d 
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_cluster_link_delete", "cluster_links", e.code())
 }

--- a/lxd/db/cluster/entity_type_cluster_member.go
+++ b/lxd/db/cluster/entity_type_cluster_member.go
@@ -31,17 +31,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeClusterMember) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_node_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON nodes
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_node_delete", "nodes", e.code())
 }

--- a/lxd/db/cluster/entity_type_common.go
+++ b/lxd/db/cluster/entity_type_common.go
@@ -1,5 +1,9 @@
 package cluster
 
+import (
+	"fmt"
+)
+
 // entityTypeCommon acts as a base entityTypeDBInfo.
 type entityTypeCommon struct{}
 
@@ -36,4 +40,33 @@ func (e entityTypeCommon) onInsertTriggerSQL() (name string, sql string) {
 // onUpdateTriggerSQL returns empty because most entityTypeDBInfo implementations have an update trigger.
 func (e entityTypeCommon) onUpdateTriggerSQL() (name string, sql string) {
 	return "", ""
+}
+
+// standardOnDeleteTriggerSQL generates the standard AFTER DELETE trigger that cleans up
+// auth_groups_permissions and warnings rows when an entity is deleted.
+func standardOnDeleteTriggerSQL(triggerName string, tableName string, code int64) (name string, sql string) {
+	return triggerName, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON %s
+	BEGIN
+	DELETE FROM auth_groups_permissions
+		WHERE entity_type = %d
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, triggerName, tableName, code, code)
+}
+
+// projectEntityIDFromURLQuery generates the standard idFromURLQuery SQL for entities that
+// live under a project and are identified by a single name column.
+func projectEntityIDFromURLQuery(tableName string) string {
+	return fmt.Sprintf(`
+SELECT ?, %s.id
+FROM %s
+JOIN projects ON %s.project_id = projects.id
+WHERE projects.name = ?
+	AND '' = ?
+	AND %s.name = ?`, tableName, tableName, tableName, tableName)
 }

--- a/lxd/db/cluster/entity_type_identity_provider_group.go
+++ b/lxd/db/cluster/entity_type_identity_provider_group.go
@@ -31,17 +31,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeIdentityProviderGroup) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_identity_provider_group_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON identity_provider_groups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_identity_provider_group_delete", "identity_provider_groups", e.code())
 }

--- a/lxd/db/cluster/entity_type_image.go
+++ b/lxd/db/cluster/entity_type_image.go
@@ -39,16 +39,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeImage) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_image_delete"
-	return name, fmt.Sprintf(`CREATE TRIGGER %s
-	AFTER DELETE ON images
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_image_delete", "images", e.code())
 }

--- a/lxd/db/cluster/entity_type_image_alias.go
+++ b/lxd/db/cluster/entity_type_image_alias.go
@@ -29,27 +29,9 @@ func (e entityTypeImageAlias) urlByIDQuery() string {
 }
 
 func (e entityTypeImageAlias) idFromURLQuery() string {
-	return `
-SELECT ?, images_aliases.id 
-FROM images_aliases 
-JOIN projects ON images_aliases.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND images_aliases.name = ? `
+	return projectEntityIDFromURLQuery("images_aliases")
 }
 
 func (e entityTypeImageAlias) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_image_alias_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON images_aliases
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_image_alias_delete", "images_aliases", e.code())
 }

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -29,27 +29,9 @@ func (e entityTypeInstance) urlByIDQuery() string {
 }
 
 func (e entityTypeInstance) idFromURLQuery() string {
-	return `
-SELECT ?, instances.id 
-FROM instances 
-JOIN projects ON instances.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND instances.name = ?`
+	return projectEntityIDFromURLQuery("instances")
 }
 
 func (e entityTypeInstance) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_instance_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON instances
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_instance_delete", "instances", e.code())
 }

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -47,17 +47,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeInstanceBackup) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_instance_backup_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON instances_backups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_instance_backup_delete", "instances_backups", e.code())
 }

--- a/lxd/db/cluster/entity_type_instance_snapshot.go
+++ b/lxd/db/cluster/entity_type_instance_snapshot.go
@@ -42,17 +42,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeInstanceSnapshot) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_instance_snapshot_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON instances_snapshots
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_instance_snapshot_delete", "instances_snapshots", e.code())
 }

--- a/lxd/db/cluster/entity_type_network.go
+++ b/lxd/db/cluster/entity_type_network.go
@@ -29,27 +29,9 @@ func (e entityTypeNetwork) urlByIDQuery() string {
 }
 
 func (e entityTypeNetwork) idFromURLQuery() string {
-	return `
-SELECT ?, networks.id 
-FROM networks 
-JOIN projects ON networks.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks.name = ?`
+	return projectEntityIDFromURLQuery("networks")
 }
 
 func (e entityTypeNetwork) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_network_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON networks
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_network_delete", "networks", e.code())
 }

--- a/lxd/db/cluster/entity_type_network_acl.go
+++ b/lxd/db/cluster/entity_type_network_acl.go
@@ -29,27 +29,9 @@ func (e entityTypeNetworkACL) urlByIDQuery() string {
 }
 
 func (e entityTypeNetworkACL) idFromURLQuery() string {
-	return `
-SELECT ?, networks_acls.id 
-FROM networks_acls 
-JOIN projects ON networks_acls.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks_acls.name = ?`
+	return projectEntityIDFromURLQuery("networks_acls")
 }
 
 func (e entityTypeNetworkACL) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_network_acl_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON networks_acls
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_network_acl_delete", "networks_acls", e.code())
 }

--- a/lxd/db/cluster/entity_type_network_zone.go
+++ b/lxd/db/cluster/entity_type_network_zone.go
@@ -29,27 +29,9 @@ func (e entityTypeNetworkZone) urlByIDQuery() string {
 }
 
 func (e entityTypeNetworkZone) idFromURLQuery() string {
-	return `
-SELECT ?, networks_zones.id 
-FROM networks_zones 
-JOIN projects ON networks_zones.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks_zones.name = ?`
+	return projectEntityIDFromURLQuery("networks_zones")
 }
 
 func (e entityTypeNetworkZone) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_network_zone_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON networks_zones
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_network_zone_delete", "networks_zones", e.code())
 }

--- a/lxd/db/cluster/entity_type_placement_group.go
+++ b/lxd/db/cluster/entity_type_placement_group.go
@@ -35,13 +35,7 @@ func (e entityTypePlacementGroup) urlsByProjectQuery() string {
 }
 
 func (e entityTypePlacementGroup) idFromURLQuery() string {
-	return `
-SELECT ?, placement_groups.id 
-FROM placement_groups
-JOIN projects ON placement_groups.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND placement_groups.name = ?`
+	return projectEntityIDFromURLQuery("placement_groups")
 }
 
 func (e entityTypePlacementGroup) onDeleteTriggerSQL() (name string, sql string) {

--- a/lxd/db/cluster/entity_type_profile.go
+++ b/lxd/db/cluster/entity_type_profile.go
@@ -29,27 +29,9 @@ func (e entityTypeProfile) urlByIDQuery() string {
 }
 
 func (e entityTypeProfile) idFromURLQuery() string {
-	return `
-SELECT ?, profiles.id 
-FROM profiles 
-JOIN projects ON profiles.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND profiles.name = ?`
+	return projectEntityIDFromURLQuery("profiles")
 }
 
 func (e entityTypeProfile) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_profile_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON profiles
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_profile_delete", "profiles", e.code())
 }

--- a/lxd/db/cluster/entity_type_project.go
+++ b/lxd/db/cluster/entity_type_project.go
@@ -35,17 +35,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeProject) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_project_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON projects
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_project_delete", "projects", e.code())
 }

--- a/lxd/db/cluster/entity_type_replicator.go
+++ b/lxd/db/cluster/entity_type_replicator.go
@@ -29,27 +29,9 @@ func (e entityTypeReplicator) urlByIDQuery() string {
 }
 
 func (e entityTypeReplicator) idFromURLQuery() string {
-	return `
-SELECT ?, replicators.id
-FROM replicators
-JOIN projects ON replicators.project_id = projects.id
-WHERE projects.name = ?
-	AND '' = ?
-	AND replicators.name = ?`
+	return projectEntityIDFromURLQuery("replicators")
 }
 
 func (e entityTypeReplicator) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_replicator_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON replicators
-	BEGIN
-	DELETE FROM auth_groups_permissions
-		WHERE entity_type = %d
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_replicator_delete", "replicators", e.code())
 }

--- a/lxd/db/cluster/entity_type_storage_bucket.go
+++ b/lxd/db/cluster/entity_type_storage_bucket.go
@@ -47,17 +47,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeStorageBucket) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_storage_bucket_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON storage_buckets
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_storage_bucket_delete", "storage_buckets", e.code())
 }

--- a/lxd/db/cluster/entity_type_storage_pool.go
+++ b/lxd/db/cluster/entity_type_storage_pool.go
@@ -31,17 +31,5 @@ WHERE '' = ?
 }
 
 func (e entityTypeStoragePool) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_storage_pool_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON storage_pools
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_storage_pool_delete", "storage_pools", e.code())
 }

--- a/lxd/db/cluster/entity_type_storage_volume.go
+++ b/lxd/db/cluster/entity_type_storage_volume.go
@@ -75,17 +75,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeStorageVolume) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_storage_volume_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON storage_volumes
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_storage_volume_delete", "storage_volumes", e.code())
 }

--- a/lxd/db/cluster/entity_type_storage_volume_backup.go
+++ b/lxd/db/cluster/entity_type_storage_volume_backup.go
@@ -79,17 +79,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeStorageVolumeBackup) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_storage_volume_backup_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON storage_volumes_backups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_storage_volume_backup_delete", "storage_volumes_backups", e.code())
 }

--- a/lxd/db/cluster/entity_type_storage_volume_snapshot.go
+++ b/lxd/db/cluster/entity_type_storage_volume_snapshot.go
@@ -79,17 +79,5 @@ WHERE projects.name = ?
 }
 
 func (e entityTypeStorageVolumeSnapshot) onDeleteTriggerSQL() (name string, sql string) {
-	name = "on_storage_volume_snapshot_delete"
-	return name, fmt.Sprintf(`
-CREATE TRIGGER %s
-	AFTER DELETE ON storage_volumes_snapshots
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, name, e.code(), e.code())
+	return standardOnDeleteTriggerSQL("on_storage_volume_snapshot_delete", "storage_volumes_snapshots", e.code())
 }

--- a/lxd/db/cluster/placement_groups.go
+++ b/lxd/db/cluster/placement_groups.go
@@ -11,7 +11,6 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
-	"github.com/canonical/lxd/shared/logger"
 )
 
 // PlacementGroupsRow represents a single row of the placement_groups table.
@@ -92,32 +91,7 @@ func GetPlacementGroupsAndURLs(ctx context.Context, tx *sql.Tx, projectName *str
 
 // CreatePlacementGroupConfig creates config for a new placement group with the given ID.
 func CreatePlacementGroupConfig(ctx context.Context, tx *sql.Tx, placementGroupID int64, config map[string]string) error {
-	q := `INSERT INTO placement_groups_config (placement_group_id, key, value) VALUES(?, ?, ?)`
-
-	stmt, err := tx.Prepare(q)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		err := stmt.Close()
-		if err != nil {
-			logger.Warn("Failed closing statement", logger.Ctx{"query": q, "err": err})
-		}
-	}()
-
-	for k, v := range config {
-		if v == "" {
-			continue
-		}
-
-		_, err = stmt.Exec(placementGroupID, k, v)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return CreateEntityConfig(ctx, tx, "placement_groups_config", "placement_group_id", placementGroupID, config)
 }
 
 // UpdatePlacementGroupConfig updates the placement group config with the given ID.

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -134,26 +134,7 @@ func GetReplicatorsAndURLs(ctx context.Context, tx *sql.Tx, projectName *string,
 
 // CreateReplicatorConfig creates config for a new replicator with the given ID.
 func CreateReplicatorConfig(ctx context.Context, tx *sql.Tx, replicatorID int64, config map[string]string) error {
-	str := "INSERT INTO replicators_config (replicator_id, key, value) VALUES(?, ?, ?)"
-	stmt, err := tx.Prepare(str)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = stmt.Close() }()
-
-	for k, v := range config {
-		if v == "" {
-			continue
-		}
-
-		_, err = stmt.ExecContext(ctx, replicatorID, k, v)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return CreateEntityConfig(ctx, tx, "replicators_config", "replicator_id", replicatorID, config)
 }
 
 // UpdateReplicatorConfig updates the replicator with the given ID, setting its config.

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1506,46 +1506,9 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 		// Load profiles.
 		if len(req.Profiles) > 0 {
-			profileFilters := make([]dbCluster.ProfileFilter, 0, len(req.Profiles))
-			for _, profileName := range req.Profiles {
-				profileFilters = append(profileFilters, dbCluster.ProfileFilter{
-					Project: &profileProject,
-					Name:    &profileName,
-				})
-			}
-
-			dbProfiles, err := dbCluster.GetProfiles(ctx, tx.Tx(), profileFilters...)
+			profiles, err = instanceProfilesFromNames(ctx, tx, profileProject, req.Profiles)
 			if err != nil {
 				return err
-			}
-
-			dbProfileConfigs, err := dbCluster.GetConfig(ctx, tx.Tx(), "profile")
-			if err != nil {
-				return err
-			}
-
-			dbProfileDevices, err := dbCluster.GetDevices(ctx, tx.Tx(), "profile")
-			if err != nil {
-				return err
-			}
-
-			profilesByName := make(map[string]dbCluster.Profile, len(dbProfiles))
-			for _, dbProfile := range dbProfiles {
-				profilesByName[dbProfile.Name] = dbProfile
-			}
-
-			for _, profileName := range req.Profiles {
-				profile, found := profilesByName[profileName]
-				if !found {
-					return fmt.Errorf("Requested profile %q does not exist", profileName)
-				}
-
-				apiProfile, err := profile.ToAPI(ctx, tx.Tx(), dbProfileConfigs, dbProfileDevices)
-				if err != nil {
-					return err
-				}
-
-				profiles = append(profiles, *apiProfile)
 			}
 		}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -225,60 +225,60 @@ func createFromNone(r *http.Request, s *state.State, projectName string, profile
 	return operations.OperationResponse(op)
 }
 
-func createFromMigration(r *http.Request, s *state.State, projectName string, profiles []api.Profile, req *api.InstancesPost, isClusterNotification bool) response.Response {
-	requestor, err := request.GetRequestor(r.Context())
-	if err == nil {
-		if requestor.CallerProtocol() == "" {
-			return response.SmartError(errors.New("Failed checking request origin: Protocol not set in request context"))
-		}
+// instanceMigrationSinkResult holds the outputs of prepareInstanceMigrationSink needed by
+// callers to construct operations or run the migration directly.
+type instanceMigrationSinkResult struct {
+	// run performs the actual migration transfer. It must be called exactly once.
+	run func(ctx context.Context, op *operations.Operation) error
+	// push indicates whether the migration source will push data to us.
+	push bool
+	// sink provides Metadata() and Connect() for push-mode operation args.
+	sink *migrationSink
+	// revert must be disarmed by the caller (via Success) once the run function
+	// is guaranteed to be invoked. If the caller fails before that point,
+	// deferring revert.Fail() ensures proper cleanup.
+	revert *revert.Reverter
+}
 
-		// If the protocol is not [request.ProtocolCluster] (e.g. not an internal request) and the node has been
-		// evacuated, reject the request.
-		if s.DB.Cluster.LocalNodeIsEvacuated() && requestor.CallerProtocol() != request.ProtocolCluster {
-			return response.Forbidden(errors.New("Cluster member is evacuated"))
-		}
-	}
-
+// prepareInstanceMigrationSink sets up a migration sink for receiving an instance via pull or
+// push migration. It handles both new-instance creation and refresh of an existing instance.
+// The returned result contains a run hook, a reverter, and (for push mode) the sink.
+//
+// The caller must arrange for result.revert.Fail() on error and result.revert.Success() once
+// the run hook is guaranteed to be invoked (e.g. after scheduling the operation).
+func prepareInstanceMigrationSink(ctx context.Context, s *state.State, projectName string, profiles []api.Profile, req *api.InstancesPost, clusterMoveSourceName string) (result *instanceMigrationSinkResult, err error) {
 	// Validate migration mode.
 	if req.Source.Mode != "pull" && req.Source.Mode != "push" {
-		return response.NotImplemented(fmt.Errorf("Mode %q not implemented", req.Source.Mode))
+		return nil, fmt.Errorf("Mode %q not implemented", req.Source.Mode)
 	}
 
 	dbType, err := instancetype.New(string(req.Type))
 	if err != nil {
-		return response.BadRequest(err)
+		return nil, err
 	}
 
 	if dbType != instancetype.Container && dbType != instancetype.VM {
-		return response.BadRequest(fmt.Errorf("Instance type not supported %q", req.Type))
+		return nil, fmt.Errorf("Instance type not supported %q", req.Type)
 	}
 
-	storagePool, args, resp := setupInstanceArgs(s, dbType, projectName, profiles, req)
-	if resp != nil {
-		return resp
+	storagePool, args, err := setupInstanceArgs(s, dbType, projectName, profiles, req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed setting up instance args: %w", err)
 	}
 
 	var inst instance.Instance
 	var instOp *operationlock.InstanceOperation
-	var cleanup revert.Hook
-
-	// Decide if this is an internal cluster move request.
-	var clusterMoveSourceName string
-	if isClusterNotification && req.Source.Source != "" {
-		clusterMoveSourceName = req.Source.Source
-	}
 
 	// Early check for refresh and cluster same name move to check instance exists.
 	if req.Source.Refresh || (clusterMoveSourceName != "" && clusterMoveSourceName == req.Name) {
 		inst, err = instance.LoadByProjectAndName(s, projectName, req.Name)
 		if err != nil {
 			if !response.IsNotFoundError(err) {
-				return response.SmartError(err)
+				return nil, err
 			}
 
 			if clusterMoveSourceName != "" {
-				// Cluster move doesn't allow renaming as part of migration so fail here.
-				return response.SmartError(errors.New("Cluster move does not allow renaming"))
+				return nil, errors.New("Cluster move does not allow renaming")
 			}
 
 			req.Source.Refresh = false
@@ -287,19 +287,23 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 
 	// Reject any attempts to refresh a running instance.
 	if req.Source.Refresh && inst != nil && inst.IsRunning() {
-		return response.BadRequest(fmt.Errorf("Cannot refresh running instance %q", req.Name))
+		return nil, fmt.Errorf("Cannot refresh running instance %q", req.Name)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	rev := revert.New()
+	defer func() {
+		if err != nil {
+			rev.Fail()
+		}
+	}()
 
 	// We keep the ContainerOnly for backward compatibility.
 	instanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly //nolint:staticcheck,unused
 
 	if inst == nil {
-		_, err := storagePools.LoadByName(s, storagePool)
+		_, err = storagePools.LoadByName(s, storagePool)
 		if err != nil {
-			return response.InternalError(err)
+			return nil, fmt.Errorf("Failed loading storage pool: %w", err)
 		}
 
 		api.InstanceCreateConfigKeyPolicy.Apply(args.Config, nil)
@@ -308,29 +312,30 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, instOp, cleanup, err = instance.CreateInternal(r.Context(), s, *args, true)
+		var cleanup revert.Hook
+		inst, instOp, cleanup, err = instance.CreateInternal(ctx, s, *args, true)
 		if err != nil {
-			return response.InternalError(fmt.Errorf("Failed creating instance record: %w", err))
+			return nil, fmt.Errorf("Failed creating instance record: %w", err)
 		}
 
-		revert.Add(cleanup)
+		rev.Add(cleanup)
 	} else {
 		// For refresh requests, validate and apply target config before migration transfer starts.
 		// Skip this during internal cluster move requests, where config update semantics differ.
 		if req.Source.Refresh && clusterMoveSourceName == "" {
-			err = inst.Update(r.Context(), *args, instance.UpdateActionUserRefresh)
+			err = inst.Update(ctx, *args, instance.UpdateActionUserRefresh)
 			if err != nil {
-				return response.SmartError(fmt.Errorf("Failed applying refresh target instance config: %w", err))
+				return nil, fmt.Errorf("Failed applying refresh target instance config: %w", err)
 			}
 		}
 
 		instOp, err = inst.LockExclusive()
 		if err != nil {
-			return response.SmartError(fmt.Errorf("Failed getting exclusive access to instance: %w", err))
+			return nil, fmt.Errorf("Failed getting exclusive access to instance: %w", err)
 		}
 	}
 
-	revert.Add(func() { instOp.Done(err) })
+	rev.Add(func() { instOp.Done(err) })
 
 	push := false
 	var dialer *websocket.Dialer
@@ -340,7 +345,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 	} else {
 		dialer, err = setupWebsocketDialer(req.Source.Certificate)
 		if err != nil {
-			return response.SmartError(fmt.Errorf("Failed setting up websocket dialer for migration sink connections: %w", err))
+			return nil, fmt.Errorf("Failed setting up websocket dialer for migration sink connections: %w", err)
 		}
 	}
 
@@ -358,11 +363,11 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 
 	sink, err := newMigrationSink(&migrationArgs)
 	if err != nil {
-		return response.InternalError(err)
+		return nil, fmt.Errorf("Failed creating migration sink: %w", err)
 	}
 
 	// Copy reverter so far so we can use it inside run after this function has finished.
-	runRevert := revert.Clone()
+	runRevert := rev.Clone()
 
 	run := func(ctx context.Context, op *operations.Operation) error {
 		defer runRevert.Fail()
@@ -390,20 +395,55 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		return nil
 	}
 
+	return &instanceMigrationSinkResult{
+		run:    run,
+		push:   push,
+		sink:   sink,
+		revert: rev,
+	}, nil
+}
+
+func createFromMigration(r *http.Request, s *state.State, projectName string, profiles []api.Profile, req *api.InstancesPost, isClusterNotification bool) response.Response {
+	requestor, err := request.GetRequestor(r.Context())
+	if err == nil {
+		if requestor.CallerProtocol() == "" {
+			return response.SmartError(errors.New("Failed checking request origin: Protocol not set in request context"))
+		}
+
+		// If the protocol is not [request.ProtocolCluster] (e.g. not an internal request) and the node has been
+		// evacuated, reject the request.
+		if s.DB.Cluster.LocalNodeIsEvacuated() && requestor.CallerProtocol() != request.ProtocolCluster {
+			return response.Forbidden(errors.New("Cluster member is evacuated"))
+		}
+	}
+
+	// Decide if this is an internal cluster move request.
+	var clusterMoveSourceName string
+	if isClusterNotification && req.Source.Source != "" {
+		clusterMoveSourceName = req.Source.Source
+	}
+
+	result, err := prepareInstanceMigrationSink(r.Context(), s, projectName, profiles, req, clusterMoveSourceName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	defer result.revert.Fail()
+
 	opArgs := operations.OperationArgs{
 		ProjectName: projectName,
 		EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
 		Type:        operationtype.InstanceCreate,
-		RunHook:     run,
+		RunHook:     result.run,
 		Metadata: map[string]any{
 			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "instances", req.Name).Project(projectName).String(),
 		},
 	}
 
-	if push {
+	if result.push {
 		opArgs.Class = operations.OperationClassWebsocket
-		opArgs.Metadata = sink.Metadata()
-		opArgs.ConnectHook = sink.Connect
+		opArgs.Metadata = result.sink.Metadata()
+		opArgs.ConnectHook = result.sink.Connect
 	} else {
 		opArgs.Class = operations.OperationClassTask
 	}
@@ -413,7 +453,7 @@ func createFromMigration(r *http.Request, s *state.State, projectName string, pr
 		return response.InternalError(err)
 	}
 
-	revert.Success()
+	result.revert.Success()
 	return operations.OperationResponse(op)
 }
 
@@ -446,9 +486,9 @@ func createFromConversion(r *http.Request, s *state.State, projectName string, p
 		}
 	}
 
-	storagePool, args, resp := setupInstanceArgs(s, dbType, projectName, profiles, req)
-	if resp != nil {
-		return resp
+	storagePool, args, err := setupInstanceArgs(s, dbType, projectName, profiles, req)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	revert := revert.New()
@@ -556,9 +596,9 @@ func createFromCopy(r *http.Request, s *state.State, projectName string, profile
 			_, rootDevice, _ := api.GetRootDiskDevice(source.ExpandedDevices().CloneNative())
 			sourcePoolName := rootDevice["pool"]
 
-			destPoolName, _, _, _, resp := instanceFindStoragePool(s, targetProject, req)
-			if resp != nil {
-				return resp
+			destPoolName, _, _, _, err := instanceFindStoragePool(s, targetProject, req)
+			if err != nil {
+				return response.SmartError(err)
 			}
 
 			if sourcePoolName != destPoolName {
@@ -1014,12 +1054,66 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	return operations.OperationResponse(op)
 }
 
+// instanceProfilesFromNames loads the named profiles from the database and returns them as API
+// structs in the same order as the input names. It is intended to be called inside a cluster
+// transaction.
+func instanceProfilesFromNames(ctx context.Context, tx *db.ClusterTx, projectName string, names []string) ([]api.Profile, error) {
+	if len(names) == 0 {
+		return []api.Profile{}, nil
+	}
+
+	profileFilters := make([]dbCluster.ProfileFilter, 0, len(names))
+	for _, name := range names {
+		profileFilters = append(profileFilters, dbCluster.ProfileFilter{
+			Project: &projectName,
+			Name:    &name,
+		})
+	}
+
+	dbProfiles, err := dbCluster.GetProfiles(ctx, tx.Tx(), profileFilters...)
+	if err != nil {
+		return nil, err
+	}
+
+	dbProfileConfigs, err := dbCluster.GetConfig(ctx, tx.Tx(), "profile")
+	if err != nil {
+		return nil, err
+	}
+
+	dbProfileDevices, err := dbCluster.GetDevices(ctx, tx.Tx(), "profile")
+	if err != nil {
+		return nil, err
+	}
+
+	profilesByName := make(map[string]dbCluster.Profile, len(dbProfiles))
+	for _, p := range dbProfiles {
+		profilesByName[p.Name] = p
+	}
+
+	profiles := make([]api.Profile, 0, len(names))
+	for _, name := range names {
+		profile, found := profilesByName[name]
+		if !found {
+			return nil, fmt.Errorf("Profile %q not found in project %q", name, projectName)
+		}
+
+		apiProfile, err := profile.ToAPI(ctx, tx.Tx(), dbProfileConfigs, dbProfileDevices)
+		if err != nil {
+			return nil, err
+		}
+
+		profiles = append(profiles, *apiProfile)
+	}
+
+	return profiles, nil
+}
+
 // setupInstanceArgs sets the database instance arguments and determines the storage pool to use.
-func setupInstanceArgs(s *state.State, instType instancetype.Type, projectName string, profiles []api.Profile, req *api.InstancesPost) (storagePool string, instArgs *db.InstanceArgs, resp response.Response) {
+func setupInstanceArgs(s *state.State, instType instancetype.Type, projectName string, profiles []api.Profile, req *api.InstancesPost) (storagePool string, instArgs *db.InstanceArgs, err error) {
 	// Parse the architecture name
 	architecture, err := osarch.ArchitectureId(req.Architecture)
 	if err != nil {
-		return "", nil, response.BadRequest(err)
+		return "", nil, api.StatusErrorf(http.StatusBadRequest, "%w", err)
 	}
 
 	// Prepare the instance creation request.
@@ -1037,13 +1131,13 @@ func setupInstanceArgs(s *state.State, instType instancetype.Type, projectName s
 		Stateful:     req.Stateful,
 	}
 
-	storagePool, storagePoolProfile, localRootDiskDeviceKey, localRootDiskDevice, resp := instanceFindStoragePool(s, projectName, req)
-	if resp != nil {
-		return "", nil, resp
+	storagePool, storagePoolProfile, localRootDiskDeviceKey, localRootDiskDevice, err := instanceFindStoragePool(s, projectName, req)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if storagePool == "" {
-		return "", nil, response.BadRequest(errors.New("Cannot find a storage pool for the instance to use"))
+		return "", nil, api.StatusErrorf(http.StatusBadRequest, "Cannot find a storage pool for the instance to use")
 	}
 
 	if localRootDiskDeviceKey == "" && storagePoolProfile == "" {
@@ -1672,7 +1766,7 @@ func instancesPostSelectClusterMember(ctx context.Context, tx *db.ClusterTx, pla
 	return tx.GetNodeWithLeastInstances(ctx, filteredCandidates)
 }
 
-func instanceFindStoragePool(s *state.State, projectName string, req *api.InstancesPost) (storagePool string, storagePoolProfile string, localRootDiskDeviceKey string, localRootDiskDevice map[string]string, resp response.Response) {
+func instanceFindStoragePool(s *state.State, projectName string, req *api.InstancesPost) (storagePool string, storagePoolProfile string, localRootDiskDeviceKey string, localRootDiskDevice map[string]string, err error) {
 	// Grab the container's root device if one is specified
 	localRootDiskDeviceKey, localRootDiskDevice, _ = api.GetRootDiskDevice(req.Devices)
 	if localRootDiskDeviceKey != "" {
@@ -1714,7 +1808,7 @@ func instanceFindStoragePool(s *state.State, projectName string, req *api.Instan
 			return nil
 		})
 		if err != nil {
-			return "", "", "", nil, response.SmartError(err)
+			return "", "", "", nil, err
 		}
 	}
 
@@ -1733,10 +1827,10 @@ func instanceFindStoragePool(s *state.State, projectName string, req *api.Instan
 		})
 		if err != nil {
 			if response.IsNotFoundError(err) {
-				return "", "", "", nil, response.BadRequest(errors.New("This LXD instance does not have any storage pools configured"))
+				return "", "", "", nil, api.StatusErrorf(http.StatusBadRequest, "This LXD instance does not have any storage pools configured")
 			}
 
-			return "", "", "", nil, response.SmartError(err)
+			return "", "", "", nil, err
 		}
 
 		if len(pools) == 1 {

--- a/lxd/lifecycle/replicator.go
+++ b/lxd/lifecycle/replicator.go
@@ -1,6 +1,9 @@
 package lifecycle
 
 import (
+	"context"
+
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -18,13 +21,13 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a replicator.
-func (a ReplicatorAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
+func (a ReplicatorAction) Event(ctx context.Context, name string, projectName string, eventCtx map[string]any) api.EventLifecycle {
 	u := api.NewURL().Path(version.APIVersion, "replicators", name).Project(projectName)
 
 	return api.EventLifecycle{
 		Action:    string(a),
 		Source:    u.String(),
-		Context:   ctx,
-		Requestor: requestor,
+		Context:   eventCtx,
+		Requestor: request.CreateRequestor(ctx),
 	}
 }

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -542,6 +542,9 @@ func (op *Operation) start() {
 				var childFailed bool
 				var childCancelled bool
 				for _, childOp := range op.children {
+					// Use context.Background() so that the parent waits for every child
+					// to finish even if the parent's context has been cancelled. The
+					// parent must collect all child outcomes before reporting its own result.
 					childErr := childOp.Wait(context.Background())
 					if childErr != nil {
 						if errors.Is(childErr, context.Canceled) {


### PR DESCRIPTION
Follow-up to #18012.

Refactoring & de-duplication:

- Extract prepareInstanceMigrationSink from createFromMigration and reuse it in the replicator restore path, eliminating duplicated migration sink setup.
- Extract CreateEntityConfig helper for config table inserts across entity types.
- De-duplicate onDeleteTriggerSQL and idFromURLQuery in the cluster DB layer.
- Use WebsocketSecrets struct instead of manually constructing websocket secret maps.
- Use instanceProfilesFromNames in the instancesPost handler to avoid redundant profile lookups.

Clarity & documentation:

- Add comment clarifying the additive nature of replicator restore mode.
- Add comment explaining context.Background() usage in child operation wait.
- Update ReplicatorAction.Event to follow the established context-based lifecycle event pattern.
