### PR TITLE
lxd/events: lxd: Add authorization security event emission (authz_fail and authz_admin)

### DIFF
--- a/lxd/auth/drivers/authorization.go
+++ b/lxd/auth/drivers/authorization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 
 	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -19,7 +20,7 @@ var ErrUnknownDriver = errors.New("Unknown driver")
 type authorizer interface {
 	auth.Authorizer
 
-	init(driverName string, logger logger.Logger) error
+	init(driverName string, logger logger.Logger, sendSecurity func(*api.EventSecurity)) error
 	load(ctx context.Context, opts Opts) error
 }
 
@@ -27,12 +28,21 @@ type authorizer interface {
 // particular driver.
 type Opts struct {
 	openfgaDatastore storage.OpenFGADatastore
+	sendSecurity     func(*api.EventSecurity)
 }
 
 // WithOpenFGADatastore should be passed into LoadAuthorizer when using the embedded openfga driver.
 func WithOpenFGADatastore(store storage.OpenFGADatastore) func(*Opts) {
 	return func(o *Opts) {
 		o.openfgaDatastore = store
+	}
+}
+
+// WithSendSecurity wires a callback into the authorizer so denial paths can
+// emit authz_fail security events without depending on the events package.
+func WithSendSecurity(send func(*api.EventSecurity)) func(*Opts) {
+	return func(o *Opts) {
+		o.sendSecurity = send
 	}
 }
 
@@ -49,7 +59,7 @@ func LoadAuthorizer(ctx context.Context, driver string, logger logger.Logger, op
 	}
 
 	d := driverFunc()
-	err := d.init(driver, logger)
+	err := d.init(driver, logger, opts.sendSecurity)
 	if err != nil {
 		return nil, fmt.Errorf("Failed initializing authorizer: %w", err)
 	}

--- a/lxd/auth/drivers/common.go
+++ b/lxd/auth/drivers/common.go
@@ -5,15 +5,17 @@ package drivers
 import (
 	"errors"
 
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
 type commonAuthorizer struct {
-	driverName string
-	logger     logger.Logger
+	driverName   string
+	logger       logger.Logger
+	sendSecurity func(*api.EventSecurity)
 }
 
-func (c *commonAuthorizer) init(driverName string, l logger.Logger) error {
+func (c *commonAuthorizer) init(driverName string, l logger.Logger, sendSecurity func(*api.EventSecurity)) error {
 	if l == nil {
 		return errors.New("Cannot initialise authorizer: nil logger provided")
 	}
@@ -22,6 +24,7 @@ func (c *commonAuthorizer) init(driverName string, l logger.Logger) error {
 
 	c.driverName = driverName
 	c.logger = l
+	c.sendSecurity = sendSecurity
 	return nil
 }
 

--- a/lxd/auth/drivers/common.go
+++ b/lxd/auth/drivers/common.go
@@ -3,9 +3,13 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 
+	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -31,4 +35,23 @@ func (c *commonAuthorizer) init(driverName string, l logger.Logger, sendSecurity
 // Driver returns the driver name.
 func (c *commonAuthorizer) Driver() string {
 	return c.driverName
+}
+
+// emitAuthzFail builds and sends an authz_fail security event for a denial.
+// No-op when the driver was loaded without a send callback (e.g. unit tests).
+//
+// can_edit denials on server and storage_pool are intentionally suppressed:
+// GET handlers probe these to decide whether to render sensitive config and
+// those probes are expected denials, not real authorization failures.
+func (c *commonAuthorizer) emitAuthzFail(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement, entityType entity.Type) {
+	if c.sendSecurity == nil {
+		return
+	}
+
+	if entitlement == auth.EntitlementCanEdit && (entityType == entity.TypeServer || entityType == entity.TypeStoragePool) {
+		return
+	}
+
+	evt := security.AuthzFail.WithSuffix(string(entitlement), entityURL.String()).UserEvent(ctx, security.LevelWarning, "Authorization denied")
+	c.sendSecurity(evt)
 }

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -396,6 +396,7 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 			l.Info("Access denied", logger.Ctx{"http_code": responseCode})
 		}
 
+		e.emitAuthzFail(ctx, entityURL, entitlement, entityType)
 		return api.NewGenericStatusError(responseCode)
 	}
 

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -84,11 +84,13 @@ func (t *tls) CheckPermission(ctx context.Context, entityURL *api.URL, entitleme
 			return nil
 		}
 
+		t.emitAuthzFail(ctx, entityURL, entitlement, entityType)
 		return api.StatusErrorf(http.StatusForbidden, "Certificate is restricted")
 	}
 
 	// Check project level permissions against the certificates project list.
 	if !slices.Contains(requestor.CallerAllowedProjectNames(), projectName) {
+		t.emitAuthzFail(ctx, entityURL, entitlement, entityType)
 		return api.StatusErrorf(http.StatusForbidden, "User does not have permission for project %q", projectName)
 	}
 

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
@@ -367,6 +368,9 @@ func createAuthGroup(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.AuthGroupCreated.Event(group.Name, request.CreateRequestor(r.Context()), nil)
 	s.Events.SendLifecycle("", lc)
 
+	secEvt := security.AuthzAdmin.WithSuffix("group_create", group.Name).UserEvent(r.Context(), security.LevelInfo, "Authorization group created")
+	s.Events.SendSecurity(secEvt)
+
 	return response.SyncResponseLocation(true, nil, entity.AuthGroupURL(group.Name).String())
 }
 
@@ -549,6 +553,9 @@ func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.AuthGroupUpdated.Event(groupName, request.CreateRequestor(r.Context()), nil)
 	s.Events.SendLifecycle("", lc)
 
+	secEvt := security.AuthzAdmin.WithSuffix("group_edit", groupName).UserEvent(r.Context(), security.LevelInfo, "Authorization group updated")
+	s.Events.SendSecurity(secEvt)
+
 	return response.EmptySyncResponse
 }
 
@@ -659,6 +666,9 @@ func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.AuthGroupUpdated.Event(groupName, request.CreateRequestor(r.Context()), nil)
 	s.Events.SendLifecycle("", lc)
 
+	secEvt := security.AuthzAdmin.WithSuffix("group_edit", groupName).UserEvent(r.Context(), security.LevelInfo, "Authorization group updated")
+	s.Events.SendSecurity(secEvt)
+
 	return response.EmptySyncResponse
 }
 
