### PR TITLE
Backup: Perform defensive check against config

### DIFF
--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -86,6 +86,10 @@ func ConfigToInstanceDBArgs(state *state.State, c *config.Config, projectName st
 // It returns the converted contents and doesn't modify the provided config.
 // In case the requested format is already present it's a noop.
 func ConvertFormat(backupConf *config.Config, version uint32) (*config.Config, error) {
+	if backupConf == nil {
+		return nil, errors.New("Backup config is nil")
+	}
+
 	// Create a copy of the original config.
 	copyBackupConf := config.NewConfig(backupConf.LastModified())
 	err := shared.DeepCopy(backupConf, copyBackupConf)


### PR DESCRIPTION
Based on a copilot comment in https://github.com/canonical/lxd/pull/18226#discussion_r3188211624. 

It's unlikely that a caller (during migration) triggers it but let's make it more robust.
