### PR TITLE
Fix operation entity URLs for storage volumes/backups/snapshots

### DIFF
--- a/lxd/devlxd_storage.go
+++ b/lxd/devlxd_storage.go
@@ -398,12 +398,12 @@ func devLXDStoragePoolVolumeGetHandler(d *Daemon, r *http.Request) response.Resp
 
 	projectName := inst.Project().Name
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
-	vol, etag, err := devLXDStoragePoolVolumeGet(r.Context(), d, r.URL.Query().Get("target"), projectName, poolName, volName, volType)
+	vol, etag, err := devLXDStoragePoolVolumeGet(r.Context(), d, r.URL.Query().Get("target"), projectName, details.pool.Name(), details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -422,13 +422,14 @@ func devLXDStoragePoolVolumePutHandler(d *Daemon, r *http.Request) response.Resp
 	projectName := inst.Project().Name
 	target := r.URL.Query().Get("target")
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Retrieve the volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, inst.Project().Name, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, inst.Project().Name, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -467,7 +468,7 @@ func devLXDStoragePoolVolumePutHandler(d *Daemon, r *http.Request) response.Resp
 
 	etag := r.Header.Get("If-Match")
 
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", "custom", volName).Project(projectName)
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", "custom", details.volumeName).Project(projectName)
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -503,19 +504,20 @@ func devLXDStoragePoolVolumeDeleteHandler(d *Daemon, r *http.Request) response.R
 	projectName := inst.Project().Name
 	target := r.URL.Query().Get("target")
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Retrieve the volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, inst.Project().Name, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, inst.Project().Name, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Delete storage volume.
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", "custom", volName).Project(projectName)
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", "custom", details.volumeName).Project(projectName)
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -542,7 +544,7 @@ func devLXDStoragePoolVolumeSnapshotsGetHandler(d *Daemon, r *http.Request) resp
 		return response.DevLXDErrorResponse(err)
 	}
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -551,7 +553,7 @@ func devLXDStoragePoolVolumeSnapshotsGetHandler(d *Daemon, r *http.Request) resp
 	target := r.URL.Query().Get("target")
 
 	// Restrict access to custom volumes.
-	if volType != "custom" {
+	if details.volumeTypeName != "custom" {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusBadRequest, "Only snapshots from custom storage volumes can be retrieved"))
 	}
 
@@ -562,13 +564,14 @@ func devLXDStoragePoolVolumeSnapshotsGetHandler(d *Daemon, r *http.Request) resp
 	}
 
 	// Retrieve the parent volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Get storage volume snapshots.
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", volType, volName, "snapshots").Project(projectName).WithQuery("recursion", "1")
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", details.volumeTypeName, details.volumeName, "snapshots").Project(projectName).WithQuery("recursion", "1")
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -608,7 +611,7 @@ func devLXDStoragePoolVolumeSnapshotsPostHandler(d *Daemon, r *http.Request) res
 		return response.DevLXDErrorResponse(err)
 	}
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -617,12 +620,13 @@ func devLXDStoragePoolVolumeSnapshotsPostHandler(d *Daemon, r *http.Request) res
 	target := r.URL.Query().Get("target")
 
 	// Restrict access to custom volumes.
-	if volType != "custom" {
+	if details.volumeTypeName != "custom" {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusBadRequest, "Only snapshots for custom storage volumes can be created"))
 	}
 
 	// Retrieve the parent volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -640,7 +644,7 @@ func devLXDStoragePoolVolumeSnapshotsPostHandler(d *Daemon, r *http.Request) res
 	}
 
 	// Create storage volume snapshot.
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", volType, volName, "snapshots").Project(projectName)
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", details.volumeTypeName, details.volumeName, "snapshots").Project(projectName)
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -667,7 +671,7 @@ func devLXDStoragePoolVolumeSnapshotGetHandler(d *Daemon, r *http.Request) respo
 		return response.DevLXDErrorResponse(err)
 	}
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -681,18 +685,19 @@ func devLXDStoragePoolVolumeSnapshotGetHandler(d *Daemon, r *http.Request) respo
 	target := r.URL.Query().Get("target")
 
 	// Restrict access to custom volumes.
-	if volType != "custom" {
+	if details.volumeTypeName != "custom" {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusBadRequest, "Only snapshots from custom storage volumes can be retrieved"))
 	}
 
 	// Retrieve the parent volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Get storage volume snapshot.
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", volType, volName, "snapshots", snapName).Project(projectName)
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapName).Project(projectName)
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -729,7 +734,7 @@ func devLXDStoragePoolVolumeSnapshotDeleteHandler(d *Daemon, r *http.Request) re
 		return response.DevLXDErrorResponse(err)
 	}
 
-	poolName, volType, volName, err := extractVolumeParams(r)
+	details, err := request.GetContextValue[storageVolumeDetails](r.Context(), ctxStorageVolumeDetails)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
@@ -743,18 +748,19 @@ func devLXDStoragePoolVolumeSnapshotDeleteHandler(d *Daemon, r *http.Request) re
 	target := r.URL.Query().Get("target")
 
 	// Restrict access to custom volumes.
-	if volType != "custom" {
+	if details.volumeTypeName != "custom" {
 		return response.DevLXDErrorResponse(api.NewStatusError(http.StatusBadRequest, "Only snapshots from custom storage volumes can be deleted"))
 	}
 
 	// Retrieve the parent volume first to ensure the caller owns it.
-	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, volName, volType)
+	poolName := details.pool.Name()
+	_, _, err = devLXDStoragePoolVolumeGet(r.Context(), d, target, projectName, poolName, details.volumeName, details.volumeTypeName)
 	if err != nil {
 		return response.DevLXDErrorResponse(err)
 	}
 
 	// Delete storage volume snapshot.