@@ -727,6 +737,10 @@ func renameAuthGroup(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.AuthGroupRenamed.Event(groupPost.Name, request.CreateRequestor(r.Context()), map[string]any{"old_name": groupName})
 	s.Events.SendLifecycle("", lc)
 
+	// Rename is treated as an edit per spec; no separate group_rename action.
+	secEvt := security.AuthzAdmin.WithSuffix("group_edit", groupPost.Name).UserEvent(r.Context(), security.LevelInfo, "Authorization group renamed from "+groupName)
+	s.Events.SendSecurity(secEvt)
+
 	return response.SyncResponseLocation(true, nil, entity.AuthGroupURL(groupPost.Name).String())
 }
 
@@ -769,6 +783,9 @@ func deleteAuthGroup(d *Daemon, r *http.Request) response.Response {
 	// Send a lifecycle event for the group deletion
 	lc := lifecycle.AuthGroupDeleted.Event(groupName, request.CreateRequestor(r.Context()), nil)
 	s.Events.SendLifecycle("", lc)
+
+	secEvt := security.AuthzAdmin.WithSuffix("group_delete", groupName).UserEvent(r.Context(), security.LevelInfo, "Authorization group deleted")
+	s.Events.SendSecurity(secEvt)
 
 	return response.EmptySyncResponse
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1170,7 +1170,7 @@ func (d *Daemon) init() error {
 	var err error
 
 	// Set default authorizer.
-	d.authorizer, err = authDrivers.LoadAuthorizer(d.shutdownCtx, authDrivers.DriverTLS, logger.Log)
+	d.authorizer, err = authDrivers.LoadAuthorizer(d.shutdownCtx, authDrivers.DriverTLS, logger.Log, authDrivers.WithSendSecurity(d.events.SendSecurity))
 	if err != nil {
 		return err
 	}
@@ -1620,7 +1620,7 @@ func (d *Daemon) init() error {
 
 	// Load the embedded OpenFGA authorizer. This cannot be loaded until after the cluster database is initialised,
 	// so the TLS authorizer must be loaded first to set up clustering.
-	d.authorizer, err = authDrivers.LoadAuthorizer(d.shutdownCtx, authDrivers.DriverEmbeddedOpenFGA, logger.Log, authDrivers.WithOpenFGADatastore(openfga.NewOpenFGAStore(d.db.Cluster)))
+	d.authorizer, err = authDrivers.LoadAuthorizer(d.shutdownCtx, authDrivers.DriverEmbeddedOpenFGA, logger.Log, authDrivers.WithOpenFGADatastore(openfga.NewOpenFGAStore(d.db.Cluster)), authDrivers.WithSendSecurity(d.events.SendSecurity))
 	if err != nil {
 		return err
 	}

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -2332,8 +2332,39 @@ func newIdentityNotificationFunc(s *state.State, r *http.Request, networkCert *s
 		lc := action.Event(authenticationMethod, identifier, request.CreateRequestor(r.Context()), nil)
 		s.Events.SendLifecycle("", lc)
 
+		// Emit an authz_admin security event alongside the lifecycle event.
+		// Per spec, identity_create fires only for TLS and bearer identities:
+		// OIDC identities are auto-provisioned on first login and are not
+		// created via an administrative action.
+		suffix := authzAdminSuffixForIdentityAction(action, authenticationMethod)
+		if suffix != "" {
+			secEvt := security.AuthzAdmin.WithSuffix(suffix, authenticationMethod+"/"+identifier).UserEvent(r.Context(), security.LevelInfo, "Identity "+string(action))
+			s.Events.SendSecurity(secEvt)
+		}
+
 		return &lc, nil
 	}
+}
+
+// authzAdminSuffixForIdentityAction maps a lifecycle identity action to the
+// corresponding authz_admin event suffix. Returns an empty string when no
+// security event should be emitted for the given action (e.g. OIDC first-login
+// creations, which are not administrative actions).
+func authzAdminSuffixForIdentityAction(action lifecycle.IdentityAction, authenticationMethod string) string {
+	switch action {
+	case lifecycle.IdentityCreated:
+		if authenticationMethod == api.AuthenticationMethodOIDC {
+			return ""
+		}
+
+		return "identity_create"
+	case lifecycle.IdentityUpdated:
+		return "identity_edit"
+	case lifecycle.IdentityDeleted:
+		return "identity_delete"
+	}
+
+	return ""
 }
 
 // validateIdentityCert validates the certificate and returns its fingerprint.

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -15,6 +15,7 @@ import (
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -352,6 +353,9 @@ func createIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	lc := lifecycle.IdentityProviderGroupCreated.Event(idpGroup.Name, request.CreateRequestor(r.Context()), nil)
 	s.Events.SendLifecycle("", lc)
 
+	secEvt := security.AuthzAdmin.WithSuffix("idp_group_create", idpGroup.Name).UserEvent(r.Context(), security.LevelInfo, "Identity provider group created")
+	s.Events.SendSecurity(secEvt)
+
 	return response.SyncResponseLocation(true, nil, entity.IdentityProviderGroupURL(idpGroup.Name).String())
 }
 
@@ -404,6 +408,10 @@ func renameIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 
 		return response.SmartError(err)
 	}
+
+	// Rename is treated as an edit per spec, no separate idp_group_rename action.
+	secEvt := security.AuthzAdmin.WithSuffix("idp_group_edit", idpGroupPost.Name).UserEvent(r.Context(), security.LevelInfo, "Identity provider group renamed from "+idpGroupName)
+	s.Events.SendSecurity(secEvt)
 
 	return response.SyncResponseLocation(true, nil, entity.IdentityProviderGroupURL(idpGroupPost.Name).String())
 }
