### PR TITLE
storage: Add PowerStore driver

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3086,3 +3086,16 @@ This includes the following new endpoints (see {ref}`rest-api` for details):
 
 Adds a new `security` event type conforming to OWASP security event logging guidelines.
 Security events are accessible via `GET /1.0/events?type=security` and can be routed to Grafana Loki by adding `security` to the `loki.types` server configuration.
+
+## `storage_driver_powerstore`
+
+Adds a new `powerstore` storage driver which allows the consumption of storage volumes from a PowerStore storage array using iSCSI.
+
+The following pool level configuration keys have been added:
+
+1. {config:option}`storage-powerstore-pool-conf:powerstore.gateway`
+1. {config:option}`storage-powerstore-pool-conf:powerstore.gateway.verify`
+1. {config:option}`storage-powerstore-pool-conf:powerstore.user.name`
+1. {config:option}`storage-powerstore-pool-conf:powerstore.user.password`
+1. {config:option}`storage-powerstore-pool-conf:powerstore.mode`
+1. {config:option}`storage-powerstore-pool-conf:powerstore.target`

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6499,6 +6499,203 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```
 
 <!-- config group storage-powerflex-volume-conf end -->
+<!-- config group storage-powerstore-pool-conf start -->
+```{config:option} powerstore.gateway storage-powerstore-pool-conf
+:scope: "global"
+:shortdesc: "Address of the PowerStore Gateway"
+:type: "string"
+
+```
+
+```{config:option} powerstore.gateway.verify storage-powerstore-pool-conf
+:defaultdesc: "`true`"
+:scope: "global"
+:shortdesc: "Whether to verify the PowerStore Gateway's certificate"
+:type: "bool"
+
+```
+
+```{config:option} powerstore.mode storage-powerstore-pool-conf
+:defaultdesc: "the discovered mode"
+:scope: "global"
+:shortdesc: "How volumes are mapped to the local server"
+:type: "string"
+The mode to use to map PowerStore volumes to the local server.
+Supported value is `iscsi`.
+```
+
+```{config:option} powerstore.target storage-powerstore-pool-conf
+:defaultdesc: "target addresses"
+:shortdesc: "List of target addresses the LXD connects to."
+:type: "string"
+A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
+```
+
+```{config:option} powerstore.user.name storage-powerstore-pool-conf
+:defaultdesc: "`admin`"
+:scope: "global"
+:shortdesc: "User for PowerStore Gateway authentication"
+:type: "string"
+Name of the PowerStore user with an admin role that gives LXD full control over managed storage pools.
+```
+
+```{config:option} powerstore.user.password storage-powerstore-pool-conf
+:scope: "global"
+:shortdesc: "Password for PowerStore Gateway authentication"
+:type: "string"
+
+```
+
+```{config:option} rsync.bwlimit storage-powerstore-pool-conf
+:defaultdesc: "`0` (no limit)"
+:scope: "global"
+:shortdesc: "Upper limit on the socket I/O for `rsync`"
+:type: "string"
+When `rsync` must be used to transfer storage entities, this option specifies the upper limit
+to be placed on the socket I/O.
+```
+
+```{config:option} rsync.compression storage-powerstore-pool-conf
+:defaultdesc: "`true`"
+:scope: "global"
+:shortdesc: "Whether to use compression while migrating storage pools"
+:type: "bool"
+
+```
+
+```{config:option} volume.size storage-powerstore-pool-conf
+:defaultdesc: "`10GiB`"
+:scope: "global"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+```
+
+<!-- config group storage-powerstore-pool-conf end -->
+<!-- config group storage-powerstore-volume-conf start -->
+```{config:option} block.filesystem storage-powerstore-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
+:shortdesc: "File system of the storage volume"
+:type: "string"
+Valid options: `btrfs`, `ext4`, `xfs`
+If not set, `ext4` is assumed.
+```
+
+```{config:option} block.mount_options storage-powerstore-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
+:shortdesc: "Mount options for block-backed file system volumes"
+:type: "string"
+
+```
+
+```{config:option} security.shared storage-powerstore-volume-conf
+:condition: "virtual-machine or custom block volume"
+:defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
+:shortdesc: "Enable volume sharing"
+:type: "bool"
+Enable this option to allow the volume to be shared across multiple instances despite the possibility of data loss.
+
+```
+
+```{config:option} security.shifted storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enable this option to allow the volume to be attached to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmapped` or `false`"
+:scope: "global"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-powerstore-volume-conf
+:defaultdesc: "same as `volume.size`"
+:scope: "global"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+```
+
+```{config:option} snapshots.expiry storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template for scheduled snapshots and unnamed snapshots.
+
+The `snapshots.pattern` option uses a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+If no matching snapshots exist, the placeholder is replaced with `0`.
+Otherwise, it is replaced with the next snapshot index, which is one higher than the highest existing matching snapshot index.
+```
+
+```{config:option} snapshots.schedule storage-powerstore-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+```{config:option} volatile.devlxd.owner storage-powerstore-volume-conf
+:defaultdesc: "DevLXD owner identity ID"
+:scope: "global"
+:shortdesc: "ID of the DevLXD identity that owns the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.idmap.last storage-powerstore-volume-conf
+:condition: "filesystem"
+:shortdesc: "JSON-serialized UID/GID map that has been applied to the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.idmap.next storage-powerstore-volume-conf
+:condition: "filesystem"
+:shortdesc: "JSON-serialized UID/GID map that has been applied to the volume"
+:type: "string"
+
+```
+
+```{config:option} volatile.uuid storage-powerstore-volume-conf
+:defaultdesc: "random UUID"
+:scope: "global"
+:shortdesc: "Volume UUID"
+:type: "string"
+
+```
+
+<!-- config group storage-powerstore-volume-conf end -->
 <!-- config group storage-pure-pool-conf start -->
 ```{config:option} pure.api.token storage-pure-pool-conf
 :shortdesc: "API authorization token for Pure Storage gateway"

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -49,23 +49,23 @@ Feature                                     | Directory | Btrfs | LVM   | ZFS
 (storage-drivers-features-nonlocal)=
 ### Non-local storage features
 
-Feature                                     | Ceph RBD | CephFS | Ceph Object | Dell PowerFlex | Pure Storage | HPE Alletra
-:---                                        | :---     | :---   | :---        | :---           | :---         | :---
-{ref}`storage-optimized-image-storage`      | ✅       | ➖     | ➖          | ❌              | ✅          | ✅
-{ref}`storage-optimized-instance-creation`  | ✅       | ➖     | ➖          | ❌              | ✅          | ✅
-{ref}`storage-optimized-snapshot-creation`  | ✅       | ✅     | ➖          | ✅              | ✅          | ✅
-{ref}`storage-optimized-backup`             | ❌       | ➖     | ➖          | ❌              | ❌          | ❌
-{ref}`storage-optimized-volume-transfer`    | ✅[^4]   | ➖     | ➖          | ❌              | ❌          | ❌
-{ref}`storage-optimized-volume-refresh`     | ✅[^5]   | ➖     | ➖          | ❌              | ✅[^6]      | ✅[^6]
-{ref}`storage-copy-on-write`                | ✅       | ✅     | ➖          | ✅              | ✅          | ✅
-{ref}`storage-block-based`                  | ✅       | ❌     | ➖          | ✅              | ✅          | ✅
-{ref}`storage-instant-cloning`              | ✅       | ✅     | ➖          | ❌              | ✅          | ❌
-{ref}`storage-driver-usable-in-container`   | ❌       | ➖     | ➖          | ❌              | ❌          | ❌
-{ref}`storage-restore-older-snapshots`      | ✅       | ✅     | ➖          | ✅              | ✅          | ✅
-{ref}`storage-quotas`                       | ✅       | ✅     | ✅          | ✅              | ✅          | ✅
-{ref}`storage-available-init`               | ✅       | ❌     | ❌          | ❌              | ❌          | ❌
-{ref}`storage-object-storage`               | ❌       | ❌     | ✅          | ❌              | ❌          | ❌
-{ref}`storage-volume-recovery`              | ✅       | ✅     | ✅          | ✅[^7]          | ✅[^7]      | ❌
+Feature                                     | Ceph RBD | CephFS | Ceph Object | Dell PowerFlex | Dell PowerStore | Pure Storage | HPE Alletra
+:---                                        | :---     | :---   | :---        | :---           | :---            | :---         | :---
+{ref}`storage-optimized-image-storage`      | ✅       | ➖     | ➖          | ❌              | ✅             | ✅          | ✅
+{ref}`storage-optimized-instance-creation`  | ✅       | ➖     | ➖          | ❌              | ✅             | ✅          | ✅
+{ref}`storage-optimized-snapshot-creation`  | ✅       | ✅     | ➖          | ✅              | ✅             | ✅          | ✅
+{ref}`storage-optimized-backup`             | ❌       | ➖     | ➖          | ❌              | ❌             | ❌          | ❌
+{ref}`storage-optimized-volume-transfer`    | ✅[^4]   | ➖     | ➖          | ❌              | ❌             | ❌          | ❌
+{ref}`storage-optimized-volume-refresh`     | ✅[^5]   | ➖     | ➖          | ❌              | ✅[^6]         | ✅[^6]      | ✅[^6]
+{ref}`storage-copy-on-write`                | ✅       | ✅     | ➖          | ✅              | ✅             | ✅          | ✅
+{ref}`storage-block-based`                  | ✅       | ❌     | ➖          | ✅              | ✅             | ✅          | ✅
+{ref}`storage-instant-cloning`              | ✅       | ✅     | ➖          | ❌              | ✅             | ✅          | ❌
+{ref}`storage-driver-usable-in-container`   | ❌       | ➖     | ➖          | ❌              | ❌             | ❌          | ❌
+{ref}`storage-restore-older-snapshots`      | ✅       | ✅     | ➖          | ✅              | ✅             | ✅          | ✅
+{ref}`storage-quotas`                       | ✅       | ✅     | ✅          | ✅              | ✅             | ✅          | ✅
+{ref}`storage-available-init`               | ✅       | ❌     | ❌          | ❌              | ❌             | ❌          | ❌
+{ref}`storage-object-storage`               | ❌       | ❌     | ✅          | ❌              | ❌             | ❌          | ❌
+{ref}`storage-volume-recovery`              | ✅       | ✅     | ✅          | ✅[^7]          | ❌             | ✅[^7]      | ❌
 
 [^4]: Volumes of type `block` will fall back to non-optimized transfer when migrating to an older LXD server that doesn't yet support the `RBD_AND_RSYNC` migration type.
 [^5]: Only for volumes of type `block`.
@@ -105,6 +105,7 @@ LXD provides drivers for the following types of remote storage:
 
 storage_ceph
 storage_powerflex
