### PR TITLE
Use io.CopyN with 4MiB buffer everywhere

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Image handling functions
@@ -273,7 +274,7 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, do func(
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err := io.Copy(io.MultiWriter(req.MetaFile, sha256), part)
+		size, err := util.SafeCopy(io.MultiWriter(req.MetaFile, sha256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +292,7 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, do func(
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(req.RootfsFile, sha256), part)
+		size, err = util.SafeCopy(io.MultiWriter(req.RootfsFile, sha256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +320,7 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, do func(
 		return nil, errors.New("No filename in Content-Disposition header")
 	}
 
-	size, err := io.Copy(io.MultiWriter(req.MetaFile, sha256), body)
+	size, err := util.SafeCopy(io.MultiWriter(req.MetaFile, sha256), body)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +466,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 				return
 			}
 
-			_, ioErr = io.Copy(fw, args.MetaFile)
+			_, ioErr = util.SafeCopy(fw, args.MetaFile)
 			if ioErr != nil {
 				return
 			}
@@ -481,7 +482,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 				return
 			}
 
-			_, ioErr = io.Copy(fw, args.RootfsFile)
+			_, ioErr = util.SafeCopy(fw, args.RootfsFile)
 			if ioErr != nil {
 				return
 			}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -23,6 +23,7 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/tcp"
+	"github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/ws"
 )
 
@@ -1211,7 +1212,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 		if outputFiles["1"] != "" {
 			reader, _ := r.getInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 			if args.Stdout != nil {
-				_, errCopy := io.Copy(args.Stdout, reader)
+				_, errCopy := util.SafeCopy(args.Stdout, reader)
 				// Regardless of errCopy value, we want to delete the file after a copy operation
 				errDelete := r.deleteInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 				if errDelete != nil {
@@ -1232,7 +1233,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 		if outputFiles["2"] != "" {
 			reader, _ := r.getInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["2"]))
 			if args.Stderr != nil {
-				_, errCopy := io.Copy(args.Stderr, reader)
+				_, errCopy := util.SafeCopy(args.Stderr, reader)
 				errDelete := r.deleteInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 				if errDelete != nil {
 					return nil, errDelete
@@ -2960,7 +2961,7 @@ func (r *ProtocolLXD) GetInstanceBackupFile(instanceName string, name string, re
 
 	// Handle the data
 	body := ioprogress.NewProgressReader(response.Body, ioprogress.WithLength(response.ContentLength), ioprogress.WithProgressHandler(req.ProgressHandler))
-	size, err := io.Copy(req.BackupFile, body)
+	size, err := util.SafeCopy(req.BackupFile, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -3,7 +3,6 @@ package lxd
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Storage volumes handling function
@@ -1046,7 +1046,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeBackupFile(pool string, volName string
 
 	// Handle the data
 	body := ioprogress.NewProgressReader(response.Body, ioprogress.WithLength(response.ContentLength), ioprogress.WithProgressHandler(req.ProgressHandler))
-	size, err := io.Copy(req.BackupFile, body)
+	size, err := util.SafeCopy(req.BackupFile, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // combinedHash is the interface that the combined hash must implement.
@@ -273,7 +274,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 
 				// Verify the patched rootfs matches the expected per-file hash.
 				patchedHash := sha256.New()
-				_, err = io.Copy(patchedHash, patchedFile)
+				_, err = util.SafeCopy(patchedHash, patchedFile)
 				if err != nil {
 					return nil, err
 				}
@@ -295,7 +296,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 					return nil, err
 				}
 
-				size, err := io.Copy(io.MultiWriter(req.RootfsFile, combinedHash), patchedFile)
+				size, err := util.SafeCopy(io.MultiWriter(req.RootfsFile, combinedHash), patchedFile)
 				if err != nil {
 					return nil, err
 				}

--- a/lxc/config/cert.go
+++ b/lxc/config/cert.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // GenerateClientCertificate will generate the needed client.crt and client.key if needed.
@@ -41,7 +41,7 @@ func (c *Config) CopyGlobalCert(src string, dst string) error {
 
 	defer func() { _ = newFile.Close() }()
 
-	_, err = io.Copy(newFile, sourceFile)
+	_, err = util.SafeCopy(newFile, sourceFile)
 	if err != nil {
 		return err
 	}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/termios"
+	"github.com/canonical/lxd/shared/util"
 )
 
 const (
@@ -640,7 +641,7 @@ func (c *cmdFilePull) run(cmd *cobra.Command, args []string) error {
 			writer = ioprogress.NewProgressWriter(writer, ioprogress.WithProgressUpdater(&progress))
 		}
 
-		_, err = io.Copy(writer, buf)
+		_, err = util.SafeCopy(writer, buf)
 		if err != nil {
 			progress.Done("")
 			return err
@@ -988,7 +989,7 @@ func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, inst string, p string,
 		}
 
 		writer := ioprogress.NewProgressWriter(f, ioprogress.WithProgressUpdater(&progress))
-		_, err = io.Copy(writer, buf)
+		_, err = util.SafeCopy(writer, buf)
 		if err != nil {
 			progress.Done("")
 			return err
@@ -1348,13 +1349,13 @@ func (c *cmdFileMount) sshfsMount(ctx context.Context, resource remoteResource, 
 		case <-ctx.Done():
 		}
 
-		cancel()                                  // Prevents error output when the io.Copy functions finish.
+		cancel()                                  // Prevents error output when the util.SafeCopy functions finish.
 		_ = sshfsCmd.Process.Signal(os.Interrupt) // This will cause sshfs to unmount.
 		_ = stdin.Close()
 	}()
 
 	go func() {
-		_, err := io.Copy(stdin, sftpConn)
+		_, err := util.SafeCopy(stdin, sftpConn)
 		if ctx.Err() == nil {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "I/O copy from instance to sshfs failed: %v\n", err)
@@ -1365,7 +1366,7 @@ func (c *cmdFileMount) sshfsMount(ctx context.Context, resource remoteResource, 
 		cancel() // Ask sshfs to end.
 	}()
 
-	_, err = io.Copy(sftpConn, stdout)
+	_, err = util.SafeCopy(sftpConn, stdout)
 	if err != nil && ctx.Err() == nil {
 		fmt.Fprintf(os.Stderr, "I/O copy from sshfs to instance failed: %v\n", err)
 	}
@@ -1552,7 +1553,7 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 					// Copy SFTP data between client and remote instance.
 					ctx, cancel := context.WithCancel(ctx)
 					go func() {
-						_, err := io.Copy(channel, sftpConn)
+						_, err := util.SafeCopy(channel, sftpConn)
 						if ctx.Err() == nil {
 							if err != nil {
 								fmt.Fprintf(os.Stderr, "I/O copy from instance to SSH failed: %v\n", err)
@@ -1560,16 +1561,16 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 								fmt.Printf("Instance disconnected for client %q\n", nConn.RemoteAddr())
 							}
 						}
-						cancel() // Prevents error output when other io.Copy finishes.
+						cancel() // Prevents error output when other util.SafeCopy finishes.
 						_ = channel.Close()
 					}()
 
-					_, err = io.Copy(sftpConn, channel)
+					_, err = util.SafeCopy(sftpConn, channel)
 					if err != nil && ctx.Err() == nil {
 						fmt.Fprintf(os.Stderr, "I/O copy from SSH to instance failed: %v\n", err)
 					}
 
-					cancel() // Prevents error output when other io.Copy finishes.
+					cancel() // Prevents error output when other util.SafeCopy finishes.
 					_ = sftpConn.Close()
 				}()
 			}

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/termios"
+	"github.com/canonical/lxd/shared/util"
 )
 
 type cmdNetworkACL struct {
@@ -312,7 +313,7 @@ func (c *cmdNetworkACLShowLog) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = io.Copy(os.Stdout, log)
+	_, err = util.SafeCopy(os.Stdout, log)
 	_ = log.Close()
 
 	return err

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,6 +16,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -309,7 +309,7 @@ func devLXDImageExportHandler(d *Daemon, r *http.Request) *devLXDResponse {
 
 		// Copy headers and response body.
 		w.WriteHeader(resp.StatusCode)
-		_, err = io.Copy(w, resp.Body)
+		_, err = util.SafeCopy(w, resp.Body)
 		if err != nil {
 			return err
 		}

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 var servers = make(map[string]*http.Server, 2)
@@ -81,7 +81,7 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Copy the data.
-		_, err = io.Copy(dst, src)
+		_, err = sharedUtil.SafeCopy(dst, src)
 		if err != nil {
 			return err
 		}

--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 func restServer(tlsConfig *tls.Config, cert *x509.Certificate, d *Daemon) *http.Server {
@@ -58,7 +59,7 @@ func createCmd(restAPI *http.ServeMux, version string, c APIEndpoint, cert *x509
 			newBody := &bytes.Buffer{}
 			captured := &bytes.Buffer{}
 			multiW := io.MultiWriter(newBody, captured)
-			_, err := io.Copy(multiW, r.Body)
+			_, err := sharedUtil.SafeCopy(multiW, r.Body)
 			if err != nil {
 				_ = response.InternalError(err).Render(w, r)
 				return

--- a/lxd-agent/templates.go
+++ b/lxd-agent/templates.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
 	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/util"
 )
 
 func templatesApply(path string) ([]string, error) {
@@ -80,7 +80,7 @@ func templatesApply(path string) ([]string, error) {
 			defer func() { _ = w.Close() }()
 
 			// Do the copy.
-			_, err = io.Copy(w, src)
+			_, err = util.SafeCopy(w, src)
 			if err != nil {
 				return err
 			}

--- a/lxd-convert/main_netcat.go
+++ b/lxd-convert/main_netcat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"io"
 	"net"
 	"os"
 	"sync"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/shared/eagain"
+	"github.com/canonical/lxd/shared/util"
 )
 
 type cmdNetcat struct {
@@ -55,12 +55,12 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	wg := sync.WaitGroup{}
 
 	wg.Go(func() {
-		_, err = io.Copy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
+		_, err = util.SafeCopy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
 		_ = conn.Close()
 	})
 
 	go func() {
-		_, _ = io.Copy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
+		_, _ = util.SafeCopy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
 	}()
 
 	// Wait

--- a/lxd-convert/transfer.go
+++ b/lxd-convert/transfer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/ws"
 )
 
@@ -138,7 +139,7 @@ func sendBlockVol(ctx context.Context, conn io.WriteCloser, path string) error {
 		_ = f.Close()
 	}()
 
-	_, err = io.Copy(conn, f)
+	_, err = util.SafeCopy(conn, f)
 	if err != nil {
 		return err
 	}

--- a/lxd-user/proxy.go
+++ b/lxd-user/proxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/util"
 )
 
 func tlsConfig(uid uint32) (*tls.Config, error) {
@@ -138,6 +138,6 @@ func proxyConnection(conn *net.UnixConn) {
 	}
 
 	// Start proxying.
-	go func() { _, _ = io.Copy(conn, tlsClient) }()
-	_, _ = io.Copy(tlsClient, conn)
+	go func() { _, _ = util.SafeCopy(conn, tlsClient) }()
+	_, _ = util.SafeCopy(tlsClient, conn)
 }

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Create a new backup.
@@ -167,7 +168,7 @@ func backupCreate(ctx context.Context, s *state.State, args db.InstanceBackup, s
 				_ = tarPipeWriter.Close()
 			}
 		} else {
-			_, err = io.Copy(writerWrapper(tarFileWriter), tarPipeReader)
+			_, err = util.SafeCopy(writerWrapper(tarFileWriter), tarPipeReader)
 		}
 
 		resCh <- err
@@ -492,7 +493,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 				_ = tarPipeWriter.Close()
 			}
 		} else {
-			_, err = io.Copy(tarFileWriter, tarPipeReader)
+			_, err = util.SafeCopy(tarFileWriter, tarPipeReader)
 		}
 
 		resCh <- err

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,6 +29,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/tcp"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 // NewGateway creates a new Gateway for managing access to the dqlite cluster.
@@ -1202,12 +1202,12 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 	// Start copying data back and forth until either the client or the
 	// server get closed or hit an error.
 	go func() {
-		_, err := io.Copy(local, remote)
+		_, err := sharedUtil.SafeCopy(local, remote)
 		remoteToLocal <- err
 	}()
 
 	go func() {
-		_, err := io.Copy(remote, local)
+		_, err := sharedUtil.SafeCopy(remote, local)
 		localToRemote <- err
 	}()
 

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -23,6 +23,7 @@ import (
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // RecoveryTarballName is the filename used for recovery tarballs.
@@ -502,7 +503,7 @@ func unpackTarball(tarballPath string, destRoot string) error {
 				return err
 			}
 
-			countWritten, err := io.Copy(file, tarReader)
+			countWritten, err := util.SafeCopy(file, tarReader)
 			if countWritten != header.Size {
 				return fmt.Errorf("Mismatched written (%d) and size (%d) for entry %q in %q", countWritten, header.Size, header.Name, tarballPath)
 			} else if err != nil {
@@ -599,7 +600,7 @@ func createTarball(tarballPath string, rootDir string, walkDir string, excludeFi
 				return err
 			}
 
-			_, err = io.Copy(tarWriter, file)
+			_, err = util.SafeCopy(tarWriter, file)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -77,6 +77,7 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -949,7 +950,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			newBody := &bytes.Buffer{}
 			captured := &bytes.Buffer{}
 			multiW := io.MultiWriter(newBody, captured)
-			_, err := io.Copy(multiW, r.Body)
+			_, err := sharedUtil.SafeCopy(multiW, r.Body)
 			if err != nil {
 				_ = response.InternalError(err).Render(w, r)
 				return

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -59,6 +59,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/validate"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -370,7 +371,7 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 			return err
 		}
 
-		_, err = io.Copy(outfile, tempfile)
+		_, err = sharedUtil.SafeCopy(outfile, tempfile)
 		if err != nil {
 			return err
 		}
@@ -731,7 +732,7 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(imageTarf, sha256), part)
+		size, err = sharedUtil.SafeCopy(io.MultiWriter(imageTarf, sha256), part)
 		info.Size += size
 
 		_ = imageTarf.Close()
@@ -766,7 +767,7 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 
 		rootfsTmpFilename = rootfsTarf.Name()
 
-		size, err = io.Copy(io.MultiWriter(rootfsTarf, sha256), part)
+		size, err = sharedUtil.SafeCopy(io.MultiWriter(rootfsTarf, sha256), part)
 		info.Size += size
 
 		_ = rootfsTarf.Close()
@@ -782,7 +783,7 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 			return nil, err
 		}
 
-		size, err = io.Copy(sha256, post)
+		size, err = sharedUtil.SafeCopy(sha256, post)
 		if err != nil {
 			l.Error("Failed copying the tarfile", logger.Ctx{"err": err})
 			return nil, err
@@ -1202,7 +1203,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 	revert.Add(func() { cleanup(builddir, post) })
 
-	_, err = io.Copy(shared.NewQuotaWriter(post, budget), r.Body)
+	_, err = sharedUtil.SafeCopy(shared.NewQuotaWriter(post, budget), r.Body)
 	if err != nil {
 		logger.Errorf("Store image POST data to disk: %v", err)
 		return response.InternalError(err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -81,6 +81,7 @@ import (
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -885,9 +886,9 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 			go func() {
 				d.logger.Debug("Migration storage NBD export starting")
 
-				go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+				go func() { _, _ = sharedUtil.SafeCopy(filesystemConn, nbdConn) }()
 
-				_, _ = io.Copy(nbdConn, filesystemConn)
+				_, _ = sharedUtil.SafeCopy(nbdConn, filesystemConn)
 				_ = nbdConn.Close()
 
 				d.logger.Debug("Migration storage NBD export finished")
@@ -904,7 +905,7 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 		}
 
 		go func() {
-			_, err := io.Copy(pipeWrite, stateConn)
+			_, err := sharedUtil.SafeCopy(pipeWrite, stateConn)
 			if err != nil {
 				d.logger.Warn("Failed reading from state connection", logger.Ctx{"err": err})
 			}
@@ -944,7 +945,7 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 		}
 
 		go func() {
-			_, err := io.Copy(pipeWrite, uncompressedState)
+			_, err := sharedUtil.SafeCopy(pipeWrite, uncompressedState)
 			if err != nil {
 				d.logger.Warn("Failed reading from state file", logger.Ctx{"path": statePath, "err": err})
 			}
@@ -1016,7 +1017,7 @@ func (d *qemu) saveState(monitor *qmp.Monitor) error {
 		_ = pipeWrite.Close()
 	}()
 
-	go func() { _, _ = io.Copy(compressedState, pipeRead) }()
+	go func() { _, _ = sharedUtil.SafeCopy(compressedState, pipeRead) }()
 
 	err = d.saveStateHandle(monitor, pipeWrite)
 	if err != nil {
@@ -7247,9 +7248,9 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 			defer func() { _ = nbdConn.Close() }()
 
 			d.logger.Debug("NBD connection on source started")
-			go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+			go func() { _, _ = sharedUtil.SafeCopy(filesystemConn, nbdConn) }()
 
-			_, _ = io.Copy(nbdConn, filesystemConn)
+			_, _ = sharedUtil.SafeCopy(nbdConn, filesystemConn)
 			d.logger.Debug("NBD connection on source finished")
 		}()
 
@@ -7314,7 +7315,7 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		_ = pipeWrite.Close()
 	}()
 
-	go func() { _, _ = io.Copy(stateConn, pipeRead) }()
+	go func() { _, _ = sharedUtil.SafeCopy(stateConn, pipeRead) }()
 
 	err = d.saveStateHandle(monitor, pipeWrite)
 	if err != nil {

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 )
 
 func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
@@ -527,7 +528,7 @@ func instanceFilePost(ctx context.Context, s *state.State, inst instance.Instanc
 		}
 
 		// Transfer the file into the instance.
-		_, err = io.Copy(file, r.Body)
+		_, err = util.SafeCopy(file, r.Body)
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 // swagger:operation GET /1.0/instances/{name}/metadata instances instance_metadata_get
@@ -502,7 +502,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 		return response.SmartError(err)
 	}
 
-	_, err = io.Copy(tempfile, template)
+	_, err = sharedUtil.SafeCopy(tempfile, template)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -630,7 +630,7 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 		return response.SmartError(err)
 	}
 
-	_, err = io.Copy(template, r.Body)
+	_, err = sharedUtil.SafeCopy(template, r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -21,6 +20,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/tcp"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // swagger:operation GET /1.0/instances/{name}/sftp instances instance_sftp
@@ -149,17 +149,17 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) err
 
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
-		_, err := io.Copy(remoteConn, r.instConn)
+		_, err := util.SafeCopy(remoteConn, r.instConn)
 		if err != nil {
 			if ctx.Err() == nil {
 				l.Warn("Failed copying SFTP instance connection to remote connection", logger.Ctx{"err": err})
 			}
 		}
 		cancel()               // Cancel context first so when remoteConn is closed it doesn't cause a warning.
-		_ = remoteConn.Close() // Trigger the cancellation of the io.Copy reading from remoteConn.
+		_ = remoteConn.Close() // Trigger the cancellation of the util.SafeCopy reading from remoteConn.
 	})
 
-	_, err = io.Copy(r.instConn, remoteConn)
+	_, err = util.SafeCopy(r.instConn, remoteConn)
 	if err != nil {
 		if ctx.Err() == nil {
 			l.Warn("Failed copying SFTP remote connection to instance connection", logger.Ctx{"err": err})
@@ -167,7 +167,7 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) err
 	}
 	cancel() // Cancel context first so when instConn is closed it doesn't cause a warning.
 
-	err = r.instConn.Close() // Trigger the cancellation of the io.Copy reading from instConn.
+	err = r.instConn.Close() // Trigger the cancellation of the util.SafeCopy reading from instConn.
 	if err != nil {
 		return fmt.Errorf("Failed closing connection to remote server: %w", err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -42,6 +42,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -796,7 +797,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	revert.Add(func() { _ = backupFile.Close() })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(backupFile, data)
+	_, err = util.SafeCopy(backupFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instancewriter/instance_tar_writer.go
+++ b/lxd/instancewriter/instance_tar_writer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/lxd/idmap"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // InstanceTarWriter provides a TarWriter implementation that handles ID shifting and hardlink tracking.
@@ -158,7 +159,7 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 			r = io.LimitReader(r, fi.Size())
 		}
 
-		_, err = io.Copy(ctw.tarWriter, r)
+		_, err = util.SafeCopy(ctw.tarWriter, r)
 		if err != nil {
 			return fmt.Errorf("Failed copying file content %q: %w", srcPath, err)
 		}
@@ -185,7 +186,7 @@ func (ctw *InstanceTarWriter) WriteFileFromReader(src io.Reader, fi os.FileInfo)
 		return fmt.Errorf("Failed writing tar header: %w", err)
 	}
 
-	_, err = io.Copy(ctw.tarWriter, src)
+	_, err = util.SafeCopy(ctw.tarWriter, src)
 	return err
 }
 

--- a/lxd/main_netcat.go
+++ b/lxd/main_netcat.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/eagain"
+	"github.com/canonical/lxd/shared/util"
 )
 
 type cmdNetcat struct {
@@ -82,7 +82,7 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	wg := sync.WaitGroup{}
 
 	wg.Go(func() {
-		_, err := io.Copy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
+		_, err := util.SafeCopy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
 		if err != nil && logErr == nil {
 			_, _ = fmt.Fprintf(logFile, "Error while copying from stdout to unix domain socket \"%s\": %s\n", args[0], err)
 		}
@@ -91,7 +91,7 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	})
 
 	go func() {
-		_, err := io.Copy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
+		_, err := util.SafeCopy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
 		if err != nil && logErr == nil {
 			_, _ = fmt.Fprintf(logFile, "Error while copying from unix domain socket \"%s\" to stdin: %s\n", args[0], err)
 		}

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -23,6 +23,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/tcp"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 var debug bool
@@ -613,7 +614,7 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 			return err
 		}
 
-		_, err := io.Copy(fw, rd)
+		_, err := sharedUtil.SafeCopy(fw, rd)
 		if err != nil {
 			return err
 		}
@@ -679,7 +680,7 @@ func (r *forwardedResponse) Render(w http.ResponseWriter, req *http.Request) err
 		w.WriteHeader(response.StatusCode)
 	}
 
-	_, err = io.Copy(w, response.Body)
+	_, err = sharedUtil.SafeCopy(w, response.Body)
 	return err
 }
 

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Debug controls additional debugging in rsync output.
@@ -255,7 +256,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.
 	// Forward from netcat to target.
 	chCopyNetcat := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(conn, readNetcatPipe)
+		_, err := util.SafeCopy(conn, readNetcatPipe)
 		chCopyNetcat <- err
 		_ = readNetcatPipe.Close()
 		_ = netcatConn.Close()
@@ -266,7 +267,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.
 	writeNetcatPipe := io.WriteCloser(netcatConn)
 	chCopyTarget := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(writeNetcatPipe, conn)
+		_, err := util.SafeCopy(writeNetcatPipe, conn)
 		chCopyTarget <- err
 		_ = writeNetcatPipe.Close()
 	}()
@@ -345,7 +346,7 @@ func Recv(path string, conn io.ReadWriteCloser, readWrapper ioprogress.ReaderWra
 
 	chCopyRsync := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(conn, stdout)
+		_, err := util.SafeCopy(conn, stdout)
 		_ = stdout.Close()
 		_ = conn.Close() // sends barrier message.
 		chCopyRsync <- err
@@ -364,7 +365,7 @@ func Recv(path string, conn io.ReadWriteCloser, readWrapper ioprogress.ReaderWra
 
 	chCopySource := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(stdin, readSourcePipe)
+		_, err := util.SafeCopy(stdin, readSourcePipe)
 		_ = stdin.Close()
 		chCopySource <- err
 	}()

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -57,6 +57,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/units"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 )
 
 var unavailablePools = make(map[string]struct{})
@@ -1969,7 +1970,7 @@ func (b *lxdBackend) isoFiller(data io.Reader) func(vol drivers.Volume, rootBloc
 
 		defer func() { _ = f.Close() }()
 
-		return io.Copy(f, data)
+		return sharedUtil.SafeCopy(f, data)
 	}
 }
 
@@ -2084,7 +2085,7 @@ func (b *lxdBackend) recvBlockVol(toFile *os.File, volName string, conn io.ReadW
 		fromPipe = ioprogress.NewProgressReader(conn, ioprogress.WithDescriptiveProgressReporter("block", "Transferring instance", progressReporter))
 	}
 
-	_, err := io.Copy(toFile, fromPipe)
+	_, err := sharedUtil.SafeCopy(toFile, fromPipe)
 	if err != nil {
 		return fmt.Errorf("Error copying from migration connection to %q: %w", toFile.Name(), err)
 	}

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/units"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // cephBlockVolSuffix suffix used for block content type volumes.
@@ -1265,7 +1266,7 @@ func (d *ceph) receiveVolume(volumeName string, conn io.ReadWriteCloser, writeWr
 	// Forward input through stdin.
 	chCopyConn := make(chan error, 1)
 	go func() {
-		_, err = io.Copy(stdin, conn)
+		_, err = util.SafeCopy(stdin, conn)
 		_ = stdin.Close()
 		chCopyConn <- err
 	}()

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/units"
+	"github.com/canonical/lxd/shared/util"
 )
 
 const (
@@ -468,7 +469,7 @@ func (d *zfs) receiveDataset(vol Volume, conn io.ReadWriteCloser, writeWrapper f
 	// Forward input through stdin.
 	chCopyConn := make(chan error, 1)
 	go func() {
-		_, err = io.Copy(stdin, conn)
+		_, err = util.SafeCopy(stdin, conn)
 		_ = stdin.Close()
 		chCopyConn <- err
 	}()

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // genericVolumeBlockExtension extension used for generic block volume disk files.
@@ -216,7 +217,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol VolumeCopy, conn io.R
 		}
 
 		d.Logger().Debug("Sending block volume", logger.Ctx{"volName": vol.name, "path": path})
-		_, err = io.Copy(conn, fromPipe)
+		_, err = util.SafeCopy(conn, fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying %q to migration connection: %w", path, err)
 		}
@@ -343,7 +344,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		d.Logger().Debug("Receiving block volume started", logger.Ctx{"volName": volName, "path": path})
 		defer d.Logger().Debug("Receiving block volume stopped", logger.Ctx{"volName": volName, "path": path})
 
-		_, err = io.Copy(to, fromPipe)
+		_, err = util.SafeCopy(to, fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
 		}
@@ -812,7 +813,7 @@ func genericVFSBackupUnpack(d Driver, s *state.State, vol VolumeCopy, snapshots 
 				}
 
 				d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
-				_, err = io.Copy(to, tr)
+				_, err = util.SafeCopy(to, tr)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -45,6 +45,7 @@ import (
 	"github.com/canonical/lxd/shared/filter"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
+	sharedUtil "github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -2630,7 +2631,7 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 	revert.Add(func() { _ = isoFile.Close() })
 
 	// Stream uploaded ISO data into temporary file.
-	size, err := io.Copy(isoFile, data)
+	size, err := sharedUtil.SafeCopy(isoFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -2694,7 +2695,7 @@ func createStoragePoolVolumeFromTarball(s *state.State, r *http.Request, request
 	revert.Add(func() { _ = os.Remove(tarFile.Name()) })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(tarFile, data)
+	_, err = sharedUtil.SafeCopy(tarFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -2751,7 +2752,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 	revert.Add(func() { _ = backupFile.Close() })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(backupFile, data)
+	_, err = sharedUtil.SafeCopy(backupFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/shared/cmd/table_test.go
+++ b/shared/cmd/table_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/util"
 )
 
 type tableSuite struct {
@@ -179,14 +179,14 @@ foo,1,/1.0/instances/foo
 		// Call method but fix stdout before making any assertions.
 		actualErr := RenderSlice(test.args.data, test.args.format, test.args.displayColumns, test.args.sortColumns, test.args.columnMap)
 
-		// Restore stdout and close the writer now so that io.Copy gets an io.EOF and doesn't block indefinitely.
+		// Restore stdout and close the writer now so that util.SafeCopy gets an io.EOF and doesn't block indefinitely.
 		os.Stdout = stdout
 		err = w.Close()
 		s.Require().NoError(err)
 
 		// Read what was printed to stdout.
 		buffer := bytes.NewBuffer(nil)
-		_, err = io.Copy(buffer, r)
+		_, err = util.SafeCopy(buffer, r)
 		s.Require().NoError(err)
 		output := buffer.String()
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -35,6 +35,7 @@ import (
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/revert"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // SnapshotDelimiter is the character used to delimit instance and snapshot names.
@@ -451,7 +452,7 @@ func WriteAll(w io.Writer, data []byte) error {
 
 	toWrite := int64(buf.Len())
 	for {
-		n, err := io.Copy(w, buf)
+		n, err := util.SafeCopy(w, buf)
 		if err != nil {
 			return err
 		}
@@ -562,7 +563,7 @@ func FileCopy(source string, dest string) error {
 		}
 	}
 
-	_, err = io.Copy(d, s)
+	_, err = util.SafeCopy(d, s)
 	if err != nil {
 		return err
 	}
@@ -1236,7 +1237,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 	var size int64
 
 	if hashFunc != nil {
-		size, err = io.Copy(io.MultiWriter(target, hashFunc), body)
+		size, err = util.SafeCopy(io.MultiWriter(target, hashFunc), body)
 		if err != nil {
 			return -1, err
 		}
@@ -1246,7 +1247,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 			return -1, fmt.Errorf("Hash mismatch for %s: %s != %s", url, result, hash)
 		}
 	} else {
-		size, err = io.Copy(target, body)
+		size, err = util.SafeCopy(target, body)
 		if err != nil {
 			return -1, err
 		}

--- a/shared/util/io.go
+++ b/shared/util/io.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"io"
+)
+
+// SafeCopy behaves like io.Copy but performs the copy through a loop of
+// io.CopyN calls using a fixed 4MiB chunk size.
+func SafeCopy(dst io.Writer, src io.Reader) (int64, error) {
+	const chunkSize = 4 * 1024 * 1024
+
+	var written int64
+	for {
+		n, err := io.CopyN(dst, src, chunkSize)
+		written += n
+		if err != nil {
+			if err == io.EOF {
+				return written, nil
+			}
+
+			return written, err
+		}
+	}
+}

--- a/shared/util/io_test.go
+++ b/shared/util/io_test.go
@@ -1,0 +1,141 @@
+package util
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSafeCopyEmpty(t *testing.T) {
+	dst := &bytes.Buffer{}
+	n, err := SafeCopy(dst, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("Expected no error for empty reader, got %v", err)
+	}
+
+	if n != 0 {
+		t.Fatalf("Expected 0 bytes written, got %d", n)
+	}
+
+	if dst.Len() != 0 {
+		t.Fatalf("Expected empty destination, got %d bytes", dst.Len())
+	}
+}
+
+func TestSafeCopySmallPayload(t *testing.T) {
+	payload := "hello, world"
+	dst := &bytes.Buffer{}
+
+	n, err := SafeCopy(dst, strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if n != int64(len(payload)) {
+		t.Fatalf("Expected %d bytes written, got %d", len(payload), n)
+	}
+
+	if dst.String() != payload {
+		t.Fatalf("Expected %q, got %q", payload, dst.String())
+	}
+}
+
+func TestSafeCopyExactlyOneChunk(t *testing.T) {
+	const chunkSize = 4 * 1024 * 1024
+	payload := bytes.Repeat([]byte("x"), chunkSize)
+	dst := &bytes.Buffer{}
+
+	n, err := SafeCopy(dst, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Expected no error for exactly one chunk, got %v", err)
+	}
+
+	if n != int64(chunkSize) {
+		t.Fatalf("Expected %d bytes written, got %d", chunkSize, n)
+	}
+
+	if !bytes.Equal(dst.Bytes(), payload) {
+		t.Fatalf("Destination content does not match source")
+	}
+}
+
+func TestSafeCopyMultipleChunks(t *testing.T) {
+	const chunkSize = 4 * 1024 * 1024
+	// 2.5 chunks to exercise the partial-last-chunk path.
+	size := int(2.5 * chunkSize)
+	payload := bytes.Repeat([]byte("a"), size)
+	dst := &bytes.Buffer{}
+
+	n, err := SafeCopy(dst, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Expected no error for multi-chunk copy, got %v", err)
+	}
+
+	if n != int64(size) {
+		t.Fatalf("Expected %d bytes written, got %d", size, n)
+	}
+
+	if !bytes.Equal(dst.Bytes(), payload) {
+		t.Fatalf("Destination content does not match source")
+	}
+}
+
+func TestSafeCopyReturnsWrittenBytesOnError(t *testing.T) {
+	sentinelErr := errors.New("write error")
+
+	// Writer that accepts exactly one chunk-sized write then errors on the next.
+	const chunkSize = 4 * 1024 * 1024
+	dst := &errorWriter{limit: chunkSize, err: sentinelErr}
+
+	// Two chunks so the second write will hit the error.
+	payload := bytes.Repeat([]byte("b"), chunkSize*2)
+
+	n, err := SafeCopy(dst, bytes.NewReader(payload))
+	if !errors.Is(err, sentinelErr) {
+		t.Fatalf("Expected sentinel error, got %v", err)
+	}
+
+	if n != int64(chunkSize) {
+		t.Fatalf("Expected %d bytes written before error, got %d", chunkSize, n)
+	}
+}
+
+func TestSafeCopyPropagatesReaderError(t *testing.T) {
+	sentinelErr := errors.New("read error")
+	dst := &bytes.Buffer{}
+
+	n, err := SafeCopy(dst, &errorReader{err: sentinelErr})
+	if !errors.Is(err, sentinelErr) {
+		t.Fatalf("Expected sentinel error, got %v", err)
+	}
+
+	if n != 0 {
+		t.Fatalf("Expected 0 bytes written on read error, got %d", n)
+	}
+}
+
+// errorWriter accepts up to limit bytes total then returns err on subsequent writes.
+type errorWriter struct {
+	limit   int
+	written int
+	err     error
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	if w.written >= w.limit {
+		return 0, w.err
+	}
+
+	w.written += len(p)
+	return len(p), nil
+}
+
+// errorReader always returns the given error immediately.
+type errorReader struct {
+	err error
+}
+
+func (r *errorReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}

--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Mirror takes a websocket and replicates all read/write to a ReadWriteCloser.
@@ -30,7 +31,7 @@ func MirrorRead(conn *websocket.Conn, rc io.Reader) chan error {
 	connRWC := NewWrapper(conn)
 
 	go func() {
-		_, err := io.Copy(connRWC, rc)
+		_, err := util.SafeCopy(connRWC, rc)
 
 		logger.Debug("Websocket: Stopped read mirror", logger.Ctx{"address": conn.RemoteAddr().String(), "err": err})
 
@@ -57,7 +58,7 @@ func MirrorWrite(conn *websocket.Conn, wc io.Writer) chan error {
 	connRWC := NewWrapper(conn)
 
 	go func() {
-		_, err := io.Copy(wc, connRWC)
+		_, err := util.SafeCopy(wc, connRWC)
 
 		logger.Debug("Websocket: Stopped write mirror", logger.Ctx{"address": conn.RemoteAddr().String(), "err": err})
 		chDone <- err

--- a/shared/ws/proxy.go
+++ b/shared/ws/proxy.go
@@ -1,11 +1,10 @@
 package ws
 
 import (
-	"io"
-
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/util"
 )
 
 // Proxy mirrors the traffic between two websockets.
@@ -25,7 +24,7 @@ func Proxy(source *websocket.Conn, target *websocket.Conn) chan struct{} {
 				break
 			}
 
-			_, err = io.Copy(w, r)
+			_, err = util.SafeCopy(w, r)
 			w.Close()
 			if err != nil {
 				break

--- a/test/godeps/client.list
+++ b/test/godeps/client.list
@@ -9,6 +9,7 @@ github.com/canonical/lxd/shared/simplestreams
 github.com/canonical/lxd/shared/tcp
 github.com/canonical/lxd/shared/termios
 github.com/canonical/lxd/shared/units
+github.com/canonical/lxd/shared/util
 github.com/canonical/lxd/shared/version
 github.com/canonical/lxd/shared/ws
 github.com/cespare/xxhash/v2

--- a/test/godeps/lxc-config.list
+++ b/test/godeps/lxc-config.list
@@ -11,6 +11,7 @@ github.com/canonical/lxd/shared/simplestreams
 github.com/canonical/lxd/shared/tcp
 github.com/canonical/lxd/shared/termios
 github.com/canonical/lxd/shared/units
+github.com/canonical/lxd/shared/util
 github.com/canonical/lxd/shared/version
 github.com/canonical/lxd/shared/ws
 github.com/cespare/xxhash/v2

--- a/test/godeps/lxd-agent.list
+++ b/test/godeps/lxd-agent.list
@@ -32,6 +32,7 @@ github.com/canonical/lxd/shared/simplestreams
 github.com/canonical/lxd/shared/tcp
 github.com/canonical/lxd/shared/termios
 github.com/canonical/lxd/shared/units
+github.com/canonical/lxd/shared/util
 github.com/canonical/lxd/shared/validate
 github.com/canonical/lxd/shared/version
 github.com/canonical/lxd/shared/ws

--- a/test/mini-loki/main.go
+++ b/test/mini-loki/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 
+	"github.com/canonical/lxd/shared/util"
 	"github.com/canonical/lxd/test/mini-loki/serve"
 )
 
@@ -67,7 +67,7 @@ func (l *loki) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (l *loki) onPush(w http.ResponseWriter, r *http.Request) {
-	_, _ = io.Copy(l.logfile, r.Body)
+	_, _ = util.SafeCopy(l.logfile, r.Body)
 	_, _ = l.logfile.WriteString("\n")
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
This prevents us from ever holding more than 4MiB of data in memory when relaying data between network connections or between network and files. That should help stabilise the memory footprint of LXD when running on busy systems.

From https://github.com/lxc/incus/pull/3192