-	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", volType, volName, "snapshots", snapName).Project(projectName)
+	url := api.NewURL().Path("1.0", "storage-pools", poolName, "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapName).Project(projectName)
 	if target != "" {
 		url = url.WithQuery("target", target)
 	}
@@ -804,26 +810,4 @@ func devLXDStoragePoolVolumeTypeAccessHandler(entitlement auth.Entitlement) func
 
 		return response.EmptySyncResponse
 	}
-}
-
-// extractVolumeParams extracts the pool name, volume type and volume name from the request URL.
-func extractVolumeParams(r *http.Request) (poolName string, volType string, volName string, err error) {
-	pathVars := mux.Vars(r)
-
-	poolName, err = url.PathUnescape(pathVars["poolName"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
-	volType, err = url.PathUnescape(pathVars["type"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
-	volName, err = url.PathUnescape(pathVars["volumeName"])
-	if err != nil {
-		return "", "", "", api.NewGenericStatusError(http.StatusBadRequest)
-	}
-
-	return poolName, volType, volName, nil
 }

--- a/lxd/devlxd_storage.go
+++ b/lxd/devlxd_storage.go
@@ -297,6 +297,10 @@ func devLXDStoragePoolVolumesPostHandler(d *Daemon, r *http.Request) response.Re
 		resp := storagePoolVolumeGet(d, req)
 		_, err = response.NewResponseCapture(req).RenderToStruct(resp, &sourceVol)
 		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusNotFound) {
+				return response.DevLXDErrorResponse(api.NewStatusError(http.StatusNotFound, "Source volume not found"))
+			}
+
 			return response.DevLXDErrorResponse(err)
 		}
 

--- a/lxd/devlxd_storage.go
+++ b/lxd/devlxd_storage.go
@@ -42,24 +42,24 @@ var devLXDStoragePoolVolumesTypeEndpoint = APIEndpoint{
 var devLXDStoragePoolVolumeTypeEndpoint = APIEndpoint{
 	MetricsType: entity.TypeStoragePool,
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}",
-	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanView)},
-	Put:         APIEndpointAction{Handler: devLXDStoragePoolVolumePutHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanEdit)},
-	Patch:       APIEndpointAction{Handler: devLXDStoragePoolVolumePutHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanEdit)},
-	Delete:      APIEndpointAction{Handler: devLXDStoragePoolVolumeDeleteHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanDelete)},
+	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Put:         APIEndpointAction{Handler: devLXDStoragePoolVolumePutHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Patch:       APIEndpointAction{Handler: devLXDStoragePoolVolumePutHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Delete:      APIEndpointAction{Handler: devLXDStoragePoolVolumeDeleteHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanDelete)},
 }
 
 var devLXDStoragePoolVolumeSnapshotsEndpoint = APIEndpoint{
 	MetricsType: entity.TypeStoragePool,
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}/snapshots",
-	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotsGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanView)},
-	Post:        APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotsPostHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanManageSnapshots)},
+	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotsGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Post:        APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotsPostHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanManageSnapshots)},
 }
 
 var devLXDStoragePoolVolumeSnapshotEndpoint = APIEndpoint{
 	MetricsType: entity.TypeStoragePool,
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}/snapshots/{snapshotName}",
-	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanView)},
-	Delete:      APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotDeleteHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanDelete)},
+	Get:         APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotGetHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Delete:      APIEndpointAction{Handler: devLXDStoragePoolVolumeSnapshotDeleteHandler, AccessHandler: devLXDStoragePoolVolumeTypeAccessHandler(auth.EntitlementCanDelete)},
 }
 
 // devLXDStoragePoolGetHandler retrieves information about the specified storage pool.
