### PR TITLE
Import: Validate struct slices and config

### DIFF
--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -93,6 +93,43 @@ func ConvertFormat(backupConf *config.Config, version uint32) (*config.Config, e
 		return nil, fmt.Errorf("Failed deep copying backup config: %w", err)
 	}
 
+	// Perform generic validation of the backup config before attempting any conversion.
+	for i, snapshot := range copyBackupConf.Snapshots {
+		if snapshot == nil {
+			return nil, fmt.Errorf("Instance snapshot %d is nil", i)
+		}
+	}
+
+	for i, snapshot := range copyBackupConf.VolumeSnapshots { //nolint:staticcheck
+		if snapshot == nil {
+			return nil, fmt.Errorf("Volume snapshot %d is nil", i)
+		}
+	}
+
+	for i, pool := range copyBackupConf.Pools {
+		if pool == nil {
+			return nil, fmt.Errorf("Pool %d is nil", i)
+		}
+	}
+
+	for i, profile := range copyBackupConf.Profiles {
+		if profile == nil {
+			return nil, fmt.Errorf("Profile %d is nil", i)
+		}
+	}
+
+	for i, volume := range copyBackupConf.Volumes {
+		if volume == nil {
+			return nil, fmt.Errorf("Volume %d is nil", i)
+		}
+
+		for j, snapshot := range volume.Snapshots {
+			if snapshot == nil {
+				return nil, fmt.Errorf("Snapshot %d of volume %d is nil", j, i)
+			}
+		}
+	}
+
 	if version <= api.BackupMetadataVersion1 {
 		// Changes from the new to the old metadata file format.
 
@@ -122,7 +159,12 @@ func ConvertFormat(backupConf *config.Config, version uint32) (*config.Config, e
 		// Rewrite the the instance and pools config keys only if observed in the old format.
 		// Currently pools are only listed in the config files of instances.
 		if copyBackupConf.Container != nil { //nolint:staticcheck
-			copyBackupConf.Instance = copyBackupConf.Container             //nolint:staticcheck
+			copyBackupConf.Instance = copyBackupConf.Container //nolint:staticcheck
+
+			if copyBackupConf.Pool == nil { //nolint:staticcheck
+				return nil, errors.New("Pool is missing")
+			}
+
 			copyBackupConf.Pools = []*api.StoragePool{copyBackupConf.Pool} //nolint:staticcheck
 		}
 

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -115,6 +115,10 @@ func GetInfo(s *state.State, r io.ReadSeeker, outputPath string) (*Info, error) 
 		return nil, fmt.Errorf("Backup is missing at %q", backupIndexPath)
 	}
 
+	if result.Config == nil {
+		return nil, fmt.Errorf("Backup config is missing at %q", backupIndexPath)
+	}
+
 	// Upgrade the config file in any case to the new format.
 	result.Config, err = ConvertFormat(result.Config, api.BackupMetadataVersion2)
 	if err != nil {


### PR DESCRIPTION
Accommodates the findings in https://github.com/lxc/incus/security/advisories/GHSA-x5r6-jr56-89pv.

In addition add a missing check for `.Config` in our backup config file retrieval via `GetInfo` (which calls `ConvertFormat` using `.Config`)