+storage_powerstore
 storage_pure
 storage_alletra
 ```

--- a/doc/reference/storage_powerstore.md
+++ b/doc/reference/storage_powerstore.md
@@ -1,0 +1,98 @@
+(storage-powerstore)=
+# Dell PowerStore - `powerstore`
+
+Dell PowerStore is a storage solution from [Dell Technologies](https://www.dell.com/).
+It offers the consumption of block storage across the network.
+
+LXD supports connecting to PowerStore storage through {abbr}`iSCSI` (Internet Small Computer Systems Interface).
+
+Ensure that the required kernel modules and the iSCSI CLI (`iscsiadm`) are installed on your host system.
+
+## Terminology
+
+PowerStore does not have a concept of storage pools.
+Instead, LXD scopes its volumes to a storage pool by prefixing each volume name with a deterministic storage pool identifier.
+This prefix prevents name conflicts between volumes belonging to different LXD storage pools on the same PowerStore array.
+
+LXD creates volumes on the PowerStore array and maps them to the respective LXD host.
+When the first volume needs to be mapped to a specific LXD host, LXD discovers and connects to the available targets provided by PowerStore.
+
+## The `powerstore` driver in LXD
+
+The `powerstore` driver in LXD uses PowerStore volumes for custom storage volumes, instances, and snapshots.
+All volumes created by LXD using the `powerstore` driver are thin-provisioned block volumes. If required (for example, for containers and custom file system volumes), LXD formats the volume with a desired file system.
+
+LXD expects PowerStore to be pre-configured and accessible. When creating the LXD storage pool, the user must specify authentication credentials that allow LXD to connect to PowerStore. LXD also assumes that it has full control over the volumes it manages.
+
+This driver provides remote storage.
+As a result, and depending on the internal network, storage access might be a bit slower compared to local storage.
+On the other hand, using remote storage has significant advantages in a cluster setup: all cluster members have access to the same storage pools with the exact same contents, without requiring the storage pools to be synchronized between members.
+
+When a volume is first mapped to the LXD host, LXD discovers the available targets from the PowerStore array and connects to them.
+Alternatively, you can specify the targets with {config:option}`storage-powerstore-pool-conf:powerstore.target`.
+
+Volume snapshots are supported by PowerStore. When a volume with at least one snapshot is copied, LXD sequentially copies snapshots into the destination volume, from which a new snapshot is created. Finally, once all snapshots are copied, the source volume is copied into the destination volume.
+
+(storage-powerstore-volume-names)=
+### Volume names
+
+The driver uses the volume's {config:option}`storage-powerstore-volume-conf:volatile.uuid` to generate a volume name.
+The pool-scoped prefix `lxd-<pool_name_hash>-` is prepended to all volume names along with special identifiers, such as `c_` or `v_`, to distinguish volume types.
+Additional identifiers, such as `.i` or `.b`, may also be appended to further distinguish volume types.
+
+Type                       | Identifier   | Example
+:--                        | :---         | :----------
+Container                  | `c_`         | `c_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14`
+Virtual machine            | `v_`         | `v_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14.b` (block volume) and `v_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14` (file system volume)
+Image (ISO)                | `i_`         | `i_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14.i`
+Custom volume              | `u_`         | `u_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14` (file system volume) or `u_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14.b` (block volume)
+Mountable snapshot clone   | `s`          | `sc_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14` (container), `sv_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14.b` (VM), or `su_5a2504b0-6a6c-4849-8ee7-ddb0b674fd14` (custom volume)
+
+Snapshots in PowerStore are native children of their parent volume. Each snapshot is named using the snapshot's own UUID with the same type prefix as the parent volume.
+Mountable snapshot clones are temporary volumes created by LXD when a snapshot needs to be directly accessed (for example, during export). The `s` prefix is prepended to the volume type identifier to distinguish them from regular volumes.
+
+(storage-powerstore-limitations)=
+### Limitations
+
+The `powerstore` driver has the following limitations:
+
+Volume size constraints
+: The minimum volume size (quota) is `1MiB` and must be a multiple of `1MiB`. The maximum volume size is `256TiB`.
+
+Volume shrinking
+: The PowerStore driver does not allow shrinking volumes.
+
+Sharing custom volumes between instances
+: The PowerStore driver "simulates" volumes with content type `filesystem` by putting a file system on top of a PowerStore volume.
+  Therefore, custom storage volumes can only be assigned to a single instance at a time.
+
+Sharing a PowerStore storage pool between multiple LXD installations
+: Sharing the same PowerStore storage pool between multiple LXD installations is not supported.
+
+Recovering PowerStore storage pools
+: Recovery of PowerStore storage pools using `lxd recover` is not supported.
+
+(storage-powerstore-options)=
+## Configuration options
+
+The following configuration options are available for storage pools that use the `powerstore` driver, as well as storage volumes in these pools.
+
+(storage-powerstore-pool-config)=
+### Storage pool configuration
+
+% Include content from [../metadata.txt](../metadata.txt)
+```{include} ../metadata.txt
+    :start-after: <!-- config group storage-powerstore-pool-conf start -->
+    :end-before: <!-- config group storage-powerstore-pool-conf end -->
+```
+
+{{volume_configuration}}
+
+(storage-powerstore-vol-config)=
+### Storage volume configuration
+
+% Include content from [../metadata.txt](../metadata.txt)
+```{include} ../metadata.txt
+    :start-after: <!-- config group storage-powerstore-volume-conf start -->
+    :end-before: <!-- config group storage-powerstore-volume-conf end -->
+```

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7184,6 +7184,217 @@
 				]
 			}
 		},
+		"storage-powerstore": {
+			"pool-conf": {
+				"keys": [
+					{
+						"powerstore.gateway": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Address of the PowerStore Gateway",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.gateway.verify": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Whether to verify the PowerStore Gateway's certificate",
+							"type": "bool"
+						}
+					},
+					{
+						"powerstore.mode": {
+							"defaultdesc": "the discovered mode",
+							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported value is `iscsi`.",
+							"scope": "global",
+							"shortdesc": "How volumes are mapped to the local server",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.target": {
+							"defaultdesc": "target addresses",
+							"longdesc": "A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.",
+							"shortdesc": "List of target addresses the LXD connects to.",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.user.name": {
+							"defaultdesc": "`admin`",
+							"longdesc": "Name of the PowerStore user with an admin role that gives LXD full control over managed storage pools.",
+							"scope": "global",
+							"shortdesc": "User for PowerStore Gateway authentication",
+							"type": "string"
+						}
+					},
+					{
+						"powerstore.user.password": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Password for PowerStore Gateway authentication",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.bwlimit": {
+							"defaultdesc": "`0` (no limit)",
+							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"scope": "global",
+							"shortdesc": "Upper limit on the socket I/O for `rsync`",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.compression": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Whether to use compression while migrating storage pools",
+							"type": "bool"
+						}
+					},
+					{
+						"volume.size": {
+							"defaultdesc": "`10GiB`",
+							"longdesc": "The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.",
+							"scope": "global",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"block.filesystem": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.filesystem`",
+							"longdesc": "Valid options: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
+							"shortdesc": "File system of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"block.mount_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.mount_options`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Mount options for block-backed file system volumes",
+							"type": "string"
+						}
+					},
+					{
+						"security.shared": {
+							"condition": "virtual-machine or custom block volume",
+							"defaultdesc": "same as `volume.security.shared` or `false`",
+							"longdesc": "Enable this option to allow the volume to be shared across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
+							"shortdesc": "Enable volume sharing",
+							"type": "bool"
+						}
+					},
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enable this option to allow the volume to be attached to multiple isolated instances.",
+							"scope": "global",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmapped` or `false`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.",
+							"scope": "global",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option uses a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nIf no matching snapshots exist, the placeholder is replaced with `0`.\nOtherwise, it is replaced with the next snapshot index, which is one higher than the highest existing matching snapshot index.",
+							"scope": "global",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.devlxd.owner": {
+							"defaultdesc": "DevLXD owner identity ID",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "ID of the DevLXD identity that owns the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.idmap.last": {
+							"condition": "filesystem",
+							"longdesc": "",
+							"shortdesc": "JSON-serialized UID/GID map that has been applied to the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.idmap.next": {
+							"condition": "filesystem",
+							"longdesc": "",
+							"shortdesc": "JSON-serialized UID/GID map that has been applied to the volume",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Volume UUID",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"storage-pure": {
 			"pool-conf": {
 				"keys": [

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4021,6 +4021,10 @@ func (b *lxdBackend) RestoreInstanceSnapshot(ctx context.Context, inst instance.
 	snapshotStorageName := project.StorageVolume(src.Project().Name, dbSnapVol.Name)
 	snapVol := b.GetVolume(volType, contentType, snapshotStorageName, dbSnapVol.Config)
 
+	if b.driver.Info().PopulateParentVolumeUUID {
+		snapVol.SetParentUUID(dbVol.Config["volatile.uuid"])
+	}
+
 	err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
@@ -6645,6 +6649,10 @@ func (b *lxdBackend) RestoreCustomVolume(ctx context.Context, projectName string
 
 	snapshotStorageName := project.StorageVolume(projectName, dbSnapVol.Name)
 	snapVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, snapshotStorageName, dbSnapVol.Config)
+
+	if b.driver.Info().PopulateParentVolumeUUID {
+		snapVol.SetParentUUID(curVol.Config["volatile.uuid"])
+	}
 
 	err = b.driver.RestoreVolume(vol, snapVol, progressReporter)
 	if err != nil {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -71,6 +71,20 @@ func (PowerStoreHost) selector() string {
 	return "id,name,os_type,initiators(id,port_name,port_type),mapped_hosts(id,host_id,volume_id)"
 }
 
+// PowerStoreVolume represents a PowerStore volume.
+type PowerStoreVolume struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Size        int64  `json:"size,omitempty"`
+	LogicalUsed int64  `json:"logical_used,omitempty"`
+	WWN         string `json:"wwn,omitempty"`
+}
+
+func (PowerStoreVolume) selector() string {
+	return "id,name,type,size,logical_used,wwn"
+}
+
 type powerStoreErrorMessage struct {
 	Message string `json:"message_l10n"`
 }
@@ -633,6 +647,131 @@ func (c *PowerStoreClient) DeleteHost(hostID string) error {
 		}
 
 		return fmt.Errorf("Failed deleting PowerStore host: %w", err)
+	}
+
+	return nil
+}
+
+func (c *PowerStoreClient) getVolumes(queryFilter map[string]string) ([]PowerStoreVolume, error) {
+	url := api.NewURL().Path("api", "rest", "volume")
+	url = url.WithQuery("select", PowerStoreVolume{}.selector())
+
+	for k, v := range queryFilter {
+		url = url.WithQuery(k, v)
+	}
+
+	var offset uint64
+	var volumes []PowerStoreVolume
+
+	for {
+		respBody := []PowerStoreVolume{}
+		respHeaders := make(http.Header)
+
+		pageURL := withPaginationQuery(url.URL, offset, powerStoreQueryResponseLimit)
+		err := c.requestAuthenticated(http.MethodGet, pageURL, nil, &respBody, respHeaders)
+		if err != nil {
+			return nil, err
+		}
+
+		nextOffset, hasMoreItems, err := parsePaginationOffset(respHeaders)
+		if err != nil {
+			return nil, err
+		}
+
+		volumes = append(volumes, respBody...)
+		offset = nextOffset
+
+		if !hasMoreItems {
+			break
+		}
+	}
+
+	return volumes, nil
+}
+
+// GetVolumes retrieves list of volume associated with the storage pool.
+func (c *PowerStoreClient) GetVolumes() ([]PowerStoreVolume, error) {
+	filter := map[string]string{
+		"name": "ilike." + c.resourceNamePrefix + "*",
+		"or":   "(type.eq.Primary,type.eq.Clone)",
+	}
+
+	vols, err := c.getVolumes(filter)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore volumes: %w", err)
+	}
+
+	return vols, nil
+}
+
+// GetVolumeID retrieves ID of a volume with a given name.
+func (c *PowerStoreClient) GetVolumeID(volumeName string) (string, error) {
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "volume", "name:"+volumeName)
+	url = url.WithQuery("or", "(type.eq.Primary,type.eq.Clone)")
+	url = url.WithQuery("select", "id")
+
+	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &resp, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return "", api.StatusErrorf(http.StatusNotFound, "Volume with name %q not found", volumeName)
+		}
+
+		return "", fmt.Errorf("Failed retrieving PowerStore volume with name %q: %w", volumeName, err)
+	}
+
+	return resp.ID, nil
+}
+
+// GetVolume retrieves volume using its name.
+func (c *PowerStoreClient) GetVolume(volumeID string) (*PowerStoreVolume, error) {
+	var resp PowerStoreVolume
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID)
+	url = url.WithQuery("or", "(type.eq.Primary,type.eq.Clone)")
+	url = url.WithQuery("select", resp.selector())
+
+	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &resp, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return nil, api.StatusErrorf(http.StatusNotFound, "Volume with ID %q not found", volumeID)
+		}
+
+		return nil, fmt.Errorf("Failed retrieving PowerStore volume: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// CreateVolume creates a new volume.
+func (c *PowerStoreClient) CreateVolume(volumeName string, sizeBytes int64) (volumeID string, err error) {
+	req := map[string]any{
+		"name": volumeName,
+		"size": sizeBytes,
+	}
+
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "volume")
+	err = c.requestAuthenticated(http.MethodPost, url.URL, req, &resp, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed creating PowerStore volume: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+// DeleteVolume deletes volume using its ID.
+func (c *PowerStoreClient) DeleteVolume(volumeID string) error {
+	req := map[string]any{
+		"immediate": true, // Do not move the volume to the "recycle bin".
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID)
+	err := c.requestAuthenticated(http.MethodDelete, url.URL, req, nil, nil)
+	if err != nil && !isPowerStoreError(err, http.StatusNotFound) {
+		return fmt.Errorf("Failed deleting PowerStore volume: %w", err)
 	}
 
 	return nil

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -884,6 +884,26 @@ func (c *PowerStoreClient) CloneVolume(srcVolumeOrSnapshotID string, dstVolumeNa
 	return resp.ID, nil
 }
 
+// RefreshVolume refreshes a volume from another volume or volume snapshot.
+//
+// NOTE: The source volume or snapshot must be within the same family, which
+// means the destination volume has previously been cloned from that volume or
+// snapshot from the same parent volume.
+func (c *PowerStoreClient) RefreshVolume(srcVolumeOrSnapshotID string, dstVolumeID string) error {
+	req := map[string]any{
+		"from_object_id":     srcVolumeOrSnapshotID,
+		"create_backup_snap": false,
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", dstVolumeID, "refresh")
+	err := c.requestAuthenticated(http.MethodPost, url.URL, req, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Failed refreshing PowerStore volume: %w", err)
+	}
+
+	return nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -32,6 +32,45 @@ const (
 	powerStoreQueryResponseLimit = 2000
 )
 
+// powerStoreResourceID represents a PowerStore resource ID.
+type powerStoreResourceID struct {
+	ID string `json:"id"`
+}
+
+func (powerStoreResourceID) selector() string {
+	return "id"
+}
+
+// PowerStoreHostInitiator represents a PowerStore host initiator.
+type PowerStoreHostInitiator struct {
+	HostID   string `json:"host_id,omitempty"`
+	PortName string `json:"port_name,omitempty"`
+	PortType string `json:"port_type,omitempty"`
+}
+
+func (PowerStoreHostInitiator) selector() string {
+	return "host_id,port_name,port_type"
+}
+
+// PowerStoreHostVolumeMapping represents a mapping between PowerStore host and volume.
+type PowerStoreHostVolumeMapping struct {
+	HostID   string `json:"host_id,omitempty"`
+	VolumeID string `json:"volume_id,omitempty"`
+}
+
+// PowerStoreHost represents a PowerStore host.
+type PowerStoreHost struct {
+	ID            string                         `json:"id,omitempty"`
+	Name          string                         `json:"name,omitempty"`
+	OsType        string                         `json:"os_type,omitempty"`
+	Initiators    []*PowerStoreHostInitiator     `json:"initiators,omitempty"`
+	MappedVolumes []*PowerStoreHostVolumeMapping `json:"mapped_hosts,omitempty"`
+}
+
+func (PowerStoreHost) selector() string {
+	return "id,name,os_type,initiators(id,port_name,port_type),mapped_hosts(id,host_id,volume_id)"
+}
+
 type powerStoreErrorMessage struct {
 	Message string `json:"message_l10n"`
 }
@@ -484,4 +523,79 @@ func (c *PowerStoreClient) DiscoveryAddresses(connectorType string) ([]string, e
 	}
 
 	return addresses, nil
+}
+
+// GetHost retrieves host using its ID.
+func (c *PowerStoreClient) GetHost(hostID string) (*PowerStoreHost, error) {
+	var host PowerStoreHost
+
+	url := api.NewURL().Path("api", "rest", "host", hostID)
+	url = url.WithQuery("select", host.selector())
+
+	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &host, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return nil, api.StatusErrorf(http.StatusNotFound, "Host with ID %q not found", hostID)
+		}
+
+		return nil, fmt.Errorf("Failed retrieving PowerStore host: %w", err)
+	}
+
+	return &host, nil
+}
+
+// CreateHost creates new host and returns its ID.
+func (c *PowerStoreClient) CreateHost(hostName string, connectorType string, qn string) (string, error) {
+	portType, err := powerStoreConnectorToPortType(connectorType)
+	if err != nil {
+		return "", err
+	}
+
+	req := map[string]any{
+		"name":    hostName,
+		"os_type": "Linux", // Required by PowerStore API.
+		"initiators": []map[string]any{
+			{
+				"port_name": qn,
+				"port_type": portType,
+			},
+		},
+	}
+
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "host")
+	err = c.requestAuthenticated(http.MethodPost, url.URL, req, &resp, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed creating PowerStore host: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+// DeleteHost deletes host using its ID.
+func (c *PowerStoreClient) DeleteHost(hostID string) error {
+	url := api.NewURL().Path("api", "rest", "host", hostID)
+	err := c.requestAuthenticated(http.MethodDelete, url.URL, nil, nil, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return api.StatusErrorf(http.StatusNotFound, "Host with ID %q not found", hostID)
+		}
+
+		return fmt.Errorf("Failed deleting PowerStore host: %w", err)
+	}
+
+	return nil
+}
+
+// powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
+func powerStoreConnectorToPortType(connectorType string) (string, error) {
+	switch connectorType {
+	case connectors.TypeISCSI:
+		return "iSCSI", nil
+	case connectors.TypeNVME:
+		return "NVMe", nil
+	default:
+		return "", fmt.Errorf("Unsupported connector type: %q", connectorType)
+	}
 }

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -1,0 +1,21 @@
+package clients
+
+// PowerStoreClient holds the PowerStore HTTP API client.
+type PowerStoreClient struct {
+	url                string
+	skipTLSVerify      bool
+	username           string
+	password           string
+	resourceNamePrefix string
+}
+
+// NewPowerStoreClient creates a new instance of the PowerStore HTTP API client.
+func NewPowerStoreClient(url string, username string, password string, skipTLSVerify bool, resourceNamePrefix string) *PowerStoreClient {
+	return &PowerStoreClient{
+		url:                url,
+		skipTLSVerify:      skipTLSVerify,
+		username:           username,
+		password:           password,
+		resourceNamePrefix: resourceNamePrefix,
+	}
+}

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -920,6 +920,55 @@ func (c *PowerStoreClient) RestoreVolume(volumeID string, snapshotID string) err
 	return nil
 }
 
+// AttachVolumeToHost attaches (maps) volume to host, returning true if the volume was freshly
+// attached to the host, and false if the volume was already attached to the host.
+func (c *PowerStoreClient) AttachVolumeToHost(volumeID string, hostID string) (bool, error) {
+	// Check if the volume is already attached to the host.
+	host, err := c.GetHost(hostID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, mapping := range host.MappedVolumes {
+		if mapping.VolumeID == volumeID {
+			// The volume is already attached to the host.
+			return false, nil
+		}
+	}
+
+	// Attach the volume to the host.
+	req := map[string]any{
+		"host_id": hostID,
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID, "attach")
+	err = c.requestAuthenticated(http.MethodPost, url.URL, req, nil, nil)
+	if err != nil {
+		return false, fmt.Errorf("Failed attaching PowerStore volume to the host: %w", err)
+	}
+
+	return true, nil
+}
+
+// DetachVolumeFromHost detaches (unmaps) volume from host.
+func (c *PowerStoreClient) DetachVolumeFromHost(volumeID string, hostID string) error {
+	req := map[string]any{
+		"host_id": hostID,
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID, "detach")
+	err := c.requestAuthenticated(http.MethodPost, url.URL, req, nil, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusUnprocessableEntity, "Could not find any host volume mappings") {
+			return api.StatusErrorf(http.StatusNotFound, "Connection between host %q and volume %q not found", hostID, volumeID)
+		}
+
+		return fmt.Errorf("Failed detaching PowerStore volume from the host: %w", err)
+	}
+
+	return nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -24,6 +24,10 @@ const (
 
 	// powerStoreCSRFHeaderName is the name of the header which contains PowerStore CSRF token.
 	powerStoreCSRFHeaderName = "dell-emc-token"
+
+	// powerStoreQueryResponseLimit defines maximum number of items PowerStore can return in
+	// a single query response.
+	powerStoreQueryResponseLimit = 2000
 )
 
 type powerStoreErrorMessage struct {
@@ -373,4 +377,64 @@ func (c *PowerStoreClient) requestAuthenticated(method string, url url.URL, reqB
 
 		return nil
 	}
+}
+
+// withPaginationQuery adds pagination parameters to the provided URL query.
+func withPaginationQuery(url url.URL, offset uint64, limit int) url.URL {
+	if limit <= 0 || limit > powerStoreQueryResponseLimit {
+		limit = powerStoreQueryResponseLimit
+	}
+
+	q := url.Query()
+	q.Set("offset", strconv.FormatUint(offset, 10))
+	q.Set("limit", strconv.Itoa(limit))
+	url.RawQuery = q.Encode()
+	return url
+}
+
+// parsePaginationOffset determines whether the response headers indicate there are more items
+// available to be retrieved and the offset to be used for the next query.
+func parsePaginationOffset(headers http.Header) (newOffset uint64, hasMore bool, err error) {
+	if headers == nil {
+		return 0, false, nil
+	}
+
+	// valid Content-Range HTTP headers returned by PowerStore have a form:
+	// - firstOffset '-' lastOffset '/' totalItems
+	// - '*' '/' totalItems
+	header := headers.Get("Content-Range")
+	if header == "" {
+		return 0, false, nil
+	}
+
+	errInvalidHeader := func() (uint64, bool, error) {
+		return 0, false, fmt.Errorf("Invalid format of Content-Range header: %q", header)
+	}
+
+	rangeStr, totalItemsStr, ok := strings.Cut(header, "/")
+	if !ok {
+		return errInvalidHeader()
+	}
+
+	if rangeStr == "*" {
+		return 0, false, nil
+	}
+
+	_, lastOffsetStr, ok := strings.Cut(rangeStr, "-")
+	if !ok {
+		return errInvalidHeader()
+	}
+
+	lastOffset, err := strconv.ParseUint(lastOffsetStr, 10, 64)
+	if err != nil {
+		return errInvalidHeader()
+	}
+
+	totalItems, err := strconv.ParseUint(totalItemsStr, 10, 64)
+	if err != nil {
+		return errInvalidHeader()
+	}
+
+	newOffset = lastOffset + 1
+	return newOffset, totalItems > newOffset, nil
 }

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,8 +13,17 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/canonical/lxd/shared/api"
+)
+
+const (
+	// powerStoreAuthCookieName is the name of the cookie which contains PowerStore auth token.
+	powerStoreAuthCookieName = "auth_cookie"
+
+	// powerStoreCSRFHeaderName is the name of the header which contains PowerStore CSRF token.
+	powerStoreCSRFHeaderName = "dell-emc-token"
 )
 
 type powerStoreErrorMessage struct {
@@ -94,6 +104,16 @@ func isPowerStoreError(err error, statusCode int, substrings ...string) bool {
 	return false
 }
 
+var powerStoreSessions = make(map[string]powerStoreSession)
+var powerStoreSessionsLock = &sync.RWMutex{}
+
+// powerStoreSession describes PowerStore login session.
+type powerStoreSession struct {
+	ID        string
+	AuthToken string
+	CSRFToken string
+}
+
 // PowerStoreClient holds the PowerStore HTTP API client.
 type PowerStoreClient struct {
 	url                string
@@ -101,6 +121,11 @@ type PowerStoreClient struct {
 	username           string
 	password           string
 	resourceNamePrefix string
+
+	// currentSession holds the current session, which is set after successful login
+	// and used for subsequent requests. Use [PowerStoreClient.session] to retrieve
+	// the current session.
+	currentSession *powerStoreSession
 }
 
 // NewPowerStoreClient creates a new instance of the PowerStore HTTP API client.
@@ -112,6 +137,126 @@ func NewPowerStoreClient(url string, username string, password string, skipTLSVe
 		password:           password,
 		resourceNamePrefix: resourceNamePrefix,
 	}
+}
+
+// sessionKey generates a hashtable key for a session.
+func (c *PowerStoreClient) sessionKey() string {
+	return c.url + c.username + c.password
+}
+
+// session retrieves the current session.
+func (c *PowerStoreClient) session() *powerStoreSession {
+	if c.currentSession != nil {
+		return c.currentSession
+	}
+
+	key := c.sessionKey()
+
+	powerStoreSessionsLock.RLock()
+	defer powerStoreSessionsLock.RUnlock()
+
+	session, ok := powerStoreSessions[key]
+	if ok {
+		s := session
+		c.currentSession = &s
+		return c.currentSession
+	}
+
+	return nil
+}
+
+// setSession sets the current session.
+func (c *PowerStoreClient) setSession(session powerStoreSession) {
+	key := c.sessionKey()
+
+	powerStoreSessionsLock.Lock()
+	defer powerStoreSessionsLock.Unlock()
+
+	powerStoreSessions[key] = session
+	c.currentSession = &session
+}
+
+// invalidateSession invalidates the current session.
+func (c *PowerStoreClient) invalidateSession() {
+	key := c.sessionKey()
+
+	powerStoreSessionsLock.Lock()
+	defer powerStoreSessionsLock.Unlock()
+
+	delete(powerStoreSessions, key)
+	c.currentSession = nil
+}
+
+// login initiates request() using PowerStore username and password.
+// If successful, the session key is retrieved and stored within client structure.
+// Once stored, the session key is reused for further requests.
+func (c *PowerStoreClient) login() (*powerStoreSession, error) {
+	session := c.session()
+	if session != nil {
+		return session, nil
+	}
+
+	url := api.NewURL().Path("/api/rest/login_session")
+	url = url.WithQuery("select", "id,user,role_ids,idle_timeout,is_password_change_required,is_built_in_user")
+
+	// Base64 encode username and password for basic authentication.
+	reqHeaders := map[string]string{
+		"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte(c.username+":"+c.password)),
+	}
+
+	respHeaders := make(http.Header)
+	respBody := []struct {
+		ID                       string `json:"id"`
+		User                     string `json:"user"`
+		IsPasswordChangeRequired bool   `json:"is_password_change_required"`
+	}{}
+
+	err := c.request(http.MethodGet, url.URL, nil, reqHeaders, &respBody, respHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("Failed logging into PowerStore: %w", err)
+	}
+
+	if len(respBody) < 1 {
+		return nil, errors.New("Failed logging into PowerStore: Login response is missing session information")
+	}
+
+	sessionInfo := respBody[0]
+	if sessionInfo.IsPasswordChangeRequired {
+		return nil, errors.New("Failed logging into PowerStore: Password change required")
+	}
+
+	resp := &http.Response{Header: http.Header{}}
+
+	// Parse CSRF token from response headers.
+	csrf := resp.Header.Get(powerStoreCSRFHeaderName)
+	if csrf == "" {
+		return nil, errors.New("Failed logging into PowerStore: Login response missing CSRF token")
+	}
+
+	// Parse auth cookie.
+	var authCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name != powerStoreAuthCookieName {
+			continue
+		}
+
+		authCookie = c
+		break
+	}
+
+	if authCookie == nil {
+		return nil, errors.New("Starting PowerStore session: Missing PowerStore authorization cookie")
+	}
+
+	// Cache new session.
+	session = &powerStoreSession{
+		ID:        sessionInfo.ID,
+		AuthToken: authCookie.Value,
+		CSRFToken: csrf,
+	}
+
+	c.setSession(*session)
+	return session, nil
 }
 
 // request issues a HTTP request against the PowerStore gateway.
@@ -188,4 +333,44 @@ func (c *PowerStoreClient) request(method string, url url.URL, reqBody map[strin
 	}
 
 	return nil
+}
+
+// requestAuthenticated issues an authenticated HTTP request against the PowerStore API gateway.
+// In case the access token is expired, the function automatically attempts to obtain a new one.
+func (c *PowerStoreClient) requestAuthenticated(method string, url url.URL, reqBody map[string]any, respBody any, respHeaders http.Header) error {
+	// If request fails with an unauthorized error, the request will be retried after
+	// requesting a new access token.
+	retries := 1
+
+	for {
+		// Ensure we are logged into the PowerStore.
+		session, err := c.login()
+		if err != nil {
+			return err
+		}
+
+		// Set access token as request header.
+		reqHeaders := map[string]string{
+			"Cookie":                 powerStoreAuthCookieName + "=" + session.AuthToken,
+			powerStoreCSRFHeaderName: session.CSRFToken,
+		}
+
+		// Initiate request.
+		err = c.request(method, url, reqBody, reqHeaders, respBody, respHeaders)
+		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusUnauthorized) && retries > 0 {
+				// The failure is likely due to an expired session.
+				// Invalidate session and try again.
+				c.invalidateSession()
+				retries--
+				continue
+			}
+
+			// Either the error is not of type unauthorized or the maximum number of
+			// retries has been exceeded.
+			return err
+		}
+
+		return nil
+	}
 }

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -525,6 +525,56 @@ func (c *PowerStoreClient) DiscoveryAddresses(connectorType string) ([]string, e
 	return addresses, nil
 }
 