@@ -787,7 +787,7 @@ func isDevLXDVolumeOwner(volConfig map[string]string, identityID string) bool {
 
 // devLXDStoragePoolVolumeTypeAccessHandler returns an access handler which checks the given entitlement
 // on a storage volume and ensures cross-project access is not allowed.
-func devLXDStoragePoolVolumeTypeAccessHandler(entityType entity.Type, entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+func devLXDStoragePoolVolumeTypeAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
 	return func(d *Daemon, r *http.Request) response.Response {
 		s := d.State()
 
@@ -797,7 +797,7 @@ func devLXDStoragePoolVolumeTypeAccessHandler(entityType entity.Type, entitlemen
 			return response.DevLXDErrorResponse(err)
 		}
 
-		err = checkStoragePoolVolumeTypeAccess(s, r, entityType, entitlement)
+		err = checkStoragePoolVolumeTypeAccess(s, r, entitlement)
 		if err != nil {
 			return response.DevLXDErrorResponse(err)
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -2582,6 +2582,9 @@ func doStoragePoolVolumeDelete(ctx context.Context, opScheduler operations.Opera
 	// We're deleting the volume on this node.
 	// When looking up the entity for the operation, we look for the volumes located on the nodes based on the target parameter.
 	// If the server is clustered, we need to set the target.
+	// Note that in this case "storageVolumeDetails" might not be set in the context, because this function is also called
+	// when force deleting a project (this means that we can't use `details.location` directly for the target parameter
+	// and instead need to do this check).
 	if s.ServerClustered && !pool.Driver().Info().Remote {
 		volumeURL = volumeURL.Target(s.ServerName)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1875,7 +1875,7 @@ func storageVolumePostClusteringMigrate(s *state.State, srcPool storagePools.Poo
 }
 
 // storagePoolVolumeTypePostMigration handles volume migration type POST requests.
-func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, poolIsRemote bool, volumeName string, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, requestProjectName string, effectiveProjectName string, details storageVolumeDetails, req api.StorageVolumePost) response.Response {
 	ws, err := newStorageMigrationSource(req.VolumeOnly, req.Target)
 	if err != nil {
 		return response.InternalError(err)
@@ -1883,24 +1883,17 @@ func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, req
 
 	var entityURL *api.URL
 	var opType operationtype.Type
-	srcVolParentName, srcVolSnapName, srcIsSnapshot := api.GetParentAndSnapshotName(volumeName)
+	srcVolParentName, srcVolSnapName, srcIsSnapshot := api.GetParentAndSnapshotName(details.fullName)
 	if srcIsSnapshot {
 		opType = operationtype.VolumeSnapshotTransfer
-		entityURL = api.NewURL().Path(version.APIVersion, "storage-pools", poolName, "volumes", "custom", srcVolParentName, "snapshots", srcVolSnapName).Project(projectName)
+		entityURL = api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", "custom", srcVolParentName, "snapshots", srcVolSnapName).Project(effectiveProjectName).Target(details.location)
 	} else {
 		opType = operationtype.VolumeMigrate
-		entityURL = api.NewURL().Path(version.APIVersion, "storage-pools", poolName, "volumes", "custom", volumeName).Project(projectName)
-	}
-
-	// We're migrating volume on this node.
-	// When looking up the entity for the operation, we look for the volumes located on the nodes based on the target parameter.
-	// If the server is clustered, we need to set the target.
-	if state.ServerClustered && !poolIsRemote {
-		entityURL = entityURL.Target(state.ServerName)
+		entityURL = api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", "custom", details.volumeName).Project(effectiveProjectName).Target(details.location)
 	}
 
 	run := func(ctx context.Context, op *operations.Operation) error {
-		return ws.DoStorage(state, projectName, poolName, volumeName, op)
+		return ws.DoStorage(state, effectiveProjectName, details.pool.Name(), details.fullName, op)
 	}
 
 	if req.Target != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1228,15 +1228,27 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 		return nil
 	}
 
+	// Get the source pool to determine the full URL of the volume.
+	srcPool, err := storagePools.LoadByName(s, req.Source.Pool)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed loading source pool: %w", err))
+	}
+
+	// Set volume location in URL if clustered and on local storage.
+	location := ""
+	if s.ServerClustered && !srcPool.Driver().Info().Remote {
+		location = req.Source.Location
+	}
+
 	var opType operationtype.Type
 	var volumeURL *api.URL
 	if shared.IsSnapshot(req.Source.Name) {
 		opType = operationtype.VolumeSnapshotCopy
 		vName, sName, _ := api.GetParentAndSnapshotName(req.Source.Name)
-		volumeURL = api.NewURL().Path(version.APIVersion, "storage-pools", req.Source.Pool, "volumes", req.Type, vName, "snapshots", sName).Project(srcProjectName)
+		volumeURL = api.NewURL().Path(version.APIVersion, "storage-pools", req.Source.Pool, "volumes", req.Type, vName, "snapshots", sName).Project(srcProjectName).Target(location)
 	} else {
 		opType = operationtype.VolumeCopy
-		volumeURL = api.NewURL().Path(version.APIVersion, "storage-pools", req.Source.Pool, "volumes", req.Type, req.Source.Name).Project(srcProjectName)
+		volumeURL = api.NewURL().Path(version.APIVersion, "storage-pools", req.Source.Pool, "volumes", req.Type, req.Source.Name).Project(srcProjectName).Target(location)
 	}
 
 	args := operations.OperationArgs{

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1629,7 +1629,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// This is a migration request so send back requested secrets.
 	if req.Migration {
-		return storagePoolVolumeTypePostMigration(s, r, requestProjectName, effectiveProjectName, details.pool.Name(), details.pool.Driver().Info().Remote, details.volumeName, req)
+		return storagePoolVolumeTypePostMigration(s, r, requestProjectName, effectiveProjectName, details, req)
 	}
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
@@ -1718,11 +1718,11 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Detect a rename request.
 	if (req.Pool == "" || req.Pool == details.pool.Name()) && (effectiveProjectName == targetProjectName) {
-		return storagePoolVolumeTypePostRename(s, r, details.pool.Name(), effectiveProjectName, &dbVolume.StorageVolume, req)
+		return storagePoolVolumeTypePostRename(s, r, details, effectiveProjectName, &dbVolume.StorageVolume, req)
 	}
 
 	// Otherwise this is a move request.
-	return storagePoolVolumeTypePostMove(s, r, details.pool.Name(), effectiveProjectName, targetProjectName, &dbVolume.StorageVolume, req)
+	return storagePoolVolumeTypePostMove(s, r, details, effectiveProjectName, targetProjectName, &dbVolume.StorageVolume, req)
 }
 
 func migrateStorageVolume(ctx context.Context, s *state.State, sourceVolumeName string, sourcePoolName string, targetNode string, projectName string, req api.StorageVolumePost, op *operations.Operation) error {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -82,19 +82,19 @@ var storagePoolVolumeTypeCmd = APIEndpoint{
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}",
 	MetricsType: entity.TypeStoragePool,
 
-	Delete: APIEndpointAction{Handler: storagePoolVolumeDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanDelete)},
-	Get:    APIEndpointAction{Handler: storagePoolVolumeGet, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanView)},
-	Patch:  APIEndpointAction{Handler: storagePoolVolumePatch, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanEdit)},
-	Post:   APIEndpointAction{Handler: storagePoolVolumePost, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanEdit)},
-	Put:    APIEndpointAction{Handler: storagePoolVolumePut, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanEdit)},
+	Delete: APIEndpointAction{Handler: storagePoolVolumeDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanDelete)},
+	Get:    APIEndpointAction{Handler: storagePoolVolumeGet, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Patch:  APIEndpointAction{Handler: storagePoolVolumePatch, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Post:   APIEndpointAction{Handler: storagePoolVolumePost, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Put:    APIEndpointAction{Handler: storagePoolVolumePut, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
 }
 
 // storagePoolVolumeTypeAccessHandler returns an access handler which checks the given entitlement on a storage volume.
-func storagePoolVolumeTypeAccessHandler(entityType entity.Type, entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+func storagePoolVolumeTypeAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
 	return func(d *Daemon, r *http.Request) response.Response {
 		s := d.State()
 
-		err := checkStoragePoolVolumeTypeAccess(s, r, entityType, entitlement)
+		err := checkStoragePoolVolumeTypeAccess(s, r, entitlement)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -103,9 +103,9 @@ func storagePoolVolumeTypeAccessHandler(entityType entity.Type, entitlement auth
 	}
 }
 
-// checkStoragePoolVolumeTypeAccess checks the given entitlement on a storage volume.
+// checkStoragePoolVolumeTypeAccess checks the given entitlement on a storage volume, snapshot, or backup.
 // If the check is successful, returns nil, otherwise returns an error.
-func checkStoragePoolVolumeTypeAccess(s *state.State, r *http.Request, entityType entity.Type, entitlement auth.Entitlement) error {
+func checkStoragePoolVolumeTypeAccess(s *state.State, r *http.Request, entitlement auth.Entitlement) error {
 	err := addStoragePoolVolumeDetailsToRequestContext(s, r)
 	if err != nil {
 		return err
@@ -117,25 +117,13 @@ func checkStoragePoolVolumeTypeAccess(s *state.State, r *http.Request, entityTyp
 	}
 
 	var u *api.URL
-	switch entityType {
-	case entity.TypeStorageVolume:
-		u = entity.StorageVolumeURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName)
-	case entity.TypeStorageVolumeBackup:
-		backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-		if err != nil {
-			return err
-		}
-
-		u = entity.StorageVolumeBackupURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, backupName)
-	case entity.TypeStorageVolumeSnapshot:
-		snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-		if err != nil {
-			return err
-		}
-
-		u = entity.StorageVolumeSnapshotURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, snapshotName)
+	switch {
+	case details.snapshotName != "":
+		u = entity.StorageVolumeSnapshotURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, details.snapshotName)
+	case details.backupName != "":
+		u = entity.StorageVolumeBackupURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, details.backupName)
 	default:
-		return fmt.Errorf("Cannot use storage volume access handler with entities of type %q", entityType)
+		u = entity.StorageVolumeURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName)
 	}
 
 	err = s.Authorizer.CheckPermission(r.Context(), u, entitlement)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1303,9 +1303,14 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 	} else {
 		// We're copying a volume from this node.
 		// When looking up the entity for the operation, we look for the volumes located on the nodes based on the target parameter.
-		// If the server is clustered, we need to set the target.
+		// If the server is clustered and the source pool is local, we need to set the target.
+		srcPool, err := storagePools.LoadByName(s, req.Source.Pool)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed loading source pool: %w", err))
+		}
+
 		location := ""
-		if s.ServerClustered && !pool.Driver().Info().Remote {
+		if s.ServerClustered && !srcPool.Driver().Info().Remote {
 			location = req.Source.Location
 		}
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1599,8 +1599,8 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		args := operations.OperationArgs{
-			ProjectName: effectiveProjectName,
-			EntityURL:   api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", "custom", details.volumeName).Project(requestProjectName),
+			ProjectName: requestProjectName, // Request project may differ from effective project.
+			EntityURL:   api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", "custom", details.volumeName).Project(effectiveProjectName).Target(details.location),
 			Type:        operationtype.VolumeMigrate,
 			Class:       operations.OperationClassTask,
 			RunHook:     run,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -2922,14 +2922,18 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 // context in addStoragePoolVolumeDetailsToRequestContext.
 const ctxStorageVolumeDetails request.CtxKey = "storage-volume-details"
 
-// storageVolumeDetails contains details common to all storage volume requests. A value of this type is added to the
-// request context when addStoragePoolVolumeDetailsToRequestContext is called. We do this to avoid repeated logic when
-// parsing the request details and/or making database calls to get the storage pool or effective project. These fields
-// are required for the storage volume access check, and are subsequently available in the storage volume handlers.
+// storageVolumeDetails contains details common to all storage volume, snapshot, and backup requests. A value of this
+// type is added to the request context when addStoragePoolVolumeDetailsToRequestContext is called (it is called by
+// storagePoolVolumeTypeAccessHandler). We do this to avoid repeated logic when parsing the request details and/or
+// making database calls to get the storage pool or effective project. These fields are required for storage volume,
+// snapshot, and backup access checks, and are subsequently available in the storage volume (snapshot/backup) handlers.
 type storageVolumeDetails struct {
 	volumeName         string
 	volumeTypeName     string
 	volumeType         cluster.StoragePoolVolumeType
+	snapshotName       string
+	backupName         string
+	fullName           string
 	location           string
 	pool               storagePools.Pool
 	forwardingNodeInfo *db.NodeInfo
@@ -2960,10 +2964,16 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 			details.location = location
 		}
 
+		// Set the full name to the volume name if not already set by snapshot or backup.
+		if details.fullName == "" {
+			details.fullName = details.volumeName
+		}
+
 		request.SetContextValue(r, ctxStorageVolumeDetails, details)
 	}()
 
-	volumeName, err := url.PathUnescape(mux.Vars(r)["volumeName"])
+	muxVars := mux.Vars(r)
+	volumeName, err := url.PathUnescape(muxVars["volumeName"])
 	if err != nil {
 		return err
 	}
@@ -2974,7 +2984,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 		return api.StatusErrorf(http.StatusBadRequest, "Invalid storage volume %q", volumeName)
 	}
 
-	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
+	volumeTypeName, err := url.PathUnescape(muxVars["type"])
 	if err != nil {
 		return err
 	}
@@ -2988,6 +2998,28 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	}
 
 	details.volumeType = volumeType
