### PR TITLE
Cluster: Fix non-control-plane standby demotion when below standby target

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -935,13 +935,19 @@ func rolesAdjust(roles *app.RolesChanges, leaderID uint64, nodes []db.RaftNode, 
 			candidates = filterPromotionCandidates(candidates, memberRoles)
 		}
 
-		if len(candidates) == 0 {
+		if len(candidates) > 0 {
+			domains := roles.FailureDomains(onlineStandBys)
+			roles.SortCandidates(candidates, domains)
+			return client.StandBy, candidates, false
+		}
+
+		if !controlPlaneActive {
 			return -1, nil, false
 		}
 
-		domains := roles.FailureDomains(onlineStandBys)
-		roles.SortCandidates(candidates, domains)
-		return client.StandBy, candidates, false
+		// When control-plane is active and no eligible control-plane spares exist,
+		// fall through to Phase 2, which demotes non-control-plane standbys that
+		// should not hold database roles.
 	}
 
 	// Demote extra online standbys.

--- a/lxd/cluster/membership_adjust_test.go
+++ b/lxd/cluster/membership_adjust_test.go
@@ -160,6 +160,46 @@ func TestAdjustRoles_ActiveDemotesNonControlPlaneStandby(t *testing.T) {
 	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
 }
 
+// TestAdjustRoles_ActiveDemotesNonControlPlaneStandbyBelowTarget verifies that
+// when control-plane mode is active, a non-control-plane standby is demoted even
+// when the standby count is below the configured target and no control-plane spare
+// is available to fill the gap.
+func TestAdjustRoles_ActiveDemotesNonControlPlaneStandbyBelowTarget(t *testing.T) {
+	nodes := []db.RaftNode{
+		{NodeInfo: client.NodeInfo{ID: 1, Address: "10.0.0.1:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "10.0.0.2:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "10.0.0.3:8443", Role: db.RaftVoter}},
+		{NodeInfo: client.NodeInfo{ID: 4, Address: "10.0.0.4:8443", Role: db.RaftStandBy}},
+		{NodeInfo: client.NodeInfo{ID: 5, Address: "10.0.0.5:8443", Role: db.RaftSpare}},
+		{NodeInfo: client.NodeInfo{ID: 6, Address: "10.0.0.6:8443", Role: db.RaftSpare}},
+	}
+
+	connectivity := map[string]bool{
+		"10.0.0.1:8443": true,
+		"10.0.0.2:8443": true,
+		"10.0.0.3:8443": true,
+		"10.0.0.4:8443": true,
+		"10.0.0.5:8443": true,
+		"10.0.0.6:8443": true,
+	}
+
+	// All control-plane members are already voters; no control-plane spare exists.
+	// Member 4 is a non-control-plane standby, members 5 and 6 are non-control-plane spares.
+	memberRoles := map[string][]db.ClusterRole{
+		"10.0.0.1:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.2:8443": {db.ClusterRoleControlPlane},
+		"10.0.0.3:8443": {db.ClusterRoleControlPlane},
+	}
+
+	// Target is 2 standbys but only 1 exists (non-control-plane). Because no eligible
+	// control-plane spare can fill the gap, the non-control-plane standby must still be demoted.
+	roles := testRolesChanges(nodes, connectivity, 3, 2)
+	role, candidates, _ := rolesAdjust(roles, 1, nodes, connectivity, memberRoles)
+
+	assert.Equal(t, db.RaftSpare, role)
+	assert.Equal(t, []uint64{4}, testNodeIDs(candidates))
+}
+
 // TestAdjustRoles_ActiveInterleavesDemotionsAndPromotions verifies the
 // activation transition used by integration tests: non-control-plane voters are
 // demoted, then control-plane spares are promoted before the next demotion.


### PR DESCRIPTION
When control-plane mode is active, a non-control-plane member could get stuck holding the database-standby role. Fix by falling through to the control-plane demotion phases instead of returning early.

Fixes #18163.