+// GetCurrentHost retrieves the PowerStore host linked to the current LXD host.
+// The PowerStore host is considered a match if it includes the fully qualified
+// name of the LXD host that is determined by the configured mode.
+func (c *PowerStoreClient) GetCurrentHost(connectorType string, qn string) (*PowerStoreHost, error) {
+	portType, err := powerStoreConnectorToPortType(connectorType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find initiator with the provided port type (connector type) and name (qualified name),
+	// and retrieve the ID of the host it belongs to.
+	var initiator PowerStoreHostInitiator
+
+	url := api.NewURL().Path("api", "rest", "initiator")
+	url = url.WithQuery("select", initiator.selector())
+	url = url.WithQuery("port_type", "eq."+string(portType))
+	url = url.WithQuery("port_name", "eq."+qn)
+
+	var initiators []PowerStoreHostInitiator
+	err = c.requestAuthenticated(http.MethodGet, url.URL, nil, &initiators, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore host initiator: %w", err)
+	}
+
+	switch len(initiators) {
+	case 0:
+		return nil, api.StatusErrorf(http.StatusNotFound, "Host initiator with port name %q and type %q not found", qn, portType)
+	case 1:
+		initiator = initiators[0]
+	default:
+		return nil, fmt.Errorf("Multiple host initiators found with port name %q and type %q", qn, portType)
+	}
+
+	// Retrieve the actual host.
+	var host PowerStoreHost
+	url = api.NewURL().Path("api", "rest", "host", initiator.HostID)
+	url = url.WithQuery("select", host.selector())
+
+	err = c.requestAuthenticated(http.MethodGet, url.URL, nil, &host, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return nil, api.StatusErrorf(http.StatusNotFound, "Host with initiator port name %q and type %q not found", qn, portType)
+		}
+
+		return nil, fmt.Errorf("Failed retrieving PowerStore host: %w", err)
+	}
+
+	return &host, nil
+}
+
 // GetHost retrieves host using its ID.
 func (c *PowerStoreClient) GetHost(hostID string) (*PowerStoreHost, error) {
 	var host PowerStoreHost

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -85,6 +85,20 @@ func (PowerStoreVolume) selector() string {
 	return "id,name,type,size,logical_used,wwn"
 }
 
+// PowerStoreApplianceMetrics represents metrics collected from a PowerStore appliance.
+type PowerStoreApplianceMetrics struct {
+	ID                     string `json:"id,omitempty"`
+	Name                   string `json:"name,omitempty"`
+	LastLogicalTotalSpace  int64  `json:"last_logical_total_space,omitempty"`
+	LastLogicalUsedSpace   int64  `json:"last_logical_used_space,omitempty"`
+	LastPhysicalTotalSpace int64  `json:"last_physical_total_space,omitempty"`
+	LastPhysicalUsedSpace  int64  `json:"last_physical_used_space,omitempty"`
+}
+
+func (PowerStoreApplianceMetrics) selector() string {
+	return "id,name,last_logical_total_space,last_logical_used_space,last_physical_total_space,last_physical_used_space"
+}
+
 type powerStoreErrorMessage struct {
 	Message string `json:"message_l10n"`
 }
@@ -967,6 +981,40 @@ func (c *PowerStoreClient) DetachVolumeFromHost(volumeID string, hostID string) 
 	}
 
 	return nil
+}
+
+// GetApplianceMetrics retrieves appliance metrics.
+func (c *PowerStoreClient) GetApplianceMetrics() ([]PowerStoreApplianceMetrics, error) {
+	url := api.NewURL().Path("api", "rest", "appliance_list_cma_view")
+	url = url.WithQuery("select", PowerStoreApplianceMetrics{}.selector())
+
+	var offset uint64
+	var metrics []PowerStoreApplianceMetrics
+
+	for {
+		respBody := []PowerStoreApplianceMetrics{}
+		respHeaders := make(http.Header)
+
+		pageURL := withPaginationQuery(url.URL, offset, -1)
+		err := c.requestAuthenticated(http.MethodGet, pageURL, nil, &respBody, respHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("Failed retrieving metrics of PowerStore appliances: %w", err)
+		}
+
+		nextOffset, hasMoreItems, err := parsePaginationOffset(respHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("Failed retrieving metrics of PowerStore appliances: %w", err)
+		}
+
+		metrics = append(metrics, respBody...)
+		offset = nextOffset
+
+		if !hasMoreItems {
+			break
+		}
+	}
+
+	return metrics, nil
 }
 
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -866,6 +866,24 @@ func (c *PowerStoreClient) ResizeVolume(volumeID string, newSize int64) error {
 	return nil
 }
 
