### PR TITLE
doc: append version number in RTD version switcher flyout menu

### DIFF
--- a/doc/_static/rtd-versions-flyout.js
+++ b/doc/_static/rtd-versions-flyout.js
@@ -1,0 +1,59 @@
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+    // This script customizes the RTD flyout to show a version label next to "default", based on an RTD environment variable.
+
+    // The RTD flyout addon renders <readthedocs-flyout> before firing this
+    // event, so the element is already in the DOM by the time this listener
+    // runs. We check immediately, and also watch for any late insertion.
+
+    // Read the version label injected at build time from the FLYOUT_DEFAULT_VERSION_LABEL env var.
+    // This var needs to be manually defined in the RTD project dashboard, to whatever should appear in parenthese next to "default" in the flyout, such as "v5.21".
+    const versionLabel = window.flyoutDefaultVersionLabel;
+    if (!versionLabel) return;
+
+    function patchFlyout(root) {
+        let patched = false;
+        // Patch the version links in the dropdown list.
+        root.querySelectorAll("a").forEach(link => {
+            if (link.textContent.trim() === "default") {
+                link.textContent = `default (${versionLabel})`;
+                patched = true;
+            }
+        });
+        // Patch the "default" label shown on the flyout toggle button.
+        const versionSpan = root.querySelector("span.version");
+        if (versionSpan) {
+            versionSpan.childNodes.forEach(node => {
+                if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === "default") {
+                    node.textContent = node.textContent.replace("default", `default (${versionLabel})`);
+                    patched = true;
+                }
+            });
+        }
+        return patched;
+    }
+
+    function watchAndPatch(root) {
+        if (patchFlyout(root)) return;
+        // Shadow DOM content may not be fully rendered yet; watch for it.
+        const observer = new MutationObserver(function () {
+            if (patchFlyout(root)) observer.disconnect();
+        });
+        observer.observe(root, { childList: true, subtree: true });
+    }
+
+    // Check immediately — the flyout is likely already in the DOM.
+    const flyout = document.querySelector("readthedocs-flyout");
+    if (flyout) {
+        watchAndPatch(flyout.shadowRoot || flyout);
+        return;
+    }
+
+    // Fallback: watch for the element to be inserted later.
+    const bodyObserver = new MutationObserver(function () {
+        const flyout = document.querySelector("readthedocs-flyout");
+        if (!flyout) return;
+        bodyObserver.disconnect();
+        watchAndPatch(flyout.shadowRoot || flyout);
+    });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
+});

--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -7,3 +7,10 @@
   <meta name="robots" content="noindex">
   {% endif %}
 {% endblock %}
+
+{% block theme_scripts %}
+{{ super() }}
+<script>
+  window.flyoutDefaultVersionLabel = "{{ flyout_default_version_label }}";
+</script>
+{% endblock theme_scripts %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -266,6 +266,7 @@ html_css_files = [
 # Adds custom JavaScript files, located under 'html_static_path' or from external link
 html_js_files = [
     'https://assets.ubuntu.com/v1/287a5e8f-bundle.js',
+    'rtd-versions-flyout.js',
 ]
 
 # Feedback button at the top; enabled by default
@@ -313,6 +314,10 @@ if os.path.exists('./substitutions.yaml'):
 if os.path.exists('./related_topics.yaml'):
     with open('./related_topics.yaml', 'r') as fd:
         myst_substitutions.update(yaml.safe_load(fd.read()))
+
+# Version label shown in the RTD flyout next to "default", in parentheses.
+# Set the FLYOUT_DEFAULT_VERSION_LABEL environment variable in the RTD project dashboard.
+html_context['flyout_default_version_label'] = os.environ.get('FLYOUT_DEFAULT_VERSION_LABEL', '')
 
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {


### PR DESCRIPTION
This adds a version label next to the `default` version in the RTD version switcher flyout. The same implementation is used in MicroCloud (https://github.com/canonical/microcloud/pull/1336) and its use is documented internally [here](https://docs.google.com/document/d/1Hal4pdoj03cNyyjDKMu9DFWqWFKWO5581vLan9WYo3A/edit?tab=t.0#heading=h.4hy9bznyoue2). 

It will look like this:
<img width="339" height="160" alt="image" src="https://github.com/user-attachments/assets/47175fd0-cad4-4356-aa38-9fb3127770d4" />


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
