### PR TITLE
CLI: Fix bad rendering on error during import

### DIFF
--- a/lxc/import.go
+++ b/lxc/import.go
@@ -106,6 +106,8 @@ func (c *cmdImport) run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
+	defer progress.Done("")
+
 	deviceMap, err := parseDeviceOverrides(c.flagDevice)
 	if err != nil {
 		return err
@@ -126,11 +128,8 @@ func (c *cmdImport) run(cmd *cobra.Command, args []string) error {
 	// Wait for operation to finish.
 	err = cli.CancelableWait(op, &progress)
 	if err != nil {
-		progress.Done("")
 		return err
 	}
-
-	progress.Done("")
 
 	return nil
 }

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2927,6 +2927,8 @@ func (c *cmdStorageVolumeImport) run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
+	defer progress.Done("")
+
 	createArgs := lxd.StoragePoolVolumeBackupArgs{
 		BackupFile: ioprogress.NewProgressReader(file, ioprogress.WithLength(fstat.Size()), ioprogress.WithProgressUpdater(&progress)),
 		Name:       volName,
@@ -2950,11 +2952,8 @@ func (c *cmdStorageVolumeImport) run(cmd *cobra.Command, args []string) error {
 	// Wait for operation to finish.
 	err = cli.CancelableWait(op, &progress)
 	if err != nil {
-		progress.Done("")
 		return err
 	}
-
-	progress.Done("")
 
 	return nil
 }


### PR DESCRIPTION
Prevent seeing 

`Importing instance: 100% (2.32GB/s)Error: Instance definition in backup config is missing`

and fix to get

`Error: Instance definition in backup config is missing`