### PR TITLE
Replicator fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -293,6 +293,8 @@ jobs:
             backends: ${{ needs.code-tests.outputs.fast-backend }}
           - group: cluster_storage
             backends: all
+          - group: replicator_storage
+            backends: all
           - group: image
             backends: fasts
           - group: instance

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/sftp"
@@ -22,6 +23,7 @@ type Operation interface {
 	GetWebsocket(secret string) (conn *websocket.Conn, err error)
 	RemoveHandler(target *EventTarget) (err error)
 	Refresh() (err error)
+	URL() *url.URL
 	Wait() (err error)
 	WaitContext(ctx context.Context) error
 }

--- a/client/operations.go
+++ b/client/operations.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/version"
 )
 
 // The Operation type represents an ongoing LXD operation (asynchronous processing).
@@ -83,6 +85,12 @@ func (op *operation) Cancel() error {
 // Get returns the API operation struct.
 func (op *operation) Get() api.Operation {
 	return op.Operation
+}
+
+// URL returns the full URL to this operation on the server.
+func (op *operation) URL() *url.URL {
+	u := api.NewURL().Scheme(op.r.httpBaseURL.Scheme).Host(op.r.httpBaseURL.Host).Path(version.APIVersion, "operations", op.ID)
+	return &u.URL
 }
 
 // GetWebsocket returns a raw websocket connection from the operation.
@@ -429,4 +437,9 @@ func (op noopOperation) AddHandler(function func(api.Operation)) (*EventTarget, 
 // RemoveHandler removes a function to be called whenever an event is received.
 func (op noopOperation) RemoveHandler(target *EventTarget) error {
 	return errors.New("Cannot remove handler, client operation does not support event listeners")
+}
+
+// URL returns nil because noopOperation has no server association.
+func (op noopOperation) URL() *url.URL {
+	return nil
 }

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -240,6 +240,7 @@ func projectUsedByMap(ctx context.Context, tx *sql.Tx, projectName string) (map[
 		entity.TypeNetworkACL,
 		entity.TypeStorageBucket,
 		entity.TypePlacementGroup,
+		entity.TypeReplicator,
 	}
 
 	entityURLs, err := dbCluster.GetEntityURLs(ctx, tx, projectName, reportedEntityTypes...)
@@ -251,7 +252,7 @@ func projectUsedByMap(ctx context.Context, tx *sql.Tx, projectName string) (map[
 }
 
 // projectUsedBy returns a list of URLs for all instances, images, profiles,
-// storage volumes, storage buckets, networks, acls, and placement groups that use this project.
+// storage volumes, storage buckets, networks, acls, placement groups, and replicators that use this project.
 func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *dbCluster.Project) ([]string, error) {
 	m, err := projectUsedByMap(ctx, tx.Tx(), project.Name)
 	if err != nil {

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1115,20 +1115,6 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 					return fmt.Errorf("Failed getting instance %q from remote: %w", instName, err)
 				}
 
-				// Only create a snapshot if the instance has no existing snapshot schedule.
-				// When a schedule is set, the most recent existing snapshot is reused.
-				if snapshot && freshInst.ExpandedConfig["snapshots.schedule"] == "" {
-					snapOp, err := dstClient.CreateInstanceSnapshot(instName, api.InstanceSnapshotsPost{})
-					if err != nil {
-						return fmt.Errorf("Failed creating snapshot of instance %q: %w", instName, err)
-					}
-
-					err = snapOp.Wait()
-					if err != nil {
-						return fmt.Errorf("Failed waiting for snapshot of instance %q: %w", instName, err)
-					}
-				}
-
 				remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{Migration: true})
 				if err != nil {
 					return fmt.Errorf("Failed starting migration source on remote for instance %q: %w", instName, err)

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1505,7 +1505,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 func replicatorCheckInstancesStopped(allInsts []instance.Instance) error {
 	for _, inst := range allInsts {
 		if inst.LocalConfig()["volatile.last_state.power"] == instance.PowerStateRunning {
-			return fmt.Errorf("Instance %q is running, stop all project instances before running --restore", inst.Name())
+			return fmt.Errorf("Instance %q is running, stop all project instances before restoring", inst.Name())
 		}
 	}
 

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -34,6 +34,7 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/validate"
+	"github.com/canonical/lxd/shared/version"
 )
 
 var replicatorsCmd = APIEndpoint{
@@ -1158,14 +1159,12 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		}, nil
 	}
 
-	// Restore mode: iterate over the current leader cluster's instance list. Build a lookup
-	// from instance name to host address for routing to the correct cluster member.
-	instMemberAddress := make(map[string]string, len(allInsts))
-	for _, inst := range allInsts {
-		instMemberAddress[inst.Name()] = nodeAddressByName[inst.Location()]
-	}
-
+	// Restore mode: iterate over the current leader cluster's instance list.
 	childArgs := make([]*operations.OperationArgs, 0, len(iterNames))
+
+	// Use our cluster certificate so the leader can verify TLS when
+	// pushing data back to us.
+	localCertPEM := string(clusterCert.PublicKey())
 
 	for _, instName := range iterNames {
 		copyFunc := func(ctx context.Context, op *operations.Operation) error {
@@ -1190,27 +1189,16 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Failed getting instance %q from current leader cluster: %w", instName, err)
 			}
 
-			remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{Migration: true})
-			if err != nil {
-				return fmt.Errorf("Failed starting migration source on current leader cluster for instance %q: %w", instName, err)
-			}
-
-			remoteOpInfo := remoteMigrateOp.Get()
-			remoteSecrets, err := remoteOpInfo.WebsocketSecrets()
-			if err != nil {
-				return fmt.Errorf("Failed getting websocket secrets for instance %q migration: %w", instName, err)
-			}
-
-			connInfo, err := dstClient.GetConnectionInfo()
-			if err != nil {
-				return fmt.Errorf("Failed getting connection info for current leader cluster: %w", err)
-			}
-
-			remoteOpURL := connInfo.URL + "/1.0/operations/" + remoteOpInfo.ID
-
 			// If the instance lives on another cluster member, forward the restore
 			// migration to that member so the refresh runs where the storage volume is.
-			memberAddress := instMemberAddress[instName]
+			var memberAddress string
+			for _, inst := range allInsts {
+				if inst.Name() == instName {
+					memberAddress = nodeAddressByName[inst.Location()]
+					break
+				}
+			}
+
 			if memberAddress != "" {
 				memberClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 				if err != nil {
@@ -1219,29 +1207,55 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 				memberClient = memberClient.UseProject(projectName)
 
+				// Set up a push-mode migration sink on the hosting cluster member.
 				restoreOp, err := memberClient.CreateInstance(api.InstancesPost{
 					Name:        instName,
 					InstancePut: freshInst.Writable(),
 					Type:        api.InstanceType(freshInst.Type),
 					Source: api.InstanceSource{
-						Type:        api.SourceTypeMigration,
-						Mode:        "pull",
-						Operation:   remoteOpURL,
-						Websockets:  remoteSecrets,
-						Certificate: targetCertPEM,
-						Refresh:     true,
+						Type:    api.SourceTypeMigration,
+						Mode:    "push",
+						Refresh: true,
 					},
 				})
 				if err != nil {
 					return fmt.Errorf("Failed requesting restore on hosting cluster member for instance %q: %w", instName, err)
 				}
 
-				err = restoreOp.Wait()
+				restoreOpCancelled := false
+				defer func() {
+					if !restoreOpCancelled {
+						_ = restoreOp.Cancel()
+					}
+				}()
+
+				restoreOpAPI := restoreOp.Get()
+				restoreSecrets, err := restoreOpAPI.WebsocketSecrets()
 				if err != nil {
-					return fmt.Errorf("Restore of instance %q failed on hosting cluster member: %w", instName, err)
+					return fmt.Errorf("Failed getting websocket secrets from hosting cluster member for instance %q: %w", instName, err)
 				}
 
-				return remoteMigrateOp.Wait()
+				// Tell the current leader cluster to push-migrate the instance to the hosting cluster member's sink.
+				remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{
+					Migration: true,
+					Target: &api.InstancePostTarget{
+						Operation:   restoreOp.URL().String(),
+						Websockets:  restoreSecrets,
+						Certificate: localCertPEM,
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("Failed starting push migration on current leader cluster for instance %q: %w", instName, err)
+				}
+
+				restoreOpCancelled = true
+
+				err = remoteMigrateOp.Wait()
+				if err != nil {
+					return fmt.Errorf("Restore of instance %q failed on current leader cluster: %w", instName, err)
+				}
+
+				return restoreOp.Wait()
 			}
 
 			// Load profiles for the instance to pass to the migration sink.
@@ -1254,7 +1268,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Failed loading profiles for instance %q: %w", instName, err)
 			}
 
-			// Build a migration request that the shared migration-sink core understands.
+			// Set up a push-mode migration sink locally so the leader pushes data to us.
 			migrateReq := &api.InstancesPost{
 				InstancePut: api.InstancePut{
 					Architecture: freshInst.Architecture,
@@ -1268,12 +1282,9 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				Name: instName,
 				Type: api.InstanceType(freshInst.Type),
 				Source: api.InstanceSource{
-					Type:        api.SourceTypeMigration,
-					Mode:        "pull",
-					Operation:   remoteOpURL,
-					Websockets:  remoteSecrets,
-					Certificate: targetCertPEM,
-					Refresh:     true,
+					Type:    api.SourceTypeMigration,
+					Mode:    "push",
+					Refresh: true,
 				},
 			}
 
@@ -1284,13 +1295,65 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 			defer result.revert.Fail()
 
-			err = result.run(ctx, op)
+			// Schedule the sink operation so it gets an ID and can accept websocket connections.
+			sinkOpArgs := operations.OperationArgs{
+				ProjectName: projectName,
+				EntityURL:   api.NewURL().Path(version.APIVersion, "projects", projectName),
+				Type:        operationtype.InstanceCreate,
+				Class:       operations.OperationClassWebsocket,
+				Metadata:    result.sink.Metadata(),
+				ConnectHook: result.sink.Connect,
+				RunHook:     result.run,
+			}
+
+			var sinkOp *operations.Operation
+			if op.Requestor() != nil {
+				sinkOp, err = operations.ScheduleUserOperationFromOperation(s, op, sinkOpArgs)
+			} else {
+				sinkOp, err = operations.ScheduleServerOperation(s, sinkOpArgs)
+			}
+
 			if err != nil {
-				return fmt.Errorf("Restore of instance %q failed: %w", instName, err)
+				return fmt.Errorf("Failed scheduling migration sink operation for instance %q: %w", instName, err)
+			}
+
+			_, sinkOpAPI := sinkOp.Render()
+			sinkSecrets, err := sinkOpAPI.WebsocketSecrets()
+			if err != nil {
+				return fmt.Errorf("Failed getting websocket secrets from local sink for instance %q: %w", instName, err)
+			}
+
+			// Build the operation URL using this node's cluster address.
+			localAddress := nodeAddressByName[s.ServerName]
+			sinkOpURL := "https://" + localAddress + sinkOp.URL()
+
+			// Tell the current leader cluster to push-migrate the instance to our local sink.
+			remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{
+				Migration: true,
+				Target: &api.InstancePostTarget{
+					Operation:   sinkOpURL,
+					Websockets:  sinkSecrets,
+					Certificate: localCertPEM,
+				},
+			})
+			if err != nil {
+				sinkOp.Cancel()
+				return fmt.Errorf("Failed starting push migration on current leader cluster for instance %q: %w", instName, err)
+			}
+
+			remoteErr := remoteMigrateOp.Wait()
+			if remoteErr != nil {
+				sinkOp.Cancel()
+				return fmt.Errorf("Restore of instance %q failed on current leader cluster: %w", instName, remoteErr)
+			}
+
+			sinkErr := sinkOp.Wait(context.Background())
+			if sinkErr != nil {
+				return fmt.Errorf("Restore of instance %q failed: %w", instName, sinkErr)
 			}
 
 			result.revert.Success()
-			return remoteMigrateOp.Wait()
+			return nil
 		}
 
 		childArgs = append(childArgs, &operations.OperationArgs{
@@ -1427,12 +1490,12 @@ func replicateInstance(ctx context.Context, s *state.State, op *operations.Opera
 			return fmt.Errorf("Failed starting push migration for instance %q: %w", instName, err)
 		}
 
-		destOpCancelled = true
-
 		err = srcMigrateOp.Wait()
 		if err != nil {
 			return fmt.Errorf("Replication of instance %q failed on hosting cluster member: %w", instName, err)
 		}
+
+		destOpCancelled = true
 
 		return destOp.Wait()
 	}

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1162,7 +1162,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 						Operation:   remoteOpURL,
 						Websockets:  remoteSecrets,
 						Certificate: targetCertPEM,
-						Refresh:     inst != nil,
+						Refresh:     true,
 					},
 				}
 

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1074,7 +1074,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 	// In restore mode, all project instances across all cluster members must be stopped
 	// before proceeding. The restore operation refreshes each existing instance from the
-	// leader cluster and creates any that only exist on the leader; a running instance
+	// current leader cluster and creates any that only exist on the leader; a running instance
 	// cannot be refreshed. Fail fast here to avoid a partial restore where some instances
 	// are updated and others are not.
 	if restore {
@@ -1084,7 +1084,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		}
 	}
 
-	// In restore mode the leader cluster is the source of truth: use its instance list so
+	// In restore mode the current leader cluster is the source of truth: use its instance list so
 	// that instances created on the leader after failover are included. Restore is additive
 	// only: local instances that do not exist on the leader are left in place and not deleted.
 	var iterNames []string
@@ -1098,27 +1098,73 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		for _, ri := range remoteInsts {
 			iterNames = append(iterNames, ri.Name)
 		}
-	} else {
-		// Forward replication: iterate over all instances in the project,
-		// including those on other cluster members.
-		iterNames = make([]string, 0, len(allInsts))
-		for _, inst := range allInsts {
-			iterNames = append(iterNames, inst.Name())
-		}
 	}
 
