### PR TITLE
lxd/events: Add security sys user events

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -29,6 +29,7 @@ import (
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
@@ -1233,6 +1234,12 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := newClusterConfig.LokiServer()
 
 		if lokiURL == "" || lokiLoglevel == "" || len(lokiTypes) == 0 {
+			if d.lokiClient != nil {
+				// Emit "monitoring disabled" security event, since loki configuration is being unset.
+				// This should be the last log entry that is sent to loki.
+				d.events.SendSecurity(security.SysMonitorDisabled.ServerEvent(security.LevelWarning, "Loki monitoring disabled"))
+			}
+
 			d.internalListener.RemoveHandler("loki")
 			if d.lokiClient != nil {
 				d.lokiClient.Stop()

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -569,7 +569,7 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkRenamed.Event(req.Name, requestor, logger.Ctx{"old_name": name}))
 
 	// Notify other members, update the cache, and send an identity lifecycle event.
-	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identityIdentifier, true)
+	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identityIdentifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -648,8 +648,8 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r.Context())
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkDeleted.Event(name, requestor, nil))
 
-	// Notify other members, update the cache, and send an identity lifecycle event.
-	_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identity.Identifier, true)
+	// Notify other members, update the cache, send an identity lifecycle event, and send an identity deleted security event.
+	_, err = notify(lifecycle.IdentityDeleted, api.AuthenticationMethodTLS, identity.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -822,8 +822,8 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 	// Send cluster link lifecycle event.
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
 
-	// Notify other members, update the cache, and send a lifecycle event.
-	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false)
+	// Notify other members, update the cache, send an identity lifecycle event, and send an identity created security event.
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -958,8 +958,8 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		// Send cluster link lifecycle event.
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
 
-		// Notify other members, update the cache, and send an identity lifecycle event.
-		lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, fingerprint, true)
+		// Notify other members, update the cache, send an identity lifecycle event, and send an identity created security event.
+		lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, fingerprint, true, true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1083,8 +1083,8 @@ func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPo
 	// Send cluster link lifecycle event.
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(clusterLinkName, requestor, nil))
 