+
+	// Get snapshot name if present
+	_, ok := muxVars["snapshotName"]
+	if ok {
+		details.snapshotName, err = url.PathUnescape(muxVars["snapshotName"])
+		if err != nil {
+			return err
+		}
+
+		details.fullName = volumeName + shared.SnapshotDelimiter + details.snapshotName
+	}
+
+	// Get backup name if present
+	_, ok = muxVars["backupName"]
+	if ok {
+		details.backupName, err = url.PathUnescape(muxVars["backupName"])
+		if err != nil {
+			return err
+		}
+
+		details.fullName = volumeName + shared.SnapshotDelimiter + details.backupName
+	}
 
 	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1825,11 +1825,18 @@ func storageVolumePostClusteringMigrate(s *state.State, srcPool storagePools.Poo
 			return nil
 		}
 
+		// Add the target parameter if the source pool is not remote and the server is clustered.
+		// This is required to uniquely reference a storage volume since names are not unique within a project or pool.
+		sourceVolumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", srcPool.Name(), "volumes", "custom", srcVolumeName).Project(srcProjectName)
+		if s.ServerClustered && !srcPool.Driver().Info().Remote {
+			sourceVolumeURL.Target(srcMember.Name)
+		}
+
 		args := operations.OperationArgs{
 			ProjectName: srcProjectName,
 			Type:        operationtype.VolumeMigrate,
 			Class:       operations.OperationClassWebsocket,
-			EntityURL:   api.NewURL().Path(version.APIVersion, "storage-pools", srcPool.Name(), "volumes", "custom", srcVolumeName).Project(srcProjectName),
+			EntityURL:   sourceVolumeURL,
 			Metadata:    srcMigration.Metadata(),
 			RunHook:     run,
 			ConnectHook: srcMigration.Connect,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -3061,7 +3061,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	details.forwardingNodeInfo = remoteNodeInfo
 	if remoteNodeInfo != nil {
 		location = remoteNodeInfo.Name
-	} else {
+	} else if s.ServerClustered {
 		location = s.ServerName
 	}
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1934,32 +1934,27 @@ func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, req
 }
 
 // storagePoolVolumeTypePostRename handles volume rename type POST requests.
