### PR TITLE
doc: fix give feedback button

### DIFF
--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -16,5 +16,6 @@
 {{ super() }}
 <script>
   window.flyoutDefaultVersionLabel = "{{ flyout_default_version_label }}";
+  const github_url = "{{ github_url }}";
 </script>
 {% endblock theme_scripts %}


### PR DESCRIPTION
PR #18202 introduced a {% block theme_scripts %} override in _templates/base.html. Despite the use of super(), this caused the github_url variable set in the theme's base.html to be unset unintentionally, which then caused the "Give feedback" button to stop working. This commit re-adds it.

This commit should be backported to the other versions' branches at the same time that the commit from the abovementioned PR is backported (https://github.com/canonical/lxd/commit/85076dd14293216d232e2633f4c5ed1dd4e928f3). I can backport them together once this PR is merged.
