### PR TITLE
Unidirectional cluster links

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3620,3 +3620,8 @@ The following changes are included:
 - `id`: Now accepts either a CDI identifier for `gputype=mig` devices or a DRM card ID selector for the parent GPU. Supported CDI formats are `nvidia.com/mig=<uuid>` and `nvidia.com/mig=<dev_idx>:<mig_idx>`. When a CDI identifier is provided, it is used directly and is mutually exclusive with `mig.uuid`, `mig.gi`, and `mig.ci`.
 
 Because the legacy `nvidia.runtime` instance-level option is incompatible with CDI-based MIG passthrough, attaching a `gputype=mig` device to a container with {config:option}`instance-nvidia:nvidia.runtime` set to `true` is rejected. To preserve backward compatibility, an upgrade patch unsets `nvidia.runtime` on existing containers and snapshots that have a `gputype=mig` device attached.
+
+(extension-cluster-links-unidirectional)=
+## `cluster_links_unidirectional`
+
+This extends the {ref}`cluster links <exp-cluster-links>` API with support for unidirectional cluster links. The local cluster consumes a trust token issued by the remote cluster to establish the link and pin the remote's certificate. The remote cluster creates a dedicated identity for the local cluster and can authenticate its incoming requests, but does not store addresses for the local cluster and cannot initiate outbound requests to it.

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -158,52 +158,76 @@ See {ref}`howto-cluster-groups` and {ref}`cluster-target-instance` for more info
 (exp-cluster-links)=
 ## Cluster links
 
-Cluster links enable authenticated communication between separate LXD clusters by establishing a bidirectional trust relationship using mutual TLS certificates.
+Cluster links enable communication between separate LXD clusters by pinning the remote cluster's TLS certificate and optionally establishing mutual trust.
 
-### How cluster links work
+Cluster links are the foundation for {ref}`replicators <exp-replicators>`, which use bidirectional links to sync instances across clusters for active-passive disaster recovery. Unidirectional links are suited to scenarios where one cluster needs to read from another without granting reciprocal access.
 
-1. **Trust establishment**: Each cluster presents its certificate to the other, establishing mutual trust.
-1. **Identity creation**: LXD automatically creates a special identity for each linked cluster with type `Cluster link certificate`.
-1. **Permission control**: The linked cluster's permissions are managed through LXD's {ref}`fine-grained-authorization` system.
-1. **Secure communication**: All communication between clusters uses TLS encryption with certificate verification.
+### Link types
 
-#### Connection process
+There are two link types, each suited to different trust and access requirements:
 
-Both clusters coordinate to create a link.
+`bidirectional`
+: Either cluster can initiate requests to the other cluster. The clusters authenticate each other using mutual TLS, and both clusters create an identity for the other side. This is the default type.
+
+`unidirectional`
+: Requests can only be sent in one direction: from Cluster A to Cluster B. Cluster A pins B's certificate and uses a token to activate a pending identity that B created for A. B stores only a TLS identity for A (no cluster link record) and can authenticate incoming requests from A, but holds no address for A and cannot initiate requests to it.
+
+### Connection process
+
+All link types rely on TLS certificate pinning: Cluster A fetches and pins Cluster B's certificate before making any connection. The link type determines the level (and direction) of trust that is established between Cluster A and Cluster B.
+
+#### Bidirectional connection process
 
 1. **Cluster A** creates a pending cluster link and generates a trust token.
 1. **Cluster B** uses this token to establish the connection and send its certificate back.
-1. Both clusters validate certificates and activate the bidirectional link.
-1. The link becomes active and both clusters can communicate.
+1. Both clusters validate certificates and activate their cluster links.
+1. The trust relationship is established and both clusters can communicate.
+
+#### Unidirectional connection process
+
+1. **Cluster B** issues a pending identity token using [`lxc auth identity create`](lxc_auth_identity_create.md) `cluster-link/<name>`.
+1. **Cluster A** consumes the token with [`lxc cluster link create`](lxc_cluster_link_create.md) `<name> --token <token> --unidirectional`, pins Cluster B's certificate, and calls back to B to activate the pending identity.
+1. Cluster A has an active cluster link to Cluster B with no associated identity. Cluster B has an active TLS identity for Cluster A but no cluster link record.
 
 For more information, see: {ref}`howto-cluster-links-create`.
 
 (exp-clusters-links-identity)=
-### Identity management for cluster links
+### Identity management
 
-When you create a cluster link, LXD automatically creates an identity for the linked cluster. This identity is of type `Cluster link certificate` and is used to authenticate that cluster. These identities are managed using {ref}`fine-grained-authorization`.
+The identities created depend on the link type:
 
-The identity can be in one of two states:
+- **Bidirectional**: LXD creates a `Cluster link certificate` identity on each side. The identity can be in one of two states:
+  - **Pending**: A trust token has been generated but the link has not been activated yet.
+  - **Active**: Both clusters have exchanged certificates and the link is operational.
+- **Unidirectional**: Cluster B creates a TLS identity for Cluster A (no cluster link record); Cluster A stores Cluster B's certificate directly without an associated identity.
 
-- **Pending**: When a trust token is generated but the link hasn't been activated yet.
-- **Active**: When both clusters have exchanged certificates and the link is operational.
+Identities are managed using {ref}`fine-grained authorization <fine-grained-authorization>`.
 
-#### Security considerations
+### Security considerations
 
 - **Certificate validation**: All connections verify certificate fingerprints.
 - **Fine-grained permissions**: Linked clusters can be granted specific entitlements (for example, only backup operations).
 - **Identity isolation**: Each cluster link gets its own identity that can be managed independently.
 - **Group membership**: Cluster link identities can be assigned to authentication groups for bulk permission management.
 
-Together, these controls limit the blast radius of a compromised link by enforcing mutual authentication and least-privilege access. They also make it possible to revoke a single link’s access without impacting other cluster-to-cluster trust relationships.
+Together, these controls limit the potential impact of a compromised link by enforcing certificate-based trust and least-privilege access. They also make it possible to revoke a single link's access without impacting other cluster-to-cluster trust relationships.
 
-#### Cluster link member status
+### Removal
 
-A cluster link member can have one of the following statuses. You can see member status with `lxc cluster link info` (while `lxc cluster link list` shows the link identity status and link type); see {ref}`howto-cluster-links-view`.
+Deleting a cluster link revokes the security trust it established. The scope depends on the link type:
+
+- **Bidirectional**: Run [`lxc cluster link delete`](lxc_cluster_link_delete.md) on both clusters to fully remove the trust relationship.
+- **Unidirectional**: Deleting on Cluster A removes only A's link. Cluster B's identity remains until B explicitly revokes it with [`lxc auth identity delete`](lxc_auth_identity_delete.md) `cluster-link/<name-for-cluster-a>`.
+
+### Member status
+
+A cluster link member can have one of the following statuses. Run [`lxc cluster link info`](lxc_cluster_link_info.md) to check member status. (Refer to {ref}`howto-cluster-links-view` for additional details.)
 
 - `ACTIVE`: Reachable and authenticated. The link is usable for requests according to the {ref}`entitlements <fine-grained-authorization>` you granted.
 - `UNAUTHENTICATED`: Reachable but not authenticated. The remote cluster cannot use the link yet; resolve the trust exchange before relying on it.
 - `UNREACHABLE`: Not reachable. Requests that depend on the link will fail until connectivity is restored or the remote cluster is online.
