### PR TITLE
storage/connector: Delete iSCSI device using write-only permission

### DIFF
--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -379,7 +379,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 	}
 
 	// Filter that makes sure the found device resolves to a multipath device.
-	multipathDeviceFiler := func(devicePath string) bool {
+	multipathDeviceFilter := func(devicePath string) bool {
 		if !diskPathFilter(devicePath) {
 			return false
 		}
@@ -394,7 +394,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 
 	// The multipath command is synchronous, but udev updates the /dev/disk/by-id
 	// symlinks asynchronously. Wait for the multipath-backed device path to appear.
-	return block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, multipathDeviceFiler)
+	return block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, multipathDeviceFilter)
 }
 
 // GetDiskDevicePath returns the path of the mapped iSCSI device.

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -423,7 +423,7 @@ func (c *connectorISCSI) RemoveDiskDevice(ctx context.Context, devicePath string
 	removeDevice := func(devName string) error {
 		path := "/sys/block/" + devName + "/device/delete"
 
-		err := os.WriteFile(path, []byte("1"), 0400)
+		err := os.WriteFile(path, []byte("1"), 0200)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}


### PR DESCRIPTION
Use write-only permission when writing into device's sysfs `delete` file.

This is a *cosmetic* change because `os.WriteFile` only applies the mode when creating a file. The sysfs delete file already exists, so its permissions are not changed anyway. However, the sysfs delete file has permissions `0200`, so it is nice if we match that.

Reported by code quality scanner.