### PR TITLE
doc: backport versioning tooling (stable-5.21)

### DIFF
--- a/doc/_static/rtd-versions-flyout.js
+++ b/doc/_static/rtd-versions-flyout.js
@@ -1,0 +1,59 @@
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+    // This script customizes the RTD flyout to show a version label next to "default", based on an RTD environment variable.
+
+    // The RTD flyout addon renders <readthedocs-flyout> before firing this
+    // event, so the element is already in the DOM by the time this listener
+    // runs. We check immediately, and also watch for any late insertion.
+
+    // Read the version label injected at build time from the FLYOUT_DEFAULT_VERSION_LABEL env var.
+    // This var needs to be manually defined in the RTD project dashboard, to whatever should appear in parenthese next to "default" in the flyout, such as "v5.21".
+    const versionLabel = window.flyoutDefaultVersionLabel;
+    if (!versionLabel) return;
+
+    function patchFlyout(root) {
+        let patched = false;
+        // Patch the version links in the dropdown list.
+        root.querySelectorAll("a").forEach(link => {
+            if (link.textContent.trim() === "default") {
+                link.textContent = `default (${versionLabel})`;
+                patched = true;
+            }
+        });
+        // Patch the "default" label shown on the flyout toggle button.
+        const versionSpan = root.querySelector("span.version");
+        if (versionSpan) {
+            versionSpan.childNodes.forEach(node => {
+                if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === "default") {
+                    node.textContent = node.textContent.replace("default", `default (${versionLabel})`);
+                    patched = true;
+                }
+            });
+        }
+        return patched;
+    }
+
+    function watchAndPatch(root) {
+        if (patchFlyout(root)) return;
+        // Shadow DOM content may not be fully rendered yet; watch for it.
+        const observer = new MutationObserver(function () {
+            if (patchFlyout(root)) observer.disconnect();
+        });
+        observer.observe(root, { childList: true, subtree: true });
+    }
+
+    // Check immediately — the flyout is likely already in the DOM.
+    const flyout = document.querySelector("readthedocs-flyout");
+    if (flyout) {
+        watchAndPatch(flyout.shadowRoot || flyout);
+        return;
+    }
+
+    // Fallback: watch for the element to be inserted later.
+    const bodyObserver = new MutationObserver(function () {
+        const flyout = document.querySelector("readthedocs-flyout");
+        if (!flyout) return;
+        bodyObserver.disconnect();
+        watchAndPatch(flyout.shadowRoot || flyout);
+    });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
+});

--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -1,0 +1,9 @@
+{% extends "!base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing for older RTD versions defined in conf.py (noindex_versions). #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -7,3 +7,10 @@
   <meta name="robots" content="noindex">
   {% endif %}
 {% endblock %}
+
+{% block theme_scripts %}
+{{ super() }}
+<script>
+  window.flyoutDefaultVersionLabel = "{{ flyout_default_version_label }}";
+</script>
+{% endblock theme_scripts %}

--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -12,5 +12,6 @@
 {{ super() }}
 <script>
   window.flyoutDefaultVersionLabel = "{{ flyout_default_version_label }}";
+  const github_url = "{{ github_url }}";
 </script>
 {% endblock theme_scripts %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -262,8 +262,11 @@ html_css_files = [
     'cookie-banner.css',
 ]
 
-# Adds custom JavaScript files, located under 'html_static_path'
-html_js_files = ['js/bundle.js']
+# Adds custom JavaScript files, located under 'html_static_path' or from external link
+html_js_files = [
+    'js/bundle.js',
+    'rtd-versions-flyout.js',
+]
 
 # Feedback button at the top; enabled by default
 # To disable the button, uncomment the line below:
@@ -309,6 +312,10 @@ if os.path.exists('./substitutions.yaml'):
 if os.path.exists('./related_topics.yaml'):
     with open('./related_topics.yaml', 'r') as fd:
         myst_substitutions.update(yaml.safe_load(fd.read()))
+
+# Version label shown in the RTD flyout next to "default", in parentheses.
+# Set the FLYOUT_DEFAULT_VERSION_LABEL environment variable in the RTD project dashboard.
+html_context['flyout_default_version_label'] = os.environ.get('FLYOUT_DEFAULT_VERSION_LABEL', '')
 
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -440,3 +440,14 @@ with open(".sphinx/latex_elements_template.txt", "rt") as file:
     latex_config = file.read()
 
 latex_elements = ast.literal_eval(latex_config.replace("$PROJECT", project))
+
+
+###########################################
+### Prevent indexing of older docs versions
+###########################################
+
+# Add RTD docs version slugs for versions that should not be indexed by search engines
+noindex_versions = {"stable-5.0", "stable-4.0"}
+
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+html_context["seo_noindex"] = rtd_version in noindex_versions


### PR DESCRIPTION
Backports related to working with versions in the documentation. The commit regarding the feedback button reverts an error introduced in the previous flyout-related commit.