-	// Restore mode: iterate over the current leader cluster's instance list. Build a
-	// lookup from instance name to member address for routing to the correct cluster
-	// member. Instances that only exist on the current leader cluster (created after
-	// failover) will not be present in this map; the empty-string lookup signals that
-	// the instance should be created locally rather than refreshed on a specific member.
+	replicatorURL := entity.ReplicatorURL(projectName, name)
+	projectURL := entity.ProjectURL(projectName)
+
+	// Forward replication: iterate over all loaded instances directly.
+	if !restore {
+		childArgs := make([]*operations.OperationArgs, 0, len(allInsts))
+
+		for _, inst := range allInsts {
+			memberAddress := nodeAddressByName[inst.Location()]
+
+			copyFunc := func(ctx context.Context, op *operations.Operation) error {
+				dstClient, err := lxdCluster.ConnectCluster(ctx, *clusterLink, lxdCluster.GetClusterLinkConnectionArgs(clusterCert, targetCert))
+				if err != nil {
+					return fmt.Errorf("Failed connecting to target cluster: %w", err)
+				}
+
+				dstClient = dstClient.UseProject(projectName)
+
+				return replicateInstance(ctx, s, op, inst, memberAddress, snapshot, dstClient, targetCertPEM)
+			}
+
+			childArgs = append(childArgs, &operations.OperationArgs{
+				ProjectName: projectName,
+				EntityURL:   projectURL,
+				Type:        operationtype.ReplicatorRunInstance,
+				Class:       operations.OperationClassTask,
+				Metadata: map[string]any{
+					api.MetadataEntityURL: entity.InstanceURL(projectName, inst.Name()).String(),
+				},
+				RunHook: copyFunc,
+			})
+		}
+
+		return operations.OperationArgs{
+			ProjectName:       projectName,
+			EntityURL:         replicatorURL,
+			Type:              operationtype.ReplicatorRun,
+			Class:             operations.OperationClassTask,
+			ConflictReference: replicatorURL.String(), // Prevents concurrent runs; paired with ConflictActionFail on the operation type to enforce cluster-wide exclusivity.
+			Children:          childArgs,
+			RunHook: func(_ context.Context, op *operations.Operation) error {
+				runStatus := api.ReplicatorStatusCompleted
+				for _, child := range op.Children() {
+					if child.Status() != api.Success {
+						runStatus = api.ReplicatorStatusFailed
+						break
+					}
+				}
+
+				// Use a fresh context so the status write always completes, even if the operation context was cancelled.
+				// Only the status is updated here; last_run_date was already set when the operation started.
+				return s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return dbCluster.UpdateReplicatorLastRunStatus(ctx, tx.Tx(), replicatorID, runStatus)
+				})
+			},
+		}, nil
+	}
+
+	// Restore mode: iterate over the current leader cluster's instance list. Build a lookup
+	// from instance name to host address for routing to the correct cluster member.
 	instMemberAddress := make(map[string]string, len(allInsts))
 	for _, inst := range allInsts {
 		instMemberAddress[inst.Name()] = nodeAddressByName[inst.Location()]
 	}
 
-	replicatorURL := entity.ReplicatorURL(projectName, name)
-	projectURL := entity.ProjectURL(projectName)
 	childArgs := make([]*operations.OperationArgs, 0, len(iterNames))
 
 	for _, instName := range iterNames {
@@ -1130,98 +1176,53 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 			dstClient = dstClient.UseProject(projectName)
 
-			if restore {
-				// In restore mode the local copy is stale; fetch current metadata from
-				// the remote leader so the restore uses up-to-date config/state.
-				freshInst, _, err := dstClient.GetInstance(instName)
+			// In restore mode the local copy is stale; fetch current metadata from
+			// the current leader cluster so the restore uses up-to-date config/state.
+			freshInst, _, err := dstClient.GetInstance(instName)
+			if err != nil {
+				if api.StatusErrorCheck(err, http.StatusNotFound) {
+					// Instance was deleted on the current leader cluster after failover; skip it rather
+					// than failing the whole run, since the deletion is intentional.
+					logger.Warn("Skipping restore of instance deleted on current leader cluster", logger.Ctx{"instance": instName})
+					return nil
+				}
+
+				return fmt.Errorf("Failed getting instance %q from current leader cluster: %w", instName, err)
+			}
+
+			remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{Migration: true})
+			if err != nil {
+				return fmt.Errorf("Failed starting migration source on current leader cluster for instance %q: %w", instName, err)
+			}
+
+			remoteOpInfo := remoteMigrateOp.Get()
+			remoteSecrets, err := remoteOpInfo.WebsocketSecrets()
+			if err != nil {
+				return fmt.Errorf("Failed getting websocket secrets for instance %q migration: %w", instName, err)
+			}
+
+			connInfo, err := dstClient.GetConnectionInfo()
+			if err != nil {
+				return fmt.Errorf("Failed getting connection info for current leader cluster: %w", err)
+			}
+
+			remoteOpURL := connInfo.URL + "/1.0/operations/" + remoteOpInfo.ID
+
+			// If the instance lives on another cluster member, forward the restore
+			// migration to that member so the refresh runs where the storage volume is.
+			memberAddress := instMemberAddress[instName]
+			if memberAddress != "" {
+				memberClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 				if err != nil {
-					if api.StatusErrorCheck(err, http.StatusNotFound) {
-						// Instance was deleted on the leader after failover; skip it rather
-						// than failing the whole run, since the deletion is intentional.
-						logger.Warn("Skipping restore of instance deleted on leader", logger.Ctx{"instance": instName})
-						return nil
-					}
-
-					return fmt.Errorf("Failed getting instance %q from remote: %w", instName, err)
+					return fmt.Errorf("Failed connecting to hosting cluster member for instance %q: %w", instName, err)
 				}
 
-				remoteMigrateOp, err := dstClient.MigrateInstance(instName, api.InstancePost{Migration: true})
-				if err != nil {
-					return fmt.Errorf("Failed starting migration source on remote for instance %q: %w", instName, err)
-				}
+				memberClient = memberClient.UseProject(projectName)
 
-				remoteOpInfo := remoteMigrateOp.Get()
-				remoteSecrets, err := remoteOpInfo.WebsocketSecrets()
-				if err != nil {
-					return fmt.Errorf("Failed getting websocket secrets for instance %q migration: %w", instName, err)
-				}
-
-				remoteAddresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, false)
-				if len(remoteAddresses) == 0 {
-					return fmt.Errorf("No remote addresses available for cluster link %q", clusterLinkName)
-				}
-
-				remoteOpURL := "https://" + remoteAddresses[0] + "/1.0/operations/" + remoteOpInfo.ID
-
-				// If the instance lives on another cluster member, forward the restore
-				// migration to that member so the refresh runs where the storage volume is.
-				memberAddress := instMemberAddress[instName]
-				if memberAddress != "" {
-					hostClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
-					if err != nil {
-						return fmt.Errorf("Failed connecting to cluster member hosting instance %q: %w", instName, err)
-					}
-
-					hostClient = hostClient.UseProject(projectName)
-
-					restoreOp, err := hostClient.CreateInstance(api.InstancesPost{
-						Name:        instName,
-						InstancePut: freshInst.Writable(),
-						Type:        api.InstanceType(freshInst.Type),
-						Source: api.InstanceSource{
-							Type:        api.SourceTypeMigration,
-							Mode:        "pull",
-							Operation:   remoteOpURL,
-							Websockets:  remoteSecrets,
-							Certificate: targetCertPEM,
-							Refresh:     true,
-						},
-					})
-					if err != nil {
-						return fmt.Errorf("Failed requesting restore on hosting member for instance %q: %w", instName, err)
-					}
-
-					err = restoreOp.Wait()
-					if err != nil {
-						return fmt.Errorf("Restore of instance %q failed on hosting member: %w", instName, err)
-					}
-
-					return remoteMigrateOp.Wait()
-				}
-
-				// Load profiles for the instance to pass to the migration sink.
-				var profiles []api.Profile
-				err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-					profiles, err = instanceProfilesFromNames(ctx, tx, projectName, freshInst.Profiles)
-					return err
-				})
-				if err != nil {
-					return fmt.Errorf("Failed loading profiles for instance %q: %w", instName, err)
-				}
-
-				// Build a migration request that the shared migration-sink core understands.
-				migrateReq := &api.InstancesPost{
-					InstancePut: api.InstancePut{
-						Architecture: freshInst.Architecture,
-						Config:       freshInst.Config,
-						Devices:      freshInst.Devices,
-						Description:  freshInst.Description,
-						Ephemeral:    freshInst.Ephemeral,
-						Profiles:     freshInst.Profiles,
-						Stateful:     freshInst.Stateful,
-					},
-					Name: instName,
-					Type: api.InstanceType(freshInst.Type),
+				restoreOp, err := memberClient.CreateInstance(api.InstancesPost{
+					Name:        instName,
+					InstancePut: freshInst.Writable(),
+					Type:        api.InstanceType(freshInst.Type),
 					Source: api.InstanceSource{
 						Type:        api.SourceTypeMigration,
 						Mode:        "pull",
@@ -1230,236 +1231,66 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 						Certificate: targetCertPEM,
 						Refresh:     true,
 					},
-				}
-
-				result, err := prepareInstanceMigrationSink(ctx, s, projectName, profiles, migrateReq, "")
+				})
 				if err != nil {
-					return fmt.Errorf("Failed preparing migration sink for instance %q: %w", instName, err)
+					return fmt.Errorf("Failed requesting restore on hosting cluster member for instance %q: %w", instName, err)
 				}
 
