### PR TITLE
doc: update landing pages

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,14 +1,19 @@
 ---
 discourse: lxc:[LXD&#32;cluster&#32;on&#32;Raspberry&#32;Pi&#32;4](9076)
 relatedlinks: "[MicroCloud](https://canonical.com/microcloud)"
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD clusters, covering forming and managing clusters, configuring cluster networking and storage, disaster recovery, and more.
 ---
 
 (clustering)=
 # Clustering
 
-The following how-to guides cover common operations related to clustering.
+These how-to guides cover common operations related to clustering in LXD.
 
-How to create and configure a cluster:
+## Create and configure clusters
+
+LXD servers can join together as members of a cluster, then be configured for features such as control plane mode and cluster healing.
 
 ```{toctree}
 :titlesonly:
@@ -19,7 +24,9 @@ Configure networks </howto/cluster_config_networks>
 Configure storage </howto/cluster_config_storage>
 ```
 
-How to work with a cluster:
+## Manage instances and cluster groups
+
+Instances on cluster members can be accessed from and migrated to other members. Cluster groups and placement groups can be used to control how instances are distributed across cluster members.
 
 ```{toctree}
 :titlesonly:
@@ -29,7 +36,9 @@ Set up cluster groups </howto/cluster_groups>
 Use placement groups </howto/cluster_placement_groups>
 ```
 
-How to recover a cluster:
+## Recover clusters or cluster volumes
+
+Quorum loss from member failures and orphaned volume entries from interrupted migrations can both be recovered.
 
 ```{toctree}
 :titlesonly:
@@ -38,7 +47,9 @@ Recover a cluster </howto/cluster_recover>
 Recover orphaned volume entries </howto/cluster_recover_volumes>
 ```
 
-How to set up a highly available virtual IP for clusters:
+## Set up a virtual IP
+
+A highly available virtual IP provides a stable entry point for client connections even if individual cluster members go offline.
 
 ```{toctree}
 :titlesonly:
@@ -46,7 +57,9 @@ How to set up a highly available virtual IP for clusters:
 Set up a highly available virtual IP </howto/cluster_vip>
 ```
 
-How to link a cluster:
+## Link clusters
+
+Clusters can be linked together for authenticated communication, enabling features such as replicators.
 
 ```{toctree}
 :titlesonly:
@@ -55,7 +68,9 @@ Create cluster links </howto/cluster_links_create>
 Manage cluster links </howto/cluster_links_manage>
 ```
 
-How to work with replicators:
+## Use replicators
+
+Replicators continuously copy storage volumes from one LXD cluster to another for disaster recovery purposes.
 
 ```{toctree}
 :titlesonly:

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -1,12 +1,18 @@
+---
+myst:
+  html_meta:
+    description: An index of explanatory guides for LXD, covering instance types, storage, networking, access management, clustering, and production setup.
+---
+
 (explanation)=
 # Explanation
 
-The explanatory guides in this section introduce you to the concepts used in LXD and help you understand how things fit together.
+The explanatory guides in this section discuss the concepts used in LXD and help you understand how things fit together.
 
 (explanation-concepts)=
 ## Important concepts
 
-Before you start working with LXD, you need to be familiar with some important concepts about LXD and the instance types it provides.
+LXD's core concepts include its relationship with LXC and the instance types it supports: system containers and virtual machines.
 
 ```{toctree}
 :titlesonly:
@@ -18,8 +24,7 @@ Before you start working with LXD, you need to be familiar with some important c
 (explanation-entities)=
 ## Entities in LXD
 
-When working with LXD, you should have a basic understanding of the different entities that are used in LXD.
-See the {ref}`howtos` for instructions on how to work with these entities, and the following guides to understand the concepts behind them.
+LXD uses several distinct entity types, including images, storage pools, networks, and projects. To learn how to use them, refer to the {ref}`howtos`.
 
 ```{toctree}
 :titlesonly:
@@ -34,9 +39,7 @@ See the {ref}`howtos` for instructions on how to work with these entities, and t
 (explanation-iam)=
 ## Access management
 
-In LXD, access to the API is controlled through TLS or OpenID Connect authentication.
-When using OpenID Connect, you can grant permissions to access specific entities to different clients.
-You can also restrict access to LXD entities by confining them to specific projects.
+LXD supports multiple methods for authenticating remote API clients and provides fine-grained authorization controls. Projects can also be used to scope and restrict access.
 
 ```{toctree}
 :titlesonly:
@@ -49,7 +52,7 @@ You can also restrict access to LXD entities by confining them to specific proje
 (explanation-production)=
 ## Production setup
 
-When you're ready to move your LXD setup to production, you should read up on the concepts that are important for providing a scalable, reliable, and secure environment.
+For scalable, reliable, and secure LXD deployments, these guides help you understand the key concepts around clustering, performance tuning, and security.
 
 ```{toctree}
 :titlesonly:

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -1,14 +1,18 @@
 ---
 relatedlinks: "[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)"
+myst:
+  html_meta:
+    description: An index of how-to guides for getting started with LXD, including installation, initialization, and accessing the UI and offline documentation.
 ---
 
 (getting-started)=
 # Getting started
 
-To get started with LXD, see the documentation in this section.
+The following how-to guides cover the initial steps for setting up and accessing LXD.
 
-How to install and initialize LXD:
+## Perform initial setup
 
+LXD is most commonly installed using its snap, but other installation methods are possible. Afterward, LXD can be initialized using an interactive CLI or a preseed file.
 
 ```{toctree}
 :maxdepth: 1
@@ -17,7 +21,9 @@ Install LXD </installing>
 Initialize LXD </howto/initialize>
 ```
 
-How to access the UI and the local, offline copy of the documentation:
+## Access the UI and offline documentation
+
+The LXD UI client provides a graphical, browser-based alternative to the CLI for interacting with the LXD server. The offline documentation is especially useful for air-gapped deployments.
 
 ```{toctree}
 :maxdepth: 1
@@ -26,13 +32,15 @@ Access the UI </howto/access_ui>
 Access documentation locally </howto/access_documentation>
 ```
 
-In addition, the following clip gives a quick and easy introduction for standard use cases:
+## Watch videos
+
+The following clip gives a quick and easy introduction for standard use cases:
 
 <div>
  <script id="asciicast-226224" src="https://asciinema.org/a/226224.js" async></script>
 </div>
 
-You can also find a series of demos and tutorials on YouTube:
+A series of demos and tutorials is also available on [YouTube](https://www.youtube.com/c/LXDvideos):
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLddduKsl-KEhleT9VTR4hbtlNdtMr6cFd" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/doc/howto/index.md
+++ b/doc/howto/index.md
@@ -1,13 +1,17 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for installing, configuring, and managing LXD, including instances, storage, networks, clustering, and production deployments.
+---
+
 (howtos)=
 # How-to guides
 
 These how-to guides cover key operations and processes in LXD.
 
-(howtos-getstarted)=
-## Get started
+## Set up the LXD server and initial access
 
-To get started with LXD, install and initialize it.
-Then do some basic configuration of the server and the command-line client.
+LXD can be installed and initialized in multiple ways. Afterward, the server can be configured for network access through the CLI or UI client.
 
 ```{toctree}
 :titlesonly:
@@ -17,11 +21,9 @@ Then do some basic configuration of the server and the command-line client.
 /operation
 ```
 
-(howtos-work)=
 ## Work with LXD
 
-After the initial setup, you can start working with LXD by creating instances.
-You'll also need to set up and configure other entities.
+Instances are created from images and can be either {ref}`system containers or virtual machines <containers-and-vms>`. Projects are useful for grouping related instances and managing user access.
 
 ```{toctree}
 :titlesonly:
@@ -34,11 +36,9 @@ You'll also need to set up and configure other entities.
 /networks
 ```
 
-(howtos-production)=
 ## Get ready for production
 
-Once you are ready for production, consider setting up a LXD cluster to support the required load.
-You should also monitor your server or servers and configure them for the expected load.
+For production deployments, clusters of LXD servers help support higher loads. The production setup guides also cover performance, monitoring, backup, and disaster recovery.
 
 ```{toctree}
 :titlesonly:
@@ -48,8 +48,7 @@ You should also monitor your server or servers and configure them for the expect
 /production-setup
 ```
 
-(howtos-misc)=
-## Miscellaneous
+## Perform server administration
 
 ```{toctree}
 :titlesonly:
@@ -57,8 +56,26 @@ You should also monitor your server or servers and configure them for the expect
 Manage the snap </howto/snap>
 Harden security </howto/security_harden>
 /howto/troubleshoot
+```
+
+## Authenticate to the APIs
+
+Bearer tokens can be used to authenticate to the LXD API; refer to {ref}`authentication` for other methods. The DevLXD API is used for communication between instances and their host.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Authenticate to the LXD API using bearer tokens </howto/auth_bearer>
+Authenticate to the DevLXD API </howto/devlxd_authenticate>
+```
+
+## Engage with us
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Get support </support>
 Contribute to LXD </contributing>
-/howto/auth_bearer
-/howto/devlxd_authenticate
 ```

--- a/doc/howto/oidc.md
+++ b/doc/howto/oidc.md
@@ -1,9 +1,13 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD single sign-on (SSO) with OpenID Connect (OIDC), including Auth0, Ory Hydra, Keycloak, Entra ID, and Pocket ID.
+---
+
 (howto-oidc)=
-# How to configure single sign-on with OIDC
+# Configure single sign-on with OIDC
 
-[OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) is an interoperable authentication protocol based on the OAuth 2.0 framework. It allows applications to verify user identities and obtain basic user profile information from an external, trusted identity provider.
-
-LXD uses OIDC to authenticate users to the web UI and the CLI without needing to store a local password. In both cases, LXD redirects the user to the configured identity provider's login page via the browser. Upon successful authentication, the UI or CLI client receives a secure token from the identity provider that validates the session. For more information, see: {ref}`authentication-openid`.
+LXD uses [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) to authenticate users to the web UI and the CLI without storing local passwords. Instead, users are redirected to an external identity provider's login page. For details about this process, refer to {ref}`authentication-openid`.
 
 The following how-to guides provide detailed instructions for the SSO-based identity providers supported by LXD:
 
@@ -11,11 +15,11 @@ The following how-to guides provide detailed instructions for the SSO-based iden
 :titlesonly:
 :maxdepth: 1
 
-How to configure Auth0 </howto/oidc_auth0>
-How to configure Ory Hydra </howto/oidc_ory>
-How to configure Keycloak </howto/oidc_keycloak>
-How to configure Entra ID </howto/oidc_entra_id>
-How to configure Pocket ID </howto/oidc_pocket_id>
+Configure Auth0 </howto/oidc_auth0>
+Configure Ory Hydra </howto/oidc_ory>
+Configure Keycloak </howto/oidc_keycloak>
+Configure Entra ID </howto/oidc_entra_id>
+Configure Pocket ID </howto/oidc_pocket_id>
 ```
 
 ## Related topics

--- a/doc/howto/troubleshoot.md
+++ b/doc/howto/troubleshoot.md
@@ -1,23 +1,34 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for troubleshooting common LXD issues, including firewall configuration, instance errors, and Dqlite problems.
+---
+
 (troubleshoot)=
 # Troubleshooting
 
-If you run into problems when using LXD, check the following how-to guides to see if they help resolve your issue:
+## Fix common issues
+
+Commonly encountered issues include firewall conflicts (such as with Docker), instance errors, and Dqlite database problems.
 
 ```{toctree}
 :titlesonly:
 
 Configure your firewall </howto/network_bridge_firewalld>
-Troubleshoot instances </howto/instances_troubleshoot.md>
-Troubleshoot Dqlite </howto/dqlite_troubleshoot.md>
+Troubleshoot instances </howto/instances_troubleshoot>
+Troubleshoot networks </howto/network_ipam>
+Troubleshoot Dqlite </howto/dqlite_troubleshoot>
+Frequently asked </faq>
 ```
 
-Additional instructions are available in the following guides:
+## Dig deeper
+
+LXD provides multiple debugging methods, including CLI tools and core dump files.
 
 ```{toctree}
 :titlesonly:
 
 Debug LXD </debugging>
-Frequently asked </faq>
 ```
 
-If you cannot resolve the issue on your own, see {ref}`support` for information about where to get help.
+If the issue cannot be resolved, see {ref}`support` for information about where to get help.

--- a/doc/images.md
+++ b/doc/images.md
@@ -1,9 +1,17 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD images, including using remote images, managing local images, and copying, importing, or creating images.
+---
+
 (images)=
 # Images
 
-The following how-to guides cover common operations related to images.
+These how-to guides cover common operations related to LXD images.
 
-How to work with existing images:
+## Work with existing images
+
+Images are used to create instances. Pre-configured images can be downloaded from remote servers and managed locally, including configuring profiles to use specific images.
 
 ```{toctree}
 :titlesonly:
@@ -13,7 +21,9 @@ Manage images </howto/images_manage>
 Associate profiles </howto/images_profiles>
 ```
 
-How to import and create images:
+## Import and create images
+
+Images can be copied or imported from other servers or files. They can also be created from scratch, or from existing instances or snapshots.
 
 ```{toctree}
 :titlesonly:

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -1,13 +1,18 @@
 ---
 relatedlinks: "[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)"
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD instances, including creating, configuring, and managing instances, backup, migration, and GPU passthrough.
 ---
 
 (instances)=
 # Instances
 
-The following how-to guides cover common operations related to instances.
+These how-to guides cover common operations related to LXD instances.
 
-How to create and manage instances:
+## Create and manage instances
+
+LXD supports both system containers and virtual machines, configured using direct settings or reusable profiles.
 
 ```{toctree}
 :titlesonly:
@@ -17,10 +22,21 @@ Configure instances </howto/instances_configure.md>
 Manage instances </howto/instances_manage.md>
 Use profiles </profiles.md>
 Troubleshoot errors </howto/instances_troubleshoot.md>
+```
+
+## Attach instances to Ubuntu Pro
+
+An LXD server can automatically attach guest instances to its Ubuntu Pro subscription.
+
+```{toctree}
+:titlesonly:
+
 Auto attach Ubuntu Pro </howto/instances_ubuntu_pro_attach.md>
 ```
 
-How to work with instances:
+## Work with instances
+
+Instance files can be accessed from the host, and the instance console can be attached to for log output and debugging. Commands can also be run inside instances through the `lxc` CLI or by opening a shell.
 
 ```{toctree}
 :titlesonly:
@@ -32,24 +48,21 @@ Use cloud-init </cloud-init>
 Add a routed NIC to a VM </howto/instances_routed_nic_vm.md>
 ```
 
-How to export and move instances:
+## Back up, import, and migrate instances
+
+Instances can be backed up using snapshots, export files, or copies. Physical machines, as well as virtual machines and containers created using a different technology, can be imported as LXD instances. Instances can also be migrated between LXD servers, including live migration for VMs.
 
 ```{toctree}
 :titlesonly:
 
 Back up instances </howto/instances_backup.md>
+Import existing machines </howto/import_machines_to_instances>
 Migrate instances </howto/instances_migrate>
 ```
 
-How to import instances:
+## Pass through an NVIDIA GPU
 
-```{toctree}
-:titlesonly:
-
-Import existing machines </howto/import_machines_to_instances>
-```
-
-How to pass an NVIDIA GPU to a container with a Docker workload:
+An NVIDIA GPU can be passed through to a container running a Docker workload.
 
 ```{toctree}
 :titlesonly:

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -1,16 +1,44 @@
+---
+myst:
+  html_meta:
+    description: An index of reference information for LXD internals, including daemon behavior, syscall interception, namespaces, OVN implementation, live migration, and Dqlite.
+---
+
 # Internals
+
+These reference guides document the internal workings of LXD and are primarily intended for contributors and developers.
+
+## Runtime behavior
+
+The LXD client and daemon can use environment variables for paths, proxies, and advanced features. Daemon startup, shutdown, and signal handling are also documented here.
 
 ```{toctree}
 :titlesonly:
 
 /environment
-/reference/uefi_variables
 /daemon-behavior
+/reference/uefi_variables
+```
+
+## Security and isolation
+
+Specific system calls from containers can be intercepted and handled safely by the LXD daemon. User namespaces use UID/GID idmaps to isolate containers from the host.
+
+```{toctree}
+:titlesonly:
+
 /syscall-interception
 User namespace setup </userns-idmap>
+```
+
+## Subsystem internals
+
+```{toctree}
+:titlesonly:
+
 OVN implementation </reference/ovn-internals>
 VM live migration implementation </reference/vm_live_migration_internals>
-Dqlite </reference/dqlite-internals>
+Dqlite database for cluster state </reference/dqlite-internals>
 ```
 
 ## Related topics

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,13 +1,16 @@
 ---
 discourse: lxc:[How&#32;to&#32;use&#32;a&#32;second&#32;IP&#32;with&#32;a&#32;container&#32;and&#32;routed&#32;NIC](13021)
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD networking, including creating and configuring networks and network features such as ACLs, forwards, and BGP.
 ---
 
 (networking)=
 # Networking
 
-The following how-to guides cover common operations related to networking.
+These how-to guides cover common operations related to LXD networking.
 
-How to create and configure a network:
+## Create and configure networks
 
 ```{toctree}
 :titlesonly:
@@ -16,7 +19,9 @@ Create a network </howto/network_create>
 Configure a network </howto/network_configure>
 ```
 
-How to configure specific networking features:
+## Configure networking features
+
+These features are available for multiple types of networks.
 
 ```{toctree}
 :titlesonly:
@@ -27,7 +32,9 @@ Configure forwards </howto/network_forwards>
 Configure network zones </howto/network_zones>
 ```
 
-How to configure specific networking features (managed bridge networks only):
+## Configure bridge network features
+
+These features are available for managed bridge networks only.
 
 ```{toctree}
 :titlesonly:
@@ -36,7 +43,9 @@ Configure your firewall </howto/network_bridge_firewalld>
 Integrate with resolved </howto/network_bridge_resolved>
 ```
 
-How to configure specific networking features (OVN networks only):
+## Configure OVN network features
+
+These features are available for OVN networks only.
 
 ```{toctree}
 :titlesonly:
@@ -46,7 +55,9 @@ Configure load balancers </howto/network_load_balancers>
 Configure peer routing </howto/network_ovn_peers>
 ```
 
-How to troubleshoot your networking setup:
+## Troubleshoot networks
+
+IPAM information shows the IP addresses allocated across networks and instances, useful for diagnosing network issues.
 
 ```{toctree}
 :titlesonly:

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -1,18 +1,28 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for common LXD server and client operations, including how to configure the server and set up OIDC single sign-on.
+---
+
 (lxd-server)=
 # LXD server and client
 
-The following how-to guides cover common operations related to the LXD server:
+These how-to guides cover common operations related to the LXD server and client.
+
+## Configure the LXD server
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
-Expose LXD to the network </howto/server_expose>
 Configure the LXD server </howto/server_configure>
+Expose LXD to the network </howto/server_expose>
 Configure single sign-on with OIDC </howto/oidc>
 ```
 
-The following how-to guides cover common operations related to the LXD client (`lxc`):
+## Configure the LXD CLI client
+
+The LXD CLI client (`lxc`) can be configured to use remote servers instead of the local LXD daemon. For convenience, aliases can be set up for frequently used commands.
 
 ```{toctree}
 :titlesonly:

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -1,8 +1,16 @@
+---
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD production deployment setup, including optimizing performance, monitoring metrics, and backup and recovery operations.
+---
+
 # Production setup
 
-The following how-to guides cover common operations to prepare your LXD server setup for production.
+These how-to guides cover common operations to prepare an LXD server setup for production.
 
-How to check and improve the performance:
+## Optimize performance
+
+The `lxd-benchmark` tool measures the time to create instances in different configurations. In some scenarios, deployments can also be configured for increased bandwidth.
 
 ```{toctree}
 :titlesonly:
@@ -11,7 +19,9 @@ Benchmark performance </howto/benchmark_performance>
 Increase bandwidth </howto/network_increase_bandwidth>
 ```
 
-How to monitor your server:
+## Monitor metrics and logs
+
+LXD collects metrics and logs that can be viewed as raw data or used with observability tools like Loki and Grafana.
 
 ```{toctree}
 :titlesonly:
@@ -21,7 +31,9 @@ Send logs to Loki </howto/logs_loki>
 Set up Grafana </howto/grafana>
 ```
 
-How to back up your server and recover from failure:
+## Back up and recover
+
+Full and partial server backups protect against data loss. Instance recovery and disaster recovery options are available for different failure scenarios.
 
 ```{toctree}
 :titlesonly:

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -1,16 +1,19 @@
 ---
 relatedlinks: "[Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)"
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD projects, including creating, configuring, and working with projects, as well as confining users to projects.
 ---
 
 (projects)=
 # Projects
 
-The following how-to guides cover common operations related to projects:
+LXD projects enable grouping related instances together, as well as setting up multi-user environments where users are restricted to certain projects.
 
 ```{toctree}
 :titlesonly:
 
-Create and configure </howto/projects_create>
+Create and configure projects </howto/projects_create>
 Work with projects </howto/projects_work>
 Confine users to projects </howto/projects_confine>
 ```

--- a/doc/reference/clusters.md
+++ b/doc/reference/clusters.md
@@ -1,17 +1,17 @@
 ---
 myst:
   html_meta:
-    description: Reference for LXD cluster configuration, including members and cluster links.
+    description: An index of reference information for LXD clusters, covering cluster member and cluster link configuration options.
 ---
 
 (ref-clusters)=
 # Clusters
 
-Cluster configuration includes multiple categories:
+These reference guides cover LXD configuration settings for cluster members and cluster links. For server-level cluster configuration options, refer to {ref}`server`.
 
 ## Cluster member configuration
 
-Each cluster member has its own configuration.
+Member configuration includes custom user keys and instance scheduler information.
 
 ```{toctree}
 :titlesonly:
@@ -20,16 +20,12 @@ cluster_member_config
 
 ## Cluster link configuration
 
-Each cluster link has its own configuration.
+Link configuration includes custom user keys and cluster link member addresses.
 
 ```{toctree}
 :titlesonly:
 cluster_link_config
 ```
-
-## Additional information
-
-Server configuration: The server configuration is shared by all cluster members. See {ref}`server` for available server configuration options, including the {ref}`server-level cluster configuration options <server-options-cluster>`.
 
 ## Related topics
 

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: An index of reference guides for LXD, including configuration settings, REST API documentation, production setup, permissions, and internal details.
+---
+
 (reference)=
 # Reference
 
@@ -6,32 +12,51 @@ The reference material in this section provides technical descriptions of LXD.
 (reference-general)=
 ## General information
 
-Before you start using LXD, you should check the system requirements.
-You should also be aware of the supported architectures, its release types and snap information, the available image servers, the format for images, and the environment used for containers.
+These guides include compatibility information for operating systems running in instances, and man pages for the `lxc` CLI.
 
 ```{toctree}
 :titlesonly:
-:maxdepth: 2
+:maxdepth: 1
 
 /requirements
 /architectures
-/reference/release-notes/index
-/reference/releases-snap
-/reference/remote_image_servers
-/reference/image_format
 /guest-os-compatibility
 Container environment </container-environment>
+/reference/manpages
+```
+
+## Releases
+
+Release notes and details about the LXD release cadence and its snap.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+/reference/release-notes/index
+/reference/releases-snap
+```
+
+## Images
+
+Reference information for remote image servers and the LXD image format.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+/reference/remote_image_servers
+/reference/image_format
 ```
 
 (reference-config)=
 ## Configuration options
 
-LXD is highly configurable.
-Check the available configuration options for the LXD server and the different entities used in LXD.
+LXD is highly configurable, with options available for major entities as well as permissions for access control.
 
 ```{toctree}
 :titlesonly:
-:maxdepth: 2
+:maxdepth: 1
 :includehidden:
 
 Configuration option index </config-options>
@@ -44,80 +69,43 @@ Configuration option index </config-options>
 /reference/placement_groups
 /reference/clusters
 /reference/replicator_config
+/reference/permissions
 ```
 
 (reference-production)=
 ## Production setup
 
-Once you are ready for production, make sure your LXD server is configured to support the required load.
-You should also regularly {ref}`monitor the server metrics <metrics>`.
+The LXD server can be optimized for production workloads and can monitor server metrics.
 
 ```{toctree}
 :titlesonly:
-:maxdepth: 2
+:maxdepth: 1
 
 Production server settings </reference/server_settings>
 /reference/provided_metrics
 ```
 
-## Fine-grained permissions
+(reference-api)=
+## API and integrations
 
-If you are managing user access via {ref}`fine-grained-authorization`, check which {ref}`permissions <permissions>` can be assigned to groups.
+LXD exposes a REST API for managing all resources. The LXD CSI driver integrates LXD storage backends with Kubernetes.
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
-
-/reference/permissions
-```
-
-(reference-api)=
-## REST API
-
-All communication between LXD and its clients happens using a RESTful API over HTTP.
-Check the list of API extensions to see if a feature is available in your version of the API.
-
-```{toctree}
-:titlesonly:
-:maxdepth: 2
 
 /restapi_landing
-```
-
-(reference-csi)=
-## The LXD CSI driver reference
-
-Find reference information about the LXD Container Storage Interface (CSI) driver, used to integrate LXD storage backends with Kubernetes.
-
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
 /reference/driver_csi
 ```
 
-(reference-manpages)=
-## Man pages
-
-`lxc` is the command line client for LXD.
-Its usage is documented in the help pages for the `lxc` commands and subcommands.
-
-```{toctree}
-:titlesonly:
-:maxdepth: 2
-
-/reference/manpages
-```
-
 (reference-internal)=
-## Implementation details
+## Internal implementation details
 
-You don't need to be aware of the internal implementation details to use LXD.
-However, advanced users might be interested in knowing what happens internally.
+These guides are primarily of interest to advanced users, contributors, and developers.
 
 ```{toctree}
 :titlesonly:
-:maxdepth: 2
+:maxdepth: 1
 
 /internals
 ```

--- a/doc/reference/manpages.md
+++ b/doc/reference/manpages.md
@@ -1,5 +1,14 @@
+---
+myst:
+  html_meta:
+    description: Man pages for the LXD command line client (`lxc`), covering all commands and subcommands.
+---
+
+(reference-manpages)=
 (manpages)=
 # Man pages
+
+These man pages document all commands and subcommands of the `lxc` CLI client for LXD.
 
 ```{toctree}
 :titlesonly:

--- a/doc/reference/networks.md
+++ b/doc/reference/networks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Reference information for LXD network types, covering fully controlled networks (bridge, OVN) and external networks (macvlan, physical, SR-IOV).
+---
+
 (ref-networks)=
 # Networks
 
@@ -6,7 +12,7 @@ LXD supports different network types for {ref}`managed-networks`.
 ## Fully controlled networks
 
 <!-- Include start controlled intro -->
-Fully controlled networks create network interfaces and provide most functionality, including, for example, the ability to do IP management.
+Fully controlled networks create and manage their own network interfaces, supporting features like IP management and network ACLs, forwards, and zones.
 
 LXD supports the following network types:
 <!-- Include end controlled intro -->
@@ -21,11 +27,9 @@ network_ovn
 ## External networks
 
 <!-- Include start external intro -->
-External networks use network interfaces that already exist.
-Therefore, LXD has limited possibility to control them, and LXD features like network ACLs, network forwards and network zones are not supported.
+External networks use interfaces that already exist. As a result, LXD has limited control over them, and LXD networking features like ACLs, forwards, and zones are not supported.
 
-The main purpose for using external networks is to provide an uplink network through a parent interface.
-This external network specifies the presets to use when connecting instances or other networks to a parent interface.
+External networks mainly serve as uplink networks, providing a parent interface for connecting instances or other networks. They also specify the configuration presets applied when making those connections.
 
 LXD supports the following external network types:
 <!-- Include end external intro -->

--- a/doc/restapi_landing.md
+++ b/doc/restapi_landing.md
@@ -1,18 +1,36 @@
 ---
 relatedlinks: "[Directly&#32;interacting&#32;with&#32;the&#32;LXD&#32;API](https://ubuntu.com/blog/directly-interacting-with-the-lxd-api)"
+myst:
+  html_meta:
+    description: An index of reference guides for the REST APIs exposed by LXD, the main LXD API and the DevLXD API.
 ---
 
 (restapi)=
 # REST API
 
+These reference guides cover the REST APIs exposed by LXD, its main API and the DevLXD API.
+
+## The main LXD API
+
+The main LXD API can be used for managing instances, networks, storage, and other resources, and for subscribing to the event log.
+
 ```{toctree}
 :maxdepth: 1
 
-Main API documentation <rest-api>
+Main API overview <rest-api>
 api
 Main API extensions <api-extensions>
-Events API documentation <events>
-Instance API <dev-lxd>
+Events stream <events>
+```
+
+## DevLXD API
+
+The DevLXD API allows instances to communicate with their host over a Unix socket.
+
+```{toctree}
+:maxdepth: 1
+
+DevLXD API for instances <dev-lxd>
 ```
 
 ## Related topics

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,13 +1,18 @@
 ---
 discourse: lxc:[Share&#32;folders&#32;and&#32;volumes&#32;between&#32;host&#32;and&#32;containers](7735)
+myst:
+  html_meta:
+    description: An index of how-to guides for LXD storage operations, including managing pools, volumes, and buckets, and using storage with Kubernetes.
 ---
 
 (storage)=
 # Storage
 
-The following how-to guides cover common operations related to storage.
+These how-to guides cover common operations related to storage in LXD.
 
-How to create, manage, and use storage:
+## Create and manage storage
+
+LXD storage pools contain instance volumes and custom volumes, as well as buckets accessible via the S3 protocol.
 
 ```{toctree}
 :titlesonly:
@@ -15,23 +20,25 @@ How to create, manage, and use storage:
 Manage pools </howto/storage_pools>
 Manage volumes </howto/storage_volumes>
 Manage buckets </howto/storage_buckets>
-Create an instance in a pool </howto/storage_create_instance>
 ```
 
-How to export and move custom storage volumes:
+## Extend storage use
+
+Instance volumes can be created directly in a specific storage pool. Custom volumes can also be moved, copied, and backed up.
 
 ```{toctree}
 :titlesonly:
-
-Back up a volume </howto/storage_backup_volume>
-Move or copy a volume </howto/storage_move_volume>
+Create or move an instance in a pool </howto/storage_create_instance>
+Back up a custom volume </howto/storage_backup_volume>
+Move or copy a custom volume </howto/storage_move_volume>
 ```
 
-How to integrate LXD storage backends with Kubernetes:
+## Use storage with Kubernetes
+
+The LXD CSI driver integrates LXD storage backends with Kubernetes.
 
 ```{toctree}
 :titlesonly:
-
 Use the LXD CSI driver with Kubernetes </howto/storage_csi>
 ```
 


### PR DESCRIPTION
This PR updates landing pages in the howto/reference/explanation sections that index other guides within those sections. This brings these pages into alignment with the landing pages pattern standard across Canonical documentation, including organizing the landing page links into sections with summaries and using descriptive instead of imperative text. It also adds meta descriptions to all updated pages.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
