### PR TITLE
shared/network: implement Happy Eyeballs via Go's built-in dialer

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -20,45 +20,34 @@ const connectErrorPrefix = "Cannot connect to"
 
 // RFC3493Dialer connects to the specified server and returns the connection.
 // If the connection cannot be established then an error with the connectErrorPrefix is returned.
+// Go's built-in Happy Eyeballs (RFC 8305) races IPv6 and IPv4 concurrently when a hostname is passed.
 func RFC3493Dialer(ctx context.Context, network string, address string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, err
-	}
-
-	addrs, err := net.LookupHost(host)
+	_, _, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
 	}
 
 	kaConfig, userTimeout := tcp.KeepAliveTimeouts()
-	var errs []error
-	for _, a := range addrs {
-		a := net.JoinHostPort(a, port)
 
-		dialer := net.Dialer{
-			Timeout:         10 * time.Second,
-			KeepAliveConfig: kaConfig,
-		}
-
-		c, err := dialer.DialContext(ctx, network, a)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		tc, ok := c.(*net.TCPConn)
-		if ok {
-			err = tcp.SetUserTimeout(tc, userTimeout)
-			if err != nil {
-				logger.Warn("Failed setting TCP user timeout on outgoing connection", logger.Ctx{"address": a, "err": err})
-			}
-		}
-
-		return c, nil
+	dialer := net.Dialer{
+		Timeout:         10 * time.Second,
+		KeepAliveConfig: kaConfig,
 	}
 
-	return nil, fmt.Errorf("%s: %s (%v)", connectErrorPrefix, address, errs)
+	c, err := dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s (%w)", connectErrorPrefix, address, err)
+	}
+
+	tc, ok := c.(*net.TCPConn)
+	if ok {
+		err = tcp.SetUserTimeout(tc, userTimeout)
+		if err != nil {
+			logger.Warn("Failed setting TCP user timeout on outgoing connection", logger.Ctx{"address": address, "err": err})
+		}
+	}
+
+	return c, nil
 }
 
 // IsConnectionError returns true if the given error is due to the dialer not being able to connect to the target


### PR DESCRIPTION
Replace the manual DNS-resolve + sequential-address loop in RFC3493Dialer with a direct call to net.Dialer.DialContext using the original hostname. Go's dialer has implemented RFC 8305 Happy Eyeballs since Go 1.12: it races IPv6 and IPv4 concurrently with a ~250 ms fallback, eliminating the 10 s per-address stall that occurred when IPv6 was present but unreachable.

TCP keepalive config and TCP_USER_TIMEOUT are preserved. Context propagation to DNS resolution is also fixed as a side-effect.

I ran into this because I was trying to get lxd working on a host with a not-working IPv6. Instead of falling back to ipv4, it ran into timeouts.
The Happy Eyeballs path is a better user experience and also much less code.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