+// CloneVolume clones the volume or volume snapshot into a new volume.
+func (c *PowerStoreClient) CloneVolume(srcVolumeOrSnapshotID string, dstVolumeName string) (string, error) {
+	req := map[string]any{
+		"name":        dstVolumeName,
+		"description": `Cloned from volume with PowerStore ID "` + srcVolumeOrSnapshotID + `"`,
+	}
+
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "volume", srcVolumeOrSnapshotID, "clone")
+	err := c.requestAuthenticated(http.MethodPost, url.URL, req, &resp, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed cloning PowerStore volume: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -846,6 +846,26 @@ func (c *PowerStoreClient) DeleteVolumeSnapshot(snapshotID string) error {
 	return nil
 }
 
+// ResizeVolume resizes an existing volume.
+func (c *PowerStoreClient) ResizeVolume(volumeID string, newSize int64) error {
+	vol, err := c.GetVolume(volumeID)
+	if err != nil {
+		return err
+	}
+
+	req := map[string]any{
+		"size": newSize,
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", vol.ID)
+	err = c.requestAuthenticated(http.MethodPatch, url.URL, req, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Failed resizing PowerStore volume: %w", err)
+	}
+
+	return nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -777,6 +777,75 @@ func (c *PowerStoreClient) DeleteVolume(volumeID string) error {
 	return nil
 }
 
+// GetVolumeSnapshots retrieves list of snapshots associated with the provided volume.
+func (c *PowerStoreClient) GetVolumeSnapshots(volumeID string) ([]PowerStoreVolume, error) {
+	filter := map[string]string{
+		"type":                        "eq.Snapshot",
+		"protection_data->>parent_id": "eq." + volumeID,
+	}
+
+	snapshots, err := c.getVolumes(filter)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving PowerStore snapshots: %w", err)
+	}
+
+	return snapshots, nil
+}
+
+// GetVolumeSnapshotID retrieves ID of a volume snapshot with a given name .
+func (c *PowerStoreClient) GetVolumeSnapshotID(volumeID string, snapshotName string) (string, error) {
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "volume", "name:"+snapshotName)
+	url = url.WithQuery("protection_data->>parent_id", "eq."+volumeID)
+	url = url.WithQuery("type", "eq.Snapshot")
+	url = url.WithQuery("select", resp.selector())
+
+	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &resp, nil)
+	if err != nil {
+		if isPowerStoreError(err, http.StatusNotFound) {
+			return "", api.StatusErrorf(http.StatusNotFound, "Volume snapshot with name %q not found", snapshotName)
+		}
+
+		return "", fmt.Errorf("Failed retrieving PowerStore volume snapshot: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+// CreateVolumeSnapshot creates a new snapshot of a volume.
+func (c *PowerStoreClient) CreateVolumeSnapshot(volumeID string, snapshotName string) (string, error) {
+	req := map[string]any{
+		"name":        snapshotName,
+		"description": "LXD Volume Snapshot of " + snapshotName,
+	}
+
+	var resp powerStoreResourceID
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID, "snapshot")
+	err := c.requestAuthenticated(http.MethodPost, url.URL, req, &resp, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed creating PowerStore volume snapshot: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+// DeleteVolumeSnapshot deletes a snapshot of a volume.
+func (c *PowerStoreClient) DeleteVolumeSnapshot(snapshotID string) error {
+	req := map[string]any{
+		"immediate": true, // Do not move the snapshot to the "recycle bin".
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", snapshotID)
+	err := c.requestAuthenticated(http.MethodDelete, url.URL, req, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Failed deleting PowerStore volume snapshot: %w", err)
+	}
+
+	return nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -904,6 +904,22 @@ func (c *PowerStoreClient) RefreshVolume(srcVolumeOrSnapshotID string, dstVolume
 	return nil
 }
 
+// RestoreVolume restores the volume from its snapshot.
+func (c *PowerStoreClient) RestoreVolume(volumeID string, snapshotID string) error {
+	req := map[string]any{
+		"from_snap_id":       snapshotID,
+		"create_backup_snap": false,
+	}
+
+	url := api.NewURL().Path("api", "rest", "volume", volumeID, "restore")
+	err := c.requestAuthenticated(http.MethodPost, url.URL, req, nil, nil)
+	if err != nil {
+		return fmt.Errorf("Failed restoring PowerStore volume: %w", err)
+	}
+
+	return nil
+}
+
 // powerStoreConnectorToPortType converts connector type to PowerStore port type used in initiators.
 func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -11,10 +11,12 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -437,4 +439,49 @@ func parsePaginationOffset(headers http.Header) (newOffset uint64, hasMore bool,
 
 	newOffset = lastOffset + 1
 	return newOffset, totalItems > newOffset, nil
+}
+
+// DiscoveryAddresses retrieves list of discovery addresses used to discover storage targets for
+// the provided connector type.
+func (c *PowerStoreClient) DiscoveryAddresses(connectorType string) ([]string, error) {
+	var resp = []struct {
+		Address  string   `json:"address,omitempty"`
+		Purposes []string `json:"purposes,omitempty"`
+	}{}
+
+	url := api.NewURL().Path("api", "rest", "ip_pool_address")
+	url = url.WithQuery("select", "address,purposes")
+
+	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &resp, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed retrieving configured PowerStore IP addresses: %w", err)
+	}
+
+	// Filter IP addresses based on their purpose, which should match the connector type.
+	var purpose string
+	switch connectorType {
+	case connectors.TypeISCSI:
+		purpose = "Storage_Iscsi_Target"
+	case connectors.TypeNVME:
+		purpose = "Storage_NVMe_TCP_Port"
+	default:
+		return nil, fmt.Errorf("Unsupported connector type: %q", connectorType)
+	}
+
+	// Additionally, PowerStore might have floating IP address that can be used for
+	// NVMe/iSCSI discovery.
+	genericIPPurpose := "Storage_Cluster_Floating"
+
+	var addresses []string
+	for _, ip := range resp {
+		if slices.Contains(addresses, ip.Address) {
+			continue
+		}
+
+		if slices.Contains(ip.Purposes, purpose) || slices.Contains(ip.Purposes, genericIPPurpose) {
+			addresses = append(addresses, ip.Address)
+		}
+	}
+
+	return addresses, nil
 }

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -1,5 +1,99 @@
 package clients
 
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+type powerStoreErrorMessage struct {
+	Message string `json:"message_l10n"`
+}
+
+// powerStoreError represents PowerStore error response.
+type powerStoreError struct {
+	StatusCode int                      `json:"-"`
+	Messages   []powerStoreErrorMessage `json:"messages,omitempty"`
+}
+
+func newPowerStoreError(resp *http.Response) error {
+	if resp.StatusCode == http.StatusUnauthorized {
+		return api.NewStatusError(http.StatusUnauthorized, "Unauthorized request")
+	}
+
+	psErr := &powerStoreError{
+		StatusCode: resp.StatusCode,
+	}
+
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
+		return psErr
+	}
+
+	err := json.NewDecoder(resp.Body).Decode(psErr)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return psErr
+		}
+
+		return fmt.Errorf("Failed unmarshalling HTTP error response body: %w", err)
+	}
+
+	return psErr
+}
+
+// Error returns formatted PowerStore API error message.
+func (e *powerStoreError) Error() string {
+	msg := "PowerStore API error"
+	if e.StatusCode != 0 {
+		msg = msg + " " + strconv.Itoa(e.StatusCode)
+	}
+
+	for _, em := range e.Messages {
+		if em.Message != "" {
+			msg = msg + ": " + em.Message
+		}
+	}
+
+	return msg
+}
+
+// isPowerStoreError checks if the error is of type powerStoreError and matches the provided
+// status code. If substrings are provided, it also checks if the error message contains any
+// of the substrings.
+func isPowerStoreError(err error, statusCode int, substrings ...string) bool {
+	perr, ok := err.(*powerStoreError)
+	if !ok {
+		return false
+	}
+
+	if perr.StatusCode != statusCode {
+		return false
+	}
+
+	if len(substrings) == 0 {
+		return true
+	}
+
+	errMsg := strings.ToLower(perr.Error())
+	for _, substring := range substrings {
+		if strings.Contains(errMsg, strings.ToLower(substring)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PowerStoreClient holds the PowerStore HTTP API client.
 type PowerStoreClient struct {
 	url                string
@@ -18,4 +112,80 @@ func NewPowerStoreClient(url string, username string, password string, skipTLSVe
 		password:           password,
 		resourceNamePrefix: resourceNamePrefix,
 	}
+}
+
+// request issues a HTTP request against the PowerStore gateway.
+func (c *PowerStoreClient) request(method string, url url.URL, reqBody map[string]any, reqHeaders map[string]string, respBody any, respHeaders http.Header) error {
+	gw := c.url
+	if !strings.Contains(gw, "://") {
+		return fmt.Errorf("Invalid PowerStore URL %q: Missing protocol", gw)
+	}
+
+	gwURL, err := url.Parse(gw)
+	if err != nil {
+		return fmt.Errorf("Failed parsing PowerStore URL %q: %w", gw, err)
+	}
+
+	url.Scheme = gwURL.Scheme
+	url.Host = gwURL.Host
+
+	// Prepend gateway path with the request path in case PowerStore is served on a sub-path.
+	url.Path = path.Join(gwURL.Path, url.Path)
+
+	var reqBodyReader io.Reader
+
+	if reqBody != nil {
+		reqBodyReader, err = createBodyReader(reqBody)
+		if err != nil {
+			return err
+		}
+	}
+
+	req, err := http.NewRequest(method, url.String(), reqBodyReader)
+	if err != nil {
+		return fmt.Errorf("Failed creating request: %w", err)
+	}
+
+	// Set custom request headers.
+	for k, v := range reqHeaders {
+		req.Header.Add(k, v)
+	}
+
+	req.Header.Add("Accept", "application/json")
+	if reqBody != nil {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.skipTLSVerify,
+			},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Failed sending request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return newPowerStoreError(resp)
+	}
+
+	if respBody != nil {
+		err := json.NewDecoder(resp.Body).Decode(respBody)
+		if err != nil {
+			return fmt.Errorf("Failed reading response body from %q: %w", url.String(), err)
+		}
+	}
+
+	// Extract the response headers if requested.
+	if respHeaders != nil {
+		maps.Copy(respHeaders, resp.Header)
+	}
+
+	return nil
 }

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -1,0 +1,126 @@
+package drivers
+
+import (
+	"github.com/canonical/lxd/lxd/storage/connectors"
+	"github.com/canonical/lxd/lxd/storage/drivers/clients"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ioprogress"
+)
+
+// powerStoreLoaded indicates whether load() function was already called for the PowerStore driver.
+var powerStoreLoaded bool
+
+// powerStoreVersion holds the version of the PowerStore system.
+var powerStoreVersion string
+
+type powerstore struct {
+	common
+
+	// Holds the low level client for the PowerStore API.
+	// Use [powerstore.client] to retrieve the initialized client struct.
+	httpClient *clients.PowerStoreClient
+
+	// Holds the low level connector for the PowerStore driver.
+	// Use [powerstore.connector] to retrieve the initialized connector.
+	storageConnector connectors.Connector
+}
+
+// load initializes the PowerStore driver.
+func (d *powerstore) load() error {
+	// Done if previously loaded.
+	if powerStoreLoaded {
+		return nil
+	}
+
+	powerStoreLoaded = true
+	return nil
+}
+
+// connector retrieves an initialized storage connector based on the configured
+// PowerStore mode. The connector is cached in the driver struct.
+func (d *powerstore) connector() (connectors.Connector, error) {
+	return d.storageConnector, nil
+}
+
+// client returns the PowerStore API client.
+func (d *powerstore) client() *clients.PowerStoreClient {
+	return d.httpClient
+}
+
+// isRemote returns true indicating this driver uses remote storage.
+func (d *powerstore) isRemote() bool {
+	return true
+}
+
+// Info returns info about the driver and its environment.
+func (d *powerstore) Info() Info {
+	return Info{
+		Name:                         "powerstore",
+		Version:                      powerStoreVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
+		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
+		OptimizedImages:              true,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeVM, VolumeTypeContainer, VolumeTypeImage},
+		BlockBacking:                 true,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  false,
+		PopulateParentVolumeUUID:     true,
+		UUIDVolumeNames:              true,
+	}
+}
+
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *powerstore) FillConfig() error {
+	return nil
+}
+
+// Validate checks that all provided keys are supported and that no conflicting or missing configuration is present.
+func (d *powerstore) Validate(config map[string]string) error {
+	return nil
+}
+
+// SourceIdentifier returns a combined string consisting of the gateway address and pool name.
+func (d *powerstore) SourceIdentifier() (string, error) {
+	return "", nil
+}
+
+// ValidateSource checks whether the required config keys are set to access the remote source.
+func (d *powerstore) ValidateSource() error {
+	return nil
+}
+
+// Create is called during pool creation and is effectively using an empty driver struct.
+// WARNING: The Create() function cannot rely on any of the struct attributes being set.
+func (d *powerstore) Create() error {
+	return nil
+}
+
+// Update applies any driver changes required from a configuration change.
+func (d *powerstore) Update(changedConfig map[string]string) error {
+	return nil
+}
+
+// Mount mounts the storage pool.
+func (d *powerstore) Mount() (bool, error) {
+	return true, nil
+}
+
+// Unmount unmounts the storage pool.
+func (d *powerstore) Unmount() (bool, error) {
+	return true, nil
+}
+
+// Delete removes the storage pool from the storage device.
+func (d *powerstore) Delete(progressReporter ioprogress.ProgressReporter) error {
+	return wipeDirectory(GetPoolMountPath(d.name))
+}
+
+// GetResources returns the pool resource usage information.
+func (d *powerstore) GetResources() (*api.ResourcesStoragePool, error) {
+	res := &api.ResourcesStoragePool{}
+	return res, nil
+}

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -3,6 +3,9 @@ package drivers
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/clients"
@@ -24,6 +27,9 @@ var powerStoreSupportedConnectors = []string{
 
 // powerStoreDefaultUser represents the default PowerStore user name.
 const powerStoreDefaultUser = "admin"
+
+// Common prefix for resource names in PowerStore.
+const powerStoreResourcePrefix = "lxd-"
 
 type powerstore struct {
 	common
@@ -248,4 +254,13 @@ func (d *powerstore) Delete(progressReporter ioprogress.ProgressReporter) error 
 func (d *powerstore) GetResources() (*api.ResourcesStoragePool, error) {
 	res := &api.ResourcesStoragePool{}
 	return res, nil
+}
+
+// storagePoolScopePrefix returns the prefix used to scope PowerStore resource
+// names to an LXD storage pool. This prevents conflicts in PowerStore with
+// resources created for other LXD storage pools or at the root level.
+func (d *powerstore) storagePoolScopePrefix(poolName string) string {
+	poolID := uuid.NewSHA1(uuid.NameSpaceURL, []byte(poolName))
+	prefix := strings.ReplaceAll(poolID.String(), "-", "")
+	return powerStoreResourcePrefix + prefix + "-"
 }

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/clients"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/validate"
@@ -62,6 +63,16 @@ func (d *powerstore) connector() (connectors.Connector, error) {
 
 // client returns the PowerStore API client.
 func (d *powerstore) client() *clients.PowerStoreClient {
+	if d.httpClient == nil {
+		d.httpClient = clients.NewPowerStoreClient(
+			d.config["powerstore.gateway"],
+			d.config["powerstore.user.name"],
+			d.config["powerstore.user.password"],
+			shared.IsFalse(d.config["powerstore.gateway.verify"]),
+			d.storagePoolScopePrefix(d.name),
+		)
+	}
+
 	return d.httpClient
 }
 

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -189,11 +189,32 @@ func (d *powerstore) Validate(config map[string]string) error {
 
 // SourceIdentifier returns a combined string consisting of the gateway address and pool name.
 func (d *powerstore) SourceIdentifier() (string, error) {
-	return "", nil
+	gateway := d.config["powerstore.gateway"]
+	if gateway == "" {
+		return "", errors.New("Cannot derive identifier from empty gateway address")
+	}
+
+	if d.name == "" {
+		return "", errors.New("Cannot derive identifier from empty pool name")
+	}
+
+	return gateway + "-" + d.name, nil
 }
 
 // ValidateSource checks whether the required config keys are set to access the remote source.
 func (d *powerstore) ValidateSource() error {
+	if d.config["powerstore.gateway"] == "" {
+		return errors.New("The powerstore.gateway cannot be empty")
+	}
+
+	if d.config["powerstore.user.name"] == "" {
+		return errors.New("The powerstore.user.name cannot be empty")
+	}
+
+	if d.config["powerstore.user.password"] == "" {
+		return errors.New("The powerstore.user.password cannot be empty")
+	}
+
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -3,6 +3,8 @@ package drivers
 import (
 	"errors"
 	"fmt"
+	"net"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -42,6 +44,10 @@ type powerstore struct {
 	// Holds the low level connector for the PowerStore driver.
 	// Use [powerstore.connector] to retrieve the initialized connector.
 	storageConnector connectors.Connector
+
+	// Holds the list of low level connector targets used for connecting to PowerStore.
+	// Use [powerstore.targets] to retrieve the initialized list of targets.
+	storageConnectorTargets map[string][]string
 }
 
 // load initializes the PowerStore driver.
@@ -274,6 +280,107 @@ func (d *powerstore) Delete(progressReporter ioprogress.ProgressReporter) error 
 func (d *powerstore) GetResources() (*api.ResourcesStoragePool, error) {
 	res := &api.ResourcesStoragePool{}
 	return res, nil
+}
+
+// targets return PowerStore targets as a map of qualified names and their associated addresses.
+func (d *powerstore) targets() (map[string][]string, error) {
+	if len(d.storageConnectorTargets) > 0 {
+		return d.storageConnectorTargets, nil
+	}
+
+	connector, err := d.connector()
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch discovery addresses from PowerStore for the selected connector type.
+	discoveryAddresses, err := d.client().DiscoveryAddresses(connector.Type())
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch discovery log records for each discovery address.
+	// The records contain the information about available targets.
+	var discoveryLogRecords []any
+	for _, addr := range discoveryAddresses {
+		discovered, err := connector.Discover(d.state.ShutdownCtx, addr)
+		if err != nil {
+			// Underlying connector already logs a warning.
+			continue
+		}
+
+		discoveryLogRecords = append(discoveryLogRecords, discovered...)
+	}
+
+	if len(discoveryLogRecords) == 0 {
+		return nil, errors.New("Failed fetching discovery log records for all PowerStore target addresses")
+	}
+
+	// Parse user-specified list of addresses to connect to.
+	// If not specified, all discovered addresses will be used.
+	filterAddresses := shared.SplitNTrimSpace(d.config["powerstore.target"], ",", -1, true)
+	if len(filterAddresses) > 0 {
+		// Make sure target addresses have port configured.
+		var defaultPort string
+
+		mode := connector.Type()
+		switch mode {
+		case connectors.TypeISCSI:
+			defaultPort = connectors.ISCSIDefaultPort
+		case connectors.TypeNVME:
+			defaultPort = connectors.NVMeDefaultDiscoveryPort
+		default:
+			return nil, fmt.Errorf("Unsupported PowerStore mode %q", mode)
+		}
+
+		for i := range filterAddresses {
+			filterAddresses[i] = shared.EnsurePort(filterAddresses[i], defaultPort)
+		}
+	}
+
+	// Helper function to extract address and qualified name from a discovery log record,
+	// which differs based on the connector type.
+	parseLogEntry := func(record any) (address string, qn string, err error) {
+		switch r := record.(type) {
+		case connectors.ISCSIDiscoveryLogRecord:
+			address = r.Address
+			qn = r.IQN
+		case connectors.NVMeDiscoveryLogRecord:
+			address = net.JoinHostPort(r.TransportAddress, r.TransportServiceIdentifier)
+			qn = r.SubNQN
+		default:
+			return "", "", fmt.Errorf("Unknown discovery log record entry type %T", record)
+		}
+
+		return address, qn, nil
+	}
+
+	// Parse discovered targets and filter them by user-specified addresses if needed.
+	targets := make(map[string][]string)
+	for _, record := range discoveryLogRecords {
+		address, qn, err := parseLogEntry(record)
+		if err != nil {
+			return nil, err
+		}
+
+		if slices.Contains(targets[qn], address) {
+			continue
+		}
+
+		if len(filterAddresses) > 0 && !slices.Contains(filterAddresses, address) {
+			continue
+		}
+
+		targets[qn] = append(targets[qn], address)
+	}
+
+	if len(targets) == 0 {
+		return nil, errors.New("Failed retrieving any target from the discovery addresses")
+	}
+
+	// Cache unique discovered targets for future use and return them.
+	d.storageConnectorTargets = targets
+	return d.storageConnectorTargets, nil
 }
 
 // storagePoolScopePrefix returns the prefix used to scope PowerStore resource

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -1,10 +1,14 @@
 package drivers
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/drivers/clients"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
+	"github.com/canonical/lxd/shared/validate"
 )
 
 // powerStoreLoaded indicates whether load() function was already called for the PowerStore driver.
@@ -12,6 +16,14 @@ var powerStoreLoaded bool
 
 // powerStoreVersion holds the version of the PowerStore system.
 var powerStoreVersion string
+
+// powerStoreSupportedConnectors represents a list of storage connectors that can be used with PowerStore.
+var powerStoreSupportedConnectors = []string{
+	connectors.TypeISCSI,
+}
+
+// powerStoreDefaultUser represents the default PowerStore user name.
+const powerStoreDefaultUser = "admin"
 
 type powerstore struct {
 	common
@@ -75,11 +87,103 @@ func (d *powerstore) Info() Info {
 
 // FillConfig populates the storage pool's configuration file with the default values.
 func (d *powerstore) FillConfig() error {
+	if d.config["powerstore.user.name"] == "" {
+		d.config["powerstore.user.name"] = powerStoreDefaultUser
+	}
+
 	return nil
 }
 
 // Validate checks that all provided keys are supported and that no conflicting or missing configuration is present.
 func (d *powerstore) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.user.name)
+		// Name of the PowerStore user with an admin role that gives LXD full control over managed storage pools.
+		// ---
+		//  type: string
+		//  defaultdesc: `admin`
+		//  shortdesc: User for PowerStore Gateway authentication
+		//  scope: global
+		"powerstore.user.name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.user.password)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Password for PowerStore Gateway authentication
+		//  scope: global
+		"powerstore.user.password": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.gateway)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Address of the PowerStore Gateway
+		//  scope: global
+		"powerstore.gateway": validate.Optional(validate.IsRequestURL),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.gateway.verify)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Whether to verify the PowerStore Gateway's certificate
+		//  scope: global
+		"powerstore.gateway.verify": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.mode)
+		// The mode to use to map PowerStore volumes to the local server.
+		// Supported value is `iscsi`.
+		// ---
+		//  type: string
+		//  defaultdesc: the discovered mode
+		//  shortdesc: How volumes are mapped to the local server
+		//  scope: global
+		"powerstore.mode": validate.Optional(validate.IsOneOf(powerStoreSupportedConnectors...)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.target)
+		// A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
+		// ---
+		//  type: string
+		//  defaultdesc: target addresses
+		//  shortdesc: List of target addresses the LXD connects to.
+		"powerstore.target": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
+		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=volume.size)
+		// The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+		// ---
+		//  type: string
+		//  defaultdesc: `10GiB`
+		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
+		"volume.size": validate.Optional(validate.IsMultipleOfUnit("1MiB")),
+	}
+
+	err := d.validatePool(config, rules, d.commonVolumeRules())
+	if err != nil {
+		return err
+	}
+
+	newMode := config["powerstore.mode"]
+	oldMode := d.config["powerstore.mode"]
+
+	// Ensure powerstore.mode cannot be changed to avoid leaving volume mappings
+	// and prevent disturbing running instances.
+	if oldMode != "" && oldMode != newMode {
+		return errors.New("PowerStore mode cannot be changed")
+	}
+
+	// Check if the selected PowerStore mode is supported on this node.
+	// Also when forming the storage pool on a LXD cluster, the mode that got discovered on this
+	// host needs to be validated on the other cluster members as well. This can be done here
+	// since Validate gets executed on every cluster member when receiving the cluster
+	// notification to finally create the pool.
+	if newMode != "" {
+		connector, err := connectors.NewConnector(newMode, "")
+		if err != nil {
+			return fmt.Errorf("PowerStore mode %q is not supported: %w", newMode, err)
+		}
+
+		err = connector.LoadModules()
+		if err != nil {
+			return fmt.Errorf("PowerStore mode %q is not supported due to missing kernel modules: %w", newMode, err)
+		}
+	}
+
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -58,6 +58,15 @@ func (d *powerstore) load() error {
 // connector retrieves an initialized storage connector based on the configured
 // PowerStore mode. The connector is cached in the driver struct.
 func (d *powerstore) connector() (connectors.Connector, error) {
+	if d.storageConnector == nil {
+		connector, err := connectors.NewConnector(d.config["powerstore.mode"], d.state.OS.ServerUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		d.storageConnector = connector
+	}
+
 	return d.storageConnector, nil
 }
 

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -630,7 +630,24 @@ func (d *powerstore) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string
 
 // VolumeSnapshots returns a list of volume snapshot names for the given volume.
 func (d *powerstore) VolumeSnapshots(vol Volume) ([]string, error) {
-	return nil, ErrNotSupported
+	client := d.client()
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshots, err := client.GetVolumeSnapshots(volID)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotNames := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		snapshotNames = append(snapshotNames, snapshot.Name)
+	}
+
+	return snapshotNames, nil
 }
 
 // newMountableSnapshotVolume returns a non-snapshot [Volume] representing the temporary clone

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
@@ -182,7 +183,28 @@ func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
 
 // GetVolumeUsage returns the disk space used by the volume.
 func (d *powerstore) GetVolumeUsage(vol Volume) (int64, error) {
-	return -1, ErrNotSupported
+	// If mounted, use the filesystem stats for pretty accurate usage information.
+	if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(vol.MountPath()) {
+		var stat unix.Statfs_t
+		err := unix.Statfs(vol.MountPath(), &stat)
+		if err != nil {
+			return -1, err
+		}
+
+		return int64(stat.Blocks-stat.Bfree) * int64(stat.Bsize), nil
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return -1, err
+	}
+
+	psVol, err := d.client().GetVolume(volID)
+	if err != nil {
+		return -1, err
+	}
+
+	return psVol.LogicalUsed, nil
 }
 
 // HasVolume indicates whether a specific volume exists on the storage pool.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -155,6 +155,23 @@ func (d *powerstore) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 
 // GetVolumeDiskPath returns the location of a root disk block device.
 func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
+	if vol.IsSnapshot() {
+		// Snapshots cannot be attached directly. The [powerstore.MountVolumeSnapshot]
+		// maps a temporary clone, therefore, search for the device path of a snapshot
+		// clone.
+		cloneVol, err := d.newMountableSnapshotVolume(vol)
+		if err != nil {
+			return "", err
+		}
+
+		vol = cloneVol
+	}
+
+	if vol.IsVMBlock() || (vol.volType == VolumeTypeCustom && IsContentBlock(vol.contentType)) {
+		devPath, _, err := d.getMappedDevicePath(vol, false)
+		return devPath, err
+	}
+
 	return "", ErrNotSupported
 }
 

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -522,9 +523,203 @@ func (d *powerstore) RestoreVolume(vol Volume, snapVol Volume, progressReporter 
 	return nil
 }
 
+// refreshVolume updates an existing volume to match the state of another. For VMs, this function
+// refreshes either block or filesystem volume, depending on the volume type. Therefore, the caller
+// needs to ensure it is called twice - once for each volume type.
+func (d *powerstore) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Function to run once the volume is created, which will ensure appropriate permissions
+	// on the mount path inside the volume, and resize the volume to specified size.
+	postCreateTasks := func(v Volume) error {
+		if vol.contentType == ContentTypeFS {
+			mountTask := func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
+				return v.EnsureMountPath()
+			}
+
+			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
+			err := v.MountTask(mountTask, progressReporter)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Resize volume to the size specified.
+		err := d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	srcVolID, err := d.getVolumeID(srcVol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	volID, err := d.getVolumeID(vol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new reverter snapshot, which is used to revert the original volume in case of
+	// an error. Snapshots are also required to be first copied into destination volume,
+	// from which a new snapshot is created to effectively copy a snapshot. If any error
+	// occurs, the destination volume has been already modified and needs reverting.
+	reverterSnapshotName := "lxd-reverter-snapshot"
+
+	// Remove existing reverter snapshot.
+	reverterSnapshotID, err := client.GetVolumeSnapshotID(volID, reverterSnapshotName)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return nil, err
+	}
+
+	if reverterSnapshotID != "" {
+		err = client.DeleteVolumeSnapshot(reverterSnapshotID)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil, err
+		}
+	}
+
+	// Create new reverter snapshot.
+	reverterSnapshotID, err = client.CreateVolumeSnapshot(volID, reverterSnapshotName)
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() {
+		// Restore destination volume from reverter snapshot and remove the snapshot afterwards.
+		_ = client.RestoreVolume(volID, reverterSnapshotID)
+		_ = client.DeleteVolumeSnapshot(reverterSnapshotID)
+	})
+
+	if !srcVol.IsSnapshot() && len(refreshSnapshots) > 0 {
+		var refreshedSnapshots []string
+
+		// Refresh volume snapshots.
+		// PowerStore does not allow copying snapshots along with the volume. Therefore,
+		// we copy the missing snapshots sequentially. Each snapshot is first copied into
+		// the destination volume, from which a new snapshot is created. The process is
+		// repeated until all of the missing snapshots are copied.
+		for _, snapshot := range vol.Snapshots {
+			// Remove volume name prefix from the snapshot name, and check whether it
+			// has to be refreshed.
+			_, snapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+			if !slices.Contains(refreshSnapshots, snapshotShortName) {
+				// Skip snapshot if it doesn't have to be refreshed.
+				continue
+			}
+
+			// Find the corresponding source snapshot.
+			var srcSnapshot *Volume
+			for _, srcSnap := range srcVol.Snapshots {
+				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
+				if snapshotShortName == srcSnapshotShortName {
+					srcSnapshot = &srcSnap
+					break
+				}
+			}
+
+			if srcSnapshot == nil {
+				return nil, fmt.Errorf("Failed refreshing snapshot %q: Source snapshot does not exist", snapshotShortName)
+			}
+
+			srcSnapshotID, err := d.getVolumeID(*srcSnapshot)
+			if err != nil {
+				return nil, err
+			}
+
+			// Overwrite existing destination volume with snapshot.
+			err = client.RefreshVolume(srcSnapshotID, volID)
+			if err != nil {
+				return nil, err
+			}
+
+			// Set snapshot's parent UUID.
+			snapshot.SetParentUUID(vol.config["volatile.uuid"])
+
+			// Create snapshot of a new volume. Do not copy VM's filesystem volume snapshot,
+			// as FS volumes are already copied by this point.
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
+			if err != nil {
+				return nil, err
+			}
+
+			revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapshot, progressReporter) })
+
+			// Append snapshot to the list of successfully refreshed snapshots.
+			refreshedSnapshots = append(refreshedSnapshots, snapshotShortName)
+		}
+
+		// Ensure all snapshots were successfully refreshed.
+		missing := shared.RemoveElementsFromSlice(refreshSnapshots, refreshedSnapshots...)
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("Failed refreshing snapshots %v", missing)
+		}
+	}
+
+	// Finally, copy the source volume (or snapshot) into destination volume snapshots.
+	err = client.RefreshVolume(srcVolID, volID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = postCreateTasks(vol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := revert.Clone().Fail
+	revert.Success()
+
+	// Remove temporary reverter snapshot.
+	_ = client.DeleteVolumeSnapshot(reverterSnapshotID)
+
+	return cleanup, err
+}
+
 // RefreshVolume updates an existing volume to match the state of another.
 func (d *powerstore) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	revert := revert.New()
+	defer revert.Fail()
+
+	// For VMs, also copy the filesystem volume.
+	if vol.IsVMBlock() {
+		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
+		for _, snapshot := range vol.Snapshots {
+			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
+		for _, snapshot := range srcVol.Snapshots {
+			srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
+
+		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, allowInconsistent, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(cleanup)
+	}
+
+	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, allowInconsistent, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(cleanup)
+
+	revert.Success()
+	return nil
 }
 
 // SetVolumeQuota applies a size limit on volume.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -366,7 +366,163 @@ func (d *powerstore) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *V
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *powerstore) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Function to run once the volume is created, which will ensure appropriate permissions
+	// on the mount path inside the volume, and resize the volume to specified size.
+	postCreateTasks := func(v Volume) error {
+		if vol.contentType == ContentTypeFS {
+			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
+			mountTask := func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
+				return v.EnsureMountPath()
+			}
+
+			err := v.MountTask(mountTask, progressReporter)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Resize volume to the size specified.
+		err := d.SetVolumeQuota(v, vol.config["size"], false, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// For VMs, also copy the filesystem volume.
+	if vol.IsVMBlock() {
+		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
+		for _, snapshot := range vol.Snapshots {
+			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
+		for _, snapshot := range srcVol.Snapshots {
+			srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
+
+		// Ensure parent UUID is retained for the filesystem volumes.
+		fsVol.SetParentUUID(vol.parentUUID)
+		srcFSVol.SetParentUUID(srcVol.parentUUID)
+
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, progressReporter) })
+	}
+
+	volID := ""
+	volName, err := d.encodeVolumeName(vol.Volume)
+	if err != nil {
+		return err
+	}
+
+	srcVolID, err := d.getVolumeID(srcVol.Volume)
+	if err != nil {
+		return err
+	}
+
+	// Since snapshots are first copied into destination volume from which a new snapshot is created,
+	// we need to also remove the destination volume if an error occurs during copying of snapshots.
+	deleteVolCopy := true
+
+	// Copy volume snapshots.
+	// PowerStore does copy snapshots along with the volume. Therefore, we copy the snapshots
+	// sequentially once the volume was copied. Each snapshot is first copied into destination
+	// volume from which a new snapshot is created. The process is repeated until all snapshots
+	// are copied.
+	if !srcVol.IsSnapshot() {
+		for _, snapshot := range vol.Snapshots {
+			_, snapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+
+			// Find the corresponding source snapshot.
+			var srcSnapshot *Volume
+			for _, srcSnap := range srcVol.Snapshots {
+				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
+				if snapshotShortName == srcSnapshotShortName {
+					srcSnapshot = &srcSnap
+					break
+				}
+			}
+
+			if srcSnapshot == nil {
+				return fmt.Errorf("Failed copying snapshot %q: Source snapshot does not exist", snapshotShortName)
+			}
+
+			srcSnapshotID, err := d.getVolumeID(*srcSnapshot)
+			if err != nil {
+				return err
+			}
+
+			// Copy the snapshot.
+			if volID == "" {
+				// If this is a first snapshot, we need to clone it as the
+				// destination volume does not exist yet.
+				volID, err = client.CloneVolume(srcSnapshotID, volName)
+
+				// Volume is created, make sure to remove it in case the operation
+				// fails.
+				revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
+				deleteVolCopy = false
+			} else {
+				// Otherwise, overwrite the destination volume.
+				err = client.RefreshVolume(srcSnapshotID, volID)
+			}
+
+			if err != nil {
+				return fmt.Errorf("Failed copying snapshot %q into volume %q: %w", snapshot.name, vol.name, err)
+			}
+
+			// Set snapshot's parent UUID and retain source snapshot UUID.
+			snapshot.SetParentUUID(vol.config["volatile.uuid"])
+
+			// Create snapshot from a new volume (that was created from the source snapshot).
+			// However, do not create VM's filesystem volume snapshot, as filesystem volume is
+			// copied before block volume.
+			err = d.createVolumeSnapshot(snapshot, false, progressReporter)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Finally, copy the source volume (or snapshot) into destination volume snapshots.
+	if srcVol.IsSnapshot() || volID == "" {
+		// Copy the source volume/snapshot into destination volume.
+		_, err = client.CloneVolume(srcVolID, volName)
+	} else {
+		// Destination volume already exists, so refresh it.
+		err = client.RefreshVolume(srcVolID, volID)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Add reverted to delete destination volume, if not already added.
+	if deleteVolCopy {
+		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
+	}
+
+	err = postCreateTasks(vol.Volume)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -469,7 +469,12 @@ func (d *powerstore) BackupVolume(vol VolumeCopy, projectName string, tarWriter 
 
 // MigrateVolume sends a volume for migration.
 func (d *powerstore) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	// When performing a cluster member move don't do anything on the source member.
+	if volSrcArgs.ClusterMove {
+		return nil
+	}
+
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, progressReporter)
 }
 
 // RestoreVolume restores a volume from a snapshot.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -361,7 +361,7 @@ func (d *powerstore) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Inf
 
 // CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
 func (d *powerstore) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	return createVolumeFromImage(vol, imgVol, filler, progressReporter)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
 	"github.com/canonical/lxd/shared/validate"
@@ -198,7 +199,37 @@ func (d *powerstore) HasVolume(vol Volume) (bool, error) {
 // ListVolumes returns a list of LXD volumes in storage pool.
 // It returns all volumes and sets the volume's volatile.uuid extracted from the name.
 func (d *powerstore) ListVolumes() ([]Volume, error) {
-	return nil, ErrNotSupported
+	psVols, err := d.client().GetVolumes()
+	if err != nil {
+		return nil, err
+	}
+
+	vols := make([]Volume, 0, len(psVols))
+	for _, psVol := range psVols {
+		volType, volUUID, volContentType, isMountableSnapshot, err := d.decodeVolumeName(psVol.Name)
+		if err != nil {
+			d.logger.Debug("Unrecognized volume in PowerStore", logger.Ctx{"name": psVol.Name, "err": err.Error()})
+			continue
+		}
+
+		// Skip transient mountable snapshots clones that do not represent an actual volume.
+		if isMountableSnapshot {
+			continue
+		}
+
+		volConfig := map[string]string{
+			"volatile.uuid": volUUID.String(),
+		}
+
+		vol := NewVolume(d, d.name, volType, volContentType, "", volConfig, d.config)
+		if volContentType == ContentTypeFS {
+			vol.SetMountFilesystemProbe(true)
+		}
+
+		vols = append(vols, vol)
+	}
+
+	return vols, nil
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -13,6 +13,11 @@ import (
 	"github.com/canonical/lxd/shared/validate"
 )
 
+const (
+	powerStoreVolMinSize int64 = 1024 * 1024                     // 1 MiB in bytes.
+	powerStoreVolMaxSize int64 = 256 * 1024 * 1024 * 1024 * 1024 // 256 TiB in bytes.
+)
+
 // commonVolumeRules returns validation rules which are common for pool and volume.
 func (d *powerstore) commonVolumeRules() map[string]func(value string) error {
 	return map[string]func(value string) error{
@@ -246,4 +251,14 @@ func (d *powerstore) MountVolumeSnapshot(snapVol Volume, progressReporter ioprog
 // UnmountVolumeSnapshot unmounts the volume snapshot.
 func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return false, ErrNotSupported
+}
+
+// roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
+// multiple of 1 MiB, which is the minimum volume size on PowerStore.
+func (d *powerstore) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {
+	if sizeBytes < powerStoreVolMinSize {
+		return powerStoreVolMinSize
+	}
+
+	return roundAbove(powerStoreVolMinSize, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -366,6 +366,44 @@ func (d *powerstore) decodeVolumeName(name string) (volType VolumeType, volUUID 
 	return volType, volUUID, volContentType, isMountableSnapshot, nil
 }
 
+// getVolumeID returns the PowerStore ID for the given LXD volume or snapshot.
+// For snapshots, it resolves the parent volume first and then fetches the snapshot by name.
+func (d *powerstore) getVolumeID(vol Volume) (string, error) {
+	client := d.client()
+
+	volName, err := d.encodeVolumeName(vol)
+	if err != nil {
+		return "", err
+	}
+
+	if vol.IsSnapshot() {
+		parentVol := vol.GetParent()
+		parentVolName, err := d.encodeVolumeName(parentVol)
+		if err != nil {
+			return "", err
+		}
+
+		parentVolID, err := client.GetVolumeID(parentVolName)
+		if err != nil {
+			return "", fmt.Errorf("Failed resolving ID for snapshot parent volume %q: %w", parentVol.name, err)
+		}
+
+		snapshotID, err := client.GetVolumeSnapshotID(parentVolID, volName)
+		if err != nil {
+			return "", fmt.Errorf("Failed resolving ID for snapshot %q: %w", vol.name, err)
+		}
+
+		return snapshotID, nil
+	}
+
+	volID, err := client.GetVolumeID(volName)
+	if err != nil {
+		return "", fmt.Errorf("Failed resolving ID for volume %q: %w", vol.name, err)
+	}
+
+	return volID, nil
+}
+
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
 // multiple of 1 MiB, which is the minimum volume size on PowerStore.
 func (d *powerstore) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -527,7 +527,26 @@ func (d *powerstore) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, all
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
 func (d *powerstore) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	// When performing a cluster member move prepare the volumes on the target side.
+	if volTargetArgs.ClusterMoveSourceName != "" {
+		err := vol.EnsureMountPath()
+		if err != nil {
+			return err
+		}
+
+		if vol.IsVMBlock() {
+			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, progressReporter)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, progressReporter)
+	return err
 }
 
 // UpdateVolume applies config changes to the volume.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
@@ -612,9 +613,78 @@ func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, progressReport
 	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevicePath, d.unmapVolume, progressReporter)
 }
 
+// createVolumeSnapshot creates a snapshot of a volume. If snapshotVMfilesystem is false, a VM's filesystem volume
+// is not copied.
+func (d *powerstore) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, progressReporter ioprogress.ProgressReporter) error {
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
+	sourcePath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
+
+	if filesystem.IsMountPoint(sourcePath) {
+		// Attempt to sync and freeze filesystem, but do not error if not able to freeze (as filesystem
+		// could still be busy), as we do not guarantee the consistency of a snapshot. This is costly but
+		// try to ensure that all cached data has been committed to disk. If we don't then the snapshot
+		// of the underlying filesystem can be inconsistent or, in the worst case, empty.
+		unfreezeFS, err := d.filesystemFreeze(sourcePath)
+		if err == nil {
+			defer func() { _ = unfreezeFS() }()
+		}
+	}
+
+	// Create the parent directory.
+	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	if err != nil {
+		return err
+	}
+
+	err = snapVol.EnsureMountPath()
+	if err != nil {
+		return err
+	}
+
+	volID, err := d.getVolumeID(snapVol.GetParent())
+	if err != nil {
+		return err
+	}
+
+	snapVolName, err := d.encodeVolumeName(snapVol)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.CreateVolumeSnapshot(volID, snapVolName)
+	if err != nil {
+		return fmt.Errorf("Failed creating snapshot %q for volume %q: %w", snapVol.name, snapVol.GetParent().name, err)
+	}
+
+	revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, progressReporter) })
+
+	// For VMs, create a snapshot of the filesystem volume too.
+	// Skip if snapshotVMfilesystem is false to prevent overwriting separately copied volumes.
+	if snapVol.IsVMBlock() && snapshotVMfilesystem {
+		// Get FS volume and set parent volume UUID.
+		fsVol := snapVol.NewVMBlockFilesystemVolume()
+		fsVol.SetParentUUID(snapVol.parentUUID)
+
+		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
+		if err != nil {
+			return fmt.Errorf("Failed creating snapshot %q for volume %q: %w", fsVol.name, fsVol.GetParent().name, err)
+		}
+
+		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, progressReporter) })
+	}
+
+	revert.Success()
+	return nil
+}
+
 // CreateVolumeSnapshot creates a snapshot of a volume.
 func (d *powerstore) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	return d.createVolumeSnapshot(snapVol, true, progressReporter)
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,0 +1,158 @@
+package drivers
+
+import (
+	"io"
+
+	"github.com/canonical/lxd/lxd/backup"
+	"github.com/canonical/lxd/lxd/instancewriter"
+	"github.com/canonical/lxd/lxd/migration"
+	"github.com/canonical/lxd/shared/ioprogress"
+	"github.com/canonical/lxd/shared/revert"
+)
+
+// commonVolumeRules returns validation rules which are common for pool and volume.
+func (d *powerstore) commonVolumeRules() map[string]func(value string) error {
+	return nil
+}
+
+// FillVolumeConfig populate volume with default config.
+func (d *powerstore) FillVolumeConfig(vol Volume) error {
+	return nil
+}
+
+// ValidateVolume validates the supplied volume config.
+func (d *powerstore) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+	return nil
+}
+
+// GetVolumeDiskPath returns the location of a root disk block device.
+func (d *powerstore) GetVolumeDiskPath(vol Volume) (string, error) {
+	return "", ErrNotSupported
+}
+
+// GetVolumeUsage returns the disk space used by the volume.
+func (d *powerstore) GetVolumeUsage(vol Volume) (int64, error) {
+	return -1, ErrNotSupported
+}
+
+// HasVolume indicates whether a specific volume exists on the storage pool.
+func (d *powerstore) HasVolume(vol Volume) (bool, error) {
+	return false, nil
+}
+
+// ListVolumes returns a list of LXD volumes in storage pool.
+// It returns all volumes and sets the volume's volatile.uuid extracted from the name.
+func (d *powerstore) ListVolumes() ([]Volume, error) {
+	return nil, ErrNotSupported
+}
+
+// CreateVolume creates an empty volume and can optionally fill it by executing
+// the supplied filler function.
+func (d *powerstore) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// CreateVolumeFromBackup re-creates a volume from its exported state.
+func (d *powerstore) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
+	return nil, nil, ErrNotSupported
+}
+
+// CreateVolumeFromImage creates a new volume from an image, unpacking it directly.
+func (d *powerstore) CreateVolumeFromImage(vol Volume, imgVol *Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// CreateVolumeFromCopy provides same-pool volume copying functionality.
+func (d *powerstore) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// CreateVolumeFromMigration creates a volume being sent via a migration.
+func (d *powerstore) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// UpdateVolume applies config changes to the volume.
+func (d *powerstore) UpdateVolume(vol Volume, changedConfig map[string]string) error {
+	return ErrNotSupported
+}
+
+// DeleteVolume deletes a volume of the storage device.
+func (d *powerstore) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// RenameVolume is a no-op as renaming a volume does not change the name of the associated volume
+// resource on the remote storage.
+func (d *powerstore) RenameVolume(vol Volume, newVolName string, progressReporter ioprogress.ProgressReporter) error {
+	return nil
+}
+
+// BackupVolume creates an exported version of a volume.
+func (d *powerstore) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// MigrateVolume sends a volume for migration.
+func (d *powerstore) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// RestoreVolume restores a volume from a snapshot.
+func (d *powerstore) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// RefreshVolume updates an existing volume to match the state of another.
+func (d *powerstore) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// SetVolumeQuota applies a size limit on volume.
+func (d *powerstore) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// MountVolume mounts a volume and increments ref counter.
+func (d *powerstore) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// UnmountVolume simulates unmounting a volume.
+//
+// keepBlockDev indicates whether the backing block device should be kept mapped to the
+// host if the volume is unmounted.
+func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return false, ErrNotSupported
+}
+
+// CreateVolumeSnapshot creates a snapshot of a volume.
+func (d *powerstore) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// DeleteVolumeSnapshot removes a snapshot from the storage device.
+func (d *powerstore) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// RenameVolumeSnapshot is a no-op as renaming a volume snapshot does not change the name of
+// the associated volume resource on the remote storage.
+func (d *powerstore) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, progressReporter ioprogress.ProgressReporter) error {
+	return nil
+}
+
+// VolumeSnapshots returns a list of volume snapshot names for the given volume.
+func (d *powerstore) VolumeSnapshots(vol Volume) ([]string, error) {
+	return nil, ErrNotSupported
+}
+
+// MountVolumeSnapshot mounts a volume snapshot.
+func (d *powerstore) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
+	return ErrNotSupported
+}
+
+// UnmountVolumeSnapshot unmounts the volume snapshot.
+func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
+	return false, ErrNotSupported
+}

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,8 +1,12 @@
 package drivers
 
 import (
+	"fmt"
 	"io"
 	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
@@ -17,6 +21,29 @@ const (
 	powerStoreVolMinSize int64 = 1024 * 1024                     // 1 MiB in bytes.
 	powerStoreVolMaxSize int64 = 256 * 1024 * 1024 * 1024 * 1024 // 256 TiB in bytes.
 )
+
+const (
+	powerStoreVolPrefixSep            = "_" // Volume name prefix separator.
+	powerStoreVolSuffixSep            = "." // Volume name suffix separator.
+	powerStoreMountableSnapshotPrefix = "s" // Volume type prefix for mountable (temporary) snapshot clones.
+)
+
+// powerStoreVolTypePrefixes maps volume type to storage volume name prefix.
+var powerStoreVolTypePrefixes = map[VolumeType]string{
+	VolumeTypeContainer: "c",
+	VolumeTypeVM:        "v",
+	VolumeTypeImage:     "i",
+	VolumeTypeCustom:    "u",
+}
+
+// powerStoreVolContentTypeSuffixes maps volume's content type to storage volume name suffix.
+var powerStoreVolContentTypeSuffixes = map[ContentType]string{
+	// Suffix used for block content type volumes.
+	ContentTypeBlock: "b",
+
+	// Suffix used for ISO content type volumes.
+	ContentTypeISO: "i",
+}
 
 // commonVolumeRules returns validation rules which are common for pool and volume.
 func (d *powerstore) commonVolumeRules() map[string]func(value string) error {
@@ -251,6 +278,92 @@ func (d *powerstore) MountVolumeSnapshot(snapVol Volume, progressReporter ioprog
 // UnmountVolumeSnapshot unmounts the volume snapshot.
 func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
 	return false, ErrNotSupported
+}
+
+// encodeVolumeName derives the name of a volume resource in PowerStore from the provided volume.
+func (d *powerstore) encodeVolumeName(vol Volume) (string, error) {
+	volUUID, err := uuid.Parse(vol.config["volatile.uuid"])
+	if err != nil {
+		return "", fmt.Errorf(`Failed parsing "volatile.uuid" from volume %q: %w`, vol.name, err)
+	}
+
+	volName := volUUID.String()
+
+	// Search for the volume type prefix, and if found, prepend it to the volume name.
+	prefix := powerStoreVolTypePrefixes[vol.volType]
+	if prefix != "" {
+		// Mountable (temporary) snapshot clones have a distinct prefix. The clone
+		// name is always exactly the mountable snapshot prefix followed by the
+		// snapshot UUID. Retain prefix as it allows to distinguishing mountable
+		// snapshot clones from regular volumes.
+		if vol.name == powerStoreMountableSnapshotPrefix+volUUID.String() {
+			prefix = powerStoreMountableSnapshotPrefix + prefix
+		}
+
+		volName = prefix + powerStoreVolPrefixSep + volName
+	}
+
+	// Search for the content type suffix, and if found, append it to the volume name.
+	suffix := powerStoreVolContentTypeSuffixes[vol.contentType]
+	if suffix != "" {
+		volName = volName + powerStoreVolSuffixSep + suffix
+	}
+
+	return d.storagePoolScopePrefix(vol.pool) + volName, nil
+}
+
+// decodeVolumeName decodes the PowerStore volume resource name and extracts the stored data.
+func (d *powerstore) decodeVolumeName(name string) (volType VolumeType, volUUID uuid.UUID, volContentType ContentType, isMountableSnapshot bool, err error) {
+	// Remove common resource prefix.
+	poolAndVolName, ok := strings.CutPrefix(name, powerStoreResourcePrefix)
+	if !ok {
+		return "", uuid.Nil, "", false, fmt.Errorf("Failed decoding volume name %q: Missing LXD prefix", name)
+	}
+
+	// Remove storage pool prefix.
+	poolName, volName, ok := strings.Cut(poolAndVolName, "-")
+	if !ok || poolName == "" || volName == "" {
+		return "", uuid.Nil, "", false, fmt.Errorf("Failed decoding volume name %q: Invalid name format", name)
+	}
+
+	// Volume prefix represents volume type.
+	volPrefix, volNameWithoutPrefix, ok := strings.Cut(volName, powerStoreVolPrefixSep)
+	if ok {
+		volName = volNameWithoutPrefix
+
+		// Mountable (temporary) snapshot clones have an additional prefix which must
+		// be stripped before lookup.
+		volPrefix, ok := strings.CutPrefix(volPrefix, powerStoreMountableSnapshotPrefix)
+		if ok {
+			isMountableSnapshot = true
+		}
+
+		for k, v := range powerStoreVolTypePrefixes {
+			if v == volPrefix {
+				volType = k
+				break
+			}
+		}
+	}
+
+	// Volume suffix represents content type.
+	volName, volSuffix, ok := strings.Cut(volName, powerStoreVolSuffixSep)
+	if ok {
+		for k, v := range powerStoreVolContentTypeSuffixes {
+			if v == volSuffix {
+				volContentType = k
+				break
+			}
+		}
+	}
+
+	// The remaining string should be the UUID.
+	volUUID, err = uuid.Parse(volName)
+	if err != nil {
+		return "", uuid.Nil, "", false, fmt.Errorf("Failed decoding volume name %q: %w", name, err)
+	}
+
+	return volType, volUUID, volContentType, isMountableSnapshot, nil
 }
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
@@ -265,7 +267,72 @@ func (d *powerstore) UpdateVolume(vol Volume, changedConfig map[string]string) e
 
 // DeleteVolume deletes a volume of the storage device.
 func (d *powerstore) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	connector, err := d.connector()
+	if err != nil {
+		return err
+	}
+
+	qn, err := connector.QualifiedName()
+	if err != nil {
+		return err
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return err
+	}
+
+	host, err := client.GetCurrentHost(connector.Type(), qn)
+	if err != nil {
+		// If the host doesn't exist, continue with the deletion of the volume and
+		// do not try to delete the volume mapping as it cannot exist.
+		if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed retrieving current host for volume %q: %w", vol.name, err)
+		}
+	} else {
+		// If the host exists, attempt to delete the volume mapping for the deleted
+		// volume. If the mapping doesn't exist, continue with the deletion as the
+		// volume is already deleted.
+		err = client.DetachVolumeFromHost(volID, host.ID)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed detaching volume %q from host %q: %w", vol.name, host.Name, err)
+		}
+	}
+
+	err = client.DeleteVolume(volID)
+	if err != nil {
+		return fmt.Errorf("Failed deleting volume %q: %w", vol.name, err)
+	}
+
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.DeleteVolume(fsVol, progressReporter)
+		if err != nil {
+			return err
+		}
+	}
+
+	mountPath := vol.MountPath()
+	if vol.contentType == ContentTypeFS && shared.PathExists(mountPath) {
+		poolMountPath := GetPoolMountPath(d.name)
+		if !strings.HasPrefix(mountPath, poolMountPath+"/") {
+			return fmt.Errorf("Volume mount path %q is outside of the pool directory %q", mountPath, poolMountPath)
+		}
+
+		err := wipeDirectory(mountPath)
+		if err != nil {
+			return err
+		}
+
+		err = os.RemoveAll(mountPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Failed removing directory %q: %w", mountPath, err)
+		}
+	}
+
+	return nil
 }
 
 // RenameVolume is a no-op as renaming a volume does not change the name of the associated volume

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -356,7 +356,7 @@ func (d *powerstore) CreateVolume(vol Volume, filler *VolumeFiller, progressRepo
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *powerstore) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
-	return nil, nil, ErrNotSupported
+	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, progressReporter)
 }
 
 // CreateVolumeFromImage creates a new volume from an image, unpacking it directly.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -237,7 +237,119 @@ func (d *powerstore) ListVolumes() ([]Volume, error) {
 // CreateVolume creates an empty volume and can optionally fill it by executing
 // the supplied filler function.
 func (d *powerstore) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