+
+Member status reflects connectivity, while [`lxc cluster link list`](lxc_cluster_link_list.md) shows the link identity status and link type, which determine the permissions available to the linked cluster.
 
 (clustering-instance-placement)=
 ## Automatic placement of instances

--- a/doc/howto/cluster_links_create.md
+++ b/doc/howto/cluster_links_create.md
@@ -1,18 +1,18 @@
 ---
 myst:
   html_meta:
-    description: Create cluster links between LXD clusters using trust tokens and mutual TLS.
+    description: Create bidirectional and unidirectional cluster links between LXD clusters.
 ---
 
 (howto-cluster-links-create)=
 # How to create cluster links
 
-{ref}`Cluster links <exp-cluster-links>` can connect separate LXD clusters by establishing a trust relationship using mutual TLS with certificates, ensuring secure communication.
+{ref}`Cluster links <exp-cluster-links>` connect separate LXD clusters. There are two link types — bidirectional and unidirectional — each with a different creation flow.
 
 (howto-cluster-links-auth)=
 ## Prepare authentication
 
-Before creating cluster links, set up proper authentication groups and {ref}`manage-permissions`:
+Before creating bidirectional or unidirectional cluster links, set up proper authentication groups and {ref}`manage permissions <manage-permissions>`:
 
 ```bash
 lxc auth group create <group-name>
@@ -39,12 +39,13 @@ For example, you can create a more restricted group for backup operations only:
 
 ```bash
 lxc auth group create backup
-lxc auth group permission add backup instance can_manage_backups
+lxc auth group permission add backup instance my-instance can_manage_backups
 ```
 
-## Create a cluster link
+(howto-cluster-links-create-bidirectional)=
+## Create a bidirectional cluster link
 
-To create a new cluster link between two clusters (Cluster A and Cluster B), you must create the link on both sides. Follow these steps:
+To create a bidirectional cluster link between two clusters (Cluster A and Cluster B), you must create the link on both sides. Follow these steps:
 
 1. On Cluster A, create a new cluster link to Cluster B and receive a trust token:
 
@@ -83,13 +84,66 @@ To create a new cluster link between two clusters (Cluster A and Cluster B), you
    lxc cluster link create cluster_a --token <token-from-A> --auth-group clusters
    ```
 
+(howto-cluster-links-create-unidirectional)=
+## Create a unidirectional cluster link
+
+A unidirectional link lets Cluster A access Cluster B's resources, but Cluster B cannot initiate requests to Cluster A. Cluster B creates an identity for Cluster A, but Cluster A does not create an identity for Cluster B.
+
+Follow these steps:
+
+1. On Cluster B (the target), issue a pending identity token:
+
+   ```bash
+   lxc auth identity create cluster-link/<name-for-cluster-a> --auth-group <auth-group-name>
+   ```
+
+   This command creates a pending `Cluster link certificate` identity on Cluster B and returns a trust token.
+
+   Example:
+
+   ```bash
+   lxc auth identity create cluster-link/cluster_a --auth-group clusters
+   ```
+
+1. On Cluster A (the initiator), create the cluster link using the token from Cluster B:
+
+   ```bash
+   lxc cluster link create <name-for-cluster-b> --token <token-from-B> --unidirectional
+   ```
+
+   This command:
+   - Pins Cluster B's certificate on Cluster A.
+   - Calls back to Cluster B to activate Cluster B's pending identity for Cluster A.
+   - Stores Cluster B's addresses in {config:option}`cluster-link-volatile-conf:volatile.addresses` so Cluster A can reach B.
+
+   Example:
+
+   ```bash
+   lxc cluster link create cluster_b --token <token-from-B> --unidirectional
+   ```
+
+After these steps, Cluster A has a link with `type: unidirectional` and no associated identity. Cluster B has an active `Cluster link certificate` identity for Cluster A but no cluster link record.
+
 (howto-cluster-links-identities)=
 ## View the underlying identities
 
-When you create a cluster link, LXD automatically creates an identity for authentication. You can view this identity with:
+LXD creates `Cluster link certificate` identities differently depending on the link type:
 
-```bash
-lxc auth identity show tls/<cluster-link-name>
-```
+- **Bidirectional links:** each cluster creates an identity for the other. On either cluster, view the identity for the remote cluster with:
 
-The output shows the identity of your cluster link, with the type `Cluster link certificate`.
+  ```bash
+  lxc auth identity show tls/<cluster-link-name>
+  ```
+
+- **Unidirectional links:** only the target cluster (B) has an identity for the initiator cluster (A). The initiator cluster has no associated identity. To view the identity, run the following on Cluster B:
+
+  ```bash
+  lxc auth identity show tls/<name-for-cluster-a>
+  ```
+
+The output shows the identity with the type `Cluster link certificate`.
+
+## Next steps
+
+- {ref}`howto-replicators-setup` — set up replicators to sync instances across this link for active-passive disaster recovery.
+- {ref}`howto-cluster-links-manage` — view, configure, and delete existing cluster links.

--- a/doc/howto/cluster_links_manage.md
+++ b/doc/howto/cluster_links_manage.md
@@ -70,10 +70,16 @@ lxc auth group permission add viewers server viewer
 lxc auth identity group add tls/<cluster-link-name> viewers
 ```
 
-Alternatively, you can specify an authentication group when creating a cluster link, which will automatically assign the cluster link identity to that group:
+Alternatively, for bidirectional links you can specify an authentication group when creating the link, which will automatically assign the cluster link identity to that group:
 
 ```bash
 lxc cluster link create <cluster-link-name> --auth-group <group name>
+```
+
+For unidirectional links, `--auth-group` is not supported on the initiating cluster (Cluster A has no identity for B). Specify the auth group on the target cluster (Cluster B) when issuing the identity token:
+
+```bash
+lxc auth identity create cluster-link/<name-for-cluster-a> --auth-group <group name>
 ```
 
 (howto-cluster-links-configure)=
@@ -170,10 +176,11 @@ See [`DELETE /1.0/cluster/links/{name}`](swagger:/cluster-links/{name}/cluster_l
 ```
 ````
 
-```{admonition} To fully disconnect the cluster link on both sides
+```{admonition} Deletion behavior depends on link type
 :class: note
 
-To fully disconnect the clusters, run the command on both clusters.
+The effect of deleting a cluster link varies by type:
 