@@ -473,6 +481,9 @@ func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	secEvt := security.AuthzAdmin.WithSuffix("idp_group_edit", idpGroupName).UserEvent(r.Context(), security.LevelInfo, "Identity provider group updated")
+	s.Events.SendSecurity(secEvt)
 
 	return response.EmptySyncResponse
 }
@@ -550,6 +561,9 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	secEvt := security.AuthzAdmin.WithSuffix("idp_group_edit", idpGroupName).UserEvent(r.Context(), security.LevelInfo, "Identity provider group updated")
+	s.Events.SendSecurity(secEvt)
+
 	return response.EmptySyncResponse
 }
 
@@ -584,6 +598,9 @@ func deleteIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	secEvt := security.AuthzAdmin.WithSuffix("idp_group_delete", idpGroupName).UserEvent(r.Context(), security.LevelInfo, "Identity provider group deleted")
+	s.Events.SendSecurity(secEvt)
 
 	return response.EmptySyncResponse
 }

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -180,6 +180,7 @@ readonly test_group_standalone=(
     "security"
     "security_events"
     "security_events_bearer_authn"
+    "security_authz_events"
     "security_protection"
     "server_config"
     "server_info"

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -434,3 +434,212 @@ test_authn_events() {
   self_new_fp="$(cert_fingerprint "${LXD_CONF}/authn-self-new-cert.crt")"
   lxc config trust remove "${self_new_fp}"
 }
+
+# wait_for_security_event slurps the given JSON-Lines monitor file and waits
+# up to 10 seconds for at least one event matching the provided jq condition.
+# Usage: wait_for_security_event <monfile> <jq_select_body>
+wait_for_security_event() {
+  local monfile="${1}"
+  local jq_select="${2}"
+
+  for _ in $(seq 10); do
+    if jq --exit-status --slurp \
+      'map(select(.type == "security")) | map(select('"${jq_select}"')) | length >= 1' \
+      "${monfile}"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Expected security event not found in ${monfile}: ${jq_select}"
+  cat "${monfile}"
+  return 1
+}
+
+# count_events_tolerant counts JSON-Lines events in monfile matching the given
+# jq select expression, tolerating partial or garbled lines that can appear
+# around a monitor restart. Echoes the count.
+# Usage: count_events_tolerant <monfile> <jq_select_body>
+count_events_tolerant() {
+  local monfile="${1}"
+  local jq_select="${2}"
+
+  jq --slurp --raw-input '
+    split("\n")
+    | map(fromjson? | select(. != null))
+    | map(select('"${jq_select}"'))
+    | length' "${monfile}"
+}
+
+# assert_request_fields validates that a single security event (selected via
+# the provided jq filter) carries the request-scoped fields the emitter is
+# expected to populate. The OWASP-named fields (host_ip, hostname, port, …)
+# are produced only at the Loki forwarder; the monitor stream exposes the
+# leaner Go-style EventSecurity struct.
+# Usage: assert_request_fields <monfile> <jq_select_body>
+assert_request_fields() {
+  local monfile="${1}"
+  local jq_select="${2}"
+
+  jq --exit-status --slurp \
+    'map(select(.type == "security")) | map(select('"${jq_select}"'))
+     | .[0] as $e
+     | ($e.metadata.requestor.address // "") != ""
+       and ($e.metadata.requestor.username // "") != ""
+       and ($e.metadata.requestor.protocol // "") != ""
+       and ($e.metadata.request_method // "") != ""
+       and ($e.metadata.request_path // "") != ""' \
+    "${monfile}"
+}
+
+test_security_authz_events() {
+  local monfile="${TEST_DIR}/authz-events.jsonl"
+  rm -f "${monfile}"
+
+  lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+
+  # Wait until the monitor connection is live.
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  sub_test "authz_admin: group_create fires on auth group create"
+  lxc auth group create authz-evt-g1
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:group_create:authz-evt-g1"'
+  assert_request_fields "${monfile}" '.metadata.name == "authz_admin:group_create:authz-evt-g1"'
+
+  sub_test "authz_admin: group_edit fires on auth group edit"
+  printf 'description: updated\npermissions: []\n' | lxc auth group edit authz-evt-g1
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:group_edit:authz-evt-g1"'
+
+  sub_test "authz_admin: group_edit fires on auth group rename"
+  lxc auth group rename authz-evt-g1 authz-evt-g2
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:group_edit:authz-evt-g2"'
+
+  sub_test "authz_admin: group_delete fires on auth group delete"
+  lxc auth group delete authz-evt-g2
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:group_delete:authz-evt-g2"'
+
+  sub_test "authz_admin: idp_group_create fires on identity-provider-group create"
+  lxc auth identity-provider-group create authz-evt-idp1
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:idp_group_create:authz-evt-idp1"'
+  assert_request_fields "${monfile}" '.metadata.name == "authz_admin:idp_group_create:authz-evt-idp1"'
+
+  sub_test "authz_admin: idp_group_edit fires on identity-provider-group rename"
+  lxc auth identity-provider-group rename authz-evt-idp1 authz-evt-idp2
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:idp_group_edit:authz-evt-idp2"'
+
+  sub_test "authz_admin: idp_group_delete fires on identity-provider-group delete"
+  lxc auth identity-provider-group delete authz-evt-idp2
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_admin:idp_group_delete:authz-evt-idp2"'
+
+  sub_test "authz_admin: identity_create fires on TLS identity create"
+  lxc auth identity create tls/authz-evt-user1 --quiet
+  wait_for_security_event "${monfile}" '.metadata.name | startswith("authz_admin:identity_create:tls/")'
+
+  local tls_pending_id
+  tls_pending_id="$(lxc auth identity list --format csv | awk -F, '/^tls,.*authz-evt-user1/ {print $4}')"
+
+  sub_test "authz_admin: identity_delete fires on TLS identity delete"
+  lxc auth identity delete "tls/${tls_pending_id}"
+  wait_for_security_event "${monfile}" '.metadata.name == ("authz_admin:identity_delete:tls/'"${tls_pending_id}"'")'
+
+  sub_test "authz_admin: identity_edit fires on bearer identity group membership change"
+  lxc auth group create authz-evt-g3
+  lxc auth identity create bearer/authz-evt-bearer1
+  local bearer_id
+  bearer_id="$(lxc auth identity show bearer/authz-evt-bearer1 | awk '/^id:/ {print $2}')"
+  lxc auth identity group add "bearer/${bearer_id}" authz-evt-g3
+  wait_for_security_event "${monfile}" '.metadata.name == ("authz_admin:identity_edit:bearer/'"${bearer_id}"'")'
+  lxc auth identity delete "bearer/${bearer_id}"
+  lxc auth group delete authz-evt-g3
+
+  sub_test "authz_fail fires when fine-grained identity attempts denied edit"
+  # Create a TLS user with only can_view_projects on the server. They should be denied
+  # when trying to edit a project.
+  lxc auth group create authz-evt-viewer
+  lxc auth group permission add authz-evt-viewer server can_view_projects
+  local authz_conf token
+  authz_conf="$(mktemp -d -p "${TEST_DIR}" XXX)"
+  LXD_CONF="${authz_conf}" gen_cert_and_key "client"
+  token="$(lxc auth identity create tls/authz-evt-viewer-user --quiet --group authz-evt-viewer)"
+  LXD_CONF="${authz_conf}" lxc remote add authz-evt "${token}"
+  # Attempt an edit that requires can_edit on the default project. Denied.
+  ! LXD_CONF="${authz_conf}" lxc_remote project set authz-evt:default user.foo=bar || false
+  wait_for_security_event "${monfile}" '.metadata.name == "authz_fail:can_edit:/1.0/projects/default"'
+  assert_request_fields "${monfile}" '.metadata.name == "authz_fail:can_edit:/1.0/projects/default"'
+
+  sub_test "authz_fail does NOT fire on list filtering (GetPermissionChecker)"
+  # GetPermissionChecker is only used to filter project entities in the list
+  # handler; any emission from it would carry a /1.0/projects/<name> URL.
+  # Direct CheckPermission denials on other entities are expected and
+  # must be ignored here.
+  local list_filter_authz_fail_jq='map(select(.type == "security" and (.metadata.name | test("^authz_fail:[^:]+:/1\\.0/projects/")))) | length'
+  local list_filter_authz_fail_before list_filter_authz_fail_after
+  list_filter_authz_fail_before="$(jq --slurp "${list_filter_authz_fail_jq}" "${monfile}")"
+  local _project_list
+  _project_list="$(LXD_CONF="${authz_conf}" lxc_remote project list authz-evt: --format csv)"
+  _project_list="$(LXD_CONF="${authz_conf}" lxc_remote project list authz-evt: --format csv)"
+  sleep 1
+  list_filter_authz_fail_after="$(jq --slurp "${list_filter_authz_fail_jq}" "${monfile}")"
+  [ "$((list_filter_authz_fail_after - list_filter_authz_fail_before))" = "0" ]
+
+  sub_test "authz_fail does NOT fire on can_edit display probes (server/storage_pool)"
+  # GET /1.0 and GET /1.0/storage-pools/<name> probe can_edit on server and
+  # storage_pool to decide whether to render sensitive config. Those probes
+  # are expected denials, not real authorization failures, and must not
+  # produce authz_fail events.
+  local probe_jq='map(select(.type == "security" and (.metadata.name == "authz_fail:can_edit:/1.0" or (.metadata.name | test("^authz_fail:can_edit:/1\\.0/storage-pools/"))))) | length'
+  local probe_before probe_after _probe_info _probe_pool _probe_show
+  probe_before="$(jq --slurp "${probe_jq}" "${monfile}")"
+  _probe_info="$(LXD_CONF="${authz_conf}" lxc_remote info authz-evt:)"
+  _probe_pool="$(lxc storage list --format csv | awk --field-separator=, 'NR==1 {print $1}')"
+  if [ -n "${_probe_pool}" ]; then
+    _probe_show="$(LXD_CONF="${authz_conf}" lxc_remote storage show "authz-evt:${_probe_pool}")"
+  fi
+  sleep 1
+  probe_after="$(jq --slurp "${probe_jq}" "${monfile}")"
+  [ "$((probe_after - probe_before))" = "0" ]
+
+  sub_test "Lifecycle and authz_admin coexist without duplication"
+  # Restart monitor capturing both types. Wait for the old process to fully die
+  # before redirecting, to avoid a partial buffered write corrupting the file.
+  local old_mon_pid="${mon_pid}"
+  kill_go_proc "${old_mon_pid}" || true
+  wait "${old_mon_pid}" || true
+  lxc monitor --type=security --type=lifecycle --format=json > "${monfile}" &
+  mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+
+  local coexist_lifecycle_jq='.type == "lifecycle" and .metadata.action == "auth-group-created" and .metadata.source == "/1.0/auth/groups/authz-evt-coexist"'
+  local coexist_security_jq='.type == "security" and .metadata.name == "authz_admin:group_create:authz-evt-coexist"'
+
+  lxc auth group create authz-evt-coexist
+  # Exactly one lifecycle and one authz_admin event for the create.
+  for _ in $(seq 10); do
+    if [ "$(count_events_tolerant "${monfile}" "${coexist_lifecycle_jq}")" = "1" ] \
+      && [ "$(count_events_tolerant "${monfile}" "${coexist_security_jq}")" = "1" ]; then
+      break
+    fi
+    sleep 1
+  done
+  [ "$(count_events_tolerant "${monfile}" "${coexist_lifecycle_jq}")" = "1" ]
+  [ "$(count_events_tolerant "${monfile}" "${coexist_security_jq}")" = "1" ]
+
+  # Cleanup.
+  lxc auth group delete authz-evt-coexist
+  LXD_CONF="${authz_conf}" lxc remote remove authz-evt
+  local viewer_fp
+  viewer_fp="$(lxc auth identity list --format csv | awk -F, '/^tls,.*,authz-evt-viewer/ {print $4}')"
+  lxc auth identity delete "tls/${viewer_fp}"
+  lxc auth group delete authz-evt-viewer
+
+  kill_go_proc "${mon_pid}" || true
+  rm -f "${monfile}"
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Summary

Adds two new security event types on top of the foundation merged in #18027:

- **`authz_fail`**: emitted by both auth drivers (TLS and embedded OpenFGA) when `CheckPermission` denies a request. Captures who was denied what action on which entity, alongside the existing `Access denied` log line.
- **`authz_admin`**: emitted by the auth-group, IDP-group, and identity HTTP handlers when an administrator mutates the authorization model (group/idp_group/identity create/edit/delete).

Both event kinds use the OWASP-style `<base>:<action>:<target>` suffix shape established by the foundation PR and travel through the request-scoped `security` package so the requestor, request id, source IP, and cluster identifier fields are populated automatically.

## authz_fail (denial path)

`LoadAuthorizer` accepts a new `WithSendSecurity(func(*api.EventSecurity))` option so drivers can emit security events without depending on the full `events` package. `Daemon.init` wires `d.events.SendSecurity` through for both the bootstrap TLS authorizer and the embedded OpenFGA authorizer.

- `tls.CheckPermission` emits `authz_fail:<entitlement>:<entity URL>` from both denial branches (restricted certificate on a non-project entity, and project not in the certificate's allowed list) before returning the forbidden error.
- `embeddedOpenFGA.checkPermission` emits the same event from its central deny branch, alongside the existing `Access denied` log.
- Emission is a no-op when the driver was loaded without an event server, which keeps existing unit tests unaffected.
- List filtering via `getPermissionChecker` is intentionally not instrumented, bulk filter checks would be too noisy and aren't denials of an explicit user action.

## authz_admin (admin mutations)

- `lxd/auth_groups`: `group_create` / `group_edit` / `group_delete` next to each existing `SendLifecycle` call. Rename emits `group_edit:<new_name>` with the old name in the description per spec (no separate `group_rename` action).
- `lxd/identity_provider_groups`: same shape for `idp_group_create` / `idp_group_edit` / `idp_group_delete` across all five handlers; rename and both update/patch handlers emit `idp_group_edit`.
- `lxd/identities`: `newIdentityNotificationFunc` is extended to emit `identity_create` / `identity_edit` / `identity_delete` from a single place. OIDC `identity_create` is suppressed, OIDC identities are auto-provisioned on first login, not created via an admin action, per spec.

## Tests

`test/suites/security.sh` gains `test_security_authz_events`, registered under the existing `security_events` and `loki_security_types` test groups. It:

- Verifies `authz_fail` fires on direct `CheckPermission` denials and is **absent** on `GetPermissionChecker` list-filter paths.
- Verifies `authz_admin` events fire for all group, idp-group, and identity mutations.
- Validates request-scoped fields (requestor, request id, source IP, cluster identifier) and confirms lifecycle and security events coexist without duplication.