+	if err != nil {
+		return err
+	}
+
+	sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+
+	volName, err := d.encodeVolumeName(vol)
+	if err != nil {
+		return err
+	}
+
+	volID, err := client.CreateVolume(volName, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("Failed creating volume %q: %w", vol.name, err)
+	}
+
+	revert.Add(func() { _ = client.DeleteVolume(volID) })
+
+	if vol.contentType == ContentTypeFS {
+		devPath, cleanup, err := d.getMappedDevicePath(vol, true)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(cleanup)
+
+		volumeFilesystem := vol.ConfigBlockFilesystem()
+		_, err = makeFSType(devPath, volumeFilesystem, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// For VMs, also create the filesystem volume.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.CreateVolume(fsVol, nil, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = d.DeleteVolume(fsVol, progressReporter) })
+	}
+
+	mountTask := func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
+		// Run the volume filler function if supplied.
+		if filler != nil && filler.Fill != nil {
+			var err error
+			var devPath string
+
+			if IsContentBlock(vol.contentType) {
+				// Get the device path.
+				devPath, err = d.GetVolumeDiskPath(vol)
+				if err != nil {
+					return err
+				}
+			}
+
+			allowUnsafeResize := false
+			if vol.volType == VolumeTypeImage {
+				// Allow filler to resize initial image volume as needed.
+				// Some storage drivers don't normally allow image volumes to be resized due to
+				// them having read-only snapshots that cannot be resized. However when creating
+				// the initial image volume and filling it before the snapshot is taken resizing
+				// can be allowed and is required in order to support unpacking images larger than
+				// the default volume size. The filler function is still expected to obey any
+				// volume size restrictions configured on the pool.
+				// Unsafe resize is also needed to disable filesystem resize safety checks.
+				// This is safe because if for some reason an error occurs the volume will be
+				// discarded rather than leaving a corrupt filesystem.
+				allowUnsafeResize = true
+			}
+
+			// Run the filler.
+			err = d.runFiller(vol, devPath, filler, allowUnsafeResize)
+			if err != nil {
+				return err
+			}
+
+			// Move the GPT alt header to end of disk if needed.
+			if vol.IsVMBlock() {
+				err = d.moveGPTAltHeader(devPath)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if vol.contentType == ContentTypeFS {
+			// Run EnsureMountPath again after mounting and filling to ensure the mount
+			// directory has the correct permissions set.
+			err = vol.EnsureMountPath()
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	err = vol.MountTask(mountTask, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
@@ -402,6 +404,60 @@ func (d *powerstore) getVolumeID(vol Volume) (string, error) {
 	}
 
 	return volID, nil
+}
+
+// ensureHost returns ID of the host configured with the given qualified name.
+// If no such host exists, it creates a new host using the server name with the
+// mode appended as the host name.
+func (d *powerstore) ensureHost() (hostID string, cleanup revert.Hook, err error) {
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	connector, err := d.connector()
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Get the qualified name of the host.
+	qn, err := connector.QualifiedName()
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Fetch an existing host entry on a storage array.
+	host, err := client.GetCurrentHost(connector.Type(), qn)
+	if err != nil {
+		if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return "", nil, err
+		}
+
+		// The storage host entry with a qualified name of the current LXD host does not exist.
+		// Therefore, create a new one and name it after the server name.
+		serverName, err := ResolveServerName(d.state.ServerName)
+		if err != nil {
+			return "", nil, err
+		}
+
+		// Append the mode to the server name because storage array does not allow mixing
+		// NQNs, IQNs, and WWNs for a single host.
+		hostname := serverName + "-" + connector.Type()
+
+		hostID, err = client.CreateHost(hostname, connector.Type(), qn)
+		if err != nil {
+			return "", nil, fmt.Errorf("Failed creating host %q: %w", hostname, err)
+		}
+
+		revert.Add(func() { _ = client.DeleteHost(hostID) })
+	} else {
+		// Hostname already exists with the given qualified name.
+		hostID = host.ID
+	}
+
+	cleanup = revert.Clone().Fail
+	revert.Success()
+	return hostID, cleanup, nil
 }
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,17 +1,20 @@
 package drivers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
+	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
@@ -458,6 +461,230 @@ func (d *powerstore) ensureHost() (hostID string, cleanup revert.Hook, err error
 	cleanup = revert.Clone().Fail
 	revert.Success()
 	return hostID, cleanup, nil
+}
+
+// getMappedDevicePath returns the local device path for the given volume.
+// Indicate with mapVolume if the volume should get mapped to the system if it isn't present.
+func (d *powerstore) getMappedDevicePath(vol Volume, mapVolume bool) (string, revert.Hook, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
+	connector, err := d.connector()
+	if err != nil {
+		return "", nil, err
+	}
+
+	if mapVolume {
+		cleanup, err := d.mapVolume(vol)
+		if err != nil {
+			return "", nil, err
+		}
+
+		revert.Add(cleanup)
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return "", nil, err
+	}
+
+	psVol, err := d.client().GetVolume(volID)
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed retrieving volume %q: %w", vol.name, err)
+	}
+
+	_, wwn, ok := strings.Cut(psVol.WWN, ".")
+	if !ok {
+		return "", nil, fmt.Errorf("Failed parsing WWN for volume %q: Invalid format %q", vol.name, psVol.WWN)
+	}
+
+	// Filters devices by matching the device path with the WWN.
+	devicePathFilter := func(path string) bool {
+		return strings.Contains(path, wwn)
+	}
+
+	var devicePath string
+	if mapVolume {
+		// Wait until the disk device is mapped to the host.
+		devicePath, err = connector.WaitDiskDevicePath(d.state.ShutdownCtx, devicePathFilter)
+	} else {
+		// Expect device to be already mapped.
+		devicePath, err = connector.GetDiskDevicePath(devicePathFilter)
+	}
+
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed locating device for volume %q: %w", vol.name, err)
+	}
+
+	cleanup := revert.Clone().Fail
+	revert.Success()
+	return devicePath, cleanup, nil
+}
+
+// mapVolume maps the given volume onto this host.
+func (d *powerstore) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
+	client := d.client()
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	connector, err := d.connector()
+	if err != nil {
+		return nil, err
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	unlock, err := remoteVolumeMapLock(connector.Type(), d.Info().Name)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unlock()
+
+	// Ensure the host exists and is configured with the correct QN.
+	hostID, cleanup, err := d.ensureHost()
+	if err != nil {
+		return nil, err
+	}
+
+	reverter.Add(cleanup)
+
+	// Ensure the volume is connected to the host.
+	connCreated, err := client.AttachVolumeToHost(volID, hostID)
+	if err != nil {
+		return nil, fmt.Errorf("Failed attaching volume %q to host: %w", vol.name, err)
+	}
+
+	if connCreated {
+		reverter.Add(func() { _ = client.DetachVolumeFromHost(volID, hostID) })
+	}
+
+	// Find the array's qualified name for the configured mode.
+	targets, err := d.targets()
+	if err != nil {
+		return nil, err
+	}
+
+	outerReverter := revert.New()
+	hasUnmapReverter := false
+
+	// Connect to the array.
+	for qualifiedName, addresses := range targets {
+		connReverter, err := connector.Connect(d.state.ShutdownCtx, qualifiedName, addresses...)
+		if err != nil {
+			return nil, err
+		}
+
+		// If connect succeeded it means we have at least one established connection.
+		// However, it's reverter does not cleanup the established connections or a newly
+		// created session. Therefore, if we created a mapping, add unmapVolume to the
+		// returned (outer) reverter. Unmap ensures the target is disconnected only when
+		// no other device is using it.
+		if connCreated && !hasUnmapReverter {
+			outerReverter.Add(func() { _ = d.unmapVolume(vol) })
+			hasUnmapReverter = true
+		}
+
+		// Add connReverter to the outer reverter, as it will immediately stop
+		// any ongoing connection attempts. Note that it must be added after
+		// unmapVolume to ensure it is called first.
+		outerReverter.Add(connReverter)
+		reverter.Add(connReverter)
+	}
+
+	reverter.Success()
+	return outerReverter.Fail, nil
+}
+
+// unmapVolume unmaps the given volume from this host.
+func (d *powerstore) unmapVolume(vol Volume) error {
+	client := d.client()
+
+	connector, err := d.connector()
+	if err != nil {
+		return err
+	}
+
+	qn, err := connector.QualifiedName()
+	if err != nil {
+		return err
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return err
+	}
+
+	unlock, err := remoteVolumeMapLock(connector.Type(), d.Info().Name)
+	if err != nil {
+		return err
+	}
+
+	defer unlock()
+
+	host, err := client.GetCurrentHost(connector.Type(), qn)
+	if err != nil {
+		return err
+	}
+
+	// Get a path of a block device we want to unmap.
+	volumePath, _, _ := d.getMappedDevicePath(vol, false)
+
+	// Remove disk device.
+	if volumePath != "" {
+		err = connector.RemoveDiskDevice(d.state.ShutdownCtx, volumePath)
+		if err != nil {
+			return fmt.Errorf("Failed unmapping PowerStore volume %q: %w", vol.name, err)
+		}
+	}
+
+	// Disconnect the volume from the host and ignore error if connection does not exist.
+	err = client.DetachVolumeFromHost(volID, host.ID)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return fmt.Errorf("Failed detaching volume %q from host %q: %w", vol.name, host.Name, err)
+	}
+
+	// Wait until the volume has disappeared.
+	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
+	defer cancel()
+
+	if volumePath != "" && !block.WaitDiskDeviceGone(ctx, volumePath) {
+		return fmt.Errorf("Timeout exceeded waiting for PowerStore volume %q to disappear on path %q", vol.name, volumePath)
+	}
+
+	// If this was the last volume being unmapped from this system, disconnect the active session
+	// and remove the host from PowerStore.
+	if len(host.MappedVolumes) <= 1 {
+		targets, err := d.targets()
+		if err != nil {
+			return err
+		}
+
+		var disconnectErr error
+		for qualifiedName := range targets {
+			// Disconnect from the target.
+			err = connector.Disconnect(qualifiedName)
+			if err != nil {
+				disconnectErr = err
+			}
+		}
+
+		if disconnectErr != nil {
+			return fmt.Errorf("Failed disconnecting from targets after unmapping the last volume %q: %w", vol.name, disconnectErr)
+		}
+
+		// Remove the host from PowerStore.
+		err = d.client().DeleteHost(host.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -296,7 +296,128 @@ func (d *powerstore) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSna
 
 // SetVolumeQuota applies a size limit on volume.
 func (d *powerstore) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	// Convert to bytes.
+	sizeBytes, err := units.ParseByteSizeString(size)
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if size isn't specified.
+	if sizeBytes <= 0 {
+		return nil
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return err
+	}
+
+	psVol, err := client.GetVolume(volID)
+	if err != nil {
+		return fmt.Errorf("Failed retrieving volume %q: %w", vol.name, err)
+	}
+
+	// Do nothing if volume is already specified size (+/- 512 bytes).
+	if psVol.Size+512 > sizeBytes && psVol.Size-512 < sizeBytes {
+		return nil
+	}
+
+	// Only volume expansion is supported.
+	if sizeBytes < psVol.Size {
+		return fmt.Errorf("PowerStore volume cannot be shrunk: %w", ErrCannotBeShrunk)
+	}
+
+	// Validate the minimum size.
+	if sizeBytes < powerStoreVolMinSize {
+		minSizeStr := units.GetByteSizeStringIEC(powerStoreVolMinSize, 2)
+		return fmt.Errorf("PowerStore volume size cannot be smaller than %s", minSizeStr)
+	}
+
+	// Validate the maximum size.
+	if sizeBytes > powerStoreVolMaxSize {
+		maxSizeStr := units.GetByteSizeStringIEC(powerStoreVolMaxSize, 2)
+		return fmt.Errorf("PowerStore volume size cannot be larger than %s", maxSizeStr)
+	}
+
+	connector, err := d.connector()
+	if err != nil {
+		return err
+	}
+
+	// Resize filesystem if needed.
+	if vol.contentType == ContentTypeFS {
+		fsType := vol.ConfigBlockFilesystem()
+		devPath, cleanup, err := d.getMappedDevicePath(vol, true)
+		if err != nil {
+			return err
+		}
+
+		// Resize block device.
+		err = client.ResizeVolume(psVol.ID, sizeBytes)
+		if err != nil {
+			return fmt.Errorf("Failed resizing volume %q: %w", vol.name, err)
+		}
+
+		defer cleanup()
+
+		// Always wait for the disk to reflect the new size. In case SetVolumeQuota
+		// is called on an already mapped volume, it might take some time until
+		// the actual size of the device is reflected on the host. This is for
+		// example the case when creating a volume and the filler performs a resize
+		// in case the image exceeds the volume's size.
+		err = connector.WaitDiskDeviceResize(d.state.ShutdownCtx, devPath, sizeBytes)
+		if err != nil {
+			return fmt.Errorf("Failed waiting for volume %q to change its size: %w", vol.name, err)
+		}
+
+		// Grow the filesystem to fill block device.
+		err = growFileSystem(fsType, devPath, vol)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Only perform pre-resize checks if we are not in "unsafe" mode. In unsafe
+	// mode we expect the caller to know what they are doing and understand
+	// the risks.
+	if !allowUnsafeResize && vol.MountInUse() {
+		// We don't allow online resizing of block volumes.
+		return ErrInUse
+	}
+
+	// Resize block device.
+	err = client.ResizeVolume(psVol.ID, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("Failed resizing volume %q: %w", vol.name, err)
+	}
+
+	devPath, cleanup, err := d.getMappedDevicePath(vol, true)
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+
+	err = connector.WaitDiskDeviceResize(d.state.ShutdownCtx, devPath, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("Failed waiting for volume %q to change its size: %w", vol.name, err)
+	}
+
+	// Move the VM GPT alt header to end of disk if needed (not needed in unsafe
+	// resize mode as it is expected the caller will do all necessary post resize
+	// actions themselves).
+	if vol.IsVMBlock() && !allowUnsafeResize {
+		err = d.moveGPTAltHeader(devPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // MountVolume mounts a volume and increments ref counter.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -479,7 +479,47 @@ func (d *powerstore) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volS
 
 // RestoreVolume restores a volume from a snapshot.
 func (d *powerstore) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	ourUnmount, err := d.UnmountVolume(vol, false, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	if ourUnmount {
+		defer func() { _ = d.MountVolume(vol, progressReporter) }()
+	}
+
+	volID, err := d.getVolumeID(vol)
+	if err != nil {
+		return err
+	}
+
+	snapVolID, err := d.getVolumeID(snapVol)
+	if err != nil {
+		return err
+	}
+
+	// Overwrite existing volume by copying the given snapshot content into it.
+	err = client.RestoreVolume(volID, snapVolID)
+	if err != nil {
+		return err
+	}
+
+	// For VMs, also restore the filesystem volume.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+
+		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
+		snapFSVol.SetParentUUID(snapVol.parentUUID)
+
+		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // RefreshVolume updates an existing volume to match the state of another.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -182,7 +182,17 @@ func (d *powerstore) GetVolumeUsage(vol Volume) (int64, error) {
 
 // HasVolume indicates whether a specific volume exists on the storage pool.
 func (d *powerstore) HasVolume(vol Volume) (bool, error) {
-	return false, nil
+	// Retrieve ID of the remote volume. If it succeeds, the volume exists.
+	_, err := d.getVolumeID(vol)
+	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // ListVolumes returns a list of LXD volumes in storage pool.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -243,7 +243,7 @@ func (d *powerstore) SetVolumeQuota(vol Volume, size string, allowUnsafeResize b
 
 // MountVolume mounts a volume and increments ref counter.
 func (d *powerstore) MountVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	return mountVolume(d, vol, d.getMappedDevicePath, progressReporter)
 }
 
 // UnmountVolume simulates unmounting a volume.
@@ -251,7 +251,7 @@ func (d *powerstore) MountVolume(vol Volume, progressReporter ioprogress.Progres
 // keepBlockDev indicates whether the backing block device should be kept mapped to the
 // host if the volume is unmounted.
 func (d *powerstore) UnmountVolume(vol Volume, keepBlockDev bool, progressReporter ioprogress.ProgressReporter) (bool, error) {
-	return false, ErrNotSupported
+	return unmountVolume(d, vol, keepBlockDev, d.getMappedDevicePath, d.unmapVolume, progressReporter)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -375,7 +375,15 @@ func (d *powerstore) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWrite
 
 // UpdateVolume applies config changes to the volume.
 func (d *powerstore) UpdateVolume(vol Volume, changedConfig map[string]string) error {
-	return ErrNotSupported
+	newSize, sizeChanged := changedConfig["size"]
+	if sizeChanged {
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // DeleteVolume deletes a volume of the storage device.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -464,7 +464,7 @@ func (d *powerstore) RenameVolume(vol Volume, newVolName string, progressReporte
 
 // BackupVolume creates an exported version of a volume.
 func (d *powerstore) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, progressReporter)
 }
 
 // MigrateVolume sends a volume for migration.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -619,7 +619,48 @@ func (d *powerstore) CreateVolumeSnapshot(snapVol Volume, progressReporter iopro
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device.
 func (d *powerstore) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	client := d.client()
+
+	snapVolID, err := d.getVolumeID(snapVol)
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteVolumeSnapshot(snapVolID)
+	if err != nil {
+		return err
+	}
+
+	mountPath := snapVol.MountPath()
+	if snapVol.contentType == ContentTypeFS && shared.PathExists(mountPath) {
+		poolMountPath := GetPoolMountPath(d.name)
+		if !strings.HasPrefix(mountPath, poolMountPath+"/") {
+			return fmt.Errorf("Snapshot mount path %q is outside of the pool directory %q", mountPath, poolMountPath)
+		}
+
+		err = wipeDirectory(mountPath)
+		if err != nil {
+			return err
+		}
+
+		err = os.Remove(mountPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Failed removing %q: %w", mountPath, err)
+		}
+	}
+
+	// For VM images, delete the filesystem volume too.
+	if snapVol.IsVMBlock() {
+		fsVol := snapVol.NewVMBlockFilesystemVolume()
+		fsVol.SetParentUUID(snapVol.parentUUID)
+
+		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // RenameVolumeSnapshot is a no-op as renaming a volume snapshot does not change the name of

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -275,14 +275,171 @@ func (d *powerstore) VolumeSnapshots(vol Volume) ([]string, error) {
 	return nil, ErrNotSupported
 }
 
+// newMountableSnapshotVolume returns a non-snapshot [Volume] representing the temporary clone
+// of snapVol which is used when snapshot needs to be mounted (mounting snapshot directly is not
+// supported by PowerStore).
+//
+// The clone reuses the snapshot's own UUID. Its name is made unique by adding prefix
+// [powerStoreMountableSnapshotPrefix] that [powerstore.encodeVolumeName] prepends to
+// the volume type prefix.
+func (d *powerstore) newMountableSnapshotVolume(snapVol Volume) (Volume, error) {
+	snapUUID := snapVol.config["volatile.uuid"]
+	_, err := uuid.Parse(snapUUID)
+	if err != nil {
+		return Volume{}, fmt.Errorf(`Failed parsing "volatile.uuid" from snapshot %q: %w`, snapVol.name, err)
+	}
+
+	// Prefix snapshot clone with to allow distinguishing it from regular volumes.
+	cloneName := powerStoreMountableSnapshotPrefix + snapUUID
+
+	return NewVolume(d, d.name, snapVol.volType, snapVol.contentType, cloneName, snapVol.config, d.config), nil
+}
+
 // MountVolumeSnapshot mounts a volume snapshot.
+// Since PowerStore does not support mounting snapshots directly, this function creates a
+// temporary clone of the snapshot and mounts the clone instead.
 func (d *powerstore) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
-	return ErrNotSupported
+	revert := revert.New()
+	defer revert.Fail()
+
+	client := d.client()
+
+	snapVolID, err := d.getVolumeID(snapVol)
+	if err != nil {
+		return err
+	}
+
+	cloneVol, err := d.newMountableSnapshotVolume(snapVol)
+	if err != nil {
+		return err
+	}
+
+	cloneVolID, err := d.getVolumeID(cloneVol)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return fmt.Errorf("Failed checking for existing clone of snapshot %q: %w", snapVol.name, err)
+	}
+
+	if cloneVolID != "" {
+		// Clone volume already exists, likely from a previous mount operation
+		// did not get cleaned up properly.
+		_ = client.DeleteVolume(cloneVolID)
+	}
+
+	cloneVolName, err := d.encodeVolumeName(cloneVol)
+	if err != nil {
+		return err
+	}
+
+	cloneVolID, err = client.CloneVolume(snapVolID, cloneVolName)
+	if err != nil {
+		return fmt.Errorf("Failed creating temporary clone for snapshot %q: %w", snapVol.name, err)
+	}
+
+	revert.Add(func() { _ = client.DeleteVolume(cloneVolID) })
+
+	// For VMs, also clone the filesystem snapshot.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+		snapFsVol.SetParentUUID(snapVol.parentUUID)
+
+		fsSnapVolClone, err := d.newMountableSnapshotVolume(snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		// Clean up any stale filesystem clone.
+		fsSnapVolCloneID, err := d.getVolumeID(fsSnapVolClone)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed checking for existing FS clone of snapshot %q: %w", snapVol.name, err)
+		}
+
+		if fsSnapVolCloneID != "" {
+			_ = client.DeleteVolume(fsSnapVolCloneID)
+		}
+
+		fsSnapVolID, err := d.getVolumeID(snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		fsSnapVolCloneName, err := d.encodeVolumeName(fsSnapVolClone)
+		if err != nil {
+			return err
+		}
+
+		fsSnapVolCloneID, err = client.CloneVolume(fsSnapVolID, fsSnapVolCloneName)
+		if err != nil {
+			return fmt.Errorf("Failed creating temporary FS clone for snapshot %q: %w", snapVol.name, err)
+		}
+
+		revert.Add(func() { _ = client.DeleteVolume(fsSnapVolCloneID) })
+	}
+
+	err = d.MountVolume(cloneVol, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // UnmountVolumeSnapshot unmounts the volume snapshot.
+// Since PowerStore does not support mounting snapshots directly, this function unmounts a
+// temporary clone of the snapshot and deletes the clone.
 func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
-	return false, ErrNotSupported
+	client := d.client()
+
+	cloneVol, err := d.newMountableSnapshotVolume(snapVol)
+	if err != nil {
+		return false, err
+	}
+
+	ourUnmount, err := d.UnmountVolume(cloneVol, false, progressReporter)
+	if err != nil {
+		return false, err
+	}
+
+	if !ourUnmount {
+		return false, nil
+	}
+
+	cloneID, err := d.getVolumeID(cloneVol)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return true, fmt.Errorf("Failed finding temporary clone for snapshot %q: %w", snapVol.name, err)
+	}
+
+	if err == nil {
+		err = client.DeleteVolume(cloneID)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return true, fmt.Errorf("Failed deleting temporary clone for snapshot %q: %w", snapVol.name, err)
+		}
+	}
+
+	// For VMs, also delete the filesystem clone.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+		snapFsVol.SetParentUUID(snapVol.parentUUID)
+
+		fsSnapVolClone, err := d.newMountableSnapshotVolume(snapFsVol)
+		if err != nil {
+			return true, err
+		}
+
+		fsSnapVolCloneID, err := d.getVolumeID(fsSnapVolClone)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return true, fmt.Errorf("Failed finding temporary FS clone for snapshot %q: %w", snapVol.name, err)
+		}
+
+		if err == nil {
+			err = client.DeleteVolume(fsSnapVolCloneID)
+			if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+				return true, fmt.Errorf("Failed deleting temporary FS clone for snapshot %q: %w", snapVol.name, err)
+			}
+		}
+	}
+
+	return ourUnmount, nil
 }
 
 // encodeVolumeName derives the name of a volume resource in PowerStore from the provided volume.

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -2,27 +2,118 @@ package drivers
 
 import (
 	"io"
+	"strconv"
 
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/units"
+	"github.com/canonical/lxd/shared/validate"
 )
 
 // commonVolumeRules returns validation rules which are common for pool and volume.
 func (d *powerstore) commonVolumeRules() map[string]func(value string) error {
-	return nil
+	return map[string]func(value string) error{
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=block.filesystem)
+		// Valid options: `btrfs`, `ext4`, `xfs`
+		// If not set, `ext4` is assumed.
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.filesystem`
+		//  shortdesc: File system of the storage volume
+		//  scope: global
+		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=block.mount_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.mount_options`
+		//  shortdesc: Mount options for block-backed file system volumes
+		//  scope: global
+		"block.mount_options": validate.IsAny,
+		// lxdmeta:generate(entities=storage-powerstore; group=volume-conf; key=size)
+		// The size must be in multiples of 1 MiB. The minimum size is 1 MiB and maximum is 256 TiB.
+		// ---
+		//  type: string
+		//  defaultdesc: same as `volume.size`
+		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
+		"size": validate.Optional(validate.IsMultipleOfUnit("1MiB")),
+	}
 }
 
 // FillVolumeConfig populate volume with default config.
 func (d *powerstore) FillVolumeConfig(vol Volume) error {
+	// Copy volume.* configuration options from pool.
+	// Exclude 'block.filesystem' and 'block.mount_options'
+	// as these ones are handled below in this function and depend on the volume's type.
+	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
+	if err != nil {
+		return err
+	}
+
+	// Only validate filesystem config keys for filesystem volumes or VM block
+	// volumes (which have an associated filesystem volume).
+	if vol.ContentType() == ContentTypeFS || vol.IsVMBlock() {
+		// VM volumes will always use the default filesystem.
+		if vol.IsVMBlock() {
+			vol.config["block.filesystem"] = DefaultFilesystem
+		} else {
+			// Inherit filesystem from pool if not set.
+			if vol.config["block.filesystem"] == "" {
+				vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
+			}
+
+			// Default filesystem if neither volume nor pool specify an override.
+			if vol.config["block.filesystem"] == "" {
+				// Unchangeable volume property: Set unconditionally.
+				vol.config["block.filesystem"] = DefaultFilesystem
+			}
+		}
+
+		// Inherit filesystem mount options from pool if not set.
+		if vol.config["block.mount_options"] == "" {
+			vol.config["block.mount_options"] = d.config["volume.block.mount_options"]
+		}
+
+		// Default filesystem mount options if neither volume nor pool specify an override.
+		if vol.config["block.mount_options"] == "" {
+			// Unchangeable volume property: Set unconditionally.
+			vol.config["block.mount_options"] = "discard"
+		}
+	}
+
 	return nil
 }
 
 // ValidateVolume validates the supplied volume config.
 func (d *powerstore) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
-	return nil
+	if vol.ContentType() == ContentTypeISO {
+		sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
+		if err != nil {
+			return err
+		}
+
+		sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+		vol.SetConfigSize(strconv.FormatInt(sizeBytes, 10))
+	}
+
+	commonRules := d.commonVolumeRules()
+
+	// Disallow block.* settings for regular custom block volumes. These settings only make
+	// sense when using custom filesystem volumes. LXD will create the filesystem for these
+	// volumes, and use the mount options. When attaching a regular block volume to a VM,
+	// these are not mounted by LXD and therefore don't need these config keys.
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
+		delete(commonRules, "block.filesystem")
+		delete(commonRules, "block.mount_options")
+	}
+
+	return d.validateVolume(vol, commonRules, removeUnknownKeys)
 }
 
 // GetVolumeDiskPath returns the location of a root disk block device.

--- a/lxd/storage/drivers/driver_powerstore_volumes_test.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes_test.go
@@ -1,0 +1,310 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testUUIDString = "a5289556-c903-409a-8aa0-4af18a46738d"
+
+func Test_powerstore_encodeVolumeName(t *testing.T) {
+	// newTestVol creates a new Volume with the given UUID, VolumeType and ContentType.
+	newTestVol := func(volName string, volType VolumeType, contentType ContentType, volUUID string) Volume {
+		config := map[string]string{
+			"volatile.uuid": volUUID,
+		}
+
+		return NewVolume(nil, "testpool", volType, contentType, volName, config, nil)
+	}
+
+	d := &powerstore{}
+	prefix := d.storagePoolScopePrefix("testpool")
+
+	tests := []struct {
+		name        string
+		volume      Volume
+		wantVolName string
+		wantError   string
+	}{
+		{
+			name:      "Missing UUID",
+			volume:    newTestVol("vol-err", VolumeTypeContainer, ContentTypeFS, ""),
+			wantError: "invalid UUID length: 0",
+		},
+		{
+			name:      "Invalid UUID",
+			volume:    newTestVol("vol-err", VolumeTypeContainer, ContentTypeFS, "not-a-valid-uuid"),
+			wantError: `Failed parsing "volatile.uuid" from volume`,
+		},
+		{
+			name:        "Container FS",
+			volume:      newTestVol("c1", VolumeTypeContainer, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "c_" + testUUIDString,
+		},
+		{
+			name:        "VM FS",
+			volume:      newTestVol("vm1", VolumeTypeVM, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "v_" + testUUIDString,
+		},
+		{
+			name:        "VM Block",
+			volume:      newTestVol("vm1", VolumeTypeVM, ContentTypeBlock, testUUIDString),
+			wantVolName: prefix + "v_" + testUUIDString + ".b",
+		},
+		{
+			name:        "Image FS",
+			volume:      newTestVol("img1", VolumeTypeImage, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "i_" + testUUIDString,
+		},
+		{
+			name:        "Image Block",
+			volume:      newTestVol("img1", VolumeTypeImage, ContentTypeBlock, testUUIDString),
+			wantVolName: prefix + "i_" + testUUIDString + ".b",
+		},
+		{
+			name:        "Custom FS",
+			volume:      newTestVol("custom1", VolumeTypeCustom, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "u_" + testUUIDString,
+		},
+		{
+			name:        "Custom Block",
+			volume:      newTestVol("custom1", VolumeTypeCustom, ContentTypeBlock, testUUIDString),
+			wantVolName: prefix + "u_" + testUUIDString + ".b",
+		},
+		{
+			name:        "Custom ISO",
+			volume:      newTestVol("custom1", VolumeTypeCustom, ContentTypeISO, testUUIDString),
+			wantVolName: prefix + "u_" + testUUIDString + ".i",
+		},
+		{
+			name:        "Snapshot clone VM FS",
+			volume:      newTestVol(powerStoreMountableSnapshotPrefix+testUUIDString, VolumeTypeVM, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "sv_" + testUUIDString,
+		},
+		{
+			name:        "Snapshot clone VM Block",
+			volume:      newTestVol(powerStoreMountableSnapshotPrefix+testUUIDString, VolumeTypeVM, ContentTypeBlock, testUUIDString),
+			wantVolName: prefix + "sv_" + testUUIDString + ".b",
+		},
+		{
+			name:        "Snapshot clone Custom FS",
+			volume:      newTestVol(powerStoreMountableSnapshotPrefix+testUUIDString, VolumeTypeCustom, ContentTypeFS, testUUIDString),
+			wantVolName: prefix + "su_" + testUUIDString,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			volName, err := d.encodeVolumeName(tc.volume)
+			if tc.wantError != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantVolName, volName)
+			}
+		})
+	}
+}
+
+func Test_powerstore_decodeVolumeName(t *testing.T) {
+	testUUID := uuid.MustParse(testUUIDString)
+
+	d := &powerstore{}
+	prefix := d.storagePoolScopePrefix("testpool")
+
+	tests := []struct {
+		name                  string
+		encodedName           string
+		wantVolType           VolumeType
+		wantVolUUID           uuid.UUID
+		wantContentType       ContentType
+		wantMountableSnapshot bool
+		wantError             string
+	}{
+		{
+			name:        "Missing LXD prefix",
+			encodedName: "noprefix",
+			wantError:   "Missing LXD prefix",
+		},
+		{
+			name:        "Missing pool name separator",
+			encodedName: "lxd-nopoolsep",
+			wantError:   "Invalid name format",
+		},
+		{
+			name:        "Empty pool name",
+			encodedName: "lxd--volname",
+			wantError:   "Invalid name format",
+		},
+		{
+			name:        "Empty volume name",
+			encodedName: "lxd-pool-",
+			wantError:   "Invalid name format",
+		},
+		{
+			name:        "Invalid UUID in volume name",
+			encodedName: prefix + "c_not-a-uuid",
+			wantError:   "Failed decoding volume name",
+		},
+		{
+			name:            "Container FS",
+			encodedName:     prefix + "c_" + testUUIDString,
+			wantVolType:     VolumeTypeContainer,
+			wantVolUUID:     testUUID,
+			wantContentType: "",
+		},
+		{
+			name:            "VM FS",
+			encodedName:     prefix + "v_" + testUUIDString,
+			wantVolType:     VolumeTypeVM,
+			wantVolUUID:     testUUID,
+			wantContentType: "",
+		},
+		{
+			name:            "VM Block",
+			encodedName:     prefix + "v_" + testUUIDString + ".b",
+			wantVolType:     VolumeTypeVM,
+			wantVolUUID:     testUUID,
+			wantContentType: ContentTypeBlock,
+		},
+		{
+			name:            "Image FS",
+			encodedName:     prefix + "i_" + testUUIDString,
+			wantVolType:     VolumeTypeImage,
+			wantVolUUID:     testUUID,
+			wantContentType: "",
+		},
+		{
+			name:            "Image Block",
+			encodedName:     prefix + "i_" + testUUIDString + ".b",
+			wantVolType:     VolumeTypeImage,
+			wantVolUUID:     testUUID,
+			wantContentType: ContentTypeBlock,
+		},
+		{
+			name:            "Custom FS",
+			encodedName:     prefix + "u_" + testUUIDString,
+			wantVolType:     VolumeTypeCustom,
+			wantVolUUID:     testUUID,
+			wantContentType: "",
+		},
+		{
+			name:            "Custom Block",
+			encodedName:     prefix + "u_" + testUUIDString + ".b",
+			wantVolType:     VolumeTypeCustom,
+			wantVolUUID:     testUUID,
+			wantContentType: ContentTypeBlock,
+		},
+		{
+			name:            "Custom ISO",
+			encodedName:     prefix + "u_" + testUUIDString + ".i",
+			wantVolType:     VolumeTypeCustom,
+			wantVolUUID:     testUUID,
+			wantContentType: ContentTypeISO,
+		},
+		{
+			name:                  "Snapshot clone VM FS",
+			encodedName:           prefix + "sv_" + testUUIDString,
+			wantVolType:           VolumeTypeVM,
+			wantVolUUID:           testUUID,
+			wantContentType:       "",
+			wantMountableSnapshot: true,
+		},
+		{
+			name:                  "Snapshot clone VM Block",
+			encodedName:           prefix + "sv_" + testUUIDString + ".b",
+			wantVolType:           VolumeTypeVM,
+			wantVolUUID:           testUUID,
+			wantContentType:       ContentTypeBlock,
+			wantMountableSnapshot: true,
+		},
+		{
+			name:                  "Snapshot clone Custom FS",
+			encodedName:           prefix + "su_" + testUUIDString,
+			wantVolType:           VolumeTypeCustom,
+			wantVolUUID:           testUUID,
+			wantContentType:       "",
+			wantMountableSnapshot: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			volType, volUUID, contentType, isMountableSnapshot, err := d.decodeVolumeName(tc.encodedName)
+			if tc.wantError != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantVolType, volType)
+				assert.Equal(t, tc.wantVolUUID, volUUID)
+				assert.Equal(t, tc.wantContentType, contentType)
+				assert.Equal(t, tc.wantMountableSnapshot, isMountableSnapshot)
+			}
+		})
+	}
+}
+
+func Test_powerstore_encodeDecodeRoundTrip(t *testing.T) {
+	testUUIDParsed := uuid.MustParse(testUUIDString)
+
+	newTestVol := func(volName string, volType VolumeType, contentType ContentType) Volume {
+		config := map[string]string{
+			"volatile.uuid": testUUIDString,
+		}
+
+		return NewVolume(nil, "testpool", volType, contentType, volName, config, nil)
+	}
+
+	d := &powerstore{}
+
+	tests := []struct {
+		name            string
+		volume          Volume
+		wantVolType     VolumeType
+		wantContentType ContentType
+	}{
+		{
+			name:            "Container FS",
+			volume:          newTestVol("c1", VolumeTypeContainer, ContentTypeFS),
+			wantVolType:     VolumeTypeContainer,
+			wantContentType: "",
+		},
+		{
+			name:            "VM Block",
+			volume:          newTestVol("vm1", VolumeTypeVM, ContentTypeBlock),
+			wantVolType:     VolumeTypeVM,
+			wantContentType: ContentTypeBlock,
+		},
+		{
+			name:            "Custom ISO",
+			volume:          newTestVol("custom1", VolumeTypeCustom, ContentTypeISO),
+			wantVolType:     VolumeTypeCustom,
+			wantContentType: ContentTypeISO,
+		},
+		{
+			name:            "Image Block",
+			volume:          newTestVol("img1", VolumeTypeImage, ContentTypeBlock),
+			wantVolType:     VolumeTypeImage,
+			wantContentType: ContentTypeBlock,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := d.encodeVolumeName(tc.volume)
+			require.NoError(t, err)
+
+			volType, volUUID, contentType, isMountableSnapshot, err := d.decodeVolumeName(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantVolType, volType)
+			assert.Equal(t, testUUIDParsed, volUUID)
+			assert.Equal(t, tc.wantContentType, contentType)
+			assert.False(t, isMountableSnapshot)
+		})
+	}
+}

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -13,6 +13,7 @@ var drivers = map[string]func() driver{
 	"dir":        func() driver { return &dir{} },
 	"lvm":        func() driver { return &lvm{} },
 	"powerflex":  func() driver { return &powerflex{} },
+	"powerstore": func() driver { return &powerstore{} },
 	"pure":       func() driver { return &pure{} },
 	"alletra":    func() driver { return &alletra{} },
 	"zfs":        func() driver { return &zfs{} },

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -437,7 +437,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Quota of the storage bucket
 		//  scope: local
 		"size": validate.Optional(validate.IsSize),
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.expiry)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.expiry)
 		// Specify an expression like `1M 2H 3d 4w 5m 6y`.
 		// ---
 		//  type: string