-Deleting a cluster link removes the established trust and deletes the associated identity on the local cluster. If you only run the command on one cluster, the other cluster still has the cluster link identity and trust established (still allowing requests from the linked cluster).
+- **Bidirectional**: Deleting on one cluster removes the trust and identity only on that cluster. The other cluster retains its identity and trust until you also delete the link there. To fully disconnect, run the command on both clusters.
+- **Unidirectional**: Deleting on Cluster A removes only A's link row. Cluster B retains its identity for A until B explicitly revokes it with `lxc auth identity delete cluster-link/<name-for-cluster-a>`.
 ```

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -752,6 +752,8 @@ func resolveIdentityTypeShorthand(identityArg string) (method string, identityTy
 		return api.AuthenticationMethodBearer, api.IdentityTypeBearerTokenDevLXD, idName, nil
 	case "bearer":
 		return api.AuthenticationMethodBearer, "", idName, nil
+	case "cluster-link":
+		return api.AuthenticationMethodTLS, api.IdentityTypeCertificateClusterLink, idName, nil
 	}
 
 	return "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
@@ -843,6 +845,10 @@ func (c *cmdIdentityCreate) run(cmd *cobra.Command, args []string) error {
 
 	switch method {
 	case api.AuthenticationMethodTLS:
+		if idType == api.IdentityTypeCertificateClusterLink {
+			return c.createClusterLinkIdentity(remoteName, name)
+		}
+
 		var certFilePath string
 		if len(args) == 2 {
 			certFilePath = args[1]
@@ -962,6 +968,58 @@ func (c *cmdIdentityCreate) createTLSIdentity(remote string, name string, certFi
 		fmt.Printf("TLS identity %q created with fingerprint %q\n", name, fingerprint)
 	}
 
+	return nil
+}
+
+// createClusterLinkIdentity is called via `lxc auth identity create cluster-link/<name>`.
+// It creates a pending unidirectional cluster link identity on B.
+// Returns a token that A (the image client) can use with `lxc cluster link create --token --unidirectional`.
+func (c *cmdIdentityCreate) createClusterLinkIdentity(remote string, name string) error {
+	transporter, wrapper := newLocationHeaderTransportWrapper()
+	client, err := c.global.conf.GetInstanceServerWithConnectionArgs(remote, &lxd.ConnectionArgs{TransportWrapper: wrapper})
+	if err != nil {
+		return err
+	}
+
+	clusterLink := api.ClusterLinksPost{
+		Name: name,
+		Type: api.ClusterLinkTypeUnidirectional,
+	}
+
+	clusterLink.AuthGroups = append(clusterLink.AuthGroups, c.flagGroups...)
+
+	token, err := client.CreateIdentityClusterLinkToken(clusterLink)
+	if err != nil {
+		return err
+	}
+
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("Failed encoding identity token: %w", err)
+	}
+
+	if !c.identity.global.flagQuiet {
+		pendingIdentityURL, err := url.Parse(transporter.location)
+		if err != nil {
+			return fmt.Errorf("Received invalid location header %q: %w", transporter.location, err)
+		}
+
+		var pendingIdentityUUIDStr string
+		identityURLPrefix := api.NewURL().Path(version.APIVersion, "auth", "identities", api.AuthenticationMethodTLS).String()
+		_, err = fmt.Sscanf(pendingIdentityURL.Path, identityURLPrefix+"/%s", &pendingIdentityUUIDStr)
+		if err != nil {
+			return fmt.Errorf("Received unexpected location header %q: %w", transporter.location, err)
+		}
+
+		pendingIdentityUUID, err := uuid.Parse(pendingIdentityUUIDStr)
+		if err != nil {
+			return fmt.Errorf("Received invalid pending identity UUID %q: %w", pendingIdentityUUIDStr, err)
+		}
+
+		fmt.Printf("Cluster link %q (%s) pending identity token:\n", name, pendingIdentityUUID.String())
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString(tokenJSON))
 	return nil
 }
 

--- a/lxc/cluster_link.go
+++ b/lxc/cluster_link.go
@@ -243,7 +243,7 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Received invalid pending identity UUID %q: %w", pendingIdentityUUIDStr, err)
 			}
 
-			fmt.Printf("Cluster link %q (%s) pending identity token:"+"\n", clusterLinkName, pendingIdentityUUID.String())
+			fmt.Printf("Cluster link %q (%s) pending identity token:\n", clusterLinkName, pendingIdentityUUID.String())
 		}
 
 		// Print the base64 encoded token.

--- a/lxc/cluster_link.go
+++ b/lxc/cluster_link.go
@@ -86,9 +86,10 @@ type cmdClusterLinkCreate struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
 
-	flagToken       string
-	flagAuthGroups  []string
-	flagDescription string
+	flagToken          string
+	flagAuthGroups     []string
+	flagDescription    string
+	flagUnidirectional bool
 }
 
 func (c *cmdClusterLinkCreate) command() *cobra.Command {
@@ -97,19 +98,22 @@ func (c *cmdClusterLinkCreate) command() *cobra.Command {
 	cmd.Short = "Create cluster links"
 	cmd.Long = cli.FormatSection("Description", `Create cluster links
 