-				defer result.revert.Fail()
-
-				err = result.run(ctx, op)
+				err = restoreOp.Wait()
 				if err != nil {
-					return fmt.Errorf("Restore of instance %q failed: %w", instName, err)
+					return fmt.Errorf("Restore of instance %q failed on hosting cluster member: %w", instName, err)
 				}
 
-				result.revert.Success()
 				return remoteMigrateOp.Wait()
 			}
 
-			// Forward replication: handle both local and non-local instances.
-			memberAddress := instMemberAddress[instName]
-			if memberAddress != "" && memberAddress != nodeAddressByName[s.ServerName] {
-				// Instance on another cluster member: connect to the hosting member and
-				// drive the snapshot + push migration through its API so the migration
-				// source has direct access to the instance's storage.
-				hostClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
-				if err != nil {
-					return fmt.Errorf("Failed connecting to cluster member hosting instance %q: %w", instName, err)
-				}
-
-				hostClient = hostClient.UseProject(projectName)
-
-				// Get instance metadata from the hosting member.
-				srcInstInfo, _, err := hostClient.GetInstance(instName)
-				if err != nil {
-					return fmt.Errorf("Failed getting instance %q from hosting member: %w", instName, err)
-				}
-
-				// Create a snapshot on the hosting member if needed.
-				if snapshot && srcInstInfo.ExpandedConfig["snapshots.schedule"] == "" {
-					snapOp, err := hostClient.CreateInstanceSnapshot(instName, api.InstanceSnapshotsPost{})
-					if err != nil {
-						return fmt.Errorf("Failed creating snapshot of instance %q on hosting member: %w", instName, err)
-					}
-
-					err = snapOp.Wait()
-					if err != nil {
-						return fmt.Errorf("Failed waiting for snapshot of instance %q on hosting member: %w", instName, err)
-					}
-				}
-
-				// Re-fetch after snapshot so the writable metadata includes the new snapshot.
-				srcInstInfo, _, err = hostClient.GetInstance(instName)
-				if err != nil {
-					return fmt.Errorf("Failed getting instance %q after snapshot: %w", instName, err)
-				}
-
-				// Set up a push-mode migration sink on the destination.
-				destOp, err := dstClient.CreateInstance(api.InstancesPost{
-					Name:        instName,
-					InstancePut: srcInstInfo.Writable(),
-					Type:        api.InstanceType(srcInstInfo.Type),
-					Source: api.InstanceSource{
-						Type:    api.SourceTypeMigration,
-						Mode:    "push",
-						Refresh: true,
-					},
-				})
-				if err != nil {
-					return fmt.Errorf("Failed requesting instance create on destination for %q: %w", instName, err)
-				}
-
-				destOpCancelled := false
-				defer func() {
-					if !destOpCancelled {
-						_ = destOp.Cancel()
-					}
-				}()
-
-				destOpAPI := destOp.Get()
-				destSecrets, err := destOpAPI.WebsocketSecrets()
-				if err != nil {
-					return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
-				}
-
-				dstConnInfo, err := dstClient.GetConnectionInfo()
-				if err != nil {
-					return fmt.Errorf("Failed getting connection info for destination: %w", err)
-				}
-
-				// Tell the hosting member to push-migrate the instance to the destination.
-				srcMigrateOp, err := hostClient.MigrateInstance(instName, api.InstancePost{
-					Migration: true,
-					Target: &api.InstancePostTarget{
-						Operation:   dstConnInfo.URL + "/1.0/operations/" + destOpAPI.ID,
-						Websockets:  destSecrets,
-						Certificate: targetCertPEM,
-					},
-				})
-				if err != nil {
-					return fmt.Errorf("Failed starting push migration for instance %q: %w", instName, err)
-				}
-
-				destOpCancelled = true
-
-				err = srcMigrateOp.Wait()
-				if err != nil {
-					return fmt.Errorf("Replication of instance %q failed on hosting member: %w", instName, err)
-				}
-
-				return destOp.Wait()
-			}
-
-			// Local instance: handle replication directly.
-			inst := localInstByName(allInsts, instName)
-			if inst == nil {
-				return fmt.Errorf("Failed to find local instance %q", instName)
-			}
-
-			if snapshot && inst.ExpandedConfig()["snapshots.schedule"] == "" {
-				snapName, err := instance.NextSnapshotName(s, inst, "snap%d")
-				if err != nil {
-					return fmt.Errorf("Failed generating snapshot name for instance %q: %w", instName, err)
-				}
-
-				err = inst.Snapshot(ctx, snapName, nil, false, api.DiskVolumesModeRoot, nil)
-				if err != nil {
-					return fmt.Errorf("Failed creating snapshot of instance %q: %w", instName, err)
-				}
-			}
-
-			srcRenderRes, _, err := inst.Render()
-			if err != nil {
-				return fmt.Errorf("Failed rendering source instance %q: %w", instName, err)
-			}
-
-			srcInstInfo, ok := srcRenderRes.(*api.Instance)
-			if !ok {
-				return fmt.Errorf("Unexpected result from source instance render for %q", instName)
-			}
-
-			// Set up a push-mode migration sink on the destination. In push mode the
-			// leader (source) connects outward to the destination, so the destination
-			// does not need to reach back into the leader. This is required when the
-			// destination project is restricted, which disallows pull-mode migrations.
-			destOp, err := dstClient.CreateInstance(api.InstancesPost{
-				Name:        instName,
-				InstancePut: srcInstInfo.Writable(),
-				Type:        api.InstanceType(srcInstInfo.Type),
-				Source: api.InstanceSource{
-					Type:    api.SourceTypeMigration,
-					Mode:    "push",
-					Refresh: true,
-				},
+			// Load profiles for the instance to pass to the migration sink.
+			var profiles []api.Profile
+			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+				profiles, err = instanceProfilesFromNames(ctx, tx, projectName, freshInst.Profiles)
+				return err
 			})
 			if err != nil {
-				return fmt.Errorf("Failed requesting instance create on destination: %w", err)
+				return fmt.Errorf("Failed loading profiles for instance %q: %w", instName, err)
 			}
 
