### PR TITLE
storage/connectors: Perform iSCSI non-persistent discovery

### DIFF
--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -298,7 +298,7 @@ func (c *connectorISCSI) Discover(ctx context.Context, targetAddresses ...string
 	result := make([]any, 0)
 	for _, targetAddr := range targetAddresses {
 		targetAddr = shared.EnsurePort(targetAddr, ISCSIDefaultPort)
-		stdout, err := shared.RunCommand(ctx, "iscsiadm", "--mode", "discovery", "--type", "sendtargets", "--portal", targetAddr)
+		stdout, err := shared.RunCommand(ctx, "iscsiadm", "--mode", "discovery", "--type", "sendtargets", "--portal", targetAddr, "--op", "nonpersistent")
 		if err != nil {
 			logger.Warn("Failed connecting to discovery target", logger.Ctx{"target_address": targetAddr, "err": err})
 			continue


### PR DESCRIPTION
Use non-persistent mode for iSCSI discovery to prevent `iscsiadm` from writing node entries to  `/etc/iscsi/nodes/` as a side effect of discovery.

Adding `--op nonpersistent` causes discovery to return the same output without modifying the local node database. Node entries are created by `Connect()` via `--op new` anyway.
This ensures LXD is registring only iSCSI node entries that it is actually connecting to.