### PR TITLE
Import: Validate struct slices and config (stable-4.0)

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -573,6 +573,18 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		return fmt.Errorf("Instance definition in backup config is missing")
 	}
 
+	for i, snapshot := range backupConf.Snapshots {
+		if snapshot == nil {
+			return fmt.Errorf("Instance snapshot definition %d in backup config is missing", i)
+		}
+	}
+
+	for i, snapshot := range backupConf.VolumeSnapshots {
+		if snapshot == nil {
+			return fmt.Errorf("Volume snapshot definition %d in backup config is missing", i)
+		}
+	}
+
 	if allowNameOverride && instName != "" {
 		backupConf.Container.Name = instName
 	}

--- a/lxd/backup/backup_config.go
+++ b/lxd/backup/backup_config.go
@@ -101,6 +101,18 @@ func UpdateInstanceConfigStoragePool(c *db.Cluster, b Info, mountPath string) er
 			return fmt.Errorf("Instance definition in backup config is missing")
 		}
 
+		for i, snapshot := range backup.Snapshots {
+			if snapshot == nil {
+				return fmt.Errorf("Instance snapshot definition %d in backup config is missing", i)
+			}
+		}
+
+		for i, snapshot := range backup.VolumeSnapshots {
+			if snapshot == nil {
+				return fmt.Errorf("Volume snapshot definition %d in backup config is missing", i)
+			}
+		}
+
 		rootDiskDeviceFound := false
 
 		// Change the pool in the backup.yaml.

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -558,6 +558,10 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string, app
 		return nil, fmt.Errorf("Failed parsing instance backup file from %q: %w", backupYamlPath, err)
 	}
 
+	if backupConf.Container == nil {
+		return nil, fmt.Errorf("Instance definition in backup config is missing")
+	}
+
 	instDBArgs := backupConf.ToInstanceDBArgs(projectName)
 
 	if !applyProfiles {


### PR DESCRIPTION
Accommodates the findings in [GHSA-r7w7-mmxr-47r9](https://github.com/lxc/incus/security/advisories/GHSA-r7w7-mmxr-47r9).

Also there is a missing cherry-pick https://github.com/canonical/lxd-pkg-snap/pull/1206.

In 4.0 we can omit any checks for custom vol imports as this isn't yet supported. 