-			// Guard against leaving the destination sink operation running if we fail
-			// before starting the source; disarmed once the source op is scheduled.
-			destOpCancelled := false
-			defer func() {
-				if !destOpCancelled {
-					_ = destOp.Cancel()
-				}
-			}()
-
-			destOpAPI := destOp.Get()
-			destSecrets, err := destOpAPI.WebsocketSecrets()
-			if err != nil {
-				return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
-			}
-
-			// ConnectCluster tries each configured address in order; GetConnectionInfo
-			// returns the one that succeeded, which is what the push target must use.
-			dstConnInfo, err := dstClient.GetConnectionInfo()
-			if err != nil {
-				return fmt.Errorf("Failed getting connection info for destination: %w", err)
-			}
-
-			pushTarget := &api.InstancePostTarget{
-				Operation:   dstConnInfo.URL + "/1.0/operations/" + destOpAPI.ID,
-				Websockets:  destSecrets,
-				Certificate: targetCertPEM,
-			}
-
-			srcMigration, err := newMigrationSource(inst, false, false, false, "", pushTarget)
-			if err != nil {
-				return fmt.Errorf("Failed setting up migration source for instance %q: %w", instName, err)
-			}
-
-			migrArgs := operations.OperationArgs{
-				ProjectName: projectName,
-				EntityURL:   entity.InstanceURL(projectName, instName),
-				Type:        operationtype.InstanceMigrate,
-				Class:       operations.OperationClassTask,
-				RunHook: func(ctx context.Context, innerOp *operations.Operation) error {
-					done := make(chan struct{})
-					defer close(done)
-					go func() {
-						select {
-						case <-done:
-						case <-ctx.Done():
-							srcMigration.disconnect()
-						}
-					}()
-
-					return srcMigration.Do(ctx, s, innerOp)
+			// Build a migration request that the shared migration-sink core understands.
+			migrateReq := &api.InstancesPost{
+				InstancePut: api.InstancePut{
+					Architecture: freshInst.Architecture,
+					Config:       freshInst.Config,
+					Devices:      freshInst.Devices,
+					Description:  freshInst.Description,
+					Ephemeral:    freshInst.Ephemeral,
+					Profiles:     freshInst.Profiles,
+					Stateful:     freshInst.Stateful,
+				},
+				Name: instName,
+				Type: api.InstanceType(freshInst.Type),
+				Source: api.InstanceSource{
+					Type:        api.SourceTypeMigration,
+					Mode:        "pull",
+					Operation:   remoteOpURL,
+					Websockets:  remoteSecrets,
+					Certificate: targetCertPEM,
+					Refresh:     true,
 				},
 			}
 
-			var srcOp *operations.Operation
-			if op.Requestor() != nil {
-				srcOp, err = operations.ScheduleUserOperationFromOperation(s, op, migrArgs)
-			} else {
-				srcOp, err = operations.ScheduleServerOperation(s, migrArgs)
-			}
-
+			result, err := prepareInstanceMigrationSink(ctx, s, projectName, profiles, migrateReq, "")
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed preparing migration sink for instance %q: %w", instName, err)
 			}
 
-			destOpCancelled = true // source is now connected via websockets; cancel would interrupt an in-flight transfer
+			defer result.revert.Fail()
 
-			err = srcOp.Wait(context.Background())
+			err = result.run(ctx, op)
 			if err != nil {
-				return fmt.Errorf("Replication of instance %q failed on source: %w", instName, err)
+				return fmt.Errorf("Restore of instance %q failed: %w", instName, err)
 			}
 
-			return destOp.Wait()
+			result.revert.Success()
+			return remoteMigrateOp.Wait()
 		}
 
 		childArgs = append(childArgs, &operations.OperationArgs{
@@ -1512,15 +1343,209 @@ func replicatorCheckInstancesStopped(allInsts []instance.Instance) error {
 	return nil
 }
 
-// localInstByName finds an instance in the slice by name. Returns nil if not found.
-func localInstByName(insts []instance.Instance, name string) instance.Instance {
-	for _, inst := range insts {
-		if inst.Name() == name {
-			return inst
+// replicateInstance handles forward replication of a single instance to the
+// destination cluster. It handles both instances on the local cluster member
+// and instances on other cluster members.
+func replicateInstance(ctx context.Context, s *state.State, op *operations.Operation, inst instance.Instance, memberAddress string, snapshot bool, dstClient lxd.InstanceServer, targetCertPEM string) error {
+	instName := inst.Name()
+	projectName := inst.Project().Name
+	createSnapshot := snapshot && inst.ExpandedConfig()["snapshots.schedule"] == ""
+
+	// Instance on another cluster member: connect to the hosting cluster member and
+	// drive the snapshot + push migration through its API so the migration
+	// source has direct access to the instance's storage.
+	if inst.Location() != s.ServerName {
+		if memberAddress == "" {
+			return fmt.Errorf("Failed resolving cluster member address for instance %q", instName)
+		}
+
+		// Connect to the hosting cluster member.
+		memberClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+		if err != nil {
+			return fmt.Errorf("Failed connecting to hosting cluster member for instance %q: %w", instName, err)
+		}
+
+		memberClient = memberClient.UseProject(projectName)
+
+		// Create a snapshot on the hosting cluster member if needed.
+		if createSnapshot {
+			snapOp, err := memberClient.CreateInstanceSnapshot(instName, api.InstanceSnapshotsPost{})
+			if err != nil {
+				return fmt.Errorf("Failed creating snapshot of instance %q on hosting cluster member: %w", instName, err)
+			}
+
+			err = snapOp.Wait()
+			if err != nil {
+				return fmt.Errorf("Failed waiting for snapshot of instance %q on hosting cluster member: %w", instName, err)
+			}
+		}
+
+		// Get instance metadata from the hosting cluster member.
+		srcInstInfo, _, err := memberClient.GetInstance(instName)
+		if err != nil {
+			return fmt.Errorf("Failed getting instance %q from hosting cluster member: %w", instName, err)
+		}
+
+		// Set up a push-mode migration sink on the destination.
+		destOp, err := dstClient.CreateInstance(api.InstancesPost{
+			Name:        instName,
+			InstancePut: srcInstInfo.Writable(),
+			Type:        api.InstanceType(srcInstInfo.Type),
+			Source: api.InstanceSource{
+				Type:    api.SourceTypeMigration,
+				Mode:    "push",
+				Refresh: true,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed requesting instance create on destination for %q: %w", instName, err)
+		}
+
+		destOpCancelled := false
+		defer func() {
+			if !destOpCancelled {
+				_ = destOp.Cancel()
+			}
+		}()
+
+		destOpAPI := destOp.Get()
+		destSecrets, err := destOpAPI.WebsocketSecrets()
+		if err != nil {
+			return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
+		}
+
+		// Tell the hosting cluster member to push-migrate the instance to the destination.
+		srcMigrateOp, err := memberClient.MigrateInstance(instName, api.InstancePost{
+			Migration: true,
+			Target: &api.InstancePostTarget{
+				Operation:   destOp.URL().String(),
+				Websockets:  destSecrets,
+				Certificate: targetCertPEM,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed starting push migration for instance %q: %w", instName, err)
+		}
+
+		destOpCancelled = true
+
+		err = srcMigrateOp.Wait()
+		if err != nil {
+			return fmt.Errorf("Replication of instance %q failed on hosting cluster member: %w", instName, err)
+		}
+
+		return destOp.Wait()
+	}
+
+	// Local instance: handle replication directly.
+	// Only take a snapshot if snapshot is requested and the instance has no snapshot schedule;
+	// if a schedule is defined, scheduled snapshots already provide point-in-time history
+	// so creating an extra one here would be redundant.
+	if createSnapshot {
+		snapName, err := instance.NextSnapshotName(s, inst, "snap%d")
+		if err != nil {
+			return fmt.Errorf("Failed generating snapshot name for instance %q: %w", instName, err)
+		}
+
+		err = inst.Snapshot(ctx, snapName, nil, false, api.DiskVolumesModeRoot, nil)
+		if err != nil {
+			return fmt.Errorf("Failed creating snapshot of instance %q: %w", instName, err)
 		}
 	}
 
-	return nil
+	srcRenderRes, _, err := inst.Render()
+	if err != nil {
+		return fmt.Errorf("Failed rendering source instance %q: %w", instName, err)
+	}
+
+	srcInstInfo, ok := srcRenderRes.(*api.Instance)
+	if !ok {
+		return fmt.Errorf("Unexpected result from source instance render for %q", instName)
+	}
+
+	// Set up a push-mode migration sink on the destination. In push mode the
+	// leader (source) connects outward to the destination, so the destination
+	// does not need to reach back into the leader. This is required when the
+	// destination project is restricted, which disallows pull-mode migrations.
+	destOp, err := dstClient.CreateInstance(api.InstancesPost{
+		Name:        instName,
+		InstancePut: srcInstInfo.Writable(),
+		Type:        api.InstanceType(srcInstInfo.Type),
+		Source: api.InstanceSource{
+			Type:    api.SourceTypeMigration,
+			Mode:    "push",
+			Refresh: true,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("Failed requesting instance create on destination: %w", err)
+	}
+
+	// Guard against leaving the destination sink operation running if we fail
+	// before starting the source; disarmed once the source op is scheduled.
+	destOpCancelled := false
+	defer func() {
+		if !destOpCancelled {
+			_ = destOp.Cancel()
+		}
+	}()
+
+	destOpAPI := destOp.Get()
+	destSecrets, err := destOpAPI.WebsocketSecrets()
+	if err != nil {
+		return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
+	}
+
+	pushTarget := &api.InstancePostTarget{
+		Operation:   destOp.URL().String(),
+		Websockets:  destSecrets,
+		Certificate: targetCertPEM,
+	}
+
+	srcMigration, err := newMigrationSource(inst, false, false, false, "", pushTarget)
+	if err != nil {
+		return fmt.Errorf("Failed setting up migration source for instance %q: %w", instName, err)
+	}
+
+	migrArgs := operations.OperationArgs{
+		ProjectName: projectName,
+		EntityURL:   entity.InstanceURL(projectName, instName),
+		Type:        operationtype.InstanceMigrate,
+		Class:       operations.OperationClassTask,
+		RunHook: func(ctx context.Context, innerOp *operations.Operation) error {
+			done := make(chan struct{})
+			defer close(done)
+			go func() {
+				select {
+				case <-done:
+				case <-ctx.Done():
+					srcMigration.disconnect()
+				}
+			}()
+
+			return srcMigration.Do(ctx, s, innerOp)
+		},
+	}
+
+	var srcOp *operations.Operation
+	if op.Requestor() != nil {
+		srcOp, err = operations.ScheduleUserOperationFromOperation(s, op, migrArgs)
+	} else {
+		srcOp, err = operations.ScheduleServerOperation(s, migrArgs)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	destOpCancelled = true // source is now connected via websockets; cancel would interrupt an in-flight transfer
+
+	err = srcOp.Wait(context.Background())
+	if err != nil {
+		return fmt.Errorf("Replication of instance %q failed on source: %w", instName, err)
+	}
+
+	return destOp.Wait()
 }
 
 // runScheduledReplicators loads all replicators, checks their schedule config key against the current

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -22,7 +22,6 @@ import (
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/instance"
-	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
@@ -999,6 +998,8 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	var clusterLink *api.ClusterLink
 	var targetCert *x509.Certificate
 	var sourceProject *api.Project
+	var allInsts []instance.Instance
+	var nodeAddressByName map[string]string
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		_, clusterLink, targetCert, err = lxdCluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
@@ -1012,10 +1013,41 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		}
 
 		sourceProject, err = dbProject.ToAPI(ctx, tx.Tx())
-		return err
+		if err != nil {
+			return err
+		}
+
+		// Load all instances in the project across all cluster members as
+		// instance.Instance. instance.Load() only performs in-memory config
+		// expansion and is safe for non-local instances.
+		err = tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+			inst, err := instance.Load(s, dbInst, p)
+			if err != nil {
+				return fmt.Errorf("Failed loading instance %q: %w", dbInst.Name, err)
+			}
+
+			allInsts = append(allInsts, inst)
+			return nil
+		}, dbCluster.InstanceFilter{Project: &projectName})
+		if err != nil {
+			return fmt.Errorf("Failed listing project instances: %w", err)
+		}
+
+		// Pre-load node addresses for forwarding to other cluster members.
+		nodes, err := tx.GetNodes(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed listing cluster members: %w", err)
+		}
+
+		nodeAddressByName = make(map[string]string, len(nodes))
+		for _, node := range nodes {
+			nodeAddressByName[node.Name] = node.Address
+		}
+
+		return nil
 	})
 	if err != nil {
-		return operations.OperationArgs{}, fmt.Errorf("Failed loading replicator run state: %w", err)
+		return operations.OperationArgs{}, fmt.Errorf("Failed loading replicator state: %w", err)
 	}
 
 	clusterCert := s.Endpoints.NetworkCert()
@@ -1040,31 +1072,24 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 	targetCertPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: targetCert.Raw}))
 
-	// Load local instances for forward replication and for restore of pre-existing instances.
-	localInsts, err := instanceLoadNodeProjectAll(ctx, s, projectName, instancetype.Any)
-	if err != nil {
-		return operations.OperationArgs{}, fmt.Errorf("Failed listing instances: %w", err)
-	}
-
-	localInstsByName := make(map[string]instance.Instance, len(localInsts))
-	for _, inst := range localInsts {
-		localInstsByName[inst.Name()] = inst
-	}
-
-	// In restore mode, all local instances must be stopped before proceeding.
-	// The restore operation refreshes each existing local instance from the remote leader
-	// and creates any that only exist on the leader; a running instance cannot be refreshed.
-	// Fail fast here to avoid a partial restore where some instances are updated and
-	// others are not.
+	// In restore mode, all project instances across all cluster members must be stopped
+	// before proceeding. The restore operation refreshes each existing instance from the
+	// leader cluster and creates any that only exist on the leader; a running instance
+	// cannot be refreshed. Fail fast here to avoid a partial restore where some instances
+	// are updated and others are not.
 	if restore {
-		for _, inst := range localInsts {
-			if inst.IsRunning() {
-				return operations.OperationArgs{}, fmt.Errorf("Instance %q is running, stop all project instances before running --restore", inst.Name())
+		for _, inst := range allInsts {
+			if inst.Location() == s.ServerName {
+				if inst.IsRunning() {
+					return operations.OperationArgs{}, fmt.Errorf("Instance %q is running, stop all project instances before running --restore", inst.Name())
+				}
+			} else if inst.LocalConfig()["volatile.last_state.power"] == instance.PowerStateRunning {
+				return operations.OperationArgs{}, fmt.Errorf("Instance %q on cluster member %q is running, stop all project instances before running --restore", inst.Name(), inst.Location())
 			}
 		}
 	}
 
-	// In restore mode the remote leader is the source of truth: use its instance list so
+	// In restore mode the leader cluster is the source of truth: use its instance list so
 	// that instances created on the leader after failover are included. Restore is additive
 	// only: local instances that do not exist on the leader are left in place and not deleted.
 	var iterNames []string
@@ -1079,10 +1104,22 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 			iterNames = append(iterNames, ri.Name)
 		}
 	} else {
-		iterNames = make([]string, 0, len(localInsts))
-		for _, inst := range localInsts {
+		// Forward replication: iterate over all instances in the project,
+		// including those on other cluster members.
+		iterNames = make([]string, 0, len(allInsts))
+		for _, inst := range allInsts {
 			iterNames = append(iterNames, inst.Name())
 		}
+	}
+
+	// Restore mode: iterate over the current leader cluster's instance list. Build a
+	// lookup from instance name to member address for routing to the correct cluster
+	// member. Instances that only exist on the current leader cluster (created after
+	// failover) will not be present in this map; the empty-string lookup signals that
+	// the instance should be created locally rather than refreshed on a specific member.
+	instMemberAddress := make(map[string]string, len(allInsts))
+	for _, inst := range allInsts {
+		instMemberAddress[inst.Name()] = nodeAddressByName[inst.Location()]
 	}
 
 	replicatorURL := entity.ReplicatorURL(projectName, name)
@@ -1090,8 +1127,6 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	childArgs := make([]*operations.OperationArgs, 0, len(iterNames))
 
 	for _, instName := range iterNames {
-		inst := localInstsByName[instName] // nil for instances that only exist on the remote leader
-
 		copyFunc := func(ctx context.Context, op *operations.Operation) error {
 			dstClient, err := lxdCluster.ConnectCluster(ctx, *clusterLink, lxdCluster.GetClusterLinkConnectionArgs(clusterCert, targetCert))
 			if err != nil {
@@ -1132,6 +1167,42 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				}
 
 				remoteOpURL := "https://" + remoteAddresses[0] + "/1.0/operations/" + remoteOpInfo.ID
+
+				// If the instance lives on another cluster member, forward the restore
+				// migration to that member so the refresh runs where the storage volume is.
+				memberAddress := instMemberAddress[instName]
+				if memberAddress != "" {
+					hostClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+					if err != nil {
+						return fmt.Errorf("Failed connecting to cluster member hosting instance %q: %w", instName, err)
+					}
+
+					hostClient = hostClient.UseProject(projectName)
+
+					restoreOp, err := hostClient.CreateInstance(api.InstancesPost{
+						Name:        instName,
+						InstancePut: freshInst.Writable(),
+						Type:        api.InstanceType(freshInst.Type),
+						Source: api.InstanceSource{
+							Type:        api.SourceTypeMigration,
+							Mode:        "pull",
+							Operation:   remoteOpURL,
+							Websockets:  remoteSecrets,
+							Certificate: targetCertPEM,
+							Refresh:     true,
+						},
+					})
+					if err != nil {
+						return fmt.Errorf("Failed requesting restore on hosting member for instance %q: %w", instName, err)
+					}
+
+					err = restoreOp.Wait()
+					if err != nil {
+						return fmt.Errorf("Restore of instance %q failed on hosting member: %w", instName, err)
+					}
+
+					return remoteMigrateOp.Wait()
+				}
 
 				// Load profiles for the instance to pass to the migration sink.
 				var profiles []api.Profile
@@ -1180,6 +1251,106 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 				result.revert.Success()
 				return remoteMigrateOp.Wait()
+			}
+
+			// Forward replication: handle both local and non-local instances.
+			memberAddress := instMemberAddress[instName]
+			if memberAddress != "" && memberAddress != nodeAddressByName[s.ServerName] {
+				// Instance on another cluster member: connect to the hosting member and
+				// drive the snapshot + push migration through its API so the migration
+				// source has direct access to the instance's storage.
+				hostClient, err := lxdCluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+				if err != nil {
+					return fmt.Errorf("Failed connecting to cluster member hosting instance %q: %w", instName, err)
+				}
+
+				hostClient = hostClient.UseProject(projectName)
+
+				// Get instance metadata from the hosting member.
+				srcInstInfo, _, err := hostClient.GetInstance(instName)
+				if err != nil {
+					return fmt.Errorf("Failed getting instance %q from hosting member: %w", instName, err)
+				}
+
+				// Create a snapshot on the hosting member if needed.
+				if snapshot && srcInstInfo.ExpandedConfig["snapshots.schedule"] == "" {
+					snapOp, err := hostClient.CreateInstanceSnapshot(instName, api.InstanceSnapshotsPost{})
+					if err != nil {
+						return fmt.Errorf("Failed creating snapshot of instance %q on hosting member: %w", instName, err)
+					}
+
+					err = snapOp.Wait()
+					if err != nil {
+						return fmt.Errorf("Failed waiting for snapshot of instance %q on hosting member: %w", instName, err)
+					}
+				}
+
+				// Re-fetch after snapshot so the writable metadata includes the new snapshot.
+				srcInstInfo, _, err = hostClient.GetInstance(instName)
+				if err != nil {
+					return fmt.Errorf("Failed getting instance %q after snapshot: %w", instName, err)
+				}
+
+				// Set up a push-mode migration sink on the destination.
+				destOp, err := dstClient.CreateInstance(api.InstancesPost{
+					Name:        instName,
+					InstancePut: srcInstInfo.Writable(),
+					Type:        api.InstanceType(srcInstInfo.Type),
+					Source: api.InstanceSource{
+						Type:    api.SourceTypeMigration,
+						Mode:    "push",
+						Refresh: true,
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("Failed requesting instance create on destination for %q: %w", instName, err)
+				}
+
+				destOpCancelled := false
+				defer func() {
+					if !destOpCancelled {
+						_ = destOp.Cancel()
+					}
+				}()
+
+				destOpAPI := destOp.Get()
+				destSecrets, err := destOpAPI.WebsocketSecrets()
+				if err != nil {
+					return fmt.Errorf("Failed getting websocket secrets from destination for instance %q: %w", instName, err)
+				}
+
+				dstConnInfo, err := dstClient.GetConnectionInfo()
+				if err != nil {
+					return fmt.Errorf("Failed getting connection info for destination: %w", err)
+				}
+
+				// Tell the hosting member to push-migrate the instance to the destination.
+				srcMigrateOp, err := hostClient.MigrateInstance(instName, api.InstancePost{
+					Migration: true,
+					Target: &api.InstancePostTarget{
+						Operation:   dstConnInfo.URL + "/1.0/operations/" + destOpAPI.ID,
+						Websockets:  destSecrets,
+						Certificate: targetCertPEM,
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("Failed starting push migration for instance %q: %w", instName, err)
+				}
+
+				destOpCancelled = true
+
+				err = srcMigrateOp.Wait()
+				if err != nil {
+					return fmt.Errorf("Replication of instance %q failed on hosting member: %w", instName, err)
+				}
+
+				return destOp.Wait()
+			}
+
+			// Local instance: handle replication directly.
+			inst := localInstByName(allInsts, instName)
+			if inst == nil {
+				return fmt.Errorf("Failed to find local instance %q", instName)
 			}
 
 			if snapshot && inst.ExpandedConfig()["snapshots.schedule"] == "" {
@@ -1331,6 +1502,17 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 			})
 		},
 	}, nil
+}
+
+// localInstByName finds an instance in the slice by name. Returns nil if not found.
+func localInstByName(insts []instance.Instance, name string) instance.Instance {
+	for _, inst := range insts {
+		if inst.Name() == name {
+			return inst
+		}
+	}
+
+	return nil
 }
 
 // runScheduledReplicators loads all replicators, checks their schedule config key against the current

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1078,14 +1078,9 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 	// cannot be refreshed. Fail fast here to avoid a partial restore where some instances
 	// are updated and others are not.
 	if restore {
-		for _, inst := range allInsts {
-			if inst.Location() == s.ServerName {
-				if inst.IsRunning() {
-					return operations.OperationArgs{}, fmt.Errorf("Instance %q is running, stop all project instances before running --restore", inst.Name())
-				}
-			} else if inst.LocalConfig()["volatile.last_state.power"] == instance.PowerStateRunning {
-				return operations.OperationArgs{}, fmt.Errorf("Instance %q on cluster member %q is running, stop all project instances before running --restore", inst.Name(), inst.Location())
-			}
+		err = replicatorCheckInstancesStopped(allInsts)
+		if err != nil {
+			return operations.OperationArgs{}, err
 		}
 	}
 
@@ -1502,6 +1497,19 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 			})
 		},
 	}, nil
+}
+
+// replicatorCheckInstancesStopped verifies that all project instances across all
+// cluster members are stopped before a restore operation. It checks the
+// volatile.last_state.power config key from the database for all instances.
+func replicatorCheckInstancesStopped(allInsts []instance.Instance) error {
+	for _, inst := range allInsts {
+		if inst.LocalConfig()["volatile.last_state.power"] == instance.PowerStateRunning {
+			return fmt.Errorf("Instance %q is running, stop all project instances before running --restore", inst.Name())
+		}
+	}
+
+	return nil
 }
 
 // localInstByName finds an instance in the slice by name. Returns nil if not found.

--- a/lxd/entity_deleter.go
+++ b/lxd/entity_deleter.go
@@ -233,6 +233,22 @@ func (d placementGroupDeleter) Delete(ctx context.Context, clientType request.Cl
 	return nil
 }
 
+type replicatorDeleter struct{}
+
+// Delete deletes a replicator.
+func (d replicatorDeleter) Delete(ctx context.Context, clientType request.ClientType, op *operations.Operation, s *state.State, ref entity.Reference) error {
+	name := ref.Name()
+
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.DeleteReplicator(ctx, tx.Tx(), name, ref.ProjectName)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed deleting replicator %q: %w", name, err)
+	}
+
+	return nil
+}
+
 // getEntityDeleter returns a deleter implementation for the given entity type.
 func getEntityDeleter(t entity.Type) (entityDeleter, error) {
 	switch t {
@@ -254,6 +270,8 @@ func getEntityDeleter(t entity.Type) (entityDeleter, error) {
 		return profileDeleter{}, nil
 	case entity.TypePlacementGroup:
 		return placementGroupDeleter{}, nil
+	case entity.TypeReplicator:
+		return replicatorDeleter{}, nil
 	default:
 		return nil, fmt.Errorf("Unsupported entity type %q", t)
 	}

--- a/lxd/entity_deleter_test.go
+++ b/lxd/entity_deleter_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared/entity"
+)
+
+// TestGetEntityDeleterCoversAllProjectEntityTypes checks that every entity type
+// that requires a project has a corresponding deleter registered in
+// getEntityDeleter. If a new project-level entity type is added without a
+// deleter, this test will fail.
+func TestGetEntityDeleterCoversAllProjectEntityTypes(t *testing.T) {
+	// All known entity types. Update this list when new types are added to
+	// shared/entity/type.go.
+	allTypes := []entity.Type{
+		entity.TypeContainer,
+		entity.TypeImage,
+		entity.TypeProfile,
+		entity.TypeProject,
+		entity.TypeCertificate,
+		entity.TypeInstance,
+		entity.TypeInstanceBackup,
+		entity.TypeInstanceSnapshot,
+		entity.TypeNetwork,
+		entity.TypeNetworkACL,
+		entity.TypeClusterMember,
+		entity.TypeStoragePool,
+		entity.TypeStorageVolume,
+		entity.TypeStorageVolumeBackup,
+		entity.TypeStorageVolumeSnapshot,
+		entity.TypeClusterGroup,
+		entity.TypeStorageBucket,
+		entity.TypeServer,
+		entity.TypeImageAlias,
+		entity.TypeNetworkZone,
+		entity.TypeIdentity,
+		entity.TypeAuthGroup,
+		entity.TypeIdentityProviderGroup,
+		entity.TypePlacementGroup,
+		entity.TypeClusterLink,
+		entity.TypeReplicator,
+	}
+
+	// These project-level entity types are intentionally excluded: they are
+	// sub-entities that are deleted implicitly when their parent is deleted,
+	// so no top-level deleter is needed.
+	noDeleterNeeded := map[entity.Type]bool{
+		entity.TypeContainer:             true, // alias for TypeInstance; deleted via instanceDeleter
+		entity.TypeInstanceBackup:        true, // deleted when instance is deleted
+		entity.TypeInstanceSnapshot:      true, // deleted when instance is deleted
+		entity.TypeStorageVolumeBackup:   true, // deleted when volume is deleted
+		entity.TypeStorageVolumeSnapshot: true, // deleted when volume is deleted
+		entity.TypeImageAlias:            true, // deleted when image is deleted
+	}
+
+	for _, entityType := range allTypes {
+		requiresProject, err := entityType.RequiresProject()
+		require.NoError(t, err, "entity type %q failed RequiresProject", entityType)
+
+		if !requiresProject || noDeleterNeeded[entityType] {
+			continue
+		}
+
+		_, err = getEntityDeleter(entityType)
+		assert.NoError(t, err, "entity type %q requires a project but has no deleter registered in getEntityDeleter", entityType)
+	}
+}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1483,12 +1483,14 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				if req.Source.Refresh {
 					targetInst, err := instance.LoadInstanceDatabaseObject(ctx, tx, targetProjectName, req.Name)
 					if err != nil {
-						return fmt.Errorf("Failed loading target instance %q: %w", req.Name, err)
-					}
-
-					targetMemberInfo = clusterMemberByName(allMembers, targetInst.Node)
-					if targetMemberInfo == nil {
-						return fmt.Errorf("Failed finding target cluster member %q", targetInst.Node)
+						if !response.IsNotFoundError(err) {
+							return fmt.Errorf("Failed loading target instance %q: %w", req.Name, err)
+						}
+					} else {
+						targetMemberInfo = clusterMemberByName(allMembers, targetInst.Node)
+						if targetMemberInfo == nil {
+							return fmt.Errorf("Failed finding target cluster member %q", targetInst.Node)
+						}
 					}
 				}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1484,24 +1484,13 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 						return fmt.Errorf("Failed loading target instance %q: %w", req.Name, err)
 					}
 
-					for _, member := range allMembers {
-						if member.Name == targetInst.Node {
-							targetMemberInfo = &member
-							break
-						}
-					}
-
+					targetMemberInfo = clusterMemberByName(allMembers, targetInst.Node)
 					if targetMemberInfo == nil {
 						return fmt.Errorf("Failed finding target cluster member %q", targetInst.Node)
 					}
 				}
 
-				for _, member := range allMembers {
-					if member.Name == sourceInst.Node {
-						sourceMemberInfo = &member
-					}
-				}
-
+				sourceMemberInfo = clusterMemberByName(allMembers, sourceInst.Node)
 				if sourceMemberInfo == nil {
 					return fmt.Errorf("Failed finding source cluster member %q", sourceInst.Node)
 				}
@@ -1533,6 +1522,23 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			if sourceImage != nil && req.Profiles == nil {
 				req.Architecture = sourceImage.Architecture
 				req.Profiles = sourceImage.Profiles
+			}
+
+		case api.SourceTypeMigration:
+			// When performing a migration with refresh, route the request to the cluster member
+			// that owns the existing instance rather than triggering new placement logic.
+			if s.ServerClustered && !clusterNotification && req.Source.Refresh && targetMemberInfo == nil {
+				targetInst, err := instance.LoadInstanceDatabaseObject(ctx, tx, targetProjectName, req.Name)
+				if err != nil {
+					if !response.IsNotFoundError(err) {
+						return fmt.Errorf("Failed loading target instance %q: %w", req.Name, err)
+					}
+				} else {
+					targetMemberInfo = clusterMemberByName(allMembers, targetInst.Node)
+					if targetMemberInfo == nil {
+						return fmt.Errorf("Failed finding target cluster member %q", targetInst.Node)
+					}
+				}
 			}
 		}
 
