### PR TITLE
Image registries client-side changes

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -190,6 +190,16 @@ type InstanceServer interface {
 	GetImagesAllProjects() (images []api.Image, err error)
 	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
+	// Image registry functions ("image_registries" API extension)
+	GetImageRegistry(name string) (imageRegistry *api.ImageRegistry, ETag string, err error)
+	GetImageRegistryNames() (names []string, err error)
+	GetImageRegistryImages(name string) (images []api.Image, err error)
+	GetImageRegistries() (imageRegistries []api.ImageRegistry, err error)
+	CreateImageRegistry(imageRegistry api.ImageRegistriesPost) (op Operation, err error)
+	UpdateImageRegistry(name string, imageRegistry api.ImageRegistryPut, ETag string) (op Operation, err error)
+	RenameImageRegistry(name string, imageRegistry api.ImageRegistryPost) (op Operation, err error)
+	DeleteImageRegistry(name string) (op Operation, err error)
+
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)
 	GetNetworks() (networks []api.Network, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -642,6 +642,11 @@ type ImageCopyArgs struct {
 
 	// List of profiles to apply on the target.
 	Profiles []string
+
+	// Source image registry to use.
+	//
+	// API extension: image_registries
+	ImageRegistry string
 }
 
 // The StoragePoolVolumeCopyArgs struct is used to pass additional options

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -500,9 +500,21 @@ func (r *ProtocolLXD) getUnderlyingHTTPTransport() (*http.Transport, error) {
 // getSourceImageConnectionInfo returns the connection information for the source image.
 // The returned `info` is nil if the source image is local. In this process, the `instSrc`
 // is also updated with the minimal source fields.
+//
+// If the source image server is not provided, this function simply sets the necessary fields
+// for the `instSrc` for server-side resolution.
 func (r *ProtocolLXD) getSourceImageConnectionInfo(source ImageServer, image api.Image, instSrc *api.InstanceSource) (info *ConnectionInfo, err error) {
 	// Set the minimal source fields
 	instSrc.Type = api.SourceTypeImage
+
+	// If source image server is not provided this means the target server supports image registries.
+	// In this case, we expect a server-side resolution for the image.
+	if source == nil {
+		// Set the fingerprint from the image info.
+		instSrc.Fingerprint = image.Fingerprint
+		instSrc.Alias = ""
+		return nil, nil
+	}
 
 	sameServer, err := r.isSameServer(source)
 	if err != nil {

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -548,8 +548,8 @@ func (r *ProtocolLXD) getSourceImageConnectionInfo(source ImageServer, image api
 		return nil, err
 	}
 
-	instSrc.Protocol = info.Protocol
-	instSrc.Certificate = info.Certificate
+	instSrc.Protocol = info.Protocol       //nolint:staticcheck
+	instSrc.Certificate = info.Certificate //nolint:staticcheck
 	instSrc.Project = info.Project
 
 	// Generate secret token if needed

--- a/client/lxd_image_registries.go
+++ b/client/lxd_image_registries.go
@@ -1,0 +1,133 @@
+package lxd
+
+import (
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// GetImageRegistries returns all image registries.
+func (r *ProtocolLXD) GetImageRegistries() ([]api.ImageRegistry, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	imageRegistries := []api.ImageRegistry{}
+	_, err = r.queryStruct(http.MethodGet, api.NewURL().Path("image-registries").WithQuery("recursion", "1").String(), nil, "", &imageRegistries)
+	if err != nil {
+		return nil, err
+	}
+
+	return imageRegistries, nil
+}
+
+// GetImageRegistryNames returns a list of image registry names.
+func (r *ProtocolLXD) GetImageRegistryNames() ([]string, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	urls := []string{}
+	baseURL := api.NewURL().Path("image-registries").String()
+	_, err = r.queryStruct(http.MethodGet, baseURL, nil, "", &urls)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse URLs to extract the names.
+	return urlsToResourceNames(baseURL, urls...)
+}
+
+// GetImageRegistry returns information about an image registry.
+func (r *ProtocolLXD) GetImageRegistry(name string) (*api.ImageRegistry, string, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, "", err
+	}
+
+	imageRegistry := &api.ImageRegistry{}
+	etag, err := r.queryStruct(http.MethodGet, api.NewURL().Path("image-registries", name).String(), nil, "", &imageRegistry)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return imageRegistry, etag, nil
+}
+
+// GetImageRegistryImages returns a list of available images provided by the image registry.
+func (r *ProtocolLXD) GetImageRegistryImages(name string) ([]api.Image, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	images := []api.Image{}
+	_, err = r.queryStruct(http.MethodGet, api.NewURL().Path("image-registries", name, "images").String(), nil, "", &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// CreateImageRegistry defines a new image registry using the provided struct.
+func (r *ProtocolLXD) CreateImageRegistry(imageRegistry api.ImageRegistriesPost) (Operation, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	op, _, err := r.queryOperation(http.MethodPost, api.NewURL().Path("image-registries").String(), imageRegistry, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+// UpdateImageRegistry updates an existing image registry to match the provided struct.
+func (r *ProtocolLXD) UpdateImageRegistry(name string, imageRegistry api.ImageRegistryPut, ETag string) (Operation, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	op, _, err := r.queryOperation(http.MethodPut, api.NewURL().Path("image-registries", name).String(), imageRegistry, ETag, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+// RenameImageRegistry renames an existing image registry.
+func (r *ProtocolLXD) RenameImageRegistry(name string, imageRegistry api.ImageRegistryPost) (Operation, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	op, _, err := r.queryOperation(http.MethodPost, api.NewURL().Path("image-registries", name).String(), imageRegistry, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+// DeleteImageRegistry deletes an existing image registry.
+func (r *ProtocolLXD) DeleteImageRegistry(name string) (Operation, error) {
+	err := r.CheckExtension("image_registries")
+	if err != nil {
+		return nil, err
+	}
+
+	op, _, err := r.queryOperation(http.MethodDelete, api.NewURL().Path("image-registries", name).String(), nil, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -753,182 +753,185 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 		image.Profiles = nil
 	}
 
-	// Get source server connection information
-	info, err := source.GetConnectionInfo()
-	if err != nil {
-		return nil, err
-	}
+	var info *ConnectionInfo
 
-	// Push mode
-	if args != nil && args.Mode == "push" {
-		// Get certificate and URL
-		info, err := r.GetConnectionInfo()
+	// If a source server is provided, fetch its connection info and do push/relay modes
+	if source != nil {
+		// Get source server connection information
+		var err error
+		info, err = source.GetConnectionInfo()
 		if err != nil {
 			return nil, err
 		}
 
-		imagesPost := api.ImagesPost{
-			Source: &api.ImagesPostSource{
-				Fingerprint: image.Fingerprint,
-				Mode:        args.Mode,
-			},
-		}
-
-		if args.CopyAliases {
-			imagesPost.Aliases = image.Aliases
-		}
-
-		imagesPost.ExpiresAt = image.ExpiresAt
-		imagesPost.Properties = image.Properties
-		imagesPost.Public = args.Public
-
-		// Receive token from target server. This token is later passed to the source which will use
-		// it, together with the URL and certificate, to connect to the target.
-		tokenOp, err := r.CreateImage(imagesPost, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		opAPI := tokenOp.Get()
-
-		secret, ok := opAPI.Metadata["secret"]
-		if !ok {
-			return nil, errors.New("No token provided")
-		}
-
-		req := api.ImageExportPost{
-			Target:      info.URL,
-			Certificate: info.Certificate,
-			Secret:      secret.(string),
-			Aliases:     image.Aliases,
-			Project:     info.Project,
-			Profiles:    image.Profiles,
-		}
-
-		exportOp, err := source.ExportImage(image.Fingerprint, req)
-		if err != nil {
-			_ = tokenOp.Cancel()
-			return nil, err
-		}
-
-		rop := remoteOperation{
-			targetOp: exportOp,
-			chDone:   make(chan bool),
-		}
-
-		// Forward targetOp to remote op
-		go func() {
-			rop.err = rop.targetOp.Wait()
-			_ = tokenOp.Cancel()
-			close(rop.chDone)
-		}()
-
-		return &rop, nil
-	}
-
-	// Relay mode
-	if args != nil && args.Mode == "relay" {
-		metaFile, err := os.CreateTemp("", "lxc_image_")
-		if err != nil {
-			return nil, err
-		}
-
-		defer func() { _ = os.Remove(metaFile.Name()) }()
-
-		rootfsFile, err := os.CreateTemp("", "lxc_image_")
-		if err != nil {
-			return nil, err
-		}
-
-		defer func() { _ = os.Remove(rootfsFile.Name()) }()
-
-		// Import image
-		req := ImageFileRequest{
-			MetaFile:   metaFile,
-			RootfsFile: rootfsFile,
-		}
-
-		resp, err := source.GetImageFile(image.Fingerprint, req)
-		if err != nil {
-			return nil, err
-		}
-
-		// Export image
-		_, err = metaFile.Seek(0, io.SeekStart)
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = rootfsFile.Seek(0, io.SeekStart)
-		if err != nil {
-			return nil, err
-		}
-
-		imagePost := api.ImagesPost{}
-		imagePost.Public = args.Public
-		imagePost.Profiles = image.Profiles
-
-		if args.CopyAliases {
-			imagePost.Aliases = image.Aliases
-			if args.Aliases != nil {
-				imagePost.Aliases = append(imagePost.Aliases, args.Aliases...)
-			}
-		}
-
-		createArgs := &ImageCreateArgs{
-			MetaFile: metaFile,
-			MetaName: image.Filename,
-			Type:     image.Type,
-		}
-
-		if resp.RootfsName != "" {
-			// Deal with split images
-			createArgs.RootfsFile = rootfsFile
-			createArgs.RootfsName = image.Filename
-		}
-
-		rop := remoteOperation{
-			chDone: make(chan bool),
-		}
-
-		go func() {
-			defer close(rop.chDone)
-
-			op, err := r.CreateImage(imagePost, createArgs)
+		// Push mode
+		if args != nil && args.Mode == "push" {
+			// Get certificate and URL
+			targetInfo, err := r.GetConnectionInfo()
 			if err != nil {
-				rop.err = remoteOperationError("Failed copying image", nil)
-				return
+				return nil, err
 			}
 
-			rop.handlerLock.Lock()
-			rop.targetOp = op
-			rop.handlerLock.Unlock()
-
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			imagesPost := api.ImagesPost{
+				Source: &api.ImagesPostSource{
+					Fingerprint: image.Fingerprint,
+					Mode:        args.Mode,
+				},
 			}
 
-			err = rop.targetOp.Wait()
+			if args.CopyAliases {
+				imagesPost.Aliases = image.Aliases
+			}
+
+			imagesPost.ExpiresAt = image.ExpiresAt
+			imagesPost.Properties = image.Properties
+			imagesPost.Public = args.Public
+
+			// Receive token from target server. This token is later passed to the source which will use
+			// it, together with the URL and certificate, to connect to the target.
+			tokenOp, err := r.CreateImage(imagesPost, nil)
 			if err != nil {
-				rop.err = remoteOperationError("Failed copying image", nil)
-				return
+				return nil, err
 			}
-		}()
 
-		return &rop, nil
+			opAPI := tokenOp.Get()
+
+			secret, ok := opAPI.Metadata["secret"]
+			if !ok {
+				return nil, errors.New("No token provided")
+			}
+
+			req := api.ImageExportPost{
+				Target:      targetInfo.URL,
+				Certificate: targetInfo.Certificate,
+				Secret:      secret.(string),
+				Aliases:     image.Aliases,
+				Project:     targetInfo.Project,
+				Profiles:    image.Profiles,
+			}
+
+			exportOp, err := source.ExportImage(image.Fingerprint, req)
+			if err != nil {
+				_ = tokenOp.Cancel()
+				return nil, err
+			}
+
+			rop := remoteOperation{
+				targetOp: exportOp,
+				chDone:   make(chan bool),
+			}
+
+			// Forward targetOp to remote op
+			go func() {
+				rop.err = rop.targetOp.Wait()
+				_ = tokenOp.Cancel()
+				close(rop.chDone)
+			}()
+
+			return &rop, nil
+		}
+
+		// Relay mode
+		if args != nil && args.Mode == "relay" {
+			metaFile, err := os.CreateTemp("", "lxc_image_")
+			if err != nil {
+				return nil, err
+			}
+
+			defer func() { _ = os.Remove(metaFile.Name()) }()
+
+			rootfsFile, err := os.CreateTemp("", "lxc_image_")
+			if err != nil {
+				return nil, err
+			}
+
+			defer func() { _ = os.Remove(rootfsFile.Name()) }()
+
+			// Import image
+			req := ImageFileRequest{
+				MetaFile:   metaFile,
+				RootfsFile: rootfsFile,
+			}
+
+			resp, err := source.GetImageFile(image.Fingerprint, req)
+			if err != nil {
+				return nil, err
+			}
+
+			// Export image
+			_, err = metaFile.Seek(0, io.SeekStart)
+			if err != nil {
+				return nil, err
+			}
+
+			_, err = rootfsFile.Seek(0, io.SeekStart)
+			if err != nil {
+				return nil, err
+			}
+
+			imagePost := api.ImagesPost{}
+			imagePost.Public = args.Public
+			imagePost.Profiles = image.Profiles
+
+			if args.CopyAliases {
+				imagePost.Aliases = image.Aliases
+				if args.Aliases != nil {
+					imagePost.Aliases = append(imagePost.Aliases, args.Aliases...)
+				}
+			}
+
+			createArgs := &ImageCreateArgs{
+				MetaFile: metaFile,
+				MetaName: image.Filename,
+				Type:     image.Type,
+			}
+
+			if resp.RootfsName != "" {
+				// Deal with split images
+				createArgs.RootfsFile = rootfsFile
+				createArgs.RootfsName = image.Filename
+			}
+
+			rop := remoteOperation{
+				chDone: make(chan bool),
+			}
+
+			go func() {
+				defer close(rop.chDone)
+
+				op, err := r.CreateImage(imagePost, createArgs)
+				if err != nil {
+					rop.err = remoteOperationError("Failed copying image", nil)
+					return
+				}
+
+				rop.handlerLock.Lock()
+				rop.targetOp = op
+				rop.handlerLock.Unlock()
+
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
+
+				err = rop.targetOp.Wait()
+				if err != nil {
+					rop.err = remoteOperationError("Failed copying image", nil)
+					return
+				}
+			}()
+
+			return &rop, nil
+		}
+	} else if args == nil {
+		return nil, errors.New("Missing copy arguments")
 	}
 
 	// Prepare the copy request
 	req := api.ImagesPost{
 		Source: &api.ImagesPostSource{
-			ImageSource: api.ImageSource{
-				Certificate: info.Certificate,
-				Protocol:    info.Protocol,
-			},
 			Fingerprint: image.Fingerprint,
 			Mode:        "pull",
 			Type:        api.SourceTypeImage,
-			Project:     info.Project,
 		},
 		ImagePut: api.ImagePut{
 			Profiles:   image.Profiles,
@@ -937,12 +940,33 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 		Filename: image.Filename,
 	}
 
+	if source != nil {
+		req.Source.Certificate = info.Certificate //nolint:staticcheck
+		req.Source.Protocol = info.Protocol       //nolint:staticcheck
+		req.Source.Project = info.Project
+	} else if args != nil {
+		// If no source server is provided, we use server-side image resolution.
+		// This can either be through a remote image registry or from the target
+		// server's own local image store (e.g., when copying between projects).
+
+		// Enforce the pull mode for image download.
+		if args.ImageRegistry != "" && args.Mode != "pull" {
+			return nil, errors.New("Only pull mode is supported for image registries")
+		}
+
+		req.Source.ImageRegistry = args.ImageRegistry
+		req.Source.Project = image.Project
+		req.Source.CopyAliases = args.CopyAliases
+	} else {
+		return nil, errors.New("Missing copy arguments")
+	}
+
 	if args != nil {
 		req.Source.ImageType = args.Type
 	}
 
 	// Generate secret token if needed
-	if !image.Public {
+	if !image.Public && source != nil {
 		secret, err := source.GetImageSecret(image.Fingerprint)
 		if err != nil {
 			return nil, err
@@ -965,7 +989,12 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 		}
 	}
 
-	return r.tryCopyImage(req, info.Addresses)
+	var urls []string
+	if source != nil {
+		urls = info.Addresses
+	}
+
+	return r.tryCopyImage(req, urls)
 }
 
 // UpdateImage updates the image definition.

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -586,7 +586,19 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 // tryCopyImage iterates through the source server URLs until one lets it download the image.
 func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOperation, error) {
 	if len(urls) == 0 {
-		return nil, errors.New("The source server is not listening on the network")
+		// On legacy copy paths the source protocol is always set from the source server's connection
+		// info. If the protocol is present but no network addresses were found, the source
+		// server cannot be reached over the network, so we must abort early.
+		if req.Source.Protocol != "" { //nolint:staticcheck
+			return nil, errors.New("The source server is not listening on the network")
+		}
+
+		// When no legacy protocol is set we expect a server-side resolution path (either a remote
+		// image registry or a local image in another project). If neither is specified, there is
+		// nothing for the target server to resolve.
+		if req.Source.ImageRegistry == "" && req.Source.Project == "" {
+			return nil, errors.New("Missing image registry or source project for server-side image resolution")
+		}
 	}
 
 	rop := remoteOperation{
@@ -643,36 +655,61 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 	go func() {
 		success := false
 		var errors []remoteOperationResult
-		for _, serverURL := range urls {
-			req.Source.Server = serverURL
 
+		if len(urls) == 0 {
+			// When no source URLs are provided, we rely on the target server to resolve and fetch
+			// the image (either from a remote image registry or from its own local image store).
 			op, err := r.CreateImage(req, nil)
 			if err != nil {
-				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+				errors = append(errors, remoteOperationResult{Error: err})
+			} else {
+				rop.handlerLock.Lock()
+				rop.targetOp = op
+				rop.handlerLock.Unlock()
+
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
+
+				err = rop.targetOp.Wait()
+				if err != nil {
+					errors = append(errors, remoteOperationResult{Error: err})
+				} else {
+					success = true
+				}
 			}
+		} else {
+			for _, serverURL := range urls {
+				req.Source.Server = serverURL //nolint:staticcheck
 
-			rop.handlerLock.Lock()
-			rop.targetOp = op
-			rop.handlerLock.Unlock()
-
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
-			}
-
-			err = rop.targetOp.Wait()
-			if err != nil {
-				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-
-				if shared.IsConnectionError(err) {
+				op, err := r.CreateImage(req, nil)
+				if err != nil {
+					errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 					continue
 				}
 
+				rop.handlerLock.Lock()
+				rop.targetOp = op
+				rop.handlerLock.Unlock()
+
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
+
+				err = rop.targetOp.Wait()
+				if err != nil {
+					errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
+
+					if shared.IsConnectionError(err) {
+						continue
+					}
+
+					break
+				}
+
+				success = true
 				break
 			}
-
-			success = true
-			break
 		}
 
 		if !success {

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -190,7 +190,7 @@ func (r *ProtocolLXD) tryRebuildInstance(instanceName string, req api.InstanceRe
 		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			if operation == "" {
-				req.Source.Server = serverURL
+				req.Source.Server = serverURL //nolint:staticcheck
 			} else {
 				req.Source.Operation = serverURL + "/1.0/operations/" + url.PathEscape(operation)
 			}
@@ -616,7 +616,7 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			if operation == "" {
-				req.Source.Server = serverURL
+				req.Source.Server = serverURL //nolint:staticcheck
 			} else {
 				req.Source.Operation = serverURL + "/1.0/operations/" + url.PathEscape(operation)
 			}
@@ -922,7 +922,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets
-	req.Source.Certificate = info.Certificate
+	req.Source.Certificate = info.Certificate //nolint:staticcheck
 
 	return r.tryCreateInstance(req, info.Addresses, op)
 }
@@ -2050,7 +2050,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets
-	req.Source.Certificate = info.Certificate
+	req.Source.Certificate = info.Certificate //nolint:staticcheck
 
 	return r.tryCreateInstance(req, info.Addresses, op)
 }

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1738,6 +1738,109 @@ definitions:
                 x-go-name: Public
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    ImageRegistriesPost:
+        properties:
+            config:
+                additionalProperties:
+                    type: string
+                description: Image registry configuration map
+                example:
+                    user.*: ""
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the image registry
+                example: My new image registry
+                type: string
+                x-go-name: Description
+            name:
+                description: Registry name
+                example: ubuntu
+                type: string
+                x-go-name: Name
+            protocol:
+                description: Protocol used by the image registry ("SimpleStreams" or "LXD")
+                example: simplestreams
+                type: string
+                x-go-name: Protocol
+        title: ImageRegistriesPost represents the fields of a new image registry.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    ImageRegistry:
+        properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
+            builtin:
+                description: Whether the image registry is built-in
+                example: false
+                type: boolean
+                x-go-name: Builtin
+            config:
+                additionalProperties:
+                    type: string
+                description: Image registry configuration map
+                example:
+                    user.*: ""
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the image registry
+                example: My new image registry
+                type: string
+                x-go-name: Description
+            name:
+                description: Registry name
+                example: ubuntu
+                type: string
+                x-go-name: Name
+            protocol:
+                description: Protocol used by the image registry ("SimpleStreams" or "LXD")
+                example: simplestreams
+                type: string
+                x-go-name: Protocol
+            public:
+                description: Whether the image registry is public
+                example: true
+                type: boolean
+                x-go-name: Public
+        title: ImageRegistry is used to display an image registry.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    ImageRegistryPost:
+        properties:
+            name:
+                description: New name for the image registry
+                example: bar
+                type: string
+                x-go-name: Name
+        title: ImageRegistryPost represents the fields required to rename the image registry.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    ImageRegistryPut:
+        properties:
+            config:
+                additionalProperties:
+                    type: string
+                description: Image registry configuration map
+                example:
+                    user.*: ""
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the image registry
+                example: My new image registry
+                type: string
+                x-go-name: Description
+        title: ImageRegistryPut represents the modifiable fields of an image registry.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     ImageSource:
         description: ImageSource represents the source of a LXD image
         properties:
@@ -1751,6 +1854,14 @@ definitions:
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
+            image_registry:
+                description: |-
+                    Image registry name
+
+                    API extension: image_registries
+                example: ubuntu
+                type: string
+                x-go-name: ImageRegistry
             image_type:
                 description: |-
                     Type of image (container or virtual-machine)
@@ -1856,11 +1967,27 @@ definitions:
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
+            copy_aliases:
+                description: |-
+                    Whether to copy aliases from the source image
+
+                    API extension: image_registries
+                example: true
+                type: boolean
+                x-go-name: CopyAliases
             fingerprint:
                 description: Source image fingerprint (for type "image")
                 example: 8ae945c52bb2f2df51c923b04022312f99bbb72c356251f54fa89ea7cf1df1d0
                 type: string
                 x-go-name: Fingerprint
+            image_registry:
+                description: |-
+                    Image registry name
+
+                    API extension: image_registries
+                example: ubuntu
+                type: string
+                x-go-name: ImageRegistry
             image_type:
                 description: |-
                     Type of image (container or virtual-machine)
@@ -2997,6 +3124,14 @@ definitions:
                 example: ed56997f7c5b48e8d78986d2467a26109be6fb9f2d92e8c7b08eb8b6cec7629a
                 type: string
                 x-go-name: Fingerprint
+            image_registry:
+                description: |-
+                    Image registry name
+
+                    API extension: image_registries
+                example: ubuntu
+                type: string
+                x-go-name: ImageRegistry
             instance_only:
                 description: Whether the copy should skip the snapshots (for copy)
                 example: false

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -49,6 +49,16 @@ func (c *Config) ParseRemote(raw string) (remoteName string, resourceName string
 	return remote, object, nil
 }
 
+// ParseRemoteUnchecked splits remote and object but does not verify if the remote exists.
+func (c *Config) ParseRemoteUnchecked(raw string) (remoteName string, resourceName string) {
+	remote, object, found := strings.Cut(raw, ":")
+	if !found {
+		return "", raw
+	}
+
+	return remote, object
+}
+
 // GetInstanceServer returns a lxd.InstanceServer for the remote with the given name.
 func (c *Config) GetInstanceServer(name string) (lxd.InstanceServer, error) {
 	return c.GetInstanceServerWithConnectionArgs(name, nil)

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -31,9 +31,9 @@ type Remote struct {
 
 // ParseRemote splits remote and object.
 func (c *Config) ParseRemote(raw string) (remoteName string, resourceName string, err error) {
-	remote, object, found := strings.Cut(raw, ":")
-	if !found {
-		return c.DefaultRemote, raw, nil
+	remote, object := c.ParseRemoteUnchecked(raw)
+	if remote == "" {
+		remote = c.DefaultRemote
 	}
 
 	_, ok := c.Remotes[remote]

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -147,13 +147,16 @@ type cmdImageCopy struct {
 
 func (c *cmdImageCopy) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("copy", "[<remote>:]<image> <remote>:")
+	cmd.Use = usage("copy", "[<registry|remote>:]<image> <remote>:")
 	cmd.Aliases = []string{"cp"}
 	cmd.Short = "Copy image between servers"
 	cmd.Long = cli.FormatSection("Description", cmd.Short+`
 
 The auto-update flag instructs the server to keep this image up to date.
-It requires the source to be an alias and for it to be public.`)
+It requires the source to be an alias and for it to be public.
+
+If the destination LXD remote supports image registries, the source image
+must be from an image registry or available locally on the destination remote.`)
 
 	cmd.Flags().BoolVar(&c.flagPublic, "public", false, "Make image public")
 	cmd.Flags().BoolVar(&c.flagCopyAliases, "copy-aliases", false, "Copy aliases from source")
@@ -191,17 +194,6 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 		return errors.New("Auto update is only available in pull mode")
 	}
 
-	// Parse source remote
-	remoteName, name, err := c.global.conf.ParseRemote(args[0])
-	if err != nil {
-		return err
-	}
-
-	sourceServer, err := c.global.conf.GetImageServer(remoteName)
-	if err != nil {
-		return err
-	}
-
 	// Parse destination remote
 	resources, err := c.global.ParseServers(args[1])
 	if err != nil {
@@ -209,6 +201,40 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	}
 
 	destinationServer := resources[0].server
+	destRemote := resources[0].remote
+
+	var sourceServer lxd.ImageServer
+	var imgInfo *api.Image
+	var registryName string
+	var image string
+
+	if destinationServer.HasExtension("image_registries") {
+		// Parse source remote without validating its existence in the local config.
+		// The remote name may refer to an image registry that only the server knows about.
+		var remoteName string
+		remoteName, image = c.global.conf.ParseRemoteUnchecked(args[0])
+
+		// If the destination server supports image registries, we can use server-side image
+		// resolution and download (pull mode).
+		if c.flagMode != "pull" {
+			return errors.New("Only pull mode is supported for image registries")
+		}
+
+		imgInfo, registryName = resolveRegistryImageSource(c.global.conf.Remotes, remoteName, image, destRemote, c.global.conf.ProjectOverride)
+		sourceServer = nil
+	} else {
+		// Legacy remote lookup with validation.
+		var remoteName string
+		remoteName, image, err = c.global.conf.ParseRemote(args[0])
+		if err != nil {
+			return err
+		}
+
+		sourceServer, err = c.global.conf.GetImageServer(remoteName)
+		if err != nil {
+			return err
+		}
+	}
 
 	if resources[0].name != "" {
 		return errors.New("Cannot provide a name for the target image")
@@ -225,29 +251,41 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Copy the image
-	var imgInfo *api.Image
 	var fp string
 
-	// Resolve any alias and then grab the image information from the source
-	imgInfo, _, err = c.image.dereferenceAlias(sourceServer, imageType, name)
-	if err != nil {
-		return err
+	if sourceServer != nil {
+		// Resolve any alias and then grab the image information from the source
+		imgInfo, _, err = c.image.dereferenceAlias(sourceServer, imageType, image)
+		if err != nil {
+			return err
+		}
+	} else if imgInfo != nil {
+		imgInfo.Type = imageType
 	}
 
 	// Store the fingerprint for use when creating aliases later (as imgInfo.Fingerprint may be overridden)
 	fp = imgInfo.Fingerprint
 
-	if imgInfo.Public && imgInfo.Fingerprint != name && !strings.HasPrefix(imgInfo.Fingerprint, name) {
+	if imgInfo.Public && imgInfo.Fingerprint != image && !strings.HasPrefix(imgInfo.Fingerprint, image) {
 		// If dealing with an alias, set the imgInfo fingerprint to match the provided alias (needed for auto-update)
-		imgInfo.Fingerprint = name
+		imgInfo.Fingerprint = image
 	}
 
 	copyArgs := lxd.ImageCopyArgs{
-		AutoUpdate: c.flagAutoUpdate,
-		Public:     c.flagPublic,
-		Type:       imageType,
-		Mode:       c.flagMode,
-		Profiles:   c.flagProfile,
+		AutoUpdate:  c.flagAutoUpdate,
+		CopyAliases: c.flagCopyAliases,
+		Public:      c.flagPublic,
+		Type:        imageType,
+		Mode:        c.flagMode,
+		Profiles:    c.flagProfile,
+	}
+
+	for _, entry := range c.flagAliases {
+		copyArgs.Aliases = append(copyArgs.Aliases, api.ImageAlias{Name: entry})
+	}
+
+	if registryName != "" {
+		copyArgs.ImageRegistry = registryName
 	}
 
 	// Do the copy
@@ -276,6 +314,11 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	}
 
 	progress.Done("Image copied successfully!")
+
+	// If using an image registry, the aliases are handled server-side.
+	if sourceServer == nil {
+		return nil
+	}
 
 	// Ensure aliases
 	aliases := make([]api.ImageAlias, len(c.flagAliases))

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1064,8 +1064,8 @@ func (c *cmdImageInfo) run(cmd *cobra.Command, args []string) error {
 
 	if info.UpdateSource != nil {
 		fmt.Println("Source:")
-		fmt.Printf("    Server: %s\n", info.UpdateSource.Server)
-		fmt.Printf("    Protocol: %s\n", info.UpdateSource.Protocol)
+		fmt.Printf("    Server: %s\n", info.UpdateSource.Server)     //nolint:staticcheck
+		fmt.Printf("    Protocol: %s\n", info.UpdateSource.Protocol) //nolint:staticcheck
 		fmt.Printf("    Alias: %s\n", info.UpdateSource.Alias)
 	}
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1064,8 +1064,14 @@ func (c *cmdImageInfo) run(cmd *cobra.Command, args []string) error {
 
 	if info.UpdateSource != nil {
 		fmt.Println("Source:")
-		fmt.Printf("    Server: %s\n", info.UpdateSource.Server)     //nolint:staticcheck
-		fmt.Printf("    Protocol: %s\n", info.UpdateSource.Protocol) //nolint:staticcheck
+
+		if info.UpdateSource.ImageRegistry != "" {
+			fmt.Printf("    Image registry: %s\n", info.UpdateSource.ImageRegistry)
+		} else {
+			fmt.Printf("    Server: %s\n", info.UpdateSource.Server)     //nolint:staticcheck
+			fmt.Printf("    Protocol: %s\n", info.UpdateSource.Protocol) //nolint:staticcheck
+		}
+
 		fmt.Printf("    Alias: %s\n", info.UpdateSource.Alias)
 	}
 

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -352,7 +352,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 		}
 
 		// Fetch image info from the given remote.
-		imgRemote, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
+		imgRemoteServer, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
 		if err != nil {
 			return nil, "", err
 		}
@@ -366,7 +366,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 		}
 
 		// Create the instance.
-		op, err := d.CreateInstanceFromImage(imgRemote, *imgInfo, req)
+		op, err := d.CreateInstanceFromImage(imgRemoteServer, *imgInfo, req)
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -37,9 +37,12 @@ type cmdInit struct {
 
 func (c *cmdInit) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("init", "[<remote>:]<image> [<remote>:][<name>]")
+	cmd.Use = usage("init", "[<registry|remote>:]<image> [<remote>:][<name>]")
 	cmd.Short = "Create instances from images"
-	cmd.Long = cli.FormatSection("Description", cmd.Short)
+	cmd.Long = cli.FormatSection("Description", cmd.Short+`
+
+If the destination LXD remote supports image registries, the source image
+must be from an image registry or available locally on the destination remote.`)
 	cmd.Example = cli.FormatSection("", `lxc init ubuntu:24.04 u1
     Create a container (but do not start it)
 
@@ -132,10 +135,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 	}
 
 	if len(args) > 0 {
-		iremote, image, err = conf.ParseRemote(args[0])
-		if err != nil {
-			return nil, "", err
-		}
+		iremote, image = conf.ParseRemoteUnchecked(args[0])
 
 		if len(args) == 1 {
 			remote, name, err = conf.ParseRemote("")
@@ -161,9 +161,11 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 				return nil, "", err
 			}
 		} else if len(args) == 1 {
-			// Switch image / instance names.
-			name = image
-			remote = iremote
+			remote, name, err = conf.ParseRemote(args[0])
+			if err != nil {
+				return nil, "", err
+			}
+
 			image = ""
 			iremote = ""
 		}
@@ -268,7 +270,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 	}
 
 	// Decide whether we are creating a container or a virtual machine.
-	instanceDBType := api.InstanceTypeContainer
+	var instanceDBType api.InstanceType
 	if c.flagVM {
 		instanceDBType = api.InstanceTypeVM
 	}
@@ -351,13 +353,42 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 			image = "default"
 		}
 
-		// Fetch image info from the given remote.
-		imgRemoteServer, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
-		if err != nil {
-			return nil, "", err
+		var imgRemoteServer lxd.ImageServer
+		var imgInfo *api.Image
+		var legacyRemote string
+		var err error
+
+		// If the server supports image registries, we can use server-side image resolution and download.
+		// This avoids resolving the image on the client side, and passes the registry name or source project
+		// to the server so it can handle the resolution directly.
+		if d.HasExtension("image_registries") {
+			var registryName string
+			imgInfo, registryName = resolveRegistryImageSource(conf.Remotes, iremote, image, remote, c.global.flagProject)
+
+			// Set the image registry name on the instance source, so that LXD server handles the download.
+			req.Source.ImageRegistry = registryName
+		} else {
+			// Fetch image info from the given remote (legacy client-side resolution path).
+			// Normalize empty remote to the default remote, since ParseRemoteUnchecked
+			// does not fill in the default.
+			legacyRemote = iremote
+			if legacyRemote == "" {
+				legacyRemote = conf.DefaultRemote
+			}
+
+			imgRemoteServer, imgInfo, err = getImgInfo(conf, legacyRemote, image, c.global.flagProject, &req.Source)
+			if err != nil {
+				return nil, "", err
+			}
 		}
 
-		if conf.Remotes[iremote].Protocol != "simplestreams" {
+		// Update the source project if it was determined by getImgInfo.
+		if imgRemoteServer == nil && imgInfo.Project != "" {
+			req.Source.Project = imgInfo.Project
+		}
+
+		// Only perform legacy type and protocol checks if we are NOT using an image registry.
+		if imgRemoteServer != nil && conf.Remotes[legacyRemote].Protocol != api.ImageRegistryProtocolSimpleStreams {
 			if imgInfo.Type != "virtual-machine" && c.flagVM {
 				return nil, "", errors.New("Asked for a VM but image is of type container")
 			}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -365,8 +366,31 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 			var registryName string
 			imgInfo, registryName = resolveRegistryImageSource(conf.Remotes, iremote, image, remote, c.global.flagProject)
 
-			// Set the image registry name on the instance source, so that LXD server handles the download.
-			req.Source.ImageRegistry = registryName
+			if registryName != "" {
+				// Remote image registry.
+				// Check if the server has an image registry with this name.
+				_, _, err := d.GetImageRegistry(registryName)
+				if err != nil {
+					// Only fall back for 404 (registry not found).
+					if !api.StatusErrorCheck(err, http.StatusNotFound) {
+						return nil, "", fmt.Errorf("Failed checking image registry %q: %w", registryName, err)
+					}
+
+					// Registry not found. If the local remote is a public remote,
+					// fall back to sending the deprecated Server and Protocol fields
+					// so the server can validate the URL and auto-create the registry if supported.
+					remoteConfig := conf.Remotes[iremote]
+					if !remoteConfig.Public {
+						return nil, "", fmt.Errorf("Image registry %q not found", registryName)
+					}
+
+					req.Source.Server = remoteConfig.Addr                        //nolint:staticcheck
+					req.Source.Protocol = api.ImageRegistryProtocolSimpleStreams //nolint:staticcheck
+				} else {
+					// Registry exists on the server, use it directly.
+					req.Source.ImageRegistry = registryName
+				}
+			}
 		} else {
 			// Fetch image info from the given remote (legacy client-side resolution path).
 			// Normalize empty remote to the default remote, since ParseRemoteUnchecked

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -18,9 +18,12 @@ type cmdLaunch struct {
 
 func (c *cmdLaunch) command() *cobra.Command {
 	cmd := c.init.command()
-	cmd.Use = usage("launch", "[<remote>:]<image> [<remote>:][<name>]")
+	cmd.Use = usage("launch", "[<registry|remote>:]<image> [<remote>:][<name>]")
 	cmd.Short = "Create and start instances from images"
-	cmd.Long = cli.FormatSection("Description", cmd.Short)
+	cmd.Long = cli.FormatSection("Description", cmd.Short+`
+
+If the destination LXD remote supports image registries, the source image
+must be from an image registry or available locally on the destination remote.`)
 	cmd.Example = cli.FormatSection("", `lxc launch ubuntu:24.04 u1
     Create and start a container
 

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -144,7 +144,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 		}
 
 		iremote, image := guessImage(conf, d, remote, iremote, image)
-		imgRemote, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
+		imgRemoteServer, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			}
 		}
 
-		op, err := d.RebuildInstanceFromImage(imgRemote, *imgInfo, name, req)
+		op, err := d.RebuildInstanceFromImage(imgRemoteServer, *imgInfo, name, req)
 		if err != nil {
 			return err
 		}

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -23,7 +24,7 @@ type cmdRebuild struct {
 
 func (c *cmdRebuild) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("rebuild", "[<remote>:]<image> [<remote>:]<instance>")
+	cmd.Use = usage("rebuild", "[<registry|remote>:]<image> [<remote>:]<instance>")
 	cmd.Short = "Rebuild instance"
 	cmd.Long = cli.FormatSection("Description", `Wipe the instance root disk and re-initialize.
 The original image is used to re-initialize the instance if a different image or --empty is not specified.
@@ -31,7 +32,10 @@ The original image is used to re-initialize the instance if a different image or
 Note: The --project flag sets the project for both the image remote and the instance remote.
 If the image remote is a public remote (e.g. simplestreams) then this project is ignored by the image remote.
 If the image remote is another LXD server, specify the source project for the image remote 
-with --project and the instance remote with --target-project (if different from --project).`)
+with --project and the instance remote with --target-project (if different from --project).
+
+If the destination LXD remote supports image registries, the source image
+must be from an image registry or available locally on the destination remote.`)
 
 	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagEmpty, "empty", false, "Rebuild as an empty instance")
@@ -65,10 +69,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 		}
 
 	case 2:
-		iremote, image, err = conf.ParseRemote(args[0])
-		if err != nil {
-			return err
-		}
+		iremote, image = conf.ParseRemoteUnchecked(args[0])
 
 		remote, name, err = conf.ParseRemote(args[1])
 		if err != nil {
@@ -144,12 +145,44 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 		}
 
 		iremote, image := guessImage(conf, d, remote, iremote, image)
-		imgRemoteServer, imgInfo, err := getImgInfo(conf, iremote, image, c.global.flagProject, &req.Source)
-		if err != nil {
-			return err
+
+		var imgRemoteServer lxd.ImageServer
+		var imgInfo *api.Image
+		var legacyRemote string
+		var err error
+
+		// If the server supports image registries, we can use server-side image resolution and download.
+		// This avoids resolving the image on the client side, and passes the registry name or source project
+		// to the server so it can handle the resolution directly.
+		if d.HasExtension("image_registries") {
+			var registryName string
+			imgInfo, registryName = resolveRegistryImageSource(conf.Remotes, iremote, image, remote, c.global.flagProject)
+
+			if registryName != "" {
+				req.Source.ImageRegistry = registryName
+			}
+		} else {
+			// Fetch image info from the given remote (legacy client-side resolution path).
+			// Normalize empty remote to the default remote, since ParseRemoteUnchecked
+			// does not fill in the default.
+			legacyRemote = iremote
+			if legacyRemote == "" {
+				legacyRemote = conf.DefaultRemote
+			}
+
+			imgRemoteServer, imgInfo, err = getImgInfo(conf, legacyRemote, image, c.global.flagProject, &req.Source)
+			if err != nil {
+				return err
+			}
 		}
 
-		if conf.Remotes[iremote].Protocol != "simplestreams" {
+		// Update the source project if it was determined by getImgInfo.
+		if imgRemoteServer == nil && imgInfo.Project != "" {
+			req.Source.Project = imgInfo.Project
+		}
+
+		// Only perform legacy type and protocol checks if we are NOT using an image registry.
+		if imgRemoteServer != nil && conf.Remotes[legacyRemote].Protocol != api.ImageRegistryProtocolSimpleStreams {
 			if imgInfo.Type != "virtual-machine" && current.Type == "virtual-machine" {
 				return errors.New("Asked for a VM but image is of type container")
 			}

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -159,7 +160,29 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			imgInfo, registryName = resolveRegistryImageSource(conf.Remotes, iremote, image, remote, c.global.flagProject)
 
 			if registryName != "" {
-				req.Source.ImageRegistry = registryName
+				// Remote image registry.
+				// Check if the server has an image registry with this name.
+				_, _, err := d.GetImageRegistry(registryName)
+				if err != nil {
+					// Only fall back for 404 (registry not found).
+					if !api.StatusErrorCheck(err, http.StatusNotFound) {
+						return fmt.Errorf("Failed checking image registry %q: %w", registryName, err)
+					}
+
+					// Registry not found. If the local remote is a public remote,
+					// fall back to sending the deprecated Server and Protocol fields
+					// so the server can validate the URL and auto-create the registry if supported.
+					remoteConfig := conf.Remotes[iremote]
+					if !remoteConfig.Public {
+						return fmt.Errorf("Image registry %q not found", registryName)
+					}
+
+					req.Source.Server = remoteConfig.Addr                        //nolint:staticcheck
+					req.Source.Protocol = api.ImageRegistryProtocolSimpleStreams //nolint:staticcheck
+				} else {
+					// Registry exists on the server, use it directly.
+					req.Source.ImageRegistry = registryName
+				}
 			}
 		} else {
 			// Fetch image info from the given remote (legacy client-side resolution path).

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -349,7 +349,12 @@ func getServerSupportedFilters(filters []string, i any) (supportedFilters []stri
 
 // guessImage checks that the image name (provided by the user) is correct given an instance remote and image remote.
 func guessImage(conf *config.Config, d lxd.InstanceServer, instRemote string, imgRemote string, imageRef string) (imageRemote string, image string) {
-	if instRemote != imgRemote {
+	impliedImgRemote := imgRemote
+	if impliedImgRemote == "" {
+		impliedImgRemote = conf.DefaultRemote
+	}
+
+	if instRemote != impliedImgRemote {
 		return imgRemote, imageRef
 	}
 

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -378,6 +378,36 @@ func guessImage(conf *config.Config, d lxd.InstanceServer, instRemote string, im
 	return fields[0], fields[1]
 }
 
+// resolveRegistryImageSource determines the image source when the target server supports image registries.
+// For local copies (same server), it resolves the source project and returns an empty registry name.
+// For remote copies, it returns the image remote as the registry name.
+func resolveRegistryImageSource(confRemotes map[string]config.Remote, imgRemote string, imgRef string, instRemote string, projectOverride string) (imgInfo *api.Image, registryName string) {
+	sourceRemote := imgRemote
+	if sourceRemote == "" {
+		sourceRemote = instRemote
+	}
+
+	if sourceRemote == instRemote {
+		// Local image, determine the source project.
+		imageProject := projectOverride
+		if imageProject == "" {
+			imageProject = confRemotes[sourceRemote].Project
+		}
+
+		if imageProject == "" {
+			imageProject = api.ProjectDefaultName
+		}
+
+		return &api.Image{
+			Fingerprint: imgRef,
+			Project:     imageProject,
+		}, ""
+	}
+
+	// Remote image registry.
+	return &api.Image{Fingerprint: imgRef}, imgRemote
+}
+
 // getImgInfo returns an image server and image info for the given image name, image remote, and image project.
 // It also populates the passed in InstanceSource struct with the information about the image.
 // If imageProject is provided and the remote is a LXD server, it will be used to locate the image.

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -81,4 +82,103 @@ func (s *utilsTestSuite) TestGetServerSupportedFilters() {
 	supportedFilters, unsupportedFilters := getServerSupportedFilters(filters, api.InstanceFull{})
 	s.Equal([]string{"type=container"}, supportedFilters)
 	s.Equal([]string{"foo", "user.blah=a", "status=running,stopped"}, unsupportedFilters)
+}
+
+func (s *utilsTestSuite) TestResolveRegistryImageSource() {
+	confRemotes := map[string]config.Remote{
+		"local": {
+			Addr:    "https://127.0.0.1:8443",
+			Project: "my-project",
+		},
+		"remote1": {
+			Addr:     "https://images.example.com",
+			Protocol: "simplestreams",
+			Project:  "default",
+		},
+		"no-project": {
+			Addr: "https://127.0.0.1:8443",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		imgRemote       string
+		imgRef          string
+		instRemote      string
+		projectOverride string
+		wantFingerprint string
+		wantProject     string
+		wantRegistry    string
+	}{
+		{
+			name:            "Local image with project override",
+			imgRemote:       "local",
+			imgRef:          "abc123",
+			instRemote:      "local",
+			projectOverride: "custom-project",
+			wantFingerprint: "abc123",
+			wantProject:     "custom-project",
+			wantRegistry:    "",
+		},
+		{
+			name:            "Local image with remote project",
+			imgRemote:       "local",
+			imgRef:          "abc123",
+			instRemote:      "local",
+			projectOverride: "",
+			wantFingerprint: "abc123",
+			wantProject:     "my-project",
+			wantRegistry:    "",
+		},
+		{
+			name:            "Local image falls back to default project",
+			imgRemote:       "no-project",
+			imgRef:          "abc123",
+			instRemote:      "no-project",
+			projectOverride: "",
+			wantFingerprint: "abc123",
+			wantProject:     api.ProjectDefaultName,
+			wantRegistry:    "",
+		},
+		{
+			name:            "Empty image remote defaults to instance remote",
+			imgRemote:       "",
+			imgRef:          "abc123",
+			instRemote:      "local",
+			projectOverride: "",
+			wantFingerprint: "abc123",
+			wantProject:     "my-project",
+			wantRegistry:    "",
+		},
+		{
+			name:            "Remote image from image registry",
+			imgRemote:       "remote1",
+			imgRef:          "noble",
+			instRemote:      "local",
+			projectOverride: "",
+			wantFingerprint: "noble",
+			wantProject:     "",
+			wantRegistry:    "remote1",
+		},
+		{
+			name:            "Remote image from image registry ignores project override",
+			imgRemote:       "remote1",
+			imgRef:          "noble",
+			instRemote:      "local",
+			projectOverride: "custom-project",
+			wantFingerprint: "noble",
+			wantProject:     "",
+			wantRegistry:    "remote1",
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			imgInfo, registryName := resolveRegistryImageSource(confRemotes, tc.imgRemote, tc.imgRef, tc.instRemote, tc.projectOverride)
+
+			s.Equal(tc.wantFingerprint, imgInfo.Fingerprint)
+			s.Equal(tc.wantProject, imgInfo.Project)
+			s.Equal(tc.wantRegistry, registryName)
+		})
+	}
 }

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -101,6 +101,12 @@ type ImagesPostSource struct {
 	//
 	// API extension: image_source_project
 	Project string `json:"project" yaml:"project"`
+
+	// Whether to copy aliases from the source image
+	// Example: true
+	//
+	// API extension: image_registries
+	CopyAliases bool `json:"copy_aliases" yaml:"copy_aliases"`
 }
 
 // ImagePut represents the modifiable fields of a LXD image
@@ -288,6 +294,12 @@ type ImageSource struct {
 	//
 	// API extension: image_types
 	ImageType string `json:"image_type" yaml:"image_type"`
+
+	// Image registry name
+	// Example: ubuntu
+	//
+	// API extension: image_registries
+	ImageRegistry string `json:"image_registry" yaml:"image_registry"`
 }
 
 // ImageAliasesPost represents a new LXD image alias

--- a/shared/api/image_registry.go
+++ b/shared/api/image_registry.go
@@ -1,0 +1,104 @@
+package api
+
+// Supported image registry protocols.
+const (
+	// Image registry protocol "SimpleStreams".
+	ImageRegistryProtocolSimpleStreams = "simplestreams"
+	// Image registry protocol "LXD".
+	ImageRegistryProtocolLXD = "lxd"
+)
+
+// ImageRegistriesPost represents the fields of a new image registry.
+//
+// swagger:model
+//
+// API extension: image_registries.
+type ImageRegistriesPost struct {
+	ImageRegistryPut `yaml:",inline"`
+
+	// Registry name
+	// Example: ubuntu
+	Name string `json:"name" yaml:"name"`
+
+	// Protocol used by the image registry ("SimpleStreams" or "LXD")
+	// Example: simplestreams
+	Protocol string `json:"protocol" yaml:"protocol"`
+}
+
+// ImageRegistryPost represents the fields required to rename the image registry.
+//
+// swagger:model
+//
+// API extension: image_registries.
+type ImageRegistryPost struct {
+	// New name for the image registry
+	// Example: bar
+	Name string `json:"name" yaml:"name"`
+}
+
+// ImageRegistryPut represents the modifiable fields of an image registry.
+//
+// swagger:model
+//
+// API extension: image_registries.
+type ImageRegistryPut struct {
+	// Description of the image registry
+	// Example: My new image registry
+	Description string `json:"description" yaml:"description"`
+
+	// Image registry configuration map
+	// Example: { "user.*": "" }
+	Config map[string]string `json:"config" yaml:"config"`
+}
+
+// ImageRegistry is used to display an image registry.
+//
+// swagger:model
+//
+// API extension: image_registries.
+type ImageRegistry struct {
+	WithEntitlements `yaml:",inline"`
+
+	// Registry name
+	// Example: ubuntu
+	Name string `json:"name" yaml:"name"`
+
+	// Description of the image registry
+	// Example: My new image registry
+	Description string `json:"description" yaml:"description"`
+
+	// Protocol used by the image registry ("SimpleStreams" or "LXD")
+	// Example: simplestreams
+	Protocol string `json:"protocol" yaml:"protocol"`
+
+	// Whether the image registry is public
+	// Example: true
+	Public bool `json:"public" yaml:"public"`
+
+	// Whether the image registry is built-in
+	// Example: false
+	Builtin bool `json:"builtin" yaml:"builtin"`
+
+	// Image registry configuration map
+	// Example: { "user.*": "" }
+	Config map[string]string `json:"config" yaml:"config"`
+}
+
+// Writable converts a full [ImageRegistry] struct into a [ImageRegistryPut] struct (filters read-only fields).
+func (registry *ImageRegistry) Writable() ImageRegistryPut {
+	return ImageRegistryPut{
+		Description: registry.Description,
+		Config:      registry.Config,
+	}
+}
+
+// SetWritable sets applicable values from [ImageRegistryPut] struct to [ImageRegistry] struct.
+func (registry *ImageRegistry) SetWritable(put ImageRegistryPut) {
+	registry.Description = put.Description
+	registry.Config = put.Config
+}
+
+// Etag returns the values used for etag generation.
+func (registry *ImageRegistry) Etag() []any {
+	return []any{registry.Name, registry.Description, registry.Protocol, registry.Config}
+}

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -547,6 +547,12 @@ type InstanceSource struct {
 	// Example: ed56997f7c5b48e8d78986d2467a26109be6fb9f2d92e8c7b08eb8b6cec7629a
 	Fingerprint string `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
 
+	// Image registry name
+	// Example: ubuntu
+	//
+	// API extension: image_registries
+	ImageRegistry string `json:"image_registry" yaml:"image_registry"`
+
 	// Image filters (for image source)
 	// Example: {"os": "Ubuntu", "release": "jammy", "variant": "cloud"}
 	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`


### PR DESCRIPTION
This PR introduces the client-side changes needed to make use of the new image registries feature for image download operations. It also defines new API structs for image registries and new `ProtocolLXD` client methods for interacting with image registry API.

This is the first PR in a series to introduce image registries and update LXD's image sourcing functionality.

The actual image registry API for LXD is introduced in the following PRs.
