### PR TITLE
lxd/api_replicators: Use push mode for forward replication

### DIFF
--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -995,7 +995,6 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	var clusterLink *api.ClusterLink
 	var targetCert *x509.Certificate
 	var sourceProject *api.Project
-	var localAddr string
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		_, clusterLink, targetCert, err = lxdCluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
@@ -1009,11 +1008,6 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		}
 
 		sourceProject, err = dbProject.ToAPI(ctx, tx.Tx())
-		if err != nil {
-			return err
-		}
-
-		localAddr, err = tx.GetLocalNodeAddress(ctx)
 		return err
 	})
 	if err != nil {
@@ -1223,19 +1217,62 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Unexpected result from source instance render for %q", instName)
 			}
 
-			srcMigration, err := newMigrationSource(inst, false, false, false, "", nil)
+			// Set up a push-mode migration sink on the destination. In push mode the
+			// leader (source) connects outward to the destination, so the destination
+			// does not need to reach back into the leader. This is required when the
+			// destination project is restricted, which disallows pull-mode migrations.
+			destOp, err := dstClient.CreateInstance(api.InstancesPost{
+				Name:        instName,
+				InstancePut: srcInstInfo.Writable(),
+				Type:        api.InstanceType(srcInstInfo.Type),
+				Source: api.InstanceSource{
+					Type:    api.SourceTypeMigration,
+					Mode:    "push",
+					Refresh: true,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("Failed requesting instance create on destination: %w", err)
+			}
+
+			// Guard against leaving the destination sink operation running if we fail
+			// before starting the source; disarmed once the source op is scheduled.
+			destOpCancelled := false
+			defer func() {
+				if !destOpCancelled {
+					_ = destOp.Cancel()
+				}
+			}()
+
+			destOpAPI := destOp.Get()
+			destSecrets, err := destOpAPI.WebsocketSecrets()
+			if err != nil {
+				return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
+			}
+
+			// ConnectCluster tries each configured address in order; GetConnectionInfo
+			// returns the one that succeeded, which is what the push target must use.
+			dstConnInfo, err := dstClient.GetConnectionInfo()
+			if err != nil {
+				return fmt.Errorf("Failed getting connection info for destination: %w", err)
+			}
+
+			pushTarget := &api.InstancePostTarget{
+				Operation:   dstConnInfo.URL + "/1.0/operations/" + destOpAPI.ID,
+				Websockets:  destSecrets,
+				Certificate: targetCertPEM,
+			}
+
+			srcMigration, err := newMigrationSource(inst, false, false, false, "", pushTarget)
 			if err != nil {
 				return fmt.Errorf("Failed setting up migration source for instance %q: %w", instName, err)
 			}
-
-			networkCert := s.Endpoints.NetworkCert()
 
 			migrArgs := operations.OperationArgs{
 				ProjectName: projectName,
 				EntityURL:   entity.InstanceURL(projectName, instName),
 				Type:        operationtype.InstanceMigrate,
-				Class:       operations.OperationClassWebsocket,
-				Metadata:    srcMigration.Metadata(),
+				Class:       operations.OperationClassTask,
 				RunHook: func(ctx context.Context, innerOp *operations.Operation) error {
 					done := make(chan struct{})
 					defer close(done)
@@ -1249,7 +1286,6 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 					return srcMigration.Do(ctx, s, innerOp)
 				},
-				ConnectHook: srcMigration.Connect,
 			}
 
 			srcOp, err := func() (*operations.Operation, error) {
@@ -1263,27 +1299,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return err
 			}
 
-			sourceSecrets := make(map[string]string, len(srcMigration.conns))
-			for connName, conn := range srcMigration.conns {
-				sourceSecrets[connName] = conn.Secret()
-			}
-
-			destOp, err := dstClient.CreateInstance(api.InstancesPost{
-				Name:        instName,
-				InstancePut: srcInstInfo.Writable(),
-				Type:        api.InstanceType(srcInstInfo.Type),
-				Source: api.InstanceSource{
-					Type:        api.SourceTypeMigration,
-					Mode:        "pull",
-					Operation:   "https://" + localAddr + srcOp.URL(),
-					Websockets:  sourceSecrets,
-					Certificate: string(networkCert.PublicKey()),
-					Refresh:     true,
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("Failed requesting instance create on destination: %w", err)
-			}
+			destOpCancelled = true // source is now connected via websockets; cancel would interrupt an in-flight transfer
 
 			err = srcOp.Wait(context.Background())
 			if err != nil {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5691,6 +5691,17 @@ test_clustering_replicator_basic() {
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c3,STOPPED'
 
+  sub_test "Verify replicator succeeds when standby project has restricted=true"
+
+  # restricted=true blocks pull-mode migrations (the standby would be initiating a
+  # connection back to the source, which restricted projects disallow).
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project restricted=true
+  LXD_DIR="${LXD_TWO_DIR}" lxc delete c1 c2 c3 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '([., (.children? // [])[]] | length) == 4 and .status == "Success" and ((.children // []) | length) == 3 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  LXD_DIR="${LXD_TWO_DIR}" lxc project unset replicator-project restricted
+
   sub_test "Verify concurrent replicator runs are rejected"
 
   LXD_DIR="${LXD_TWO_DIR}" lxc delete c1 c2 c3 --project replicator-project


### PR DESCRIPTION
Forward replication was using pull mode: the leader scheduled a websocket migration source operation and told the remote standby to pull data from it via POST /instances with Mode: "pull". This is blocked when the standby project has restricted=true, because AllowInstanceCreation rejects pull-mode migrations on restricted projects.

Switch to push mode: the leader first creates a push-mode migration sink on the standby (Mode: "push", Refresh:
true), retrieves the returned websocket secrets, then starts the migration source locally with those secrets so it actively connects outward to the standby. The source operation becomes OperationClassTask rather than OperationClassWebsocket.

The restore path is unaffected. It calls MigrateInstance on the remote leader (which goes through instance_post.go, not instances_post.go, so AllowInstanceCreation is never invoked) and sets up the local sink in-process, bypassing the restriction entirely.