@@ -1964,4 +1970,16 @@ func instanceCreateFinish(ctx context.Context, s *state.State, req *api.Instance
 	}
 
 	return inst.Start(ctx, false, op)
+}
+
+// clusterMemberByName returns a pointer to the db.NodeInfo entry in members
+// whose Name matches the given name, or nil if no match is found.
+func clusterMemberByName(members []db.NodeInfo, name string) *db.NodeInfo {
+	for i := range members {
+		if members[i].Name == name {
+			return &members[i]
+		}
+	}
+
+	return nil
 }

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1403,8 +1403,10 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Only replicator runs from the configured cluster link can create instances in a standby replica project.
-		if targetProject.Config["replica.mode"] == "standby" {
+		// Only replicator runs from the configured cluster link (or internal cluster
+		// notifications forwarded by the coordinator) can create instances in a standby
+		// replica project.
+		if targetProject.Config["replica.mode"] == "standby" && !clusterNotification {
 			expectedCluster := targetProject.Config["replica.cluster"]
 
 			// Verify the request comes from the configured cluster link identity.

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -778,8 +778,13 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 			return err
 		}
 
-		// Clear the target for the subvol to use.
-		_ = os.Remove(op.dest)
+		// Clear the target for the subvol to use. During refresh the destination may already
+		// be a btrfs subvolume which os.Remove cannot delete.
+		if d.isSubvolume(op.dest) {
+			_ = d.deleteSubvolume(op.dest, true)
+		} else {
+			_ = os.Remove(op.dest)
+		}
 
 		err = os.Rename(op.src, op.dest)
 		if err != nil {
@@ -1273,6 +1278,18 @@ func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArg
 }
 
 func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, subvolumes []BTRFSSubVolume, progressReporter ioprogress.ProgressReporter) error {
+	// readonlyRestore tracks subvolume paths that were set readonly for sending and need to be
+	// restored afterward. Restoration is deferred to the end of the function rather than per-send
+	// to avoid toggling readonly state between sends. Toggling clears the received_uuid on
+	// subvolumes that were previously received, causing "cannot find parent subvolume" errors
+	// during btrfs receive on the target.
+	var readonlyRestore []string
+	defer func() {
+		for _, path := range readonlyRestore {
+			_ = d.setSubvolumeReadonlyProperty(path, false)
+		}
+	}()
+
 	// sendVolume sends a volume and its subvolumes (if negotiated subvolumes feature) to recipient.
 	sendVolume := func(v Volume, sourcePrefix string, parentPrefix string) error {
 		snapName := "" // Default to empty (sending main volume) from migrationHeader.Subvolumes.
@@ -1292,7 +1309,6 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 		sentVols := 0
 
 		// Send volume (and any subvolumes if supported) to target.
-		//revive:disable:defer Allow defer inside a loop.
 		for _, subVolume := range subvolumes {
 			if subVolume.Snapshot != snapName {
 				continue // Only sending subvolumes related to snapshot name (empty for main vol).
@@ -1314,7 +1330,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 						return err
 					}
 
-					defer func() { _ = d.setSubvolumeReadonlyProperty(parentPath, false) }()
+					readonlyRestore = append(readonlyRestore, parentPath)
 				}
 			}
 
@@ -1326,7 +1342,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 					return err
 				}
 