@@ -450,7 +450,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 			_, err := shared.GetExpiry(time.Time{}, value)
 			return err
 		},
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.schedule)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.schedule)
 		// Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 		// ---
 		//  type: string
@@ -459,7 +459,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Schedule for automatic volume snapshots
 		//  scope: global
 		"snapshots.schedule": validate.Optional(validate.IsCron([]string{"@hourly", "@daily", "@midnight", "@weekly", "@monthly", "@annually", "@yearly"})),
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=snapshots.pattern)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=snapshots.pattern)
 		// You can specify a naming template for scheduled snapshots and unnamed snapshots.
 		//
 		// {{snapshot_pattern_detail}}
@@ -474,7 +474,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// security.shifted and security.unmapped are only relevant for custom filesystem volumes.
 	if vol == nil || (vol.Type() == drivers.VolumeTypeCustom && vol.ContentType() == drivers.ContentTypeFS) {
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.shifted)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.shifted)
 		// Enable this option to allow the volume to be attached to multiple isolated instances.
 		// ---
 		//  type: bool
@@ -483,7 +483,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  shortdesc: Enable ID shifting overlay
 		//  scope: global
 		rules["security.shifted"] = validate.Optional(validate.IsBool)
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.unmapped)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.unmapped)
 		//
 		// ---
 		//  type: bool
