### PR TITLE
Replicator and cluster link fixes for 6.8 release

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4527,7 +4527,7 @@ Specify the number of days after which the unused cached image expires.
 :scope: "global"
 :shortdesc: "Target cluster link name."
 :type: "string"
-Required when creating a replicator. When updating, this key can be omitted to keep the existing cluster link.
+Required when creating a replicator.
 ```
 
 ```{config:option} schedule replicator-conf

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -522,6 +522,16 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 
 	// Get the existing cluster link.
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Prevent rename if the cluster link is referenced by any entity.
+		usedBy, err := dbCluster.GetClusterLinkUsedBy(ctx, tx.Tx(), name, true)
+		if err != nil {
+			return err
+		}
+
+		if len(usedBy) > 0 {
+			return api.StatusErrorf(http.StatusBadRequest, "Cluster link is currently in use")
+		}
+
 		clusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), name)
 		if err != nil {
 			return fmt.Errorf("Failed loading cluster link: %w", err)
@@ -600,6 +610,16 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	// Update DB entry.
 	var identity *dbCluster.IdentitiesRow
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Prevent deletion if the cluster link is referenced by any entity.
+		usedBy, err := dbCluster.GetClusterLinkUsedBy(ctx, tx.Tx(), name, true)
+		if err != nil {
+			return err
+		}
+
+		if len(usedBy) > 0 {
+			return api.StatusErrorf(http.StatusBadRequest, "Cluster link is currently in use")
+		}
+
 		// Get cluster link.
 		clusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), name)
 		if err != nil {

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1379,10 +1379,7 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 	l := logger.AddContext(logger.Ctx{"clusterLinkName": name})
 
 	var clusterLink *api.ClusterLink
-	clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-	if err != nil {
-		return response.InternalError(err)
-	}
+	clusterCert := s.Endpoints.NetworkCert()
 
 	var targetCert *x509.Certificate
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1951,10 +1951,7 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 				}
 
 				// Skip the check if the target is unreachable to allow for disaster recovery failover.