-	// Notify other members, update the cache, and send an identity lifecycle event.
-	lc, err := notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identifier.String(), true)
+	// Notify other members, update the cache, send an identity lifecycle event, and send an identity updated security event.
+	lc, err := notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, fingerprint, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2043,6 +2043,8 @@ func (d *Daemon) init() error {
 	// Unblock incoming requests
 	d.waitReady.Cancel()
 
+	d.events.SendSecurity(security.SysStartup.ServerEvent(security.LevelInfo, "LXD daemon started"))
+
 	logger.Info("Daemon started")
 
 	return nil
@@ -2184,6 +2186,12 @@ func cancelCancelableOps(ctx context.Context) error {
 
 // Stop stops the shared daemon.
 func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
+	// Emit sys_shutdown before cancelling shutdownCtx so internal sinks (e.g. the Loki client)
+	// are still alive to forward the event.
+	if d.events != nil {
+		d.events.SendSecurity(security.SysShutdown.ServerEvent(security.LevelInfo, "LXD daemon stopping"))
+	}
+
 	// Cancelling the context will make everyone aware that we're shutting down.
 	d.shutdownCtx.Cancel()
 

--- a/lxd/db/oidc/session.go
+++ b/lxd/db/oidc/session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/lxd/lxd/events"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/request/security"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
@@ -186,6 +187,25 @@ func (s *sessionHandler) StartSession(r *http.Request, res oidc.AuthenticationRe
 	if action != "" {
 		lc := action.Event(api.AuthenticationMethodOIDC, res.Email, request.CreateRequestor(r.Context()), nil)
 		s.events.SendLifecycle("", lc)
+
+		var secAction security.SecurityAction
+		var description string
+		switch action {
+		case lifecycle.IdentityCreated:
+			secAction, description = security.UserCreated, "Identity created"
+		case lifecycle.IdentityUpdated:
+			secAction, description = security.UserUpdated, "Identity updated"
+		}
+
+		// Emitted as a daemon-level event because the identity is being
+		// synced from the IdP, not created or updated by the logging-in
+		// user. The affected identity is appended to the event name suffix.
+		if secAction != "" {
+			s.events.SendSecurity(secAction.WithSuffix(api.AuthenticationMethodOIDC, res.Email).ServerEvent(
+				security.LevelInfo,
+				description,
+			))
+		}
 	}
 
 	return &sessionID, &expiry, nil

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -192,7 +192,10 @@ var bearerIdentityTokenCmd = APIEndpoint{
 
 // identityNotificationFunc is used when an identity is created, updated, or deleted.
 // The signature is defined here as a convenience so that the function signature doesn't need to be written in full when used as an argument.
-type identityNotificationFunc func(action lifecycle.IdentityAction, authenticationMethod string, identifier string, updateCache bool) (*api.EventLifecycle, error)
+// Set emitUserEvent to true to emit a `user_{created,updated,deleted}` security event.
+// This should be false when issuing/revoking tokens because `authn_token_{created,revoked}` events are emitted separately.
+// `authz_admin` events are always emitted.
+type identityNotificationFunc func(action lifecycle.IdentityAction, authenticationMethod string, identifier string, updateCache bool, emitUserEvent bool) (*api.EventLifecycle, error)
 
 const (
 	// ctxClusterDBIdentity is used in the identityAccessHandler to set a [cluster.IdentitiesRow] into the request context.
@@ -455,7 +458,7 @@ func identitiesBearerPost(d *Daemon, r *http.Request) response.Response {
 
 	// Send lifecycle event for identity creation.
 	// No need to update cache because no token has been issued for the identity yet, so they can't authenticate.
-	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodBearer, newIdentityID.String(), false)
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodBearer, newIdentityID.String(), false, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -571,7 +574,10 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 	networkCert := s.Endpoints.NetworkCert()
 	serverCert := s.ServerCert()
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
-	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodBearer, id.Identifier, true)
+	// Token issuance has its own dedicated authn_token_created security event,
+	// so suppress the generic user_updated to avoid duplicate audit records
+	// for what is conceptually a token operation rather than an identity edit.
+	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodBearer, id.Identifier, true, false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -626,7 +632,11 @@ func identityBearerTokenDelete(d *Daemon, r *http.Request) response.Response {
 	networkCert := s.Endpoints.NetworkCert()
 	serverCert := s.ServerCert()
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
-	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodBearer, id.Identifier, true)
+	// Token revocation has its own dedicated authn_token_revoked security
+	// event, so suppress the generic user_updated to avoid duplicate audit
+	// records for what is conceptually a token operation rather than an
+	// identity edit.
+	_, err = notify(lifecycle.IdentityUpdated, api.AuthenticationMethodBearer, id.Identifier, true, false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -685,8 +695,12 @@ func createIdentityTLSUntrusted(ctx context.Context, s *state.State, peerCertifi
 		return response.SmartError(err)
 	}
 
-	// Notify other members, update the cache, and send a lifecycle event.
-	lc, err := notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identifier.String(), true)
+	fingerprint := shared.CertFingerprint(cert)
+
+	// Activation replaces the pending UUID identifier with the cert
+	// fingerprint in the database, so the event must reference the
+	// fingerprint to stay resolvable.
+	lc, err := notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, fingerprint, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -757,7 +771,7 @@ func createIdentityTLSTrusted(ctx context.Context, s *state.State, peerCertifica
 	}
 
 	// Notify other members, update the cache, and send a lifecycle event.
-	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, fingerprint, true)
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, fingerprint, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -869,7 +883,7 @@ func createIdentityTLSPending(ctx context.Context, s *state.State, req api.Ident
 	}
 
 	// Notify other members, update the cache, and send a lifecycle event.
-	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false)
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1833,7 +1847,7 @@ func updateSelfIdentityUnprivileged(s *state.State, r *http.Request, id dbCluste
 
 	// Notify other cluster members to update their identity cache.
 	notify := newIdentityNotificationFunc(s, r, s.Endpoints.NetworkCert(), s.ServerCert())
-	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true)
+	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1912,7 +1926,7 @@ func updateIdentityPrivileged(s *state.State, r *http.Request, id dbCluster.Iden
 
 	// Notify other cluster members to update their identity cache.
 	notify := newIdentityNotificationFunc(s, r, s.Endpoints.NetworkCert(), s.ServerCert())
-	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true)
+	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2139,7 +2153,7 @@ func patchIdentityPrivileged(s *state.State, r *http.Request, id dbCluster.Ident
 
 	// Notify other cluster members to update their identity cache.
 	notify := newIdentityNotificationFunc(s, r, s.Endpoints.NetworkCert(), s.ServerCert())
-	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true)
+	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2203,7 +2217,7 @@ func patchSelfIdentityUnprivileged(s *state.State, r *http.Request, id dbCluster
 
 	// Notify other cluster members to update their identity cache.
 	notify := newIdentityNotificationFunc(s, r, s.Endpoints.NetworkCert(), s.ServerCert())
-	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true)
+	_, err = notify(lifecycle.IdentityUpdated, string(id.AuthMethod), id.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2298,7 +2312,7 @@ func identityDelete(d *Daemon, r *http.Request) response.Response {
 
 	// Notify other cluster members to update their identity cache.
 	notify := newIdentityNotificationFunc(s, r, s.Endpoints.NetworkCert(), s.ServerCert())
-	_, err = notify(lifecycle.IdentityDeleted, string(id.AuthMethod), id.Identifier, true)
+	_, err = notify(lifecycle.IdentityDeleted, string(id.AuthMethod), id.Identifier, true, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2309,7 +2323,7 @@ func identityDelete(d *Daemon, r *http.Request) response.Response {
 // newIdentityNotificationFunc returns a function that creates and sends a lifecycle event for the identity.
 // If updateCache is true, the local identity cache is updated and a notification is sent to other members to do the same.
 func newIdentityNotificationFunc(s *state.State, r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo) identityNotificationFunc {
-	return func(action lifecycle.IdentityAction, authenticationMethod string, identifier string, updateCache bool) (*api.EventLifecycle, error) {
+	return func(action lifecycle.IdentityAction, authenticationMethod string, identifier string, updateCache bool, emitUserEvent bool) (*api.EventLifecycle, error) {
 		if updateCache {
 			// Send a notification to other cluster members to refresh their identity cache.
 			notifier, err := cluster.NewNotifier(s, networkCert, serverCert, cluster.NotifyAlive)
@@ -2340,6 +2354,23 @@ func newIdentityNotificationFunc(s *state.State, r *http.Request, networkCert *s
 		if suffix != "" {
 			secEvt := security.AuthzAdmin.WithSuffix(suffix, authenticationMethod+"/"+identifier).UserEvent(r.Context(), security.LevelInfo, "Identity "+string(action))
 			s.Events.SendSecurity(secEvt)
+		}
+
+		var secAction security.SecurityAction
+		var description string
+		switch action {
+		case lifecycle.IdentityCreated:
+			secAction, description = security.UserCreated, "Identity created"
+		case lifecycle.IdentityUpdated:
+			secAction, description = security.UserUpdated, "Identity updated"
+		case lifecycle.IdentityDeleted:
+			secAction, description = security.UserDeleted, "Identity deleted"
+		}
+
+		// Embed the affected identity in the security event name so consumers
+		// can identify which user record was created/updated/deleted.
+		if secAction != "" && emitUserEvent {
+			s.Events.SendSecurity(secAction.WithSuffix(authenticationMethod, identifier).UserEvent(r.Context(), security.LevelInfo, description))
 		}
 
 		return &lc, nil

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -186,6 +186,7 @@ readonly test_group_standalone=(
     "security_sys_events"
     "security_user_events"
     "security_user_events_cluster_link"
+    "security_user_events_oidc"
     "server_config"
     "server_info"
     "shutdown"

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -183,6 +183,8 @@ readonly test_group_standalone=(
     "security_events_bearer_authn"
     "security_authz_events"
     "security_protection"
+    "security_sys_events"
+    "security_user_events"
     "server_config"
     "server_info"
     "shutdown"

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -185,6 +185,7 @@ readonly test_group_standalone=(
     "security_protection"
     "security_sys_events"
     "security_user_events"
+    "security_user_events_cluster_link"
     "server_config"
     "server_info"
     "shutdown"

--- a/test/suites/loki.sh
+++ b/test/suites/loki.sh
@@ -55,8 +55,53 @@ test_loki_security_types() {
   lxc launch testimage c-loki-security
   lxc delete -f c-loki-security
 
-  # Changing the loki configuration sends any accumulated logs to the test server.
+  sub_test "Verify sys_monitor_disabled does not fire when security is removed from loki.types"
+  local monfile="${TEST_DIR}/loki-monitor-disabled.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  # The Loki client stays up; sys_monitor_disabled is reserved for the
+  # full enabled -> disabled transition.
+  lxc config set loki.types="lifecycle,logging"
+  sleep 1
+  jq --exit-status --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled")) | length == 0' "${monfile}"
+
+  sub_test "Verify sys_monitor_disabled fires when Loki is disabled after being enabled"
+  local sys_monitor_disabled_count_before_full_off sys_monitor_disabled_count_after_full_off
+  sys_monitor_disabled_count_before_full_off=$(jq --raw-output --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled")) | length' "${monfile}")
+
+  # Disabling loki.api.url tears down the loki client; this is the
+  # enabled -> disabled transition that emits sys_monitor_disabled.
   lxc config set loki.api.url="" loki.auth.username="" loki.auth.password="" loki.types=""
+
+  for _ in $(seq 10); do
+    sys_monitor_disabled_count_after_full_off=$(jq --raw-output --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled")) | length' "${monfile}")
+    [ "${sys_monitor_disabled_count_after_full_off}" -gt "${sys_monitor_disabled_count_before_full_off}" ] && break
+    sleep 1
+  done
+
+  [ "${sys_monitor_disabled_count_after_full_off}" -gt "${sys_monitor_disabled_count_before_full_off}" ]
+  jq --exit-status --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled" and .metadata.description == "Loki monitoring disabled")) | length == 1' "${monfile}"
+
+  sub_test "Verify sys_monitor_disabled does not fire when Loki was never configured"
+  # Loki is already off; toggling an unrelated server config must not raise
+  # a fresh sys_monitor_disabled event.
+  local sys_monitor_disabled_count_before
+  sys_monitor_disabled_count_before=$(jq --raw-output --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled")) | length' "${monfile}")
+  lxc config set core.proxy_ignore_hosts="example.invalid"
+  lxc config unset core.proxy_ignore_hosts
+  sleep 1
+  local sys_monitor_disabled_count_after
+  sys_monitor_disabled_count_after=$(jq --raw-output --slurp 'map(select(.type == "security" and .metadata.name == "sys_monitor_disabled")) | length' "${monfile}")
+  [ "${sys_monitor_disabled_count_after}" = "${sys_monitor_disabled_count_before}" ]
+
+  kill_go_proc "${mon_pid}" || true
+  rm "${monfile}"
 
   jq --exit-status '.streams[].stream | select(.type == "lifecycle")' "${log_file}"
 

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -562,6 +562,86 @@ test_security_user_events_cluster_link() {
   kill_lxd "${LXD_LINK_DIR}"
 }
 
+test_security_user_events_oidc() {
+  ensure_has_localhost_remote "${LXD_ADDR}"
+
+  spawn_oidc
+  set_oidc test-user-security test-user-security@example.com
+  lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=device"
+
+  local monfile="${TEST_DIR}/security-oidc-user-events.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  sub_test "Verify user_created fires on OIDC first login"
+  BROWSER=curl lxc remote add --accept-certificate oidc-security "${LXD_ADDR}" --auth-type oidc
+
+  lxc query oidc-security:/1.0 | jq --exit-status '.auth == "trusted"'
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:oidc:")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  # Emitted as a ServerEvent because LXD is mirroring identity state from
+  # the IdP, not creating it on behalf of the logging-in user. Hence no
+  # requestor, request_path, or request_method on the event.
+  jq --exit-status --slurp '
+    map(select(.type == "security" and (.metadata.name | startswith("user_created:oidc:")))) as $events |
+    ($events | length) == 1
+    and ($events[0].metadata.level == "info")
+    and ($events[0].metadata.description == "Identity created")
+    and ($events[0].metadata | has("requestor") | not)
+    and ($events[0].metadata | has("request_path") | not)
+    and ($events[0].metadata | has("request_method") | not)
+    ' "${monfile}"
+
+  sub_test "Verify user_updated fires when an admin updates the OIDC identity"
+  # Adding the identity to a group goes through updateIdentityPrivileged which
+  # calls newIdentityNotificationFunc(lifecycle.IdentityUpdated), emitting
+  # user_updated as a UserEvent (the admin is the actor here).
+  lxc auth group create security-oidc-test-group
+  lxc auth identity group add "oidc/test-user-security@example.com" security-oidc-test-group
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:oidc:")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:oidc:")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:oidc:")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity updated") and (.metadata.requestor.username | strings | length > 0) and (.metadata.requestor.protocol | strings | length > 0)' "${monfile}"
+
+  sub_test "Verify user_created does not fire on subsequent OIDC logins"
+  # Drop the cached cookie so the next request triggers a fresh auth flow.
+  rm -f "${LXD_CONF}/jars/oidc-security"
+
+  local before_count
+  before_count="$(jq --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:oidc:")))) | length' "${monfile}")"
+
+  BROWSER=curl lxc query oidc-security:/1.0 | jq --exit-status '.auth == "trusted"'
+
+  # Allow a short window for any (unwanted) duplicate event to land.
+  sleep 2
+
+  local after_count
+  after_count="$(jq --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:oidc:")))) | length' "${monfile}")"
+  [ "${before_count}" = "${after_count}" ]
+
+  kill_go_proc "${mon_pid}" || true
+  rm -f "${monfile}"
+
+  lxc auth group delete security-oidc-test-group
+  lxc auth identity delete oidc/test-user-security@example.com
+  lxc remote remove oidc-security
+  lxc config set oidc.issuer="" oidc.client.id=""
+  kill_oidc
+}
+
 test_security_events_bearer_authn() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -247,6 +247,226 @@ test_security_events() {
   rm -f "${monfile_lifecycle}"
 }
 
+test_security_sys_events() {
+  # Spawn a dedicated LXD daemon so the startup and shutdown cycle is
+  # isolated from the shared per-suite daemon.
+  local LXD_SYS_DIR
+  LXD_SYS_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_SYS_DIR}" false
+
+  local loki_log="${TEST_DIR}/loki.logs"
+  kill_loki
+  rm -f "${loki_log}"
+  spawn_loki
+
+  # sys_startup is broadcast at the end of Daemon.Start before any
+  # /1.0/events client can subscribe, so Loki, whose client is
+  # initialised from persisted config at startup, is the only sink that
+  # can witness it.
+  LXD_DIR="${LXD_SYS_DIR}" lxc config set \
+    loki.api.url=http://127.0.0.1:3100 \
+    loki.auth.username=loki \
+    loki.auth.password=pass \
+    loki.types=security
+
+  sub_test "Verify sys_startup is forwarded to Loki on daemon start"
+  shutdown_lxd "${LXD_SYS_DIR}"
+  respawn_lxd "${LXD_SYS_DIR}" true
+
+  for _ in $(seq 10); do
+    jq --exit-status '.streams[].values[][1] | fromjson | select(.event == "sys_startup")' "${loki_log}" && break
+    sleep 1
+  done
+
+  jq --exit-status '.streams[].values[][1] | fromjson | select(.event == "sys_startup") | (.level == "info") and (.description == "LXD daemon started") and (.useragent == null)' "${loki_log}"
+
+  sub_test "Verify sys_shutdown fires when the daemon stops"
+  # sys_shutdown is broadcast inside Daemon.Stop before the event server
+  # is torn down. A pre-subscribed lxc monitor reliably captures it
+  # because the WebSocket flushes pending frames before close.
+  local monfile="${TEST_DIR}/security-sys-shutdown.jsonl"
+  LXD_DIR="${LXD_SYS_DIR}" lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  shutdown_lxd "${LXD_SYS_DIR}"
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and .metadata.name == "sys_shutdown")) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and .metadata.name == "sys_shutdown")) | .[0] | (.metadata.level == "info") and (.metadata.description == "LXD daemon stopping") and (.metadata | has("requestor") | not)' "${monfile}"
+
+  kill_go_proc "${mon_pid}" || true
+  kill_lxd "${LXD_SYS_DIR}"
+  kill_loki
+  rm -f "${loki_log}" "${monfile}"
+}
+
+test_security_user_events() {
+  ensure_has_localhost_remote "${LXD_ADDR}"
+
+  local monfile="${TEST_DIR}/security-user-events.jsonl"
+  lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  local lifecycle_monfile="${TEST_DIR}/security-user-events-lifecycle.jsonl"
+  lxc monitor --type=lifecycle --format=json > "${lifecycle_monfile}" &
+  local lifecycle_mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${lifecycle_mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${lifecycle_mon_pid}"
+
+  sub_test "Verify user_created fires when a bearer identity is created"
+  lxc auth identity create bearer/security-user-events-bearer
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")))) | length == 1' "${monfile}"
+  # OWASP-required fields populated by the request middleware: caller protocol,
+  # address, request URI, and HTTP method. The event name encodes the affected
+  # identity ("user_created:bearer:<id>") so consumers can identify which user
+  # record was created from a collection-POST endpoint.
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:bearer:")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity created") and (.metadata.request_method == "POST") and (.metadata.request_path == "/1.0/auth/identities/bearer") and (.metadata.requestor.protocol != "") and (.metadata.requestor.address != "")' "${monfile}"
+
+  sub_test "Verify user_updated fires when a bearer identity is modified"
+  lxc auth group create security-user-events-group
+  lxc auth identity group add bearer/security-user-events-bearer security-user-events-group
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity updated") and (.metadata.requestor.protocol != "")' "${monfile}"
+
+  sub_test "Verify user_deleted fires when a bearer identity is removed"
+  lxc auth identity delete bearer/security-user-events-bearer
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity deleted") and (.metadata.request_method == "DELETE")' "${monfile}"
+
+  sub_test "Verify lifecycle and security events coexist 1:1 with no duplication"
+  # Each of the three actions raised exactly one lifecycle event and one
+  # security event; cross-stream counts must match. Bearer identities
+  # are addressed in lifecycle URLs by their generated UUID, not their
+  # friendly name, so match the source by prefix.
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-created" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length >= 1' "${lifecycle_monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-created" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length == 1' "${lifecycle_monfile}"
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-updated" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length >= 1' "${lifecycle_monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-updated" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length == 1' "${lifecycle_monfile}"
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-deleted" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length >= 1' "${lifecycle_monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "lifecycle" and .metadata.action == "identity-deleted" and (.metadata.source | startswith("/1.0/auth/identities/bearer/")))) | length == 1' "${lifecycle_monfile}"
+
+  sub_test "Verify user_created fires when a TLS identity is created"
+  gen_cert_and_key "security-tls-user"
+  lxc auth identity create tls/security-tls-user "${LXD_CONF}/security-tls-user.crt"
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity created") and (.metadata.request_method == "POST") and (.metadata.requestor.protocol != "") and (.metadata.requestor.address != "")' "${monfile}"
+
+  sub_test "Verify user_updated fires when a TLS identity is modified"
+  lxc auth identity group add tls/security-tls-user security-user-events-group
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity updated") and (.metadata.requestor.protocol != "")' "${monfile}"
+
+  sub_test "Verify user_deleted fires when a TLS identity is removed"
+  lxc auth identity delete tls/security-tls-user
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/auth/identities/tls")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity deleted") and (.metadata.request_method == "DELETE")' "${monfile}"
+
+  sub_test "Verify user_updated fires when a pending TLS identity is activated"
+  local tls_token_identity_token
+  tls_token_identity_token="$(lxc auth identity create tls/security-tls-token-user --quiet)"
+
+  local LXD_CONF_TLS_TOKEN
+  LXD_CONF_TLS_TOKEN=$(mktemp -d -p "${TEST_DIR}" XXX)
+  LXD_CONF="${LXD_CONF_TLS_TOKEN}" gen_cert_and_key "security-tls-token-user"
+  mv "${LXD_CONF_TLS_TOKEN}/security-tls-token-user.crt" "${LXD_CONF_TLS_TOKEN}/client.crt"
+  mv "${LXD_CONF_TLS_TOKEN}/security-tls-token-user.key" "${LXD_CONF_TLS_TOKEN}/client.key"
+
+  local tls_user_updated_before tls_user_updated_after
+  tls_user_updated_before="$(jq --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/auth/identities/tls")) | length' "${monfile}")"
+
+  LXD_CONF="${LXD_CONF_TLS_TOKEN}" lxc remote add security-tls-token "${tls_token_identity_token}"
+
+  for _ in $(seq 10); do
+    tls_user_updated_after="$(jq --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/auth/identities/tls")) | length' "${monfile}")"
+    [ "${tls_user_updated_after}" = "$((tls_user_updated_before + 1))" ] && break
+    sleep 1
+  done
+
+  [ "${tls_user_updated_after}" = "$((tls_user_updated_before + 1))" ]
+
+  local tls_token_fingerprint
+  tls_token_fingerprint="$(cert_fingerprint "${LXD_CONF_TLS_TOKEN}/client.crt")"
+  jq --exit-status --slurp --arg fp "${tls_token_fingerprint}" 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/auth/identities/tls" and (.metadata.name | contains($fp)))) | length >= 1' "${monfile}"
+
+  LXD_CONF="${LXD_CONF_TLS_TOKEN}" lxc remote remove security-tls-token
+  lxc auth identity delete "tls/${tls_token_fingerprint}"
+  rm -rf "${LXD_CONF_TLS_TOKEN}"
+
+  kill_go_proc "${mon_pid}" || true
+  kill_go_proc "${lifecycle_mon_pid}" || true
+
+  lxc auth group delete security-user-events-group
+
+  rm -f "${monfile}" "${lifecycle_monfile}"
+}
+
 test_security_events_bearer_authn() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