@@ -496,7 +496,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// security.shared guards virtual-machine and custom block volumes.
 	if vol == nil || ((vol.Type() == drivers.VolumeTypeCustom || vol.Type() == drivers.VolumeTypeVM) && vol.ContentType() == drivers.ContentTypeBlock) {
-		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=security.shared)
+		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=security.shared)
 		// Enable this option to allow the volume to be shared across multiple instances despite the possibility of data loss.
 		//
 		// ---
@@ -510,7 +510,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// Those keys are only valid for volumes.
 	if vol != nil {
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.uuid)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.uuid)
 		//
 		// ---
 		//  type: string
@@ -519,7 +519,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  scope: global
 		rules["volatile.uuid"] = validate.Optional(validate.IsUUID)
 
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.devlxd.owner)
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.devlxd.owner)
 		//
 		// ---
 		//  type: string
@@ -553,7 +553,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  scope: local
 		"source.recover":          validate.Optional(validate.IsBool),
 		"volatile.initial_source": validate.IsAny,
-		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-pure,storage-alletra; group=pool-conf; key=rsync.bwlimit)
+		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=pool-conf; key=rsync.bwlimit)
 		// When `rsync` must be used to transfer storage entities, this option specifies the upper limit
 		// to be placed on the socket I/O.
 		// ---