-func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, details storageVolumeDetails, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
 	newVol := *vol
 	newVol.Name = req.Name
-
-	pool, err := storagePools.LoadByName(s, poolName)
-	if err != nil {
-		return response.SmartError(err)
-	}
 
 	run := func(ctx context.Context, op *operations.Operation) error {
 		revert := revert.New()
 		defer revert.Fail()
 
-		err = pool.RenameCustomVolume(ctx, projectName, vol.Name, req.Name, op)
+		err := details.pool.RenameCustomVolume(ctx, projectName, vol.Name, req.Name, op)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = pool.RenameCustomVolume(ctx, projectName, req.Name, vol.Name, op)
+			_ = details.pool.RenameCustomVolume(ctx, projectName, req.Name, vol.Name, op)
 		})
 
 		// Update devices using the volume in instances and profiles.
 		// Perform this operation after the actual rename of the volume.
 		// This ensures the database entries are up to date.
-		_, err := storagePoolVolumeUpdateUsers(ctx, s, projectName, pool.Name(), vol, pool.Name(), &newVol)
+		_, err = storagePoolVolumeUpdateUsers(ctx, s, projectName, details.pool.Name(), vol, details.pool.Name(), &newVol)
 		if err != nil {
 			return err
 		}
@@ -1968,15 +1963,7 @@ func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName s
 		return nil
 	}
 
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", pool.Name(), "volumes", cluster.StoragePoolVolumeTypeNameCustom, vol.Name).Project(projectName)
-
-	// We're renaming volume on this node.
-	// When looking up the entity for the operation, we look for the volumes located on the nodes based on the target parameter.
-	// If the server is clustered, we need to set the target.
-	if s.ServerClustered && !pool.Driver().Info().Remote {
-		volumeURL = volumeURL.Target(s.ServerName)
-	}
-
+	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", cluster.StoragePoolVolumeTypeNameCustom, vol.Name).Project(projectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: request.ProjectParam(r),
 		Type:        operationtype.VolumeMove,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -3073,6 +3073,11 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 // the name and address of the remote member. If there is more than one cluster member with a matching volume name, an
 // error is returned.
 func getRemoteVolumeNodeInfo(ctx context.Context, s *state.State, poolName string, projectName string, volumeName string, volumeType cluster.StoragePoolVolumeType) (*db.NodeInfo, error) {
+	// If we're not clustered, then the volume must exist locally.
+	if !s.ServerClustered {
+		return nil, nil
+	}
+
 	localNodeID := s.DB.Cluster.GetNodeID()
 	var err error
 	var nodes []db.NodeInfo

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1317,10 +1317,10 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		if shared.IsSnapshot(req.Source.Name) {
 			opType = operationtype.VolumeSnapshotCopy
 			vName, sName, _ := api.GetParentAndSnapshotName(req.Source.Name)
-			entityURL = entity.StorageVolumeSnapshotURL(srcProjectName, location, req.Source.Pool, req.Type, vName, sName).Project(projectName)
+			entityURL = entity.StorageVolumeSnapshotURL(srcProjectName, location, req.Source.Pool, req.Type, vName, sName)
 		} else {
 			opType = operationtype.VolumeCopy
-			entityURL = entity.StorageVolumeURL(srcProjectName, location, req.Source.Pool, req.Type, req.Source.Name).Project(projectName)
+			entityURL = entity.StorageVolumeURL(srcProjectName, location, req.Source.Pool, req.Type, req.Source.Name)
 		}
 
 		run = func(ctx context.Context, op *operations.Operation) error {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1981,14 +1981,9 @@ func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, details st
 }
 
 // storagePoolVolumeTypePostMove handles volume move type POST requests.
-func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName string, requestProjectName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, details storageVolumeDetails, effectiveProjectName string, targetProjectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
 	newVol := *vol
 	newVol.Name = req.Name
-
-	pool, err := storagePools.LoadByName(s, poolName)
-	if err != nil {
-		return response.SmartError(err)
-	}
 
 	newPool, err := storagePools.LoadByName(s, req.Pool)
 	if err != nil {
@@ -2000,7 +1995,7 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 		defer revert.Fail()
 
 		// Update devices using the volume in instances and profiles.
-		cleanup, err := storagePoolVolumeUpdateUsers(ctx, s, requestProjectName, pool.Name(), vol, newPool.Name(), &newVol)
+		cleanup, err := storagePoolVolumeUpdateUsers(ctx, s, effectiveProjectName, details.pool.Name(), vol, newPool.Name(), &newVol)
 		if err != nil {
 			return err
 		}
@@ -2009,12 +2004,12 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
-		err = newPool.CreateCustomVolumeFromCopy(ctx, projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
+		err = newPool.CreateCustomVolumeFromCopy(ctx, targetProjectName, effectiveProjectName, newVol.Name, "", nil, details.pool.Name(), vol.Name, true, op)
 		if err != nil {
 			return err
 		}
 
-		err = pool.DeleteCustomVolume(ctx, requestProjectName, vol.Name, op)
+		err = details.pool.DeleteCustomVolume(ctx, effectiveProjectName, vol.Name, op)
 		if err != nil {
 			return err
 		}
@@ -2023,9 +2018,9 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 		return nil
 	}
 
-	volumeURL := entity.StorageVolumeURL(requestProjectName, vol.Location, vol.Pool, vol.Type, vol.Name)
+	volumeURL := entity.StorageVolumeURL(effectiveProjectName, vol.Location, vol.Pool, vol.Type, vol.Name)
 	args := operations.OperationArgs{
-		ProjectName: requestProjectName,
+		ProjectName: request.ProjectParam(r), // Request project may differ from effective project.
 		EntityURL:   volumeURL,
 		Type:        operationtype.VolumeMove,
 		Class:       operations.OperationClassTask,

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -638,16 +638,16 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return nil
 	}
 
-	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", details.backupName).Project(requestProjectName)
+	originalEntityURLWithoutProject := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", details.backupName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
-		EntityURL:   originalEntityURL,
+		EntityURL:   originalEntityURLWithoutProject.Project(effectiveProjectName),
 		Type:        operationtype.CustomVolumeBackupRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     rename,
 		Metadata: map[string]any{
-			api.MetadataOriginalEntityURL: originalEntityURL.String(),
-			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", newBackupName).Project(requestProjectName).String(),
+			api.MetadataOriginalEntityURL: originalEntityURLWithoutProject.Project(requestProjectName).String(),
+			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", newBackupName).Project(requestProjectName).Target(details.location).String(),
 		},
 	}
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -39,23 +39,23 @@ var storagePoolVolumeTypeCustomBackupsCmd = APIEndpoint{
 	MetricsType: entity.TypeStoragePool,
 
 	Get:  APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupsGet, AccessHandler: allowProjectResourceList(false)},
-	Post: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupsPost, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanManageBackups)},
+	Post: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupsPost, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanManageBackups)},
 }
 
 var storagePoolVolumeTypeCustomBackupCmd = APIEndpoint{
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}/backups/{backupName}",
 	MetricsType: entity.TypeStoragePool,
 