-				clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-				if err != nil {
-					return fmt.Errorf("Failed loading cluster certificate: %w", err)
-				}
+				clusterCert := s.Endpoints.NetworkCert()
 
 				args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
 				targetClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -345,7 +345,7 @@ func replicatorValidateConfig(ctx context.Context, s *state.State, config map[st
 		//  type: string
 		//  shortdesc: Target cluster link name.
 		//  scope: global
-		"cluster": validate.Optional(func(value string) error {
+		"cluster": validate.Required(func(value string) error {
 			err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				_, err := dbCluster.GetClusterLink(ctx, tx.Tx(), value)
 				if err != nil {
@@ -403,6 +403,8 @@ func replicatorValidateConfig(ctx context.Context, s *state.State, config map[st
 		}
 	}
 
+	// The validator loop only runs for keys present in config, so a missing "cluster" key
+	// must be caught separately.
 	if config["cluster"] == "" {
 		return fmt.Errorf("Replicator configuration key %q is required", "cluster")
 	}

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -340,7 +340,7 @@ func replicatorGet(d *Daemon, r *http.Request) response.Response {
 func replicatorValidateConfig(ctx context.Context, s *state.State, config map[string]string) error {
 	replicatorConfigKeys := map[string]func(value string) error{
 		// lxdmeta:generate(entities=replicator; group=conf; key=cluster)
-		// Required when creating a replicator. When updating, this key can be omitted to keep the existing cluster link.
+		// Required when creating a replicator.
 		// ---
 		//  type: string
 		//  shortdesc: Target cluster link name.
@@ -732,10 +732,12 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 		req.Config = map[string]string{}
 	}
 
-	for k, v := range apiReplicator.Config {
-		_, ok := req.Config[k]
-		if !ok {
-			req.Config[k] = v
+	if isPatch {
+		for k, v := range apiReplicator.Config {
+			_, ok := req.Config[k]
+			if !ok {
+				req.Config[k] = v
+			}
 		}
 	}
 

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1292,13 +1292,13 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				},
 			}
 
-			srcOp, err := func() (*operations.Operation, error) {
-				if op.Requestor() != nil {
-					return operations.ScheduleUserOperationFromOperation(s, op, migrArgs)
-				}
+			var srcOp *operations.Operation
+			if op.Requestor() != nil {
+				srcOp, err = operations.ScheduleUserOperationFromOperation(s, op, migrArgs)
+			} else {
+				srcOp, err = operations.ScheduleServerOperation(s, migrArgs)
+			}
 
-				return operations.ScheduleServerOperation(s, migrArgs)
-			}()
 			if err != nil {
 				return err
 			}

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1018,10 +1018,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		return operations.OperationArgs{}, fmt.Errorf("Failed loading replicator run state: %w", err)
 	}
 
-	clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-	if err != nil {
-		return operations.OperationArgs{}, fmt.Errorf("Failed loading cluster certificate: %w", err)
-	}
+	clusterCert := s.Endpoints.NetworkCert()
 
 	connArgs := lxdCluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
 	targetClient, err := lxdCluster.ConnectCluster(ctx, *clusterLink, connArgs)

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -197,10 +197,7 @@ func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, na
 		return nil
 	}
 
-	clusterCert, err := util.LoadClusterCert(s.OS.VarDir)
-	if err != nil {
-		return err
-	}
+	clusterCert := s.Endpoints.NetworkCert()
 
 	targetClient, err := ConnectCluster(ctx, *clusterLink, GetClusterLinkConnectionArgs(clusterCert, targetCert))
 	if err != nil {

--- a/lxd/cluster/membership_adjust_test.go
+++ b/lxd/cluster/membership_adjust_test.go
@@ -273,7 +273,7 @@ func TestAdjustRoles_InactiveAllowsNonControlPlanePromotion(t *testing.T) {
 }
 
 // testRolesChanges creates a RolesChanges test fixture using raft nodes and connectivity.
-func testRolesChanges(nodes []db.RaftNode, connectivity map[string]bool, voters int, standBys int) *app.RolesChanges {
+func testRolesChanges(nodes []db.RaftNode, connectivity map[string]bool, voters int, standbys int) *app.RolesChanges {
 	state := make(map[client.NodeInfo]*client.NodeMetadata, len(nodes))
 	for i, node := range nodes {
 		if connectivity[node.Address] {
@@ -291,7 +291,7 @@ func testRolesChanges(nodes []db.RaftNode, connectivity map[string]bool, voters 
 	return &app.RolesChanges{
 		Config: app.RolesConfig{
 			Voters:   voters,
-			StandBys: standBys,
+			StandBys: standbys,
 		},
 		State: state,
 	}

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
@@ -169,6 +172,73 @@ func UpdateClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID int6
 	}
 
 	return CreateClusterLinkConfig(ctx, tx, clusterLinkID, config)
+}
+
+// clusterConfigRef describes an entity type whose config table may reference a cluster link via the 'cluster' key.
+// To support a new entity type, add an entry here.
+type clusterConfigRef struct {
+	typeCode    int64
+	configTable string // e.g. "replicators_config"
+	idColumn    string // Foreign key column in configTable, e.g. "replicator_id"
+	entityTable string // e.g. "replicators"
+}
+
+// clusterConfigRefs lists every entity type whose config may contain a 'cluster' key referencing a cluster link.
+var clusterConfigRefs = []clusterConfigRef{
+	{
+		typeCode:    entityTypeCodeReplicator,
+		configTable: "replicators_config",
+		idColumn:    "replicator_id",
+		entityTable: "replicators",
+	},
+}
+
+// GetClusterLinkUsedBy returns a list of URLs of all entities that reference the cluster link with the given name via the 'cluster' config key.
+// If firstOnly is true then the search stops after the first match.
+func GetClusterLinkUsedBy(ctx context.Context, tx *sql.Tx, clusterLinkName string, firstOnly bool) ([]string, error) {
+	var b strings.Builder
+	args := make([]any, 0, len(clusterConfigRefs))
+
+	for i, ref := range clusterConfigRefs {
+		if i > 0 {
+			b.WriteString("\nUNION ")
+		}
+
+		b.WriteString(`SELECT ` + strconv.FormatInt(ref.typeCode, 10) + `, ` + ref.entityTable + `.name, projects.name FROM ` + ref.entityTable + `
+JOIN ` + ref.configTable + ` ON ` + ref.entityTable + `.id = ` + ref.configTable + `.` + ref.idColumn + `
+JOIN projects ON ` + ref.entityTable + `.project_id = projects.id
+WHERE ` + ref.configTable + `.key = 'cluster' AND ` + ref.configTable + `.value = ?`)
+		args = append(args, clusterLinkName)
+	}
+
+	if firstOnly {
+		b.WriteString(" LIMIT 1")
+	}
+
+	var urls []string
+	err := query.Scan(ctx, tx, b.String(), func(scan func(dest ...any) error) error {
+		var eType EntityType
+		var eName string
+		var pName string
+		err := scan(&eType, &eName, &pName)
+		if err != nil {
+			return err
+		}
+
+		switch entity.Type(eType) {
+		case entity.TypeReplicator:
+			urls = append(urls, entity.ReplicatorURL(pName, eName).String())
+		default:
+			return errors.New("Unexpected entity type in cluster link usage query")
+		}
+
+		return nil
+	}, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed finding references to cluster link: %w", err)
+	}
+
+	return urls, nil
 }
 
 // GetClusterLinksAndURLs returns all cluster links that pass the given filter, along with their entity URLs.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5059,7 +5059,7 @@
 				"keys": [
 					{
 						"cluster": {
-							"longdesc": "Required when creating a replicator. When updating, this key can be omitted to keep the existing cluster link.",
+							"longdesc": "Required when creating a replicator.",
 							"scope": "global",
 							"shortdesc": "Target cluster link name.",
 							"type": "string"

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -965,9 +965,15 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 		}
 
 		// If there are no snapshots on the target, there's no point in doing an optimized
-		// refresh.
+		// refresh. Delete the existing volume if it exists so that zfs receive can create
+		// a fresh dataset (it cannot overwrite a clone with a full stream).
 		if len(snapshots) == 0 {
 			volTargetArgs.Refresh = false
+
+			err = d.DeleteVolume(vol.Volume, progressReporter)
+			if err != nil {
+				return err
+			}
 		}
 
 		var respSnapshots []ZFSDataset

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -49,10 +49,6 @@ readonly test_group_cluster=(
     "clustering_project_limits"
     "clustering_link_auth"
     "clustering_link_info"
-    "clustering_replicator_basic"
-    "clustering_replicator_scheduled"
-    "clustering_replicator_dr"
-    "clustering_replicator_snapshot"
 )
 
 readonly test_group_cluster_storage=(
@@ -63,6 +59,10 @@ readonly test_group_cluster_storage=(
     "clustering_recovery"
     "clustering_storage"
     "clustering_storage_single_node"
+    "clustering_replicator_basic"
+    "clustering_replicator_scheduled"
+    "clustering_replicator_dr"
+    "clustering_replicator_snapshot"
 )
 
 readonly test_group_instance=(

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5732,6 +5732,10 @@ test_clustering_replicator_basic() {
   # Unset schedule so it does not interfere with the rest of the test.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator unset my-replicator schedule --project replicator-project
 
+  sub_test "Verify cluster link cannot be deleted while referenced by a replicator"
+
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two 2>&1)" = 'Error: Error deleting "lxd_two" from database: Cluster link is currently in use' ]
+
   # Cleanup
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5570,10 +5570,10 @@ test_clustering_link_info() {
 test_clustering_replicator_basic() {
   # Create two standalone clustered LXD daemons to simulate two separate clusters.
   LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_ONE_DIR}" false
+  spawn_lxd "${LXD_ONE_DIR}" true
 
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_TWO_DIR}" false
+  spawn_lxd "${LXD_TWO_DIR}" true
 
   # Enable clustering on LXD_ONE.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
@@ -5619,10 +5619,11 @@ test_clustering_replicator_basic() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
 
   # Setup storage on both clusters.
-  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
   # Create replicator on LXD_ONE.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
@@ -5741,10 +5742,10 @@ test_clustering_replicator_basic() {
 test_clustering_replicator_scheduled() {
   # Create two standalone clustered LXD daemons to simulate two separate clusters.
   LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_ONE_DIR}" false
+  spawn_lxd "${LXD_ONE_DIR}" true
 
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_TWO_DIR}" false
+  spawn_lxd "${LXD_TWO_DIR}" true
 
   # Enable clustering on both.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
@@ -5771,10 +5772,11 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
 
   # Setup storage on both clusters.
-  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
   # Create the replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
@@ -5840,10 +5842,10 @@ test_clustering_replicator_scheduled() {
 test_clustering_replicator_dr() {
   # Create two standalone clustered LXD daemons to simulate two separate clusters.
   LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_ONE_DIR}" false
+  spawn_lxd "${LXD_ONE_DIR}" true
 
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_TWO_DIR}" false
+  spawn_lxd "${LXD_TWO_DIR}" true
 
   # Enable clustering on both.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
@@ -5870,10 +5872,11 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
 
   # Setup storage on both clusters.
-  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
   # Create the replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
@@ -5995,10 +5998,10 @@ test_clustering_replicator_dr() {
 test_clustering_replicator_snapshot() {
   # Create two standalone clustered LXD daemons to simulate two separate clusters.
   LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_ONE_DIR}" false
+  spawn_lxd "${LXD_ONE_DIR}" true
 
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_TWO_DIR}" false
+  spawn_lxd "${LXD_TWO_DIR}" true
 
   # Enable clustering on both.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
@@ -6024,10 +6027,11 @@ test_clustering_replicator_snapshot() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
 
   # Setup storage on both clusters.
-  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 dir --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="pool1" --project replicator-project
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
   LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
 

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -765,6 +765,20 @@ migration() {
 
   lxc_remote delete -f l1:c1 l2:c1
 
+  # On zfs, refreshing a clone (no shared snapshots) via pull mode used to fail because
+  # zfs receive cannot overwrite a clone with a full stream.
+  sub_test "Refresh ZFS clone via pull mode succeeds when no shared snapshots exist"
+  # c1 on l1 is created as a ZFS clone of the image snapshot.
+  lxc_remote init testimage l1:c1
+  # Copy c1 to l2 — l2:c1 is also a ZFS clone.
+  lxc_remote copy l1:c1 l2:c1 --refresh
+  # Pull c1 back from l2 to l1 with refresh. Since c1 on l1 has no snapshots,
+  # there are no shared snapshots with l2:c1, so a full ZFS stream is used.
+  # The existing l1:c1 clone must be deleted first or zfs receive fails.
+  lxc_remote copy l2:c1 l1:c1 --refresh --mode=pull
+  # Cleanup
+  lxc_remote delete l1:c1 l2:c1
+
   # migrate ISO custom volumes
   truncate -s 8MiB foo.iso
   lxc storage volume import l1:"${pool}" ./foo.iso iso1


### PR DESCRIPTION
## Cluster link protection

Add GetClusterLinkUsedBy and prevent cluster link deletion and rename when in-use.

## Cluster cert fix

Replace all util.LoadClusterCert calls in cluster link connection paths with s.Endpoints.NetworkCert(). LoadClusterCert reads/generates cluster.crt from disk, which diverges from the cert actually registered with the remote on standalone LXD nodes (no cluster.crt). Using NetworkCert() ensures the presented cert always matches what the remote trusts.

## Replicator API hardening

- Fix updateReplicator so config merging only applies to PATCH, not PUT
- Switch the cluster config key validator from validate.Optional to validate.Required
- Simplify the operation scheduling conditional for readability

## ZFS migration fix

Delete the ZFS clone volume before a refresh migration via pull mode when no shared snapshots exist, fixing a failure in that path.

## Tests

- Add assertion that a cluster link cannot be deleted while referenced by a replicator
- Add test coverage for the ZFS clone refresh scenario
- Use storage_backend in replicator clustering tests; run replicator tests against all storage drivers