@@ -297,7 +517,8 @@ test_authn_events() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   # Helper: poll the JSONL monitor file (up to 10 s) for jq_filter, then kill
-  # the monitor, assert one final time, and remove the file.
+  # the monitor and assert one final time. Cleanup of the file is the
+  # caller's responsibility so that follow-on assertions can read it.
   _wait_authn_event() {
     local monfile="${1}" mon_pid="${2}" jq_filter="${3}"
     for _ in $(seq 10); do
@@ -306,7 +527,6 @@ test_authn_events() {
     done
     kill_go_proc "${mon_pid}" || true
     jq --exit-status --slurp "${jq_filter}" "${monfile}"
-    rm -f "${monfile}"
   }
 
   sub_test "Verify authn_login_fail does not fire on public unauthenticated endpoints"
@@ -343,6 +563,7 @@ test_authn_events() {
 
   _wait_authn_event "${monfile}" "${mon_pid}" \
     'map(select(.type == "security" and .metadata.name == "authn_login_fail:tls" and .metadata.level == "warning" and (.metadata.requestor.address // "") != "")) | length >= 1'
+  rm -f "${monfile}"
 
   sub_test "Verify authn_token_created fires when a bearer token is issued"
   lxc auth identity create bearer/authn-bearer-test
@@ -361,6 +582,13 @@ test_authn_events() {
   _wait_authn_event "${monfile}" "${mon_pid}" \
     "map(select(.type == \"security\" and .metadata.name == \"authn_token_created:${bearer_id}\" and .metadata.level == \"info\")) | length >= 1"
 
+  # Token issuance must not also raise user_updated: the lifecycle
+  # IdentityUpdated event still fires for cluster cache refresh, but the
+  # generic user_updated security event would be duplicative with the
+  # dedicated authn_token_created event above.
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")))) | length == 0' "${monfile}"
+  rm -f "${monfile}"
+
   sub_test "Verify authn_token_revoked fires when a bearer token is revoked"
   monfile="${TEST_DIR}/authn-token-revoked.jsonl"
   lxc monitor --type=security --format=json > "${monfile}" &
@@ -371,6 +599,11 @@ test_authn_events() {
 
   _wait_authn_event "${monfile}" "${mon_pid}" \
     "map(select(.type == \"security\" and .metadata.name == \"authn_token_revoked:${bearer_id}\" and .metadata.level == \"info\")) | length >= 1"
+
+  # Same rationale as the issue path: revocation must not raise user_updated
+  # alongside the dedicated authn_token_revoked event.
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")))) | length == 0' "${monfile}"
+  rm -f "${monfile}"
 
   lxc auth identity delete bearer/authn-bearer-test
 
@@ -395,6 +628,7 @@ test_authn_events() {
 
   _wait_authn_event "${monfile}" "${mon_pid}" \
     "map(select(.type == \"security\" and .metadata.name == \"authn_certificate_change:${old_fp}\" and .metadata.level == \"info\")) | length >= 1"
+  rm -f "${monfile}"
 
   local new_fp
   new_fp="$(cert_fingerprint "${LXD_CONF}/authn-new-cert.crt")"
@@ -429,6 +663,7 @@ test_authn_events() {
   # the old fingerprint.
   _wait_authn_event "${monfile}" "${mon_pid}" \
     "map(select(.type == \"security\" and .metadata.name == \"authn_certificate_change:${self_old_fp}\" and .metadata.requestor.username == \"${self_old_fp}\")) | length >= 1"
+  rm -f "${monfile}"
 
   local self_new_fp
   self_new_fp="$(cert_fingerprint "${LXD_CONF}/authn-self-new-cert.crt")"

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -467,6 +467,101 @@ test_security_user_events() {
   rm -f "${monfile}" "${lifecycle_monfile}"
 }
 
+test_security_user_events_cluster_link() {
+  # The cluster-link POST/DELETE handlers share newIdentityNotificationFunc
+  # with the bearer/TLS identity paths, but they sit behind /1.0/cluster/links
+  # and a separate trust-token activation flow, so a regression in the
+  # cluster-link request context would not be caught by the bearer/TLS tests.
+  # A dedicated cluster-enabled daemon is spawned because cluster-link APIs
+  # require the daemon to be in cluster mode, which the shared per-suite
+  # daemon is not.
+  local LXD_LINK_DIR
+  LXD_LINK_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_LINK_DIR}" false
+
+  LXD_DIR="${LXD_LINK_DIR}" lxc cluster enable security-user-events-node
+
+  local monfile="${TEST_DIR}/security-cluster-link-user-events.jsonl"
+  LXD_DIR="${LXD_LINK_DIR}" lxc monitor --type=security --format=json > "${monfile}" &
+  local mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${mon_pid}"
+
+  sub_test "Verify user_created fires when a pending cluster link is created"
+  LXD_DIR="${LXD_LINK_DIR}" lxc cluster link create security-user-events-link --quiet
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and .metadata.request_path == "/1.0/cluster/links")) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and .metadata.request_path == "/1.0/cluster/links")) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_created:")) and .metadata.request_path == "/1.0/cluster/links")) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity created") and (.metadata.request_method == "POST") and (.metadata.requestor.protocol != "")' "${monfile}"
+
+  sub_test "Verify user_updated fires when a cluster link is renamed"
+  LXD_DIR="${LXD_LINK_DIR}" lxc cluster link rename security-user-events-link security-user-events-link-renamed
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/cluster/links/security-user-events-link")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/cluster/links/security-user-events-link")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and (.metadata.request_path | startswith("/1.0/cluster/links/security-user-events-link")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity updated") and (.metadata.request_method == "POST")' "${monfile}"
+
+  sub_test "Verify user_deleted fires when a pending cluster link is removed"
+  LXD_DIR="${LXD_LINK_DIR}" lxc cluster link delete security-user-events-link-renamed
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/cluster/links")))) | length >= 1' "${monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/cluster/links")))) | length == 1' "${monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_deleted:")) and (.metadata.request_path | startswith("/1.0/cluster/links")))) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity deleted") and (.metadata.request_method == "DELETE")' "${monfile}"
+
+  sub_test "Verify user_updated fires when a pending cluster link is activated"
+  local LXD_LINK_DIR_REMOTE
+  LXD_LINK_DIR_REMOTE=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_LINK_DIR_REMOTE}" false
+
+  LXD_DIR="${LXD_LINK_DIR_REMOTE}" lxc cluster enable security-user-events-node-remote
+
+  local activation_monfile="${TEST_DIR}/security-cluster-link-user-events-activation.jsonl"
+  # Activation updates the pending identity on the token-issuing daemon.
+  LXD_DIR="${LXD_LINK_DIR}" lxc monitor --type=security --format=json > "${activation_monfile}" &
+  local activation_mon_pid=$!
+  for _ in $(seq 10); do
+    kill -0 "${activation_mon_pid}" && break
+    sleep 1
+  done
+  kill -0 "${activation_mon_pid}"
+
+  local cluster_link_trust_token
+  cluster_link_trust_token="$(LXD_DIR="${LXD_LINK_DIR}" lxc cluster link create security-user-events-link-remote --quiet)"
+  LXD_DIR="${LXD_LINK_DIR_REMOTE}" lxc cluster link create security-user-events-link-local --token "${cluster_link_trust_token}"
+
+  for _ in $(seq 10); do
+    jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/cluster/links")) | length >= 1' "${activation_monfile}" && break
+    sleep 1
+  done
+
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/cluster/links")) | length == 1' "${activation_monfile}"
+  jq --exit-status --slurp 'map(select(.type == "security" and (.metadata.name | startswith("user_updated:")) and .metadata.request_path == "/1.0/cluster/links")) | .[0] | (.metadata.level == "info") and (.metadata.description == "Identity updated") and (.metadata.request_method == "POST") and (.metadata.requestor.address != "")' "${activation_monfile}"
+
+  kill_go_proc "${activation_mon_pid}" || true
+  rm -f "${activation_monfile}"
+  kill_lxd "${LXD_LINK_DIR_REMOTE}"
+
+  kill_go_proc "${mon_pid}" || true
+  rm -f "${monfile}"
+
+  kill_lxd "${LXD_LINK_DIR}"
+}
+
 test_security_events_bearer_authn() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Summary