-	Get:    APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupGet, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeBackup, auth.EntitlementCanView)},
-	Post:   APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupPost, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeBackup, auth.EntitlementCanEdit)},
-	Delete: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeBackup, auth.EntitlementCanDelete)},
+	Get:    APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupGet, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Post:   APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupPost, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Delete: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanDelete)},
 }
 
 var storagePoolVolumeTypeCustomBackupExportCmd = APIEndpoint{
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}/backups/{backupName}/export",
 	MetricsType: entity.TypeStoragePool,
 
-	Get: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupExportGet, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeBackup, auth.EntitlementCanView)},
+	Get: APIEndpointAction{Handler: storagePoolVolumeTypeCustomBackupExportGet, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
 }
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/volumes/{type}/{volumeName}/backups storage storage_pool_volumes_type_backups_get

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -6,12 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -515,12 +512,6 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return response.SmartError(err)
 	}
 
-	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -542,9 +533,7 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return resp
 	}
 
-	fullName := details.volumeName + shared.SnapshotDelimiter + backupName
-
-	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), fullName)
+	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), details.fullName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -597,12 +586,6 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return response.SmartError(err)
 	}
 
-	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -637,9 +620,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return response.BadRequest(err)
 	}
 
-	oldName := details.volumeName + shared.SnapshotDelimiter + backupName
-
-	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), oldName)
+	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), details.fullName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -652,12 +633,12 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 			return err
 		}
 