-				defer func() { _ = d.setSubvolumeReadonlyProperty(sourcePath, false) }()
+				readonlyRestore = append(readonlyRestore, sourcePath)
 			}
 
 			d.logger.Debug("Sending subvolume", logger.Ctx{"name": v.name, "source": sourcePath, "parent": parentPath, "path": subVolume.Path})

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -67,6 +67,7 @@ readonly test_group_replicator_storage=(
     "clustering_replicator_dr"
     "clustering_replicator_snapshot"
     "clustering_replicator_multi_member"
+    "clustering_replicator_vm"
 )
 
 readonly test_group_instance=(

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -59,10 +59,14 @@ readonly test_group_cluster_storage=(
     "clustering_recovery"
     "clustering_storage"
     "clustering_storage_single_node"
+)
+
+readonly test_group_replicator_storage=(
     "clustering_replicator_basic"
     "clustering_replicator_scheduled"
     "clustering_replicator_dr"
     "clustering_replicator_snapshot"
+    "clustering_replicator_multi_member"
 )
 
 readonly test_group_instance=(
@@ -280,6 +284,7 @@ readonly test_group_standalone_storage=(
 readonly test_group_all=(
     "${test_group_cluster[@]}"
     "${test_group_cluster_storage[@]}"
+    "${test_group_replicator_storage[@]}"
     "${test_group_instance[@]}"
     "${test_group_image[@]}"
     "${test_group_network[@]}"

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -67,6 +67,7 @@ readonly test_group_replicator_storage=(
     "clustering_replicator_dr"
     "clustering_replicator_snapshot"
     "clustering_replicator_multi_member"
+    "clustering_replicator_evacuated_member"
     "clustering_replicator_vm"
 )
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5998,7 +5998,7 @@ test_clustering_replicator_dr() {
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected with a clear error.
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before running --restore' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 
   sub_test "Restore: set LXD_ONE to standby and restore c1, c2, and c3 from LXD_TWO"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6098,3 +6098,147 @@ test_clustering_replicator_snapshot() {
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_ONE_DIR}"
 }
+
+test_clustering_replicator_multi_member() {
+  local poolDriver
+  poolDriver=$(storage_backend "${LXD_INITIAL_DIR}")
+
+  # Ceph uses a single shared OSD pool name derived from TEST_DIR. Bootstrapping two
+  # separate clusters (source + target) would create the same pool name twice, causing
+  # "Pool seems to be in use by another LXD instance" errors.
+  if [ "${poolDriver}" = "ceph" ]; then
+    return
+  fi
+
+  # Source cluster: multi-member cluster (node1 + node2) to verify replication
+  # of instances on remote cluster members.
+  spawn_lxd_and_bootstrap_cluster "${poolDriver}"
+
+  local cert
+  # shellcheck disable=SC2153
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+  spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}" "${poolDriver}"
+
+  # Target cluster: separate single-node cluster (node3).
+  spawn_lxd_and_bootstrap_cluster "${poolDriver}" "" 3
+
+  # Create projects on both clusters.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
+  LXD_DIR="${LXD_THREE_DIR}" lxc project create replicator-project
+
+  # Setup auth groups.
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+
+  LXD_B_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_b --quiet --auth-group replicator-group)"
+
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_THREE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_DIR="${LXD_THREE_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
+
+  # Configure replica project settings.
+  LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=standby
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b replica.mode=leader
+
+  # Setup storage: the bootstrapped clusters already have a "data" pool;
+  # add a root device to the default profile in the replicator project.
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool=data --project replicator-project
+  LXD_DIR="${LXD_THREE_DIR}" lxc profile device add default root disk path="/" pool=data --project replicator-project
+
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
+
+  sub_test "Verify instances on different source members are replicated"
+
+  # Create instances on different source cluster members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc launch --target node1 testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage c2 --project replicator-project -d "${SMALL_ROOT_DISK}"
+
+  # Verify instances are on the expected members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c1,node1'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c2,node2'
+
+  # Create replicator and run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+
+  # Both instances must appear on the target cluster.
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+
+  # The replicator operation must report success with two child operations.
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+
+  sub_test "Verify snapshot=true works for instances on other cluster members"
+
+  LXD_DIR="${LXD_THREE_DIR}" lxc delete c1 c2 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator set my-replicator snapshot=true --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+
+  # Snapshots must have been created on both source instances.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
+
+  # Both instances and their snapshots must be on the target.
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,1'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,1'
+
+  sub_test "Verify idempotent run with instances on other cluster members"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+
+  # Snapshot count must have incremented on both source instances after the second snapshot=true run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+
+  # Target must also reflect the new snapshots.
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,2'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,2'
+
+  sub_test "Verify --restore rejects running instances on other members"
+
+  # Simulate failover: source becomes standby, target becomes leader.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
+  LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=leader
+
+  # c1 is still running on node1 — restore must refuse to proceed.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1; then
+    echo "ERROR: restore unexpectedly succeeded with a running instance" >&2
+    exit 1
+  fi
+
+  sub_test "Verify --restore from target back to multi-member source"
+
+  # Stop all instances on the source cluster before restore.
+  LXD_DIR="${LXD_ONE_DIR}" lxc stop c1 --force --project replicator-project 2>/dev/null || true
+
+  # Run restore: pulls instances from the target (LXD_THREE) back to source (LXD_ONE).
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
+
+  # Restore operation must succeed with both instances.
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '.status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+
+  # Both instances must be present on the source cluster with their snapshots.
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,2'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,2'
+
+  # Verify instances were restored to their original cluster members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c1,node1'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c2,node2'
+
+  # Cleanup: instances exist on both clusters after replication + restore.
+  LXD_DIR="${LXD_THREE_DIR}" lxc delete c1 c2 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete c1 c2 --project replicator-project
+  LXD_DIR="${LXD_THREE_DIR}" lxc profile device remove default root --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project
+  kill_lxd "${LXD_THREE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+  teardown_clustering_netns
+  teardown_clustering_bridge
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6242,3 +6242,90 @@ test_clustering_replicator_multi_member() {
   teardown_clustering_netns
   teardown_clustering_bridge
 }
+
+test_clustering_replicator_vm() {
+  # Two standalone clustered LXD daemons simulating separate clusters.
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_ONE_DIR}" true
+
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_TWO_DIR}" true
+
+  # Enable clustering on both.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster enable node2
+
+  # Create projects on both clusters.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project create replicator-project
+
+  # Setup auth groups and cluster links.
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_ONE_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --quiet --auth-group replicator-group)"
+
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
+
+  # Configure replica project settings.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one replica.mode=standby
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
+
+  # Setup storage on both clusters.
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
+
+  sub_test "Verify VM replication works"
+
+  # Create an empty VM (no image needed).
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --vm --empty v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}" --project replicator-project
+
+  # Create replicator and run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create vm-replicator cluster=lxd_two --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
+
+  # VM must appear on the target cluster.
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,0'
+
+  sub_test "Verify VM replication with snapshot=true"
+
+  LXD_DIR="${LXD_TWO_DIR}" lxc delete v1 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator set vm-replicator snapshot=true --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
+
+  # A snapshot must have been created on the source VM.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
+
+  # VM and snapshot must be on the target.
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,1'
+
+  sub_test "Verify idempotent second run for VM replication"
+
+  # Run again without deleting anything; exercises the refresh (Refresh: true)
+  # path which previously failed with backup file write errors (#18205).
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
+
+  # Operation must succeed.
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '.status == "Success" and ((.children // []) | length) == 1 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+
+  # snapshot=true creates a second snapshot, so source now has 2.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+
+  # VM must still exist with both snapshots on the target.
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,2'
+
+  # Cleanup
+  LXD_DIR="${LXD_TWO_DIR}" lxc delete v1 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete v1 --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6252,6 +6252,163 @@ test_clustering_replicator_multi_member() {
   teardown_clustering_bridge
 }
 