Adds two new security event categories on top of the foundation merged in #18027:

- **`sys_*`** ; daemon lifecycle and monitoring-pipeline events: `sys_startup`, `sys_shutdown`, `sys_monitor_disabled`.
- **`user_*`** ; identity-mutation events: `user_created`, `user_updated`, `user_deleted` for every authentication method (TLS, bearer, cluster-link, OIDC).

Both kinds use the OWASP-style naming established by the foundation PR. Daemon-level events use `ServerEvent` (no requestor / request context). Request-scoped user events go through the security package's `UserEvent`, which automatically fills the requestor (username, protocol), request metadata (path, method, project), and source IP / user-agent from the per-request audit info stashed at the API root handlers. The `cluster_identifier` and `cluster_member_name` fields are added at the Loki forwarder (from server-static config and the event envelope's Location), so they appear in the OWASP audit line but not in the `/1.0/events` payload

## sys_* events

- `lxd/daemon`: emit `sys_startup` at the end of `Daemon.Start` after `waitReady` is cancelled, so the event server is fully reachable to subscribers. Emit `sys_shutdown` at the top of `Daemon.Stop` before any teardown work that could close the event server.
- `lxd/api_1.0`: emit `sys_monitor_disabled` (warning level) when a server-config change clears the Loki configuration. Gated on `d.lokiClient != nil` so it only fires on the enabled-to-disabled transition, never when Loki was unconfigured to begin with or on unrelated config changes.

