### PR TITLE
lxd/storage/drivers/utils_ceph: use legacy CephFS mount syntax on kernel < 5.17

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -173,7 +173,7 @@ again:
 }
 
 // diskCephfsOptions returns the mntSrcPath and fsOptions to use for mounting a cephfs share.
-func diskCephfsOptions(clusterName string, userName string, fsName string, fsPath string) (string, []string, error) {
+func diskCephfsOptions(clusterName string, userName string, fsName string, fsPath string, modernMountSyntax bool) (string, []string, error) {
 	ctx := context.TODO()
 
 	// Get the FSID.
@@ -200,7 +200,7 @@ func diskCephfsOptions(clusterName string, userName string, fsName string, fsPat
 		return "", nil, err
 	}
 
-	srcPath, fsOptions := storageDrivers.CephBuildMount(userName, secret, fsid, monitors, fsName, fsPath, msMode)
+	srcPath, fsOptions := storageDrivers.CephBuildMount(userName, secret, fsid, monitors, fsName, fsPath, msMode, modernMountSyntax)
 
 	return srcPath, fsOptions, nil
 }

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1749,7 +1749,7 @@ func (d *disk) createDevice(srcPath string) (func(), string, bool, error) {
 			clusterName, userName := d.cephCreds()
 
 			// Get the mount options.
-			mntSrcPath, fsOptions, fsErr := diskCephfsOptions(clusterName, userName, mdsName, mdsPath)
+			mntSrcPath, fsOptions, fsErr := diskCephfsOptions(clusterName, userName, mdsName, mdsPath, d.state.OS.CephModernMountSyntax)
 			if fsErr != nil {
 				return nil, "", false, fsErr
 			}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -324,7 +324,7 @@ func (d *cephfs) Create() error {
 		return err
 	}
 
-	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode)
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode, d.state.OS.CephModernMountSyntax)
 	options = append(options, "mount_timeout=10")
 
 	// Mount the pool.
@@ -407,7 +407,7 @@ func (d *cephfs) Delete(progressReporter ioprogress.ProgressReporter) error {
 		return err
 	}
 
-	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode)
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, "/", msMode, d.state.OS.CephModernMountSyntax)
 	options = append(options, "mount_timeout=10")
 
 	// Mount the pool.
@@ -603,7 +603,7 @@ func (d *cephfs) Mount() (bool, error) {
 		return false, err
 	}
 
