### PR TITLE
Server: Fix local config being wiped out by reverter

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -849,7 +848,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	nodeChanged := map[string]string{}
 	var newNodeConfig *node.Config
-	oldNodeConfig := make(map[string]string)
+	var oldNodeConfig map[string]string
 
 	err = s.DB.Node.Transaction(r.Context(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
@@ -859,7 +858,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 
 		// Keep old config around in case something goes wrong. In that case the config will be reverted.
-		maps.Copy(oldNodeConfig, newNodeConfig.Dump())
+		oldNodeConfig = newNodeConfig.Dump()
 
 		// We currently don't allow changing the cluster.https_address once it's set.
 		if s.ServerClustered {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1130,9 +1130,13 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	// correlated with others, and need to be processed first (for example
 	// core.https_address need to be processed before
 	// cluster.https_address).
-
 	value, ok := nodeChanged["core.https_address"]
+	coreHTTPSAddressUnset := false
 	if ok {
+		if value == "" {
+			coreHTTPSAddressUnset = true
+		}
+
 		err := s.Endpoints.NetworkUpdateAddress(value)
 		if err != nil {
 			return err
@@ -1141,9 +1145,11 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		s.Endpoints.NetworkUpdateTrustedProxy(newClusterConfig.HTTPSTrustedProxy())
 	}
 
-	value, ok = nodeChanged["cluster.https_address"]
-	if ok {
-		err := s.Endpoints.ClusterUpdateAddress(value)
+	// If the cluster.https_address is changed, or if the core.https_address is unset then we need to ensure
+	// that, if set, the cluster's HTTPS address is re-activated.
+	_, ok = nodeChanged["cluster.https_address"]
+	if ok || (coreHTTPSAddressUnset && newNodeConfig.ClusterAddress() != "") {
+		err := s.Endpoints.ClusterUpdateAddress(newNodeConfig.ClusterAddress())
 		if err != nil {
 			return err
 		}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -908,34 +908,37 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() {
-		for key := range nodeValues {
-			val, ok := oldNodeConfig[key]
-			if !ok {
-				nodeValues[key] = ""
-			} else {
-				nodeValues[key] = val
+	if len(nodeChanged) > 0 {
+		revert.Add(func() {
+			for key := range nodeValues {
+				val, ok := oldNodeConfig[key]
+				if !ok {
+					nodeValues[key] = ""
+				} else {
+					nodeValues[key] = val
+				}
 			}
-		}
 
-		err = s.DB.Node.Transaction(r.Context(), func(ctx context.Context, tx *db.NodeTx) error {
-			newNodeConfig, err := node.ConfigLoad(ctx, tx)
+			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
+			err = s.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
+				newNodeConfig, err := node.ConfigLoad(ctx, tx)
+				if err != nil {
+					return fmt.Errorf("Failed loading local config: %w", err)
+				}
+
+				_, err = newNodeConfig.Replace(nodeValues)
+				if err != nil {
+					return fmt.Errorf("Failed updating local config: %w", err)
+				}
+
+				return nil
+			})
+
 			if err != nil {
-				return fmt.Errorf("Failed loading local config: %w", err)
+				logger.Warn("Failed reverting local config", logger.Ctx{"err": err})
 			}
-
-			_, err = newNodeConfig.Replace(nodeValues)
-			if err != nil {
-				return fmt.Errorf("Failed updating local config: %w", err)
-			}
-
-			return nil
 		})
-
-		if err != nil {
-			logger.Warn("Failed reverting local config", logger.Ctx{"err": err})
-		}
-	})
+	}
 
 	// Then deal with cluster wide configuration
 	var clusterChanged map[string]string

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -909,7 +909,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	if len(nodeChanged) > 0 {
 		revert.Add(func() {
 			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
-			err = s.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
+			err := s.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 				newNodeConfig, err := node.ConfigLoad(ctx, tx)
 				if err != nil {
 					return fmt.Errorf("Failed loading local config: %w", err)
@@ -964,8 +964,8 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	if len(clusterChanged) > 0 {
 		revert.Add(func() {
 			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
-			err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-				newClusterConfig, err = clusterConfig.Load(ctx, tx)
+			err := s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+				newClusterConfig, err := clusterConfig.Load(ctx, tx)
 				if err != nil {
 					return fmt.Errorf("Failed loading cluster config: %w", err)
 				}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -846,7 +846,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 	}
 
-	nodeChanged := map[string]string{}
+	var nodeChanged map[string]string
 	var newNodeConfig *node.Config
 	var oldNodeConfig map[string]string
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -878,7 +878,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 			}
 
 			if curConfig["cluster.https_address"] != newClusterHTTPSAddress {
-				return errors.New("Changing cluster.https_address is currently not supported")
+				return api.StatusErrorf(http.StatusBadRequest, "Changing cluster.https_address is currently not supported")
 			}
 		}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -997,7 +997,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 			serverPut := server.Writable()
 			serverPut.Config = make(map[string]any)
-			// Only propagated cluster-wide changes
+			// Only propagate cluster-wide changes.
 			for key, value := range clusterChanged {
 				serverPut.Config[key] = value
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -560,8 +560,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 
 		// Copy the old config so that the update triggers have access to it.
 		// In this case it will not be used as we are not changing any node values.
-		oldNodeConfig := make(map[string]string)
-		maps.Copy(oldNodeConfig, s.LocalConfig.Dump())
+		oldNodeConfig := s.LocalConfig.Dump()
 
 		// Run any update triggers.
 		err = doAPI10UpdateTriggers(d, nil, changed, oldNodeConfig, s.LocalConfig, config)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -856,7 +856,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		var err error
 		newNodeConfig, err = node.ConfigLoad(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed loading node config: %w", err)
+			return fmt.Errorf("Failed loading local config: %w", err)
 		}
 
 		// Keep old config around in case something goes wrong. In that case the config will be reverted.
@@ -866,7 +866,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		if s.ServerClustered {
 			curConfig, err := tx.Config(ctx)
 			if err != nil {
-				return fmt.Errorf("Cannot fetch node config from database: %w", err)
+				return fmt.Errorf("Cannot fetch local config from database: %w", err)
 			}
 
 			newClusterHTTPSAddress := ""
@@ -921,19 +921,19 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		err = s.DB.Node.Transaction(r.Context(), func(ctx context.Context, tx *db.NodeTx) error {
 			newNodeConfig, err := node.ConfigLoad(ctx, tx)
 			if err != nil {
-				return fmt.Errorf("Failed loading node config: %w", err)
+				return fmt.Errorf("Failed loading local config: %w", err)
 			}
 
 			_, err = newNodeConfig.Replace(nodeValues)
 			if err != nil {
-				return fmt.Errorf("Failed updating node config: %w", err)
+				return fmt.Errorf("Failed updating local config: %w", err)
 			}
 
 			return nil
 		})
 
 		if err != nil {
-			logger.Warn("Failed reverting node config", logger.Ctx{"err": err})
+			logger.Warn("Failed reverting local config", logger.Ctx{"err": err})
 		}
 	})
 
@@ -1204,7 +1204,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		_, storageType := config.ParseDaemonStorageConfigKey(projectVolumeConfigKey)
 		err := projectStorageVolumeChange(s, oldValue, nodeChanged[projectVolumeConfigKey], storageType)
 		if err != nil {
-			return fmt.Errorf("Failed setting node config %q: %w", projectVolumeConfigKey, err)
+			return fmt.Errorf("Failed setting local config %q: %w", projectVolumeConfigKey, err)
 		}
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -538,7 +538,12 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		logger.Debug("Handling config changed notification")
 		changed := make(map[string]string)
 		for key, value := range req.Config {
-			changed[key], _ = value.(string)
+			stringValue, ok := value.(string)
+			if !ok {
+				return response.BadRequest(fmt.Errorf("Invalid config value type for %q: expected string", key))
+			}
+
+			changed[key] = stringValue
 		}
 
 		// Get the current (updated) config.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -972,59 +972,62 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 	}
 
-	revert.Add(func() {
-		for key := range stringReqConfig {
-			val, ok := oldClusterConfig[key]
-			if !ok {
-				stringReqConfig[key] = ""
-			} else {
-				stringReqConfig[key] = val
+	if len(clusterChanged) > 0 {
+		revert.Add(func() {
+			for key := range stringReqConfig {
+				val, ok := oldClusterConfig[key]
+				if !ok {
+					stringReqConfig[key] = ""
+				} else {
+					stringReqConfig[key] = val
+				}
 			}
-		}
 
-		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			newClusterConfig, err = clusterConfig.Load(ctx, tx)
+			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
+			err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+				newClusterConfig, err = clusterConfig.Load(ctx, tx)
+				if err != nil {
+					return fmt.Errorf("Failed loading cluster config: %w", err)
+				}
+
+				_, err = newClusterConfig.Replace(tx, stringReqConfig)
+				if err != nil {
+					return fmt.Errorf("Failed updating cluster config: %w", err)
+				}
+
+				return nil
+			})
+
 			if err != nil {
-				return fmt.Errorf("Failed loading cluster config: %w", err)
+				logger.Warn("Failed reverting cluster config", logger.Ctx{"err": err})
 			}
-
-			_, err = newClusterConfig.Replace(tx, stringReqConfig)
-			if err != nil {
-				return fmt.Errorf("Failed updating cluster config: %w", err)
-			}
-
-			return nil
 		})
 
+		// Notify the other nodes about cluster config changes
+		notifier, err := cluster.NewNotifier(s, s.Endpoints.NetworkCert(), s.ServerCert(), cluster.NotifyAlive)
 		if err != nil {
-			logger.Warn("Failed reverting cluster config", logger.Ctx{"err": err})
+			return response.SmartError(err)
 		}
-	})
 
-	// Notify the other nodes about changes
-	notifier, err := cluster.NewNotifier(s, s.Endpoints.NetworkCert(), s.ServerCert(), cluster.NotifyAlive)
-	if err != nil {
-		return response.SmartError(err)
-	}
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
+			server, etag, err := client.GetServer()
+			if err != nil {
+				return err
+			}
 
-	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
-		server, etag, err := client.GetServer()
+			serverPut := server.Writable()
+			serverPut.Config = make(map[string]any)
+			// Only propagated cluster-wide changes
+			for key, value := range clusterChanged {
+				serverPut.Config[key] = value
+			}
+
+			return client.UpdateServer(serverPut, etag)
+		})
 		if err != nil {
-			return err
+			logger.Error("Failed notifying other members about config change", logger.Ctx{"err": err})
+			return response.SmartError(err)
 		}
-
-		serverPut := server.Writable()
-		serverPut.Config = make(map[string]any)
-		// Only propagated cluster-wide changes
-		for key, value := range clusterChanged {
-			serverPut.Config[key] = value
-		}
-
-		return client.UpdateServer(serverPut, etag)
-	})
-	if err != nil {
-		logger.Error("Failed notifying other members about config change", logger.Ctx{"err": err})
-		return response.SmartError(err)
 	}
 
 	// Update the daemon config.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -908,15 +908,6 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	if len(nodeChanged) > 0 {
 		revert.Add(func() {
-			for key := range nodeValues {
-				val, ok := oldNodeConfig[key]
-				if !ok {
-					nodeValues[key] = ""
-				} else {
-					nodeValues[key] = val
-				}
-			}
-
 			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
 			err = s.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 				newNodeConfig, err := node.ConfigLoad(ctx, tx)
@@ -924,7 +915,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 					return fmt.Errorf("Failed loading local config: %w", err)
 				}
 
-				_, err = newNodeConfig.Replace(nodeValues)
+				_, err = newNodeConfig.Replace(oldNodeConfig)
 				if err != nil {
 					return fmt.Errorf("Failed updating local config: %w", err)
 				}
@@ -972,15 +963,6 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	if len(clusterChanged) > 0 {
 		revert.Add(func() {
-			for key := range stringReqConfig {
-				val, ok := oldClusterConfig[key]
-				if !ok {
-					stringReqConfig[key] = ""
-				} else {
-					stringReqConfig[key] = val
-				}
-			}
-
 			// Use context.Background for revert in case client disconnects after changes made and an error occurs.
 			err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 				newClusterConfig, err = clusterConfig.Load(ctx, tx)
@@ -988,7 +970,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 					return fmt.Errorf("Failed loading cluster config: %w", err)
 				}
 
-				_, err = newClusterConfig.Replace(tx, stringReqConfig)
+				_, err = newClusterConfig.Replace(tx, oldClusterConfig)
 				if err != nil {
 					return fmt.Errorf("Failed updating cluster config: %w", err)
 				}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -891,7 +891,7 @@ func projectNodeConfigRename(d *Daemon, ctx context.Context, oldName string, new
 
 		localConfig, err = node.ConfigLoad(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed loading local node config: %w", err)
+			return fmt.Errorf("Failed loading local config: %w", err)
 		}
 
 		_, err = localConfig.Patch(map[string]string{
@@ -903,7 +903,7 @@ func projectNodeConfigRename(d *Daemon, ctx context.Context, oldName string, new
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("Failed updating project-specific config keys in the local node config: %w", err)
+		return fmt.Errorf("Failed updating project-specific config keys in the local config: %w", err)
 	}
 
 	// Update local config cache.
@@ -1083,7 +1083,7 @@ func projectNodeConfigDelete(d *Daemon, s *state.State, name string) error {
 
 		config, err = node.ConfigLoad(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed loading local node config: %w", err)
+			return fmt.Errorf("Failed loading local config: %w", err)
 		}
 
 		// Unmount the project-specific storage volumes.
@@ -1107,7 +1107,7 @@ func projectNodeConfigDelete(d *Daemon, s *state.State, name string) error {
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("Failed clearing project-specific config keys from the local node config: %w", err)
+		return fmt.Errorf("Failed clearing project-specific config keys from the local config: %w", err)
 	}
 
 	// Update local config cache.
@@ -1381,7 +1381,7 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 		// Clear the project-specific config keys from the local node config.
 		err = projectNodeConfigDelete(d, s, name)
 		if err != nil {
-			return fmt.Errorf("Failed deleting project specific information from local node configuration: %w", err)
+			return fmt.Errorf("Failed deleting project specific information from local configuration: %w", err)
 		}
 
 		// Send notification to all cluster members to update the node schema and handle forced project deletion (if requested).

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -31,12 +31,12 @@ func Load(ctx context.Context, tx *db.ClusterTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
 	values, err := tx.Config(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("cannot fetch node config from database: %w", err)
+		return nil, fmt.Errorf("cannot fetch cluster config from database: %w", err)
 	}
 
 	m, err := config.SafeLoad(&ConfigSchema, values)
 	if err != nil {
-		return nil, fmt.Errorf("failed loading node config: %w", err)
+		return nil, fmt.Errorf("failed loading cluster config: %w", err)
 	}
 
 	return &Config{m: m}, nil

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -57,7 +57,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed fetching node configuration: %w", err)
+			return fmt.Errorf("Failed fetching local configuration: %w", err)
 		}
 
 		localClusterAddress = config.ClusterAddress()
@@ -374,7 +374,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed fetching node configuration: %w", err)
+			return fmt.Errorf("Failed fetching local configuration: %w", err)
 		}
 
 		localClusterAddress = config.ClusterAddress()

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -153,7 +153,7 @@ func updateLocalAddress(database *db.Node, address string) error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("Failed updating node configuration: %w", err)
+		return fmt.Errorf("Failed updating local configuration: %w", err)
 	}
 
 	return nil

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -74,7 +74,7 @@ func daemonStorageVolumesUnmount(s *state.State, ctx context.Context) error {
 
 			err := unmountDaemonStorageVolume(s, value)
 			if err != nil {
-				return fmt.Errorf("Failed unmounting project storage volume %q set under node config key %q: %w", value, key, err)
+				return fmt.Errorf("Failed unmounting project storage volume %q set under local config key %q: %w", value, key, err)
 			}
 		}
 	}
@@ -130,7 +130,7 @@ func daemonStorageMount(s *state.State) error {
 
 		err := mountDaemonStorageVolume(s, value)
 		if err != nil {
-			return fmt.Errorf("Failed mounting project storage volume %q set under node config key %q: %w", value, key, err)
+			return fmt.Errorf("Failed mounting project storage volume %q set under local config key %q: %w", value, key, err)
 		}
 	}
 

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -3368,7 +3368,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 SELECT ?, ?, 'lvm.vg_name', name FROM storage_pools WHERE id=?
 `, poolID, nodeID, poolID)
 			if err != nil {
-				return fmt.Errorf("Failed creating lvm.vg_name node config: %w", err)
+				return fmt.Errorf("Failed creating lvm.vg_name local config: %w", err)
 			}
 		}
 	}
@@ -3410,7 +3410,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 SELECT ?, ?, 'zfs.pool_name', name FROM storage_pools WHERE id=?
 `, poolID, nodeID, poolID)
 			if err != nil {
-				return fmt.Errorf("Failed creating zfs.pool_name node config: %w", err)
+				return fmt.Errorf("Failed creating zfs.pool_name local config: %w", err)
 			}
 		}
 	}
@@ -4667,7 +4667,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
   VALUES(?, ?, 'zfs.pool_name', ?)
 `, poolID, nodeID, poolName)
 			if err != nil {
-				return fmt.Errorf("failed creating zfs.pool_name node config: %w", err)
+				return fmt.Errorf("failed creating zfs.pool_name local config: %w", err)
 			}
 		}
 	}

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -237,8 +237,8 @@ CREATE TABLE identities_certificates (
 ) WITHOUT ROWID;
 -- We can't cascade deletion from the identities tables to the certificates table.
 -- This trigger ensures that certificates are deleted when an identity is deleted via foreign key cascade deletion
--- in the association table. 
-CREATE TRIGGER identities_certificates_after_delete 
+-- in the association table.
+CREATE TRIGGER identities_certificates_after_delete
     AFTER DELETE ON identities_certificates
 	BEGIN
 	DELETE FROM certificates

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -628,7 +628,7 @@ func (c *ClusterTx) BootstrapNode(name string, address string) error {
 func (c *ClusterTx) UpdateNodeConfig(ctx context.Context, id int64, config map[string]string) error {
 	err := cluster.UpdateConfig(ctx, c.Tx(), "node", int(id), config)
 	if err != nil {
-		return fmt.Errorf("Cannot update node config: %w", err)
+		return fmt.Errorf("Cannot update local config: %w", err)
 	}
 
 	return nil

--- a/lxd/endpoints/cluster.go
+++ b/lxd/endpoints/cluster.go
@@ -38,7 +38,7 @@ func (e *Endpoints) ClusterUpdateAddress(address string) error {
 		return nil
 	}
 
-	logger.Info("Update cluster address")
+	logger.Info("Update cluster address", logger.Ctx{"address": address, "oldAddress": oldAddress})
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/lxd/endpoints/metrics.go
+++ b/lxd/endpoints/metrics.go
@@ -39,7 +39,7 @@ func (e *Endpoints) MetricsUpdateAddress(address string, cert *shared.CertInfo) 
 		return nil
 	}
 
-	logger.Info("Update metrics address")
+	logger.Info("Update metrics address", logger.Ctx{"address": address, "oldAddress": oldAddress})
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -69,7 +69,7 @@ func (e *Endpoints) NetworkUpdateAddress(address string) error {
 
 	clusterAddress := e.clusterAddress()
 
-	logger.Info("Update network address")
+	logger.Info("Update network address", logger.Ctx{"address": address, "oldAddress": oldAddress})
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/lxd/endpoints/pprof.go
+++ b/lxd/endpoints/pprof.go
@@ -51,7 +51,7 @@ func (e *Endpoints) PprofUpdateAddress(address string) error {
 		address = util.CanonicalNetworkAddress(address, shared.HTTPDefaultPort)
 	}
 
-	oldAddress := e.NetworkAddress()
+	oldAddress := e.PprofAddress()
 	if address == oldAddress {
 		return nil
 	}

--- a/lxd/endpoints/pprof.go
+++ b/lxd/endpoints/pprof.go
@@ -56,7 +56,7 @@ func (e *Endpoints) PprofUpdateAddress(address string) error {
 		return nil
 	}
 
-	logger.Info("Update pprof address")
+	logger.Info("Update pprof address", logger.Ctx{"address": address, "oldAddress": oldAddress})
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -25,12 +25,12 @@ func ConfigLoad(ctx context.Context, tx *db.NodeTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
 	values, err := tx.Config(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot fetch node config from database: %w", err)
+		return nil, fmt.Errorf("Cannot fetch local config from database: %w", err)
 	}
 
 	m, err := config.SafeLoad(&ConfigSchema, values)
 	if err != nil {
-		return nil, fmt.Errorf("Failed loading node config: %w", err)
+		return nil, fmt.Errorf("Failed loading local config: %w", err)
 	}
 
 	return &Config{tx: tx, m: m}, nil

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -601,7 +601,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
   VALUES(?, ?, 'lvm.thinpool_name', ?)
 `, poolID, nodeID, value)
 			if err != nil {
-				return fmt.Errorf("Failed creating lvm.thinpool_name node config: %w", err)
+				return fmt.Errorf("Failed creating lvm.thinpool_name local config: %w", err)
 			}
 		}
 	}
@@ -2297,7 +2297,7 @@ func patchRemoveMAASConfigKeys(_ string, d *Daemon) error {
 		})
 	})
 	if err != nil {
-		return fmt.Errorf("Failed removing maas.machine from local node config: %w", err)
+		return fmt.Errorf("Failed removing maas.machine from local config: %w", err)
 	}
 
 	// Remove all MAAS keys from the cluster database.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2158,6 +2158,14 @@ test_clustering_address() {
   # the port is the same as cluster.https_address.
   LXD_DIR="${LXD_ONE_DIR}" lxc config set "core.https_address" "0.0.0.0:8444"
 
+  sub_test "Verify cluster member is reachable via cluster.https_address when core.https_address is unset"
+  # When core.https_address is unset, the member should still serve the REST API
+  # on its cluster.https_address.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset "core.https_address"
+  url="https://100.64.1.101:8444"
+  lxc remote set-url cluster "${url}"
+  lxc storage list cluster: | grep -wF data
+
   LXD_DIR="${LXD_TWO_DIR}" lxc delete c1
 
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown


### PR DESCRIPTION
- Also don't sent cluster notifications unnecessarily for local config changes.
- Removes references to "node config" in errors and replaces with "local config"
- Fixes related issue where if a member's `core.https_address` was previously set to an address that "covered" the `cluster.https_address` (e.g. `:8443`), then if it was unset then the listener for the `cluster.https_address` was not reinstated.
- Fix incorrect pprof listener address comparison on change.

Fixes https://github.com/canonical/lxd/issues/18171