## user_* events

- `lxd/identities`: extend `newIdentityNotificationFunc` (the single emission point used by `identities.go` and `api_cluster_link.go`) to emit `user_created` / `user_updated` / `user_deleted` immediately after each existing lifecycle event. This covers every TLS, bearer, and cluster-link create/update/delete site without per-handler changes.
- `lxd/db/oidc`: emit `user_created` / `user_updated` from `sessionHandler.StartSession`, mirroring the existing `IdentityCreated` (gated on `firstTimeLogin`) and `IdentityUpdated` (gated on `doUpdateIdentity`) lifecycle paths. Subsequent logins that produce no metadata change emit neither, matching lifecycle behaviour and satisfying the spec rule that `user_created` fires only on first IdP authentication.

Each security event lands on a separate event-type stream, so no consumer sees duplication of the lifecycle and security events for the same action.

## Tests

`test/suites/security.sh` gains three new tests, registered in `test/includes/test-groups.sh`:

- **`test_security_sys_events`** : spawns a dedicated daemon with Loki preconfigured, restarts it to capture `sys_startup` via the Loki sink (the only channel that observes a pre-subscribe event), and uses `lxc monitor --type=security` to capture `sys_shutdown` on stop.
- **`test_security_user_events`** : drives a bearer-identity create/update/delete cycle and asserts each action raises exactly one `user_*` event with OWASP-required fields, alongside its existing `identity-*` lifecycle event (1:1, no duplication).
- **`test_security_user_events_oidc`**: drives the `mini-oidc` fixture to assert `user_created` fires once on the first authenticated API call and does not re-fire on subsequent logins.

`test/suites/loki.sh` extends `test_loki_security_types` with two sub-tests covering the `sys_monitor_disabled` enabled-to-disabled transition and the no-fire path when Loki was never configured.