-	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, fsPath, msMode)
+	srcPath, options := CephBuildMount(userName, key, fsid, monitors, fsName, fsPath, msMode, d.state.OS.CephModernMountSyntax)
 	options = append(options, "mount_timeout=10")
 
 	if shared.IsTrue(d.config["cephfs.fscache"]) {

--- a/lxd/storage/drivers/utils_ceph.go
+++ b/lxd/storage/drivers/utils_ceph.go
@@ -145,7 +145,7 @@ func CephFSID(ctx context.Context, cluster string) (string, error) {
 }
 
 // CephBuildMount creates a mount string and option list from mount parameters.
-func CephBuildMount(user string, key string, fsid string, monitors Monitors, fsName string, path string, msMode string) (source string, options []string) {
+func CephBuildMount(user string, key string, fsid string, monitors Monitors, fsName string, path string, msMode string, modernMountSyntax bool) (source string, options []string) {
 	// Ceph mount paths must begin with a '/'. If it doesn't (or is empty),
 	// prefix it now.
 	if !strings.HasPrefix(path, "/") {
@@ -158,12 +158,8 @@ func CephBuildMount(user string, key string, fsid string, monitors Monitors, fsN
 		monAddrs = monitors.V2
 	}
 
-	// Build the source path.
-	source = fmt.Sprintf("%s@%s.%s=%s", user, fsid, fsName, path)
-
-	// Build the options list.
+	// Build the base options list.
 	options = []string{
-		"mon_addr=" + strings.Join(monAddrs, "/"),
 		"name=" + user,
 	}
 
@@ -172,7 +168,28 @@ func CephBuildMount(user string, key string, fsid string, monitors Monitors, fsN
 		options = append(options, "secret="+key)
 	}
 
+	// ms_mode support was introduce 5.11 (00498b994113a871a556f7ff24a4cf8a00611700)
 	options = append(options, "ms_mode="+msMode)
+
+	// The modern mount syntax requires 5.17+ kernel.
+	// This behavior aligns with that of `mount.ceph` (not used by LXD) where
+	// the modern syntax is used by default when supported, and legacy syntax is
+	// used as a fallback for older kernels.
+	if modernMountSyntax {
+		// Modern syntax (>= 5.17)
+		source = fmt.Sprintf("%s@%s.%s=%s", user, fsid, fsName, path)
+		options = append(options, "mon_addr="+strings.Join(monAddrs, "/"))
+	} else {
+		// Legacy syntax (< 5.17)
+		// Monitors must be passed entirely in the source string.
+		source = strings.Join(monAddrs, ",") + ":" + path
+
+		// mds_namespace= (deprecated synonym for fs=) is the only option supported by old kernels
+		// https://docs.ceph.com/en/pacific/cephfs/mount-using-kernel-driver/#backward-compatibility
+		if fsName != "" {
+			options = append(options, "mds_namespace="+fsName)
+		}
+	}
 
 	return source, options
 }

--- a/lxd/storage/drivers/utils_ceph_test.go
+++ b/lxd/storage/drivers/utils_ceph_test.go
@@ -11,16 +11,17 @@ import (
 
 func TestCephBuildMount(t *testing.T) {
 	tests := []struct {
-		name        string
-		user        string
-		key         string
-		fsid        string
-		monitors    Monitors
-		fsName      string
-		path        string
-		msMode      string
-		wantSource  string
-		wantOptions []string
+		name              string
+		user              string
+		key               string
+		fsid              string
+		monitors          Monitors
+		fsName            string
+		path              string
+		msMode            string
+		modernMountSyntax bool
+		wantSource        string
+		wantOptions       []string
 	}{
 		{
 			name: "V2 monitors with key",
@@ -31,10 +32,11 @@ func TestCephBuildMount(t *testing.T) {
 				V1: []string{"10.0.0.1:6789"},
 				V2: []string{"10.0.0.1:3300"},
 			},
-			fsName:     "myfs",
-			path:       "/",
-			msMode:     "prefer-secure",
-			wantSource: "admin@abc-def-123.myfs=/",
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:3300",
 				"name=admin",
@@ -50,15 +52,38 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V1: []string{"10.0.0.1:6789", "10.0.0.2:6789"},
 			},
-			fsName:     "myfs",
-			path:       "/subdir",
-			msMode:     "prefer-secure",
-			wantSource: "admin@abc-def-123.myfs=/subdir",
+			fsName:            "myfs",
+			path:              "/subdir",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/subdir",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "V1 only monitors (legacy mount syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789", "10.0.0.2:6789"},
+			},
+			fsName:            "myfs",
+			path:              "/subdir",
+			msMode:            "prefer-secure",
+			modernMountSyntax: false,
+			wantSource:        "10.0.0.1:6789,10.0.0.2:6789:/subdir",
+			wantOptions: []string{
+				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+				"mds_namespace=myfs",
+				"fsid=abc-def-123",
 			},
 		},
 		{
@@ -70,10 +95,11 @@ func TestCephBuildMount(t *testing.T) {
 				V1: []string{"10.0.0.1:6789"},
 				V2: []string{"10.0.0.1:3300", "10.0.0.2:3300", "10.0.0.3:3300"},
 			},
-			fsName:     "cephfs",
-			path:       "/data/pool",
-			msMode:     "prefer-secure",
-			wantSource: "client1@uuid-456.cephfs=/data/pool",
+			fsName:            "cephfs",
+			path:              "/data/pool",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "client1@uuid-456.cephfs=/data/pool",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:3300/10.0.0.2:3300/10.0.0.3:3300",
 				"name=client1",
@@ -89,10 +115,11 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V2: []string{"10.0.0.1:3300"},
 			},
-			fsName:     "myfs",
-			path:       "/",
-			msMode:     "prefer-secure",
-			wantSource: "admin@abc-def-123.myfs=/",
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:3300",
 				"name=admin",
@@ -107,10 +134,11 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V1: []string{"10.0.0.1:6789"},
 			},
-			fsName:     "myfs",
-			path:       "subdir",
-			msMode:     "prefer-secure",
-			wantSource: "admin@abc-def-123.myfs=/subdir",
+			fsName:            "myfs",
+			path:              "subdir",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/subdir",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:6789",
 				"name=admin",
@@ -126,10 +154,11 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V1: []string{"10.0.0.1:6789"},
 			},
-			fsName:     "myfs",
-			path:       "",
-			msMode:     "prefer-secure",
-			wantSource: "admin@abc-def-123.myfs=/",
+			fsName:            "myfs",
+			path:              "",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:6789",
 				"name=admin",
@@ -145,10 +174,11 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V2: []string{"10.0.0.1:3300"},
 			},
-			fsName:     "myfs",
-			path:       "/",
-			msMode:     "secure",
-			wantSource: "admin@abc-def-123.myfs=/",
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:3300",
 				"name=admin",
@@ -164,10 +194,11 @@ func TestCephBuildMount(t *testing.T) {
 			monitors: Monitors{
 				V2: []string{"10.0.0.1:3300"},
 			},
-			fsName:     "myfs",
-			path:       "/",
-			msMode:     "prefer-crc",
-			wantSource: "admin@abc-def-123.myfs=/",
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "prefer-crc",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
 				"mon_addr=10.0.0.1:3300",
 				"name=admin",
@@ -179,7 +210,7 @@ func TestCephBuildMount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			source, options := CephBuildMount(tt.user, tt.key, tt.fsid, tt.monitors, tt.fsName, tt.path, tt.msMode)
+			source, options := CephBuildMount(tt.user, tt.key, tt.fsid, tt.monitors, tt.fsName, tt.path, tt.msMode, tt.modernMountSyntax)
 			assert.Equal(t, tt.wantSource, source)
 			assert.Equal(t, tt.wantOptions, options)
 		})

--- a/lxd/storage/drivers/utils_ceph_test.go
+++ b/lxd/storage/drivers/utils_ceph_test.go
@@ -38,10 +38,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:3300",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:3300",
 			},
 		},
 		{
@@ -58,10 +58,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/subdir",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
 			},
 		},
 		{
@@ -78,12 +78,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: false,
 			wantSource:        "10.0.0.1:6789,10.0.0.2:6789:/subdir",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:6789/10.0.0.2:6789",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
 				"mds_namespace=myfs",
-				"fsid=abc-def-123",
 			},
 		},
 		{
@@ -101,10 +99,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "client1@uuid-456.cephfs=/data/pool",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:3300/10.0.0.2:3300/10.0.0.3:3300",
 				"name=client1",
 				"secret=secret123",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:3300/10.0.0.2:3300/10.0.0.3:3300",
 			},
 		},
 		{
@@ -121,9 +119,9 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:3300",
 				"name=admin",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:3300",
 			},
 		},
 		{
@@ -140,10 +138,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/subdir",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:6789",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:6789",
 			},
 		},
 		{
@@ -160,10 +158,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:6789",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:6789",
 			},
 		},
 		{
@@ -180,10 +178,10 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:3300",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=secure",
+				"mon_addr=10.0.0.1:3300",
 			},
 		},
 		{
@@ -200,10 +198,108 @@ func TestCephBuildMount(t *testing.T) {
 			modernMountSyntax: true,
 			wantSource:        "admin@abc-def-123.myfs=/",
 			wantOptions: []string{
-				"mon_addr=10.0.0.1:3300",
 				"name=admin",
 				"secret=AQBxyz==",
 				"ms_mode=prefer-crc",
+				"mon_addr=10.0.0.1:3300",
+			},
+		},
+		{
+			name: "Empty fsName (legacy syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+			},
+			fsName:            "",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: false,
+			wantSource:        "10.0.0.1:6789:/",
+			wantOptions: []string{
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Empty fsid (legacy syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+			},
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: false,
+			wantSource:        "10.0.0.1:6789:/",
+			wantOptions: []string{
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+				"mds_namespace=myfs",
+			},
+		},
+		{
+			name: "Empty fsName and fsid (legacy syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "",
+			monitors: Monitors{
+				V1: []string{"10.0.0.1:6789"},
+			},
+			fsName:            "",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: false,
+			wantSource:        "10.0.0.1:6789:/",
+			wantOptions: []string{
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+			},
+		},
+		{
+			name: "Empty fsName (modern syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "abc-def-123",
+			monitors: Monitors{
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:            "",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@abc-def-123.=/",
+			wantOptions: []string{
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:3300",
+			},
+		},
+		{
+			name: "Empty fsid (modern syntax)",
+			user: "admin",
+			key:  "AQBxyz==",
+			fsid: "",
+			monitors: Monitors{
+				V2: []string{"10.0.0.1:3300"},
+			},
+			fsName:            "myfs",
+			path:              "/",
+			msMode:            "prefer-secure",
+			modernMountSyntax: true,
+			wantSource:        "admin@.myfs=/",
+			wantOptions: []string{
+				"name=admin",
+				"secret=AQBxyz==",
+				"ms_mode=prefer-secure",
+				"mon_addr=10.0.0.1:3300",
 			},
 		},
 	}

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -114,6 +114,9 @@ type OS struct {
 	KernelVersion   version.DottedVersion
 	AppArmorVersion *version.DottedVersion // AppArmorVersion is nil if AppArmorAvailable is false.
 
+	// Storage capabilities
+	CephModernMountSyntax bool
+
 	// LXD server UUID
 	ServerUUID string
 }
@@ -218,6 +221,10 @@ func (s *OS) Init() ([]cluster.Warning, error) {
 	if err == nil {
 		s.KernelVersion = *kernelVersion
 	}
+
+	// Check if the kernel supports the modern CephFS mount syntax (>= 5.17.0).
+	minCephMountVer, _ := version.NewDottedVersion("5.17.0")
+	s.CephModernMountSyntax = s.KernelVersion.Compare(minCephMountVer) >= 0
 
 	// Fill in the boot time.
 	out, err := os.ReadFile("/proc/stat")


### PR DESCRIPTION
MicroCloud upgrade tests have shown that CephFS mounts from `latest/edge` no
longer work on Ubuntu 22.04's GA kernel (5.15). This old kernel does not
support the `user@fsid.fs_name=/[subdir]` syntax which was introduced with
Linux 5.17 via:
    
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7b19b4db5add8d9f50e854907a82a10ba4d27c42
   
While the 5.15 kernel is older than the officially supported minimum kernel
(6.8), we can still try to be compatible with it. Fixes #18198.