-When run with the --token flag, creates an active cluster link.
-When run without a token, creates a pending cluster link that must be activated by creating a cluster link on the remote cluster.`)
+Bidirectional (default): run without --token on cluster A to get a token, then run with --token on cluster B.
+Unidirectional: run "lxc auth identity create cluster-link/<name>" on B to get a token, then run with --token --unidirectional on A.`)
 	cmd.Example = cli.FormatSection("", `lxc cluster link create backup-cluster --auth-group backups
-    Create a pending cluster link reachable at "192.0.2.1:8443" and "192.0.2.2:8443" called "backup-cluster", belonging to the authentication group "backups".
+    Create a pending bidirectional cluster link called "backup-cluster".
 
-lxc cluster link create main-cluster --token <token from backup-cluster> --auth-group backups
-    Create a cluster link with "backup-cluster" called "main-cluster", belonging to the auth group "backups".
+lxc cluster link create main-cluster --token <token> --auth-group backups
+    Create an active bidirectional cluster link called "main-cluster" using a token from "backup-cluster".
 
-lxc cluster link create backup-cluster < config.yaml
-    Create a pending cluster link with the configuration from "config.yaml" called "backup-cluster".`)
+lxc cluster link create image-host --token <token> --unidirectional
+    Create a unidirectional cluster link called "image-host" using a token issued by the remote cluster.`)
 	cmd.Flags().StringVarP(&c.flagToken, "token", "t", "", cli.FormatStringFlagLabel("Trust token to use when creating cluster link"))
 	cmd.Flags().StringSliceVarP(&c.flagAuthGroups, "auth-group", "g", []string{}, cli.FormatStringFlagLabel("Authentication groups to add the newly created cluster link identity to"))
 	cmd.Flags().StringVarP(&c.flagDescription, "description", "d", "", cli.FormatStringFlagLabel("Cluster link description"))
+	cmd.Flags().BoolVar(&c.flagUnidirectional, "unidirectional", false, cli.FormatStringFlagLabel("Create a unidirectional cluster link (requires --token)"))
+
+	cmd.MarkFlagsMutuallyExclusive("unidirectional", "auth-group")
 
 	cmd.RunE = c.run
 
@@ -158,11 +162,14 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if c.flagUnidirectional && c.flagToken == "" {
+		return errors.New("--unidirectional requires --token")
+	}
+
 	clusterLink := api.ClusterLinksPost{
 		Name:           clusterLinkName,
 		ClusterLinkPut: stdinData,
-		// Bidirectional is the only supported cluster link type for now.
-		Type: api.ClusterLinkTypeBidirectional,
+		Type:           api.ClusterLinkTypeBidirectional,
 	}
 
 	if c.flagDescription != "" {
@@ -187,6 +194,23 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		clusterLink.AuthGroups = c.flagAuthGroups
 	}
 
+	// B saves A's certificate and trusts it for future communication.
+	if c.flagUnidirectional {
+		clusterLink.Type = api.ClusterLinkTypeUnidirectional
+		clusterLink.TrustToken = c.flagToken
+		err = client.CreateClusterLink(clusterLink)
+		if err != nil {
+			return err
+		}
+
+		if !c.global.flagQuiet {
+			fmt.Printf("Cluster link %s created\n", clusterLinkName)
+		}
+
+		return nil
+	}
+
+	// Bidirectional pending: no token; create pending identity and return token.
 	if c.flagToken == "" {
 		token, err := client.CreateIdentityClusterLinkToken(clusterLink)
 		if err != nil {
@@ -224,16 +248,18 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 
 		// Print the base64 encoded token.
 		fmt.Println(base64.StdEncoding.EncodeToString(tokenJSON))
-	} else {
-		clusterLink.TrustToken = c.flagToken
-		err = client.CreateClusterLink(clusterLink)
-		if err != nil {
-			return err
-		}
+		return nil
+	}
 
-		if !c.global.flagQuiet {
-			fmt.Printf("Cluster link %s created"+"\n", clusterLinkName)
-		}
+	// Bidirectional active: token provided; create active cluster link.
+	clusterLink.TrustToken = c.flagToken
+	err = client.CreateClusterLink(clusterLink)
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf("Cluster link %s created\n", clusterLinkName)
 	}
 
 	return nil

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -987,8 +987,6 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 			continue
 		}
 
-		reverter.Success()
-
 		// Send cluster link lifecycle event.
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
 
@@ -1002,6 +1000,8 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		if err != nil {
 			logger.Warn("Failed refreshing cluster link addresses after link creation", logger.Ctx{"err": err, "clusterLinkName": req.Name})
 		}
+
+		reverter.Success()
 
 		return response.SyncResponseLocation(true, nil, lc.Source)
 	}

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -981,7 +981,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 			continue
 		}
 
-		_, _, err = client.RawQuery(http.MethodPost, "/1.0/cluster/links", clusterLinksPost, "")
+		err = client.CreateClusterLink(clusterLinksPost)
 		if err != nil {
 			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
 			continue

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -942,7 +942,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 	defer reverter.Fail()
 
 	reverter.Add(func() {
-		err := s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 			return dbCluster.DeleteIdentityByAuthenticationMethodAndIdentifier(ctx, tx.Tx(), api.AuthenticationMethodTLS, fingerprint)
 		})
 		if err != nil {

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -542,19 +542,21 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading cluster link: %w", err)
 		}
 
-		// Get identity for notification and lifecycle event.
-		identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), clusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed getting identity with ID %d: %w", clusterLink.IdentityID, err)
-		}
+		// Get identity for notification and lifecycle event (bidirectional links only).
+		if clusterLink.IdentityID != nil {
+			identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), *clusterLink.IdentityID)
+			if err != nil {
+				return fmt.Errorf("Failed getting identity with ID %d: %w", *clusterLink.IdentityID, err)
+			}
 
-		identityIdentifier = identity.Identifier
+			identityIdentifier = identity.Identifier
 
-		// Rename identity.
-		identity.Name = req.Name
-		err = query.UpdateByPrimaryKey(ctx, tx.Tx(), *identity)
-		if err != nil {
-			return err
+			// Rename identity.
+			identity.Name = req.Name
+			err = query.UpdateByPrimaryKey(ctx, tx.Tx(), *identity)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Rename cluster link.
@@ -573,10 +575,12 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r.Context())
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkRenamed.Event(req.Name, requestor, logger.Ctx{"old_name": name}))
 
-	// Notify other members, update the cache, and send an identity lifecycle event.
-	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identityIdentifier, true, true)
-	if err != nil {
-		return response.SmartError(err)
+	// Notify other members and update the identity cache (bidirectional links only).
+	if identityIdentifier != "" {
+		_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identityIdentifier, true, true)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.EmptySyncResponse

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -614,7 +614,7 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
 
 	// Update DB entry.
-	var identity *dbCluster.IdentitiesRow
+	var identityIdentifier string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Prevent deletion if the cluster link is referenced by any entity.
 		usedBy, err := dbCluster.GetClusterLinksUsedBy(ctx, tx.Tx(), &name, true)
@@ -632,16 +632,24 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Get identity for notification and lifecycle event.
-		identity, err = dbCluster.GetIdentityByID(ctx, tx.Tx(), clusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed getting identity with ID %d: %w", clusterLink.IdentityID, err)
-		}
+		if clusterLink.IdentityID != nil {
+			// For bidirectional links, deleting the identity cascades to delete the cluster link.
+			identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), *clusterLink.IdentityID)
+			if err != nil {
+				return fmt.Errorf("Failed getting identity with ID %d: %w", *clusterLink.IdentityID, err)
+			}
 
-		// Deleting the identity also deletes the cluster link.
-		err = dbCluster.DeleteIdentityByAuthenticationMethodAndIdentifier(ctx, tx.Tx(), api.AuthenticationMethodTLS, identity.Identifier)
-		if err != nil {
-			return err
+			identityIdentifier = identity.Identifier
+			err = dbCluster.DeleteIdentityByAuthenticationMethodAndIdentifier(ctx, tx.Tx(), api.AuthenticationMethodTLS, identity.Identifier)
+			if err != nil {
+				return err
+			}
+		} else {
+			// For unidirectional links, delete the cluster link directly.
+			err = dbCluster.DeleteClusterLink(ctx, tx.Tx(), name)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -654,10 +662,12 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r.Context())
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkDeleted.Event(name, requestor, nil))
 
-	// Notify other members, update the cache, send an identity lifecycle event, and send an identity deleted security event.
-	_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identity.Identifier, true, true)
-	if err != nil {
-		return response.SmartError(err)
+	// Notify other members, update the cache, send an identity lifecycle event, and send an identity deleted security event (bidirectional links only).
+	if identityIdentifier != "" {
+		_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identityIdentifier, true, true)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.EmptySyncResponse

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -743,6 +743,10 @@ func clusterLinksPost(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(fmt.Errorf("Invalid trust token: %w", err))
 	}
 
+	if req.Name != "" && clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectional) {
+		return clusterLinkCreateUnidirectional(s, r, req, requestor, trustToken)
+	}
+
 	if req.Name != "" {
 		return clusterLinkCreateActive(s, r, req, clusterLinkType, networkCert, notify, requestor, trustToken)
 	}
@@ -1460,4 +1464,139 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 	wg.Wait()
 
 	return response.SyncResponse(true, clusterLinkState)
+}
+
+// clusterLinkCreateUnidirectional handles creation of a unidirectional cluster link.
+// A (image client) consumes a token issued by B (image host) to create a one-way link.
+// A pins B's certificate locally and calls back to B to activate B's pending identity for A.
+func clusterLinkCreateUnidirectional(s *state.State, r *http.Request, req api.ClusterLinksPost, requestor *api.EventLifecycleRequestor, trustToken *api.CertificateAddToken) response.Response {
+	// Check if the caller has permission to create cluster links.
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanCreateClusterLinks)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if len(trustToken.Addresses) == 0 {
+		return response.BadRequest(errors.New("No cluster addresses provided in trust token"))
+	}
+
+	// Retrieve and verify B's certificate.
+	remoteCert, _, err := cluster.CheckClusterLinkCertificate(r.Context(), trustToken.Addresses, trustToken.Fingerprint, version.UserAgent)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed validating cluster certificate: %w", err))
+	}
+
+	remotePEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: remoteCert.Raw}))
+	fingerprint := shared.CertFingerprint(remoteCert)
+
+	networkCert := s.Endpoints.NetworkCert()
+
+	// Store the cluster link and B's certificate locally. No identity for B; B never connects here.
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
+			IdentityID:  nil,
+			Name:        req.Name,
+			Description: req.Description,
+			Type:        dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectional),
+		})
+		if err != nil {
+			return fmt.Errorf("Failed creating cluster link %q: %w", req.Name, err)
+		}
+
+		if req.Config == nil {
+			req.Config = map[string]string{}
+		}
+
+		err = clusterLinkValidateConfig(req.Config)
+		if err != nil {
+			return err
+		}
+
+		req.Config["volatile.addresses"] = strings.Join(trustToken.Addresses, ",")
+		err = dbCluster.ClusterLinksConfigStore().Set(ctx, tx.Tx(), clusterLinkID, req.Config)
+		if err != nil {
+			return err
+		}
+
+		return dbCluster.SetClusterLinkCertificate(ctx, tx.Tx(), clusterLinkID, fingerprint, remotePEM)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() {
+		err := s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return dbCluster.DeleteClusterLink(ctx, tx.Tx(), req.Name)
+		})
+		if err != nil {
+			logger.Warn("Failed cleaning up unidirectional cluster link after activation failure", logger.Ctx{"err": err, "clusterLinkName": req.Name})
+		}
+	})
+
+	// Call B to activate B's pending identity for A using the identity API.
+	// Present A's cluster certificate as a TLS client cert so B can extract it
+	// from the TLS handshake and associate it with the activated identity.
+	activationErrs := make([]error, 0, len(trustToken.Addresses))
+
+	identityReq := api.IdentitiesTLSPost{
+		TrustToken: trustToken.String(),
+	}
+
+	for _, address := range trustToken.Addresses {
+		args := &lxd.ConnectionArgs{
+			TLSServerCert: remotePEM,
+			TLSClientCert: string(networkCert.PublicKey()),
+			TLSClientKey:  string(networkCert.PrivateKey()),
+			UserAgent:     version.UserAgent,
+		}
+
+		clusterAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
+		client, err := lxd.ConnectLXD("https://"+clusterAddress, args)
+		if err != nil {
+			activationErrs = append(activationErrs, fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err))
+			continue
+		}
+
+		err = client.CreateIdentityTLS(identityReq)
+		if err != nil {
+			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
+			continue
+		}
+
+		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+
+		err = cluster.RefreshClusterLinkVolatileAddresses(r.Context(), s, req.Name)
+		if err != nil {
+			logger.Warn("Failed refreshing cluster link addresses after link creation", logger.Ctx{"err": err, "clusterLinkName": req.Name})
+		}
+
+		reverter.Success()
+
+		return response.EmptySyncResponse
+	}
+
+	var statusErr error
+	errStrings := make([]string, 0, len(activationErrs))
+	for _, err := range activationErrs {
+		errStrings = append(errStrings, err.Error())
+
+		// Capture the first error that carries an HTTP status code so it can be
+		// preserved in the response via SmartError rather than falling back to a
+		// generic 502 Bad Gateway.
+		if statusErr == nil {
+			_, found := api.StatusErrorMatch(err)
+			if found {
+				statusErr = err
+			}
+		}
+	}
+
+	if statusErr != nil {
+		return response.SmartError(fmt.Errorf("Failed activating unidirectional cluster link %q after trying %d address(es): %w", req.Name, len(activationErrs), statusErr))
+	}
+
+	return response.SmartError(api.StatusErrorf(http.StatusBadGateway, "Failed activating unidirectional cluster link %q: %s", req.Name, strings.Join(errStrings, "; ")))
 }

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1011,6 +1011,9 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 	for _, err := range activationErrs {
 		errStrings = append(errStrings, err.Error())
 
+		// Capture the first error that carries an HTTP status code so it can be
+		// preserved in the response via SmartError rather than falling back to a
+		// generic 502 Bad Gateway.
 		if statusErr == nil {
 			_, found := api.StatusErrorMatch(err)
 			if found {

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -814,6 +814,13 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 			return err
 		}
 
+		// For unidirectional links, B only creates an identity for A. There is no cluster link
+		// row on B's side; A stores the link and B's certificate. B manages A's access solely
+		// through the identity.
+		if clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectional) {
+			return nil
+		}
+
 		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
 			IdentityID:  &id,
 			Name:        req.Name,
@@ -835,8 +842,10 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 		return response.InternalError(fmt.Errorf("Failed creating pending TLS identity: %w", err))
 	}
 
-	// Send cluster link lifecycle event.
-	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+	// Send cluster link lifecycle event (bidirectional only; B has no cluster link row for unidirectional links).
+	if clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeBidirectional) {
+		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+	}
 
 	// Notify other members, update the cache, send an identity lifecycle event, and send an identity created security event.
 	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false, true)

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -801,7 +801,7 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 		}
 
 		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
-			IdentityID:  id,
+			IdentityID:  &id,
 			Name:        req.Name,
 			Description: req.Description,
 			Type:        clusterLinkType,
@@ -881,7 +881,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 
 		// Create cluster link DB entry.
 		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
-			IdentityID:  id,
+			IdentityID:  &id,
 			Name:        req.Name,
 			Description: req.Description,
 			Type:        clusterLinkType,

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -956,11 +956,16 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		return response.InternalError(err)
 	}
 
-	clusterLinkPut := api.ClusterLinkPut{
-		Config: map[string]string{"volatile.addresses": strings.Join(listenAddresses, ",")},
-	}
-
 	activationErrs := make([]error, 0, len(trustToken.Addresses))
+
+	clusterLinksPost := api.ClusterLinksPost{
+		TrustToken:         trustToken.String(),
+		Type:               req.Type,
+		ClusterCertificate: string(networkCert.PublicKey()),
+		ClusterLinkPut: api.ClusterLinkPut{
+			Config: map[string]string{"volatile.addresses": strings.Join(listenAddresses, ",")},
+		},
+	}
 
 	// Send POST to remote /1.0/cluster/links to activate pending cluster link using token.
 	for _, address := range trustToken.Addresses {
@@ -976,7 +981,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 			continue
 		}
 
-		_, _, err = client.RawQuery(http.MethodPost, "/1.0/cluster/links", api.ClusterLinksPost{TrustToken: trustToken.String(), Type: req.Type, ClusterLinkPut: clusterLinkPut, ClusterCertificate: string(networkCert.PublicKey())}, "")
+		_, _, err = client.RawQuery(http.MethodPost, "/1.0/cluster/links", clusterLinksPost, "")
 		if err != nil {
 			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
 			continue

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1017,7 +1017,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 	return response.SmartError(api.StatusErrorf(http.StatusBadGateway, "Failed activating cluster link %q: %s", req.Name, strings.Join(errStrings, "; ")))
 }
 
-// clusterLinkActivate handles a server-side request to activate a pending cluster link using a trust token provided by another cluster. The caller is the remote cluster, not a human operator.
+// clusterLinkActivate handles a server-side request to activate a pending bidirectional cluster link using a trust token provided by another cluster. The caller is the remote cluster, not a human operator.
 func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPost, notify identityNotificationFunc, requestor *api.EventLifecycleRequestor, trustToken *api.CertificateAddToken, addresses []string) response.Response {
 	if trustToken.Type != api.IdentityTypeCertificateClusterLink {
 		return response.Forbidden(fmt.Errorf("Invalid trust token type %q", trustToken.Type))

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1372,33 +1372,8 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 
 	var targetCert *x509.Certificate
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbClusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), name)
-		if err != nil {
-			return err
-		}
-
-		config, err := dbCluster.ClusterLinksConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbClusterLink.ID)
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link config: %w", err)
-		}
-
-		clusterLink = dbClusterLink.ToAPI(config)
-
-		identity, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), dbClusterLink.IdentityID)
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link identity: %w", err)
-		}
-
-		certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx.Tx(), &identity.ID)
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link certificate: %w", err)
-		}
-
-		if len(certs[identity.ID]) == 0 {
-			return fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
-		}
-
-		targetCert, err = shared.ParseCert([]byte(certs[identity.ID][0]))
+		var err error
+		_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), name)
 		return err
 	})
 	if err != nil {

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -114,7 +114,8 @@ func GetClusterLinkConnectionArgs(clusterCert *shared.CertInfo, targetCert *x509
 	}
 }
 
-// LoadClusterLinkAndCert loads a cluster link by name and returns its database ID, API representation, and the parsed TLS certificate associated with its identity.
+// LoadClusterLinkAndCert loads a cluster link by name and returns its database ID, API representation, and the parsed TLS certificate.
+// For bidirectional links the certificate is loaded via the associated identity; for unidirectional links it is loaded from cluster_links_certificates.
 func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id int64, clusterLink *api.ClusterLink, cert *x509.Certificate, err error) {
 	dbLink, err := dbCluster.GetClusterLink(ctx, tx, name)
 	if err != nil {
@@ -128,23 +129,35 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 
 	clusterLink = dbLink.ToAPI(config)
 
-	identity, err := dbCluster.GetIdentityByID(ctx, tx, dbLink.IdentityID)
-	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed loading cluster link identity: %w", err)
+	var pemCert string
+	if dbLink.IdentityID != nil {
+		// Bidirectional: cert is stored via the identity.
+		identity, err := dbCluster.GetIdentityByID(ctx, tx, *dbLink.IdentityID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link identity: %w", err)
+		}
+
+		certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx, &identity.ID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
+		}
+
+		if len(certs[identity.ID]) == 0 {
+			return 0, nil, nil, fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
+		}
+
+		pemCert = certs[identity.ID][0]
+	} else {
+		// Unidirectional: cert is stored directly in cluster_links_certificates.
+		pemCert, err = dbCluster.GetClusterLinkPEMCertificate(ctx, tx, dbLink.ID)
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
+		}
 	}
 
-	certs, err := dbCluster.GetIdentitiesPEMCertificates(ctx, tx, &identity.ID)
+	cert, err = shared.ParseCert([]byte(pemCert))
 	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed loading cluster link certificate: %w", err)
-	}
-
-	if len(certs[identity.ID]) == 0 {
-		return 0, nil, nil, fmt.Errorf("No certificate found for cluster link identity %q", identity.Name)
-	}
-
-	cert, err = shared.ParseCert([]byte(certs[identity.ID][0]))
-	if err != nil {
-		return 0, nil, nil, fmt.Errorf("Failed extracting certificate from cluster link identity: %w", err)
+		return 0, nil, nil, fmt.Errorf("Failed parsing certificate for cluster link %q: %w", dbLink.Name, err)
 	}
 
 	return dbLink.ID, clusterLink, cert, nil

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -22,7 +22,8 @@ import (
 type ClusterLinkType string
 
 const (
-	clusterLinkTypeBidirectional int64 = 0
+	clusterLinkTypeBidirectional  int64 = 0
+	clusterLinkTypeUnidirectional int64 = 1
 )
 
 // ClusterLinkRow represents a single row of the cluster_links table.
@@ -45,6 +46,8 @@ func (c *ClusterLinkType) ScanInteger(clusterLinkTypeCode int64) error {
 	switch clusterLinkTypeCode {
 	case clusterLinkTypeBidirectional:
 		*c = api.ClusterLinkTypeBidirectional
+	case clusterLinkTypeUnidirectional:
+		*c = api.ClusterLinkTypeUnidirectional
 	default:
 		return fmt.Errorf("Unknown cluster link type %d", clusterLinkTypeCode)
 	}
@@ -62,6 +65,8 @@ func (c ClusterLinkType) Value() (driver.Value, error) {
 	switch c {
 	case api.ClusterLinkTypeBidirectional:
 		return clusterLinkTypeBidirectional, nil
+	case api.ClusterLinkTypeUnidirectional:
+		return clusterLinkTypeUnidirectional, nil
 	}
 
 	return nil, fmt.Errorf("Invalid cluster link type %q", c)

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -30,7 +30,7 @@ const (
 // db:model cluster_links
 type ClusterLinkRow struct {
 	ID          int64           `db:"id"`
-	IdentityID  int64           `db:"identity_id"`
+	IdentityID  *int64          `db:"identity_id"`
 	Name        string          `db:"name"`
 	Description string          `db:"description"`
 	Type        ClusterLinkType `db:"type"`

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -231,6 +232,60 @@ WHERE `)
 	}
 
 	return urls, nil
