### PR TITLE
lxd: Fix URL used for initial UI identity auth check

### DIFF
--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -248,13 +248,16 @@ func identityAccessHandler(authenticationMethod string, entitlement auth.Entitle
 			return response.SmartError(err)
 		}
 
-		if identityType.IsFineGrained() {
-			err = s.Authorizer.CheckPermission(r.Context(), entity.IdentityURL(authenticationMethod, id.Identifier), entitlement)
+		// If the identity type is a legacy certificate, use a certificate URL for the check.
+		// Otherwise, use an identity URL.
+		_, err = identityType.LegacyCertificateType()
+		if err == nil {
+			err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(id.Identifier), entitlement)
 			if err != nil {
 				return response.SmartError(err)
 			}
 		} else {
-			err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(id.Identifier), entitlement)
+			err = s.Authorizer.CheckPermission(r.Context(), entity.IdentityURL(authenticationMethod, id.Identifier), entitlement)
 			if err != nil {
 				return response.SmartError(err)
 			}
@@ -1250,11 +1253,14 @@ func identitiesGet(authenticationMethod string) func(d *Daemon, r *http.Request)
 				return false
 			}
 
-			if identityType.IsFineGrained() {
-				return canViewIdentity(entity.IdentityURL(string(id.AuthMethod), id.Identifier))
+			// If the identity type is a legacy certificate, use a certificate URL for the check.
+			// Otherwise, use an identity URL.
+			_, err = identityType.LegacyCertificateType()
+			if err == nil {
+				return canViewCertificate(entity.CertificateURL(id.Identifier))
 			}
 
-			return canViewCertificate(entity.CertificateURL(id.Identifier))
+			return canViewIdentity(entity.IdentityURL(string(id.AuthMethod), id.Identifier))
 		}
 
 		canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)


### PR DESCRIPTION
Permission checks for viewing/deleting the initial UI identity were using a /1.0/certificates URL because handler logic assumed that if an identity is not fine-grained, then it must be a certificate - which is no longer true.

This commit fixes the issue by checking if the identity has a legacy certificate type. If it does, use the /1.0/certificates URL. Otherwise use the /1.0/auth/identities URL.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