+test_clustering_replicator_evacuated_member() {
+  local poolDriver
+  poolDriver=$(storage_backend "${LXD_INITIAL_DIR}")
+
+  # Ceph pools are global, so running two separate clusters (source + target) on the
+  # same host would create the same pool name twice, causing
+  # "Pool seems to be in use by another LXD instance" errors.
+  if [ "${poolDriver}" = "ceph" ]; then
+    return
+  fi
+
+  # Source cluster: 3-member cluster (node1 + node2 + node3).
+  spawn_lxd_and_bootstrap_cluster "${poolDriver}"
+
+  local cert
+  # shellcheck disable=SC2153
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+  spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}" "${poolDriver}"
+  spawn_lxd_and_join_cluster "${cert}" 3 1 "${LXD_ONE_DIR}" "${poolDriver}"
+
+  # Target cluster: separate single-node cluster (node4).
+  spawn_lxd_and_bootstrap_cluster "${poolDriver}" "" 4
+
+  # Create projects on both clusters.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project create replicator-project
+
+  # Setup auth groups.
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+
+  LXD_B_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_b --quiet --auth-group replicator-group)"
+
+  LXD_DIR="${LXD_FOUR_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_FOUR_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_FOUR_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_DIR="${LXD_FOUR_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
+
+  # Configure replica project settings.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=standby
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b replica.mode=leader
+
+  # Setup storage profiles.
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool=data --project replicator-project
+  LXD_DIR="${LXD_FOUR_DIR}" lxc profile device add default root disk path="/" pool=data --project replicator-project
+
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
+
+  sub_test "Forward replication with evacuated member"
+
+  # Create stopped instances on node2 and node3.
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node3 testimage c2 --project replicator-project -d "${SMALL_ROOT_DISK}"
+
+  # Ensure instances move during evacuation.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c1 cluster.evacuate=migrate --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c2 cluster.evacuate=migrate --project replicator-project
+
+  # Evacuate node2; c1 should migrate to node1 or node3.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate node2 --force
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -F "status: Evacuated"
+
+  # c1 must no longer be on node2.
+  c1_location="$(LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c L c1)"
+  [ "${c1_location}" != "node2" ]
+
+  # Create replicator and run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+
+  # Both instances must appear on the target cluster.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
+  LXD_DIR="${LXD_FOUR_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+
+  sub_test "Idempotent replication with evacuated member"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+
+  # Replicator operation must succeed with two child operations.
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '.status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+
+  sub_test "Restore with evacuated member"
+
+  # Simulate failover: source becomes standby, target becomes leader.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=leader
+
+  # Run restore with node2 still evacuated.
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
+
+  # Both instances must be present on the source cluster.
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+
+  # c1 should have been restored to its post-evacuation location (not node2).
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c L c1)" = "${c1_location}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c L c2)" = "node3" ]
+
+  sub_test "Forward replication with down member"
+
+  # Flip back to leader mode.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.mode=standby
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
+
+  # Bring node2 back online. Use --action=skip because instances were already
+  # restored to their post-evacuation locations by the replicator restore.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore node2 --action=skip --force
+
+  # Move c1 to node2 and create c3 on node2.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target node2 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
+
+  # Shut down node2 to simulate a down member.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 11
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  sleep 11
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -xF "status: Offline"
+
+  # Delete target instances so the replicator creates fresh copies.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc delete c1 c2 --project replicator-project
+
+  # Run the replicator; instances on node2 (c1, c3) should fail, c2 on node3 should succeed.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1; then
+    echo "ERROR: replicator unexpectedly succeeded with a down member" >&2
+    exit 1
+  fi
+
+  # c2 (on node3) must have been replicated despite the partial failure.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+
+  # Cleanup.
+  # Respawn node2 so the source cluster has quorum for cleanup commands.
+  respawn_lxd_cluster_member "${ns2}" "${LXD_TWO_DIR}"
+  LXD_DIR="${LXD_FOUR_DIR}" lxc delete c2 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete c1 c2 c3 --project replicator-project
+  LXD_DIR="${LXD_FOUR_DIR}" lxc profile device remove default root --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project
+  # Gracefully shut down the 3-node source cluster while quorum still
+  # exists, then call kill_lxd for leftover checks and filesystem cleanup.
+  # Shut down node3 first (node1+node2 maintain quorum), then node2
+  # (node1+node2 = 2/3 quorum). Node1 is the last voter so it cannot
+  # achieve quorum; remove its socket and force-kill its process.
+  LXD_DIR="${LXD_THREE_DIR}" timeout -k 30 30 lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" timeout -k 30 30 lxd shutdown
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  kill -9 "$(cat "${LXD_ONE_DIR}/lxd.pid")" 2>/dev/null || true
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
+  kill_lxd "${LXD_FOUR_DIR}"
+  teardown_clustering_netns
+  teardown_clustering_bridge
+}
+
 test_clustering_replicator_vm() {
   # Two standalone clustered LXD daemons simulating separate clusters.
   LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -432,6 +432,15 @@ test_clustering_containers() {
   LXD_DIR="${LXD_ONE_DIR}" lxc delete -f test-refresh
   LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo
 
+  echo "Refresh copy when target does not exist yet should create the target."
+  LXD_DIR="${LXD_ONE_DIR}" lxc copy foo refresh-new --refresh --target node3
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L refresh-new)" = "node3" ]
+
+  echo "Subsequent refresh should succeed with the target already in place."
+  LXD_DIR="${LXD_ONE_DIR}" lxc copy foo refresh-new --refresh
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L refresh-new)" = "node3" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f refresh-new
+
   echo "Copy the container on node2 to node3, using a client connected to node1."
   LXD_DIR="${LXD_ONE_DIR}" lxc copy foo bar --target node3
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc list -f csv -c L bar)" = "node3" ]