+}
+
+// SetClusterLinkCertificate stores the certificate for a cluster link.
+// Any existing certificate for the link is replaced.
+func SetClusterLinkCertificate(ctx context.Context, tx *sql.Tx, clusterLinkID int64, fingerprint string, pemCert string) error {
+	// Delete any existing certificate for this link. The trigger deletes the corresponding certificates row.
+	_, err := tx.ExecContext(ctx, "DELETE FROM cluster_links_certificates WHERE cluster_link_id = ?", clusterLinkID)
+	if err != nil {
+		return fmt.Errorf("Failed deleting existing cluster link certificate: %w", err)
+	}
+
+	cert := CertificatesRow{
+		Fingerprint: fingerprint,
+		Certificate: pemCert,
+	}
+
+	certificateID, err := query.Create(ctx, tx, cert)
+	if err != nil {
+		if query.IsConflictErr(err) {
+			return fmt.Errorf("A cluster link certificate with fingerprint %q already exists; the remote cluster may already be linked", fingerprint)
+		}
+
+		return fmt.Errorf("Failed creating certificate: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, "INSERT INTO cluster_links_certificates (cluster_link_id, certificate_id) VALUES (?, ?)", clusterLinkID, certificateID)
+	if err != nil {
+		return fmt.Errorf("Failed associating cluster link with certificate: %w", err)
+	}
+
+	return nil
+}
+
+// GetClusterLinkPEMCertificate returns the PEM-encoded certificate stored for a cluster link.
+func GetClusterLinkPEMCertificate(ctx context.Context, tx *sql.Tx, clusterLinkID int64) (string, error) {
+	var pemCert string
+	err := query.Scan(ctx, tx,
+		`SELECT certificates.certificate FROM certificates
+		 JOIN cluster_links_certificates ON certificates.id = cluster_links_certificates.certificate_id
+		 WHERE cluster_links_certificates.cluster_link_id = ?`,
+		func(scan func(dest ...any) error) error {
+			return scan(&pemCert)
+		},
+		clusterLinkID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("Failed loading cluster link certificate: %w", err)
+	}
+
+	if pemCert == "" {
+		return "", api.StatusErrorf(http.StatusNotFound, "No certificate found for cluster link")
+	}
+
+	return pemCert, nil
 }
 
 // GetClusterLinksAndURLs returns all cluster links that pass the given filter, along with their entity URLs.

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -44,7 +44,7 @@ CREATE TABLE "cluster_groups" (
 );
 CREATE TABLE cluster_links (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-	identity_id INTEGER NOT NULL,
+	identity_id INTEGER,
 	description TEXT NOT NULL,
 	name TEXT NOT NULL,
 	type INTEGER NOT NULL DEFAULT 0,
@@ -52,7 +52,16 @@ CREATE TABLE cluster_links (
 	UNIQUE(name),
 	FOREIGN KEY (identity_id) REFERENCES identities (id) ON DELETE CASCADE
 );
-CREATE TABLE cluster_links_config (
+CREATE TABLE cluster_links_certificates (
+	cluster_link_id INTEGER NOT NULL,
+	certificate_id INTEGER NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	FOREIGN KEY (certificate_id) REFERENCES certificates (id) ON DELETE CASCADE,
+	UNIQUE (certificate_id),
+	PRIMARY KEY (cluster_link_id,
+    certificate_id)
+) WITHOUT ROWID;
+CREATE TABLE "cluster_links_config" (
 	cluster_link_id INTEGER NOT NULL,
 	key TEXT NOT NULL,
 	value TEXT NOT NULL,
@@ -817,5 +826,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (87, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (88, strftime("%s"))
 `

--- a/lxd/db/cluster/triggers.go
+++ b/lxd/db/cluster/triggers.go
@@ -70,6 +70,7 @@ func applyTriggers(ctx context.Context, tx *sql.Tx) error {
 
 var globalTriggers = []triggerFunc{
 	triggerIdentitiesCertificatesAfterDelete,
+	triggerClusterLinksCertificatesAfterDelete,
 }
 
 func triggerIdentitiesCertificatesAfterDelete() (name string, stmt string) {
@@ -77,6 +78,19 @@ func triggerIdentitiesCertificatesAfterDelete() (name string, stmt string) {
 	stmt = fmt.Sprintf(`
 CREATE TRIGGER %s
     AFTER DELETE ON identities_certificates
+	BEGIN
+	DELETE FROM certificates
+		WHERE certificates.id = OLD.certificate_id;
+	END;
+`, name)
+	return name, stmt
+}
+
+func triggerClusterLinksCertificatesAfterDelete() (name string, stmt string) {
+	name = "cluster_links_certificates_after_delete"
+	stmt = fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON cluster_links_certificates
 	BEGIN
 	DELETE FROM certificates
 		WHERE certificates.id = OLD.certificate_id;

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -131,6 +131,57 @@ var updates = map[int]schema.Update{
 	85: updateFromV84,
 	86: updateFromV85,
 	87: updateFromV86,
+	88: updateFromV87,
+}
+
+func updateFromV87(ctx context.Context, tx *sql.Tx) error {
+	// Recreate cluster_links with nullable identity_id to support unidirectional links.
+	// Add cluster_links_certificates to store the remote cert for unidirectional links.
+	//
+	// Renaming cluster_links to cluster_links_old causes cluster_links_config's
+	// foreign key to be rewritten to reference "cluster_links_old". We must recreate
+	// cluster_links_config to restore the correct foreign key reference to cluster_links.
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE cluster_links RENAME TO cluster_links_old;
+
+CREATE TABLE cluster_links (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	identity_id INTEGER,
+	description TEXT NOT NULL,
+	name TEXT NOT NULL,
+	type INTEGER NOT NULL DEFAULT 0,
+	UNIQUE(identity_id),
+	UNIQUE(name),
+	FOREIGN KEY (identity_id) REFERENCES identities (id) ON DELETE CASCADE
+);
+
+INSERT INTO cluster_links SELECT * FROM cluster_links_old;
+
+CREATE TABLE cluster_links_config_new (
+	cluster_link_id INTEGER NOT NULL,
+	key TEXT NOT NULL,
+	value TEXT NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	PRIMARY KEY (cluster_link_id, key)
+) WITHOUT ROWID;
+
+INSERT INTO cluster_links_config_new SELECT * FROM cluster_links_config;
+DROP TABLE cluster_links_config;
+ALTER TABLE cluster_links_config_new RENAME TO cluster_links_config;
+
+DROP TABLE cluster_links_old;
+
+CREATE TABLE cluster_links_certificates (
+	cluster_link_id INTEGER NOT NULL,
+	certificate_id INTEGER NOT NULL,
+	FOREIGN KEY (cluster_link_id) REFERENCES cluster_links (id) ON DELETE CASCADE,
+	FOREIGN KEY (certificate_id) REFERENCES certificates (id) ON DELETE CASCADE,
+	UNIQUE (certificate_id),
+	PRIMARY KEY (cluster_link_id, certificate_id)
+) WITHOUT ROWID;
+`)
+
+	return err
 }
 
 func updateFromV86(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1423,7 +1423,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			// We can check this using the requestor identity ID, since cluster links always communicate using a named
 			// TLS identity. We need to ensure the identity is not nil - since it can be nil for admin protocols.
 			// (Admins are not allowed to create instances in this project while it is in standby either).
-			if requestor.IdentityID == nil || *requestor.IdentityID != clusterLink.IdentityID {
+			if requestor.IdentityID == nil || *requestor.IdentityID != *clusterLink.IdentityID {
 				return api.StatusErrorf(http.StatusForbidden, "Cannot create instances in a standby replica project")
 			}
 		}

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -9,6 +9,11 @@ import (
 const (
 	// ClusterLinkTypeBidirectional indicates that the cluster link can be used by both clusters.
 	ClusterLinkTypeBidirectional = "bidirectional"
+
+	// ClusterLinkTypeUnidirectional indicates a one-way trust relationship (the remote cluster trusts the cluster where the unidirectional link is defined).
+	//
+	// API extension: cluster_links_unidirectional.
+	ClusterLinkTypeUnidirectional = "unidirectional"
 )
 
 // Cluster represents high-level information about a LXD cluster.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -497,6 +497,7 @@ var APIExtensions = []string{
 	"network_load_balancer_pool",
 	"clustering_evacuation_force",
 	"gpu_mig_cdi",
+	"cluster_links_unidirectional",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -52,6 +52,7 @@ readonly test_group_cluster=(
     "clustering_link_auth"
     "clustering_link_info"
     "clustering_image_proxy_bypass"
+    "clustering_link_unidirectional"
 )
 
 readonly test_group_cluster_storage=(

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6795,6 +6795,106 @@ test_clustering_replicator_unclustered() {
   # Cleanup
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project
+
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+}
+
+test_clustering_link_unidirectional() {
+  # Cluster A = LXD_ONE + LXD_TWO, Cluster B = LXD_THREE + LXD_FOUR.
+
+  # Create first 2-node cluster (node1, node2).
+  spawn_lxd_and_bootstrap_cluster
+
+  local cert
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+  spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}"
+
+  # Create second 2-node cluster (node3, node4).
+  spawn_lxd_and_bootstrap_cluster "dir" "" 3
+
+  cert="$(cert_to_yaml "${LXD_THREE_DIR}/cluster.crt")"
+  spawn_lxd_and_join_cluster "${cert}" 4 3 "${LXD_THREE_DIR}"
+
+  sub_test "Check CLI validation for unidirectional flags"
+
+  # --unidirectional without --token must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional 2>&1)" = 'Error: --unidirectional requires --token' ]
+
+  # --auth-group cannot be used with unidirectional links.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional --token fake --auth-group mygroup 2>&1)" = 'Error: if any flags in the group [unidirectional auth-group] are set none of the others can be; [auth-group unidirectional] were all set' ]
+
+  sub_test "Check unidirectional link creation"
+
+  # Cluster B issues a pending identity token via auth identity create.
+  UNIDIRECTIONAL_TOKEN="$(LXD_DIR="${LXD_THREE_DIR}" lxc auth identity create cluster-link/lxd_one --quiet)"
+
+  # Cluster A consumes the token and creates a unidirectional link to Cluster B.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_three --token "${UNIDIRECTIONAL_TOKEN}" --unidirectional
+
+  # Cluster A should have the cluster link with no associated identity (unidirectional; A never authenticates to B).
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -wF 'lxd_three'
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link show lxd_three | grep -xF 'type: unidirectional'
+  if LXD_DIR="${LXD_ONE_DIR}" lxc auth identity list --format csv | grep -wF 'lxd_three'; then
+    echo "ERROR: identity 'lxd_three' unexpectedly found on Cluster A" >&2
+    exit 1
+  fi
+
+  # Cluster B should have an active identity for Cluster A but no cluster link record.
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth identity list --format csv | grep -vF '(pending)' | grep -wF 'Cluster link certificate'
+  if LXD_DIR="${LXD_THREE_DIR}" lxc cluster link list --format csv | grep -wF 'lxd_one'; then
+    echo "ERROR: cluster link 'lxd_one' unexpectedly found on Cluster B" >&2
+    exit 1
+  fi
+
+  sub_test "Check unidirectional link: volatile.addresses populated on Cluster A"
+
+  # Cluster A stores Cluster B's addresses in volatile.addresses so it can reach B.
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link get lxd_three volatile.addresses)" != "" ]
+
+  sub_test "Check unidirectional link: Cluster B has no cluster link record"
+
+  # Cluster B has no cluster link record for A; A's addresses are never persisted on B.
+  if LXD_DIR="${LXD_THREE_DIR}" lxc cluster link list --format csv | grep -wF 'lxd_one'; then
+    echo "ERROR: cluster link 'lxd_one' unexpectedly found on Cluster B" >&2
+    exit 1
+  fi
+
+  sub_test "Check unidirectional link deletion"
+
+  # Delete from Cluster A; only A's link row is removed. Cluster B retains its identity for A.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_three
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -wF 'lxd_three'; then
+    echo "ERROR: cluster link 'lxd_three' unexpectedly found on Cluster A after deletion" >&2
+    exit 1
+  fi
+
+  # Cluster B retains its identity after Cluster A's side is deleted.
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth identity list --format csv | grep -vF '(pending)' | grep -wF 'Cluster link certificate'
+
+  # Delete B's identity for A to fully revoke access; B has no cluster link row to delete.
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth identity delete cluster-link/lxd_one
+  if LXD_DIR="${LXD_THREE_DIR}" lxc auth identity list --format csv | grep -wF 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on Cluster B after deletion" >&2
+    exit 1
+  fi
+
+  # Cleanup.
+  LXD_DIR="${LXD_FOUR_DIR}" lxd shutdown
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_FOUR_DIR}/unix.socket"
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_FOUR_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_ONE_DIR}"
 }


### PR DESCRIPTION
## Summary

Adds unidirectional cluster link support. A unidirectional link lets one cluster (A) access another cluster's (B) resources without granting B reciprocal access. B creates an identity for A and can authenticate incoming requests, but stores no addresses for A and cannot initiate outbound requests to it.
 
API extension: `cluster_links_unidirectional`
 
## How it works

1. Cluster B creates a pending identity token for A.
2. Cluster A consumes the token, pins B's certificate, and activates the pending identity on B.
3. A has a link to B with no associated identity. B has an identity and link row for A.
 
 ## Example workflow
 
     # On Cluster B: create a pending identity for A
     lxc auth identity create cluster-link/cluster-a
 
     # On Cluster A: create the unidirectional link
     lxc cluster link create cluster-b --token <token> --unidirectional
 
     # Verify on A
     lxc cluster link list
     lxc cluster link info cluster-b
 
     # Cleanup
     lxc cluster link delete cluster-b    # On A
     lxc auth identity delete cluster-link/cluster-a    # On B