@@ -562,7 +562,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  shortdesc: Upper limit on the socket I/O for `rsync`
 		//  scope: global
 		"rsync.bwlimit": validate.Optional(validate.IsSize),
-		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-pure,storage-alletra; group=pool-conf; key=rsync.compression)
+		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=pool-conf; key=rsync.compression)
 		//
 		// ---
 		//  type: bool
@@ -620,14 +620,14 @@ func validateLocalPoolCommonRules() map[string]func(string) error {
 func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error {
 	rules := poolAndVolumeCommonRules(&vol)
 
-	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.last)
+	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.last)
 	//
 	// ---
 	//   type: string
 	//   shortdesc: JSON-serialized UID/GID map that has been applied to the volume
 	//   condition: filesystem
 
-	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.next)
+	// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex,storage-powerstore,storage-pure,storage-alletra; group=volume-conf; key=volatile.idmap.next)
 	//
 	// ---
 	//   type: string

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -489,6 +489,7 @@ var APIExtensions = []string{
 	"cluster_links",
 	"replicators",
 	"event_security",
+	"storage_driver_powerstore",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION

This PR adds PowerStore storage driver.
Driver supports communication over iSCSI.

Storage drivers fields:
- `powerstore.gateway`
- `powerstore.gateway.verify`
- `powerstore.user.name`
- `powerstore.user.password`
- `powerstore.mode`
- `powerstore.target`

Rebase after:
- [x] https://github.com/canonical/lxd/pull/18231

TODO:
- [x] Add docs
- [x] Prepare LXD CI tests: https://github.com/canonical/lxd-ci/pull/746