### PR DESCRIPTION
This pull request introduces several improvements and new features related to cluster-aware instance migration, replicator support, and Btrfs migration reliability. The most notable changes include enhanced logic for instance refresh and migration routing in clusters, better handling of Btrfs subvolume states during migration, and expanded test coverage for replicator and migration scenarios. Additionally, support for replicator entities has been integrated into project usage tracking and entity deletion.

**Cluster-aware instance migration and refresh:**
- Improved the logic in `instances_post.go` to ensure that instance refresh and migration operations are routed to the correct cluster member, both when the target instance exists and when it does not, by introducing the helper function `clusterMemberByName` and updating routing for migration with refresh. [[1]](diffhunk://#diff-5f8ac174cb0dd00fbfa61d9a4c60c76e1d165c86c045dda7b1bbe70118a5ed43R1486-R1497) [[2]](diffhunk://#diff-5f8ac174cb0dd00fbfa61d9a4c60c76e1d165c86c045dda7b1bbe70118a5ed43R1530-R1546) [[3]](diffhunk://#diff-5f8ac174cb0dd00fbfa61d9a4c60c76e1d165c86c045dda7b1bbe70118a5ed43R1978-R1989) [[4]](diffhunk://#diff-7cd3b6dcbb2b188abfdc6a6141d12b1f779cd4ce27356d86f1e855dd1414923aR435-R443)
- Allowed cluster notifications to create instances in standby replica projects, not just replicator runs, improving support for internal cluster operations.

**Replicator support and project usage tracking:**
- Added `entity.TypeReplicator` to project usage tracking and documentation, and implemented a `replicatorDeleter` for proper deletion of replicator entities. [[1]](diffhunk://#diff-aacb2f1b290376e4cb83744877746e399562a1c5a1a748f8f148a0c9460ca4fdR243) [[2]](diffhunk://#diff-aacb2f1b290376e4cb83744877746e399562a1c5a1a748f8f148a0c9460ca4fdL254-R255) [[3]](diffhunk://#diff-2b2dc7aec8134ecdeb89af9f280a3b5db0d22081e6304228bd5675314d2056a3R236-R251) [[4]](diffhunk://#diff-2b2dc7aec8134ecdeb89af9f280a3b5db0d22081e6304228bd5675314d2056a3R273-R274)

**Btrfs migration reliability:**
- Enhanced Btrfs migration logic to defer restoration of subvolume readonly properties until the end of the migration, preventing issues with lost `received_uuid` and improving reliability of incremental sends. [[1]](diffhunk://#diff-4877286ef2afd4e7764471d2176388a760278282d789bd212d48849fef876830R1281-R1292) [[2]](diffhunk://#diff-4877286ef2afd4e7764471d2176388a760278282d789bd212d48849fef876830L1295) [[3]](diffhunk://#diff-4877286ef2afd4e7764471d2176388a760278282d789bd212d48849fef876830L1317-R1333) [[4]](diffhunk://#diff-4877286ef2afd4e7764471d2176388a760278282d789bd212d48849fef876830L1329-R1345)
- Improved subvolume deletion logic during refresh to handle cases where the destination is already a Btrfs subvolume. (F241abacL233R233)

**API and client improvements:**
- Added a `URL()` method to the `Operation` interface and its implementations, allowing retrieval of the full URL for an operation. [[1]](diffhunk://#diff-17fcb0110ba89de5cc463080ca07022a507374f29f1cfbd9af40b2714b143ab0R26) [[2]](diffhunk://#diff-600e6ea2300038dc1d1f24d7d808400158b647b6cd128e0316036ee7be412c7aR90-R95) [[3]](diffhunk://#diff-600e6ea2300038dc1d1f24d7d808400158b647b6cd128e0316036ee7be412c7aR441-R445)
- Updated imports in relevant files to support the new functionality. [[1]](diffhunk://#diff-17fcb0110ba89de5cc463080ca07022a507374f29f1cfbd9af40b2714b143ab0R8) [[2]](diffhunk://#diff-600e6ea2300038dc1d1f24d7d808400158b647b6cd128e0316036ee7be412c7aR7-R14)

**Test coverage expansion:**
- Added new test groups and cases for replicator storage and cluster-aware refresh scenarios, and updated error message assertions for clarity. [[1]](diffhunk://#diff-41ab59f270ee83ecfdc0812e18cca8c151e3a199bde89bb27e9b947a61d02cffR62-R71) [[2]](diffhunk://#diff-41ab59f270ee83ecfdc0812e18cca8c151e3a199bde89bb27e9b947a61d02cffR289) [[3]](diffhunk://#diff-7cd3b6dcbb2b188abfdc6a6141d12b1f779cd4ce27356d86f1e855dd1414923aR435-R443) [[4]](diffhunk://#diff-7cd3b6dcbb2b188abfdc6a6141d12b1f779cd4ce27356d86f1e855dd1414923aL5992-R6001)