-		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRenamed.Event(details.pool.Name(), details.volumeTypeName, newName, effectiveProjectName, op.EventLifecycleRequestor(), logger.Ctx{"old_name": oldName}))
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRenamed.Event(details.pool.Name(), details.volumeTypeName, newName, effectiveProjectName, op.EventLifecycleRequestor(), logger.Ctx{"old_name": details.fullName}))
 
 		return nil
 	}
 
-	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName)
+	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", details.backupName).Project(requestProjectName)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   originalEntityURL,
@@ -717,12 +698,6 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 		return response.SmartError(err)
 	}
 
-	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -745,9 +720,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 		return resp
 	}
 
-	fullName := details.volumeName + shared.SnapshotDelimiter + backupName
-
-	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), fullName)
+	backup, err := storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), details.fullName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -758,12 +731,12 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 			return err
 		}
 
-		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupDeleted.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, op.EventLifecycleRequestor(), nil))
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupDeleted.Event(details.pool.Name(), details.volumeTypeName, details.fullName, effectiveProjectName, op.EventLifecycleRequestor(), nil))
 
 		return nil
 	}
 
-	backupURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(effectiveProjectName)
+	backupURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", details.backupName).Project(effectiveProjectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   backupURL,
@@ -815,12 +788,6 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 		return response.SmartError(err)
 	}
 
-	// Get backup name.
-	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -842,19 +809,17 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 		return resp
 	}
 
-	fullName := details.volumeName + shared.SnapshotDelimiter + backupName
-
 	// Ensure the volume exists
-	_, err = storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), fullName)
+	_, err = storagePoolVolumeBackupLoadByName(r.Context(), s, effectiveProjectName, details.pool.Name(), details.fullName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	ent := response.FileResponseEntry{
-		Path: filepath.Join(s.BackupsStoragePath(effectiveProjectName), "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, fullName)),
+		Path: filepath.Join(s.BackupsStoragePath(effectiveProjectName), "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, details.fullName)),
 	}
 
-	s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRetrieved.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, request.CreateRequestor(r.Context()), nil))
+	s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRetrieved.Event(details.pool.Name(), details.volumeTypeName, details.fullName, effectiveProjectName, request.CreateRequestor(r.Context()), nil))
 
 	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -439,7 +439,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		return nil
 	}
 
-	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(requestProjectName)
+	volumeURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName).Project(effectiveProjectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   volumeURL,
@@ -447,7 +447,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		Class:       operations.OperationClassTask,
 		RunHook:     backup,
 		Metadata: map[string]any{
-			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName).String(),
+			api.MetadataEntityURL: api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName).Project(requestProjectName).Target(details.location).String(),
 		},
 	}
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -547,23 +547,16 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 		return details.pool.RenameCustomVolumeSnapshot(ctx, effectiveProjectName, details.fullName, req.Name, op)
 	}
 
-	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(requestProjectName)
-
-	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
-	// Include the target so that the entity lookup can match by node name.
-	if s.ServerClustered && !details.pool.Driver().Info().Remote {
-		originalEntityURL = originalEntityURL.Target(s.ServerName)
-	}
-
+	originalEntityURLWithoutProject := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
-		EntityURL:   originalEntityURL,
+		EntityURL:   originalEntityURLWithoutProject.Project(effectiveProjectName),
 		Type:        operationtype.VolumeSnapshotRename,
 		Class:       operations.OperationClassTask,
 		RunHook:     snapshotRename,
 		Metadata: map[string]any{
-			api.MetadataOriginalEntityURL: originalEntityURL.String(),
-			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(requestProjectName).String(),
+			api.MetadataOriginalEntityURL: originalEntityURLWithoutProject.Project(requestProjectName).String(),
+			api.MetadataEntityURL:         api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", req.Name).Project(requestProjectName).Target(details.location).String(),
 		},
 	}
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -773,14 +773,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return doStoragePoolVolumeSnapshotUpdate(ctx, s, details.pool, effectiveProjectName, dbVolume.Name, details.volumeType, req, op)
 	}
 
-	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
-
-	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
-	// Include the target so that the entity lookup can match by node name.
-	if s.ServerClustered && !details.pool.Driver().Info().Remote {
-		snapshotURL = snapshotURL.Target(s.ServerName)
-	}
-
+	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Project(effectiveProjectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   snapshotURL,
@@ -903,14 +896,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return doStoragePoolVolumeSnapshotUpdate(ctx, s, details.pool, effectiveProjectName, dbVolume.Name, details.volumeType, req, op)
 	}
 
-	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
-
-	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
-	// Include the target so that the entity lookup can match by node name.
-	if s.ServerClustered && !details.pool.Driver().Info().Remote {
-		snapshotURL = snapshotURL.Target(s.ServerName)
-	}
-
+	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Project(effectiveProjectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   snapshotURL,
@@ -1020,14 +1006,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 		return details.pool.DeleteCustomVolumeSnapshot(ctx, effectiveProjectName, details.fullName, op)
 	}
 
-	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Project(effectiveProjectName)
-
-	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
-	// Include the target so that the entity lookup can match by node name.
-	if s.ServerClustered && !details.pool.Driver().Info().Remote {
-		snapshotURL = snapshotURL.Target(s.ServerName)
-	}
-
+	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Project(effectiveProjectName).Target(details.location)
 	args := operations.OperationArgs{
 		ProjectName: requestProjectName,
 		EntityURL:   snapshotURL,

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -39,18 +39,18 @@ var storagePoolVolumeSnapshotsTypeCmd = APIEndpoint{
 	MetricsType: entity.TypeStoragePool,
 
 	Get:  APIEndpointAction{Handler: storagePoolVolumeSnapshotsTypeGet, AccessHandler: allowProjectResourceList(false)},
-	Post: APIEndpointAction{Handler: storagePoolVolumeSnapshotsTypePost, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolume, auth.EntitlementCanManageSnapshots)},
+	Post: APIEndpointAction{Handler: storagePoolVolumeSnapshotsTypePost, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanManageSnapshots)},
 }
 
 var storagePoolVolumeSnapshotTypeCmd = APIEndpoint{
 	Path:        "storage-pools/{poolName}/volumes/{type}/{volumeName}/snapshots/{snapshotName}",
 	MetricsType: entity.TypeStoragePool,
 
-	Delete: APIEndpointAction{Handler: storagePoolVolumeSnapshotTypeDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanDelete)},
-	Get:    APIEndpointAction{Handler: storagePoolVolumeSnapshotTypeGet, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanView)},
-	Post:   APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePost, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanEdit)},
-	Patch:  APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePatch, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanEdit)},
-	Put:    APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePut, AccessHandler: storagePoolVolumeTypeAccessHandler(entity.TypeStorageVolumeSnapshot, auth.EntitlementCanEdit)},
+	Delete: APIEndpointAction{Handler: storagePoolVolumeSnapshotTypeDelete, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanDelete)},
+	Get:    APIEndpointAction{Handler: storagePoolVolumeSnapshotTypeGet, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanView)},
+	Post:   APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePost, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Patch:  APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePatch, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
+	Put:    APIEndpointAction{Handler: storagePoolVolumeSnapshotTypePut, AccessHandler: storagePoolVolumeTypeAccessHandler(auth.EntitlementCanEdit)},
 }
 
 // swagger:operation POST /1.0/storage-pools/{poolName}/volumes/{type}/{volumeName}/snapshots storage storage_pool_volumes_type_snapshots_post

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -539,7 +539,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 			Target: req.Target,
 		}
 
-		return storagePoolVolumeTypePostMigration(s, r, requestProjectName, effectiveProjectName, details.pool.Name(), details.pool.Driver().Info().Remote, fullSnapshotName, req)
+		return storagePoolVolumeTypePostMigration(s, r, requestProjectName, effectiveProjectName, details, req)
 	}
 
 	// Rename the snapshot.

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -6,12 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 	"sync"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db"
@@ -499,12 +496,6 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 		return response.SmartError(err)
 	}
 
-	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != dbCluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -527,8 +518,6 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	if resp != nil {
 		return resp
 	}
-
-	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
 
 	// Parse the request.
 	req := api.StorageVolumeSnapshotPost{}
@@ -555,7 +544,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 
 	// Rename the snapshot.
 	snapshotRename := func(ctx context.Context, op *operations.Operation) error {
-		return details.pool.RenameCustomVolumeSnapshot(ctx, effectiveProjectName, fullSnapshotName, req.Name, op)
+		return details.pool.RenameCustomVolumeSnapshot(ctx, effectiveProjectName, details.fullName, req.Name, op)
 	}
 
 	originalEntityURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(requestProjectName)
@@ -639,12 +628,6 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
-	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
@@ -662,13 +645,11 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return resp
 	}
 
-	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
-
 	var dbVolume *db.StorageVolume
 	var expiry time.Time
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, details.fullName, true)
 		if err != nil {
 			return err
 		}
@@ -687,7 +668,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	snapshot := &api.StorageVolumeSnapshot{}
 	snapshot.Config = dbVolume.Config
 	snapshot.Description = dbVolume.Description
-	snapshot.Name = snapshotName
+	snapshot.Name = details.snapshotName
 	snapshot.ExpiresAt = &expiry
 	snapshot.ContentType = dbVolume.ContentType
 	snapshot.CreatedAt = dbVolume.CreatedAt
@@ -743,12 +724,6 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
-	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
@@ -767,13 +742,11 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return resp
 	}
 
-	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
-
 	var dbVolume *db.StorageVolume
 	var expiry time.Time
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, details.fullName, true)
 		if err != nil {
 			return err
 		}
@@ -878,12 +851,6 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return response.SmartError(err)
 	}
 
-	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
@@ -902,13 +869,11 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return resp
 	}
 
-	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
-
 	var dbVolume *db.StorageVolume
 	var expiry time.Time
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, details.pool.ID(), effectiveProjectName, details.volumeType, details.fullName, true)
 		if err != nil {
 			return err
 		}
@@ -1035,12 +1000,6 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 		return response.SmartError(err)
 	}
 
-	// Get the name of the storage volume.
-	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Check that the storage volume type is valid.
 	if details.volumeType != dbCluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -1064,13 +1023,11 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 		return resp
 	}
 
-	fullSnapshotName := fmt.Sprintf("%s/%s", details.volumeName, snapshotName)
-
 	snapshotDelete := func(ctx context.Context, op *operations.Operation) error {
-		return details.pool.DeleteCustomVolumeSnapshot(ctx, effectiveProjectName, fullSnapshotName, op)
+		return details.pool.DeleteCustomVolumeSnapshot(ctx, effectiveProjectName, details.fullName, op)
 	}
 
-	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", snapshotName).Project(effectiveProjectName)
+	snapshotURL := api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "snapshots", details.snapshotName).Project(effectiveProjectName)
 
 	// In a clustered environment with a non-remote pool, volumes are pinned to a specific node.
 	// Include the target so that the entity lookup can match by node name.


### PR DESCRIPTION
This has expanded a bit to simplify handlers and reuse data already held in context. The key parts are:
1. Expand `storageVolumeDetails` to include snapshot/backup names since it is used as part of the same access handling logic.
2. Make use of `storageVolumeDetails` to:
    i. Set target parameter on operation entity URLs.
    ii. Simplify volume helper functions.
3. Fixed multiple operation entity URLs that had missing target parameters or incorrect projects.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
