### PR TITLE
Backports (stable-5.21)

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -153,10 +153,10 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var certResponses []*api.Certificate
-	var baseCerts []dbCluster.Certificate
+	var certURLs []string
 	urlToCertificate := make(map[*api.URL]auth.EntitlementReporter)
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		baseCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
+		baseCerts, err := dbCluster.GetCertificates(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
@@ -175,6 +175,8 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 
 				certResponses = append(certResponses, apiCert)
 				urlToCertificate[entity.CertificateURL(apiCert.Fingerprint)] = apiCert
+			} else {
+				certURLs = append(certURLs, api.NewURL().Path(version.APIVersion, "certificates", baseCert.Fingerprint).String())
 			}
 		}
 
@@ -185,13 +187,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if !recursion {
-		body := []string{}
-		for _, baseCert := range baseCerts {
-			certificateURL := api.NewURL().Path(version.APIVersion, "certificates", baseCert.Fingerprint).String()
-			body = append(body, certificateURL)
-		}
-
-		return response.SyncResponse(true, body)
+		return response.SyncResponse(true, certURLs)
 	}
 
 	if len(withEntitlements) > 0 {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -152,23 +152,22 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if recursion {
-		var certResponses []*api.Certificate
-		var baseCerts []dbCluster.Certificate
-		urlToCertificate := make(map[*api.URL]auth.EntitlementReporter)
-		var err error
-		err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			baseCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
-			if err != nil {
-				return err
+	var certResponses []*api.Certificate
+	var baseCerts []dbCluster.Certificate
+	urlToCertificate := make(map[*api.URL]auth.EntitlementReporter)
+	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		baseCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		certResponses = make([]*api.Certificate, 0, len(baseCerts))
+		for _, baseCert := range baseCerts {
+			if !userHasPermission(entity.CertificateURL(baseCert.Fingerprint)) {
+				continue
 			}
 
-			certResponses = make([]*api.Certificate, 0, len(baseCerts))
-			for _, baseCert := range baseCerts {
-				if !userHasPermission(entity.CertificateURL(baseCert.Fingerprint)) {
-					continue
-				}
-
+			if recursion {
 				apiCert, err := baseCert.ToAPI(ctx, tx.Tx())
 				if err != nil {
 					return err
@@ -177,34 +176,32 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 				certResponses = append(certResponses, apiCert)
 				urlToCertificate[entity.CertificateURL(apiCert.Fingerprint)] = apiCert
 			}
+		}
 
-			return nil
-		})
+		return nil
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if !recursion {
+		body := []string{}
+		for _, baseCert := range baseCerts {
+			certificateURL := api.NewURL().Path(version.APIVersion, "certificates", baseCert.Fingerprint).String()
+			body = append(body, certificateURL)
+		}
+
+		return response.SyncResponse(true, body)
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, entity.TypeCertificate, withEntitlements, urlToCertificate)
 		if err != nil {
 			return response.SmartError(err)
 		}
-
-		if len(withEntitlements) > 0 {
-			err = reportEntitlements(r.Context(), s.Authorizer, entity.TypeCertificate, withEntitlements, urlToCertificate)
-			if err != nil {
-				return response.SmartError(err)
-			}
-		}
-
-		return response.SyncResponse(true, certResponses)
 	}
 
-	body := []string{}
-	for _, identity := range d.identityCache.GetByAuthenticationMethod(api.AuthenticationMethodTLS) {
-		if !userHasPermission(entity.CertificateURL(identity.Identifier)) {
-			continue
-		}
-
-		certificateURL := api.NewURL().Path(version.APIVersion, "certificates", identity.Identifier).String()
-		body = append(body, certificateURL)
-	}
-
-	return response.SyncResponse(true, body)
+	return response.SyncResponse(true, certResponses)
 }
 
 // clusterMemberJoinTokenValid searches for cluster join token that matches the join token provided.


### PR DESCRIPTION
Backports a regression and subsequent fix to ensure we don't miss it.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
