### PR TITLE
lxd/db/cluster: Apply identity certificate trigger similar to other triggers

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -96,12 +96,6 @@ CREATE TABLE identities_certificates (
     PRIMARY KEY (identity_id,
     certificate_id)
 ) WITHOUT ROWID;
-CREATE TRIGGER identities_certificates_after_delete
-    AFTER DELETE ON identities_certificates
-	BEGIN
-	DELETE FROM certificates
-		WHERE certificates.id = OLD.certificate_id;
-	END;
 CREATE TABLE identities_projects (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     identity_id INTEGER NOT NULL,
@@ -795,5 +789,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (84, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (85, strftime("%s"))
 `

--- a/lxd/db/cluster/stmt.go
+++ b/lxd/db/cluster/stmt.go
@@ -5,11 +5,8 @@
 package cluster
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
-
-	"github.com/canonical/lxd/shared/entity"
 )
 
 // RegisterStmt register a SQL statement.
@@ -64,52 +61,4 @@ func StmtString(code int) (string, error) {
 	}
 
 	return stmt, nil
-}
-
-// applyTriggers adds triggers to the database.
-//
-// Warning: These triggers are applied separately to the schema update mechanism. Changes to these triggers (especially their names)
-// may require a patch.
-func applyTriggers(ctx context.Context, tx *sql.Tx) error {
-	applyTrigger := func(name string, stmt string, entityType entity.Type) error {
-		if name == "" && stmt == "" {
-			return nil
-		} else if name == "" || stmt == "" {
-			return fmt.Errorf("Trigger name or SQL missing for entity type %q", entityType)
-		}
-
-		_, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+name)
-		if err != nil {
-			return err
-		}
-
-		_, err = tx.ExecContext(ctx, stmt)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	for entityType, entityTypeInfo := range entityTypes {
-		name, stmt := entityTypeInfo.onDeleteTriggerSQL()
-		err := applyTrigger(name, stmt, entityType)
-		if err != nil {
-			return err
-		}
-
-		name, stmt = entityTypeInfo.onUpdateTriggerSQL()
-		err = applyTrigger(name, stmt, entityType)
-		if err != nil {
-			return err
-		}
-
-		name, stmt = entityTypeInfo.onInsertTriggerSQL()
-		err = applyTrigger(name, stmt, entityType)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/lxd/db/cluster/triggers.go
+++ b/lxd/db/cluster/triggers.go
@@ -41,6 +41,13 @@ func applyTriggers(ctx context.Context, tx *sql.Tx) error {
 		return nil
 	}
 
+	for _, triggerFunc := range globalTriggers {
+		err := applyTrigger(triggerFunc, nil)
+		if err != nil {
+			return err
+		}
+	}
+
 	for entityType, entityTypeInfo := range entityTypes {
 		err := applyTrigger(entityTypeInfo.onDeleteTriggerSQL, &entityType)
 		if err != nil {
@@ -59,4 +66,21 @@ func applyTriggers(ctx context.Context, tx *sql.Tx) error {
 	}
 
 	return nil
+}
+
+var globalTriggers = []triggerFunc{
+	triggerIdentitiesCertificatesAfterDelete,
+}
+
+func triggerIdentitiesCertificatesAfterDelete() (name string, stmt string) {
+	name = "identities_certificates_after_delete"
+	stmt = fmt.Sprintf(`
+CREATE TRIGGER %s
+    AFTER DELETE ON identities_certificates
+	BEGIN
+	DELETE FROM certificates
+		WHERE certificates.id = OLD.certificate_id;
+	END;
+`, name)
+	return name, stmt
 }

--- a/lxd/db/cluster/triggers.go
+++ b/lxd/db/cluster/triggers.go
@@ -3,21 +3,29 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/canonical/lxd/shared/entity"
 )
+
+type triggerFunc func() (string, string)
 
 // applyTriggers adds triggers to the database.
 //
 // Warning: These triggers are applied separately to the schema update mechanism. Changes to these triggers (especially their names)
 // may require a patch.
 func applyTriggers(ctx context.Context, tx *sql.Tx) error {
-	applyTrigger := func(name string, stmt string, entityType entity.Type) error {
+	applyTrigger := func(triggerFunc triggerFunc, entityType *entity.Type) error {
+		name, stmt := triggerFunc()
 		if name == "" && stmt == "" {
 			return nil
 		} else if name == "" || stmt == "" {
-			return fmt.Errorf("Trigger name or SQL missing for entity type %q", entityType)
+			if entityType != nil {
+				return fmt.Errorf("Trigger name or SQL missing for entity type %q", *entityType)
+			}
+
+			return errors.New("Name or SQL missing from global trigger")
 		}
 
 		_, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+name)
@@ -34,20 +42,17 @@ func applyTriggers(ctx context.Context, tx *sql.Tx) error {
 	}
 
 	for entityType, entityTypeInfo := range entityTypes {
-		name, stmt := entityTypeInfo.onDeleteTriggerSQL()
-		err := applyTrigger(name, stmt, entityType)
+		err := applyTrigger(entityTypeInfo.onDeleteTriggerSQL, &entityType)
 		if err != nil {
 			return err
 		}
 
-		name, stmt = entityTypeInfo.onUpdateTriggerSQL()
-		err = applyTrigger(name, stmt, entityType)
+		err = applyTrigger(entityTypeInfo.onUpdateTriggerSQL, &entityType)
 		if err != nil {
 			return err
 		}
 
-		name, stmt = entityTypeInfo.onInsertTriggerSQL()
-		err = applyTrigger(name, stmt, entityType)
+		err = applyTrigger(entityTypeInfo.onInsertTriggerSQL, &entityType)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster/triggers.go
+++ b/lxd/db/cluster/triggers.go
@@ -1,0 +1,57 @@
+package cluster
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/lxd/shared/entity"
+)
+
+// applyTriggers adds triggers to the database.
+//
+// Warning: These triggers are applied separately to the schema update mechanism. Changes to these triggers (especially their names)
+// may require a patch.
+func applyTriggers(ctx context.Context, tx *sql.Tx) error {
+	applyTrigger := func(name string, stmt string, entityType entity.Type) error {
+		if name == "" && stmt == "" {
+			return nil
+		} else if name == "" || stmt == "" {
+			return fmt.Errorf("Trigger name or SQL missing for entity type %q", entityType)
+		}
+
+		_, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+name)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, stmt)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	for entityType, entityTypeInfo := range entityTypes {
+		name, stmt := entityTypeInfo.onDeleteTriggerSQL()
+		err := applyTrigger(name, stmt, entityType)
+		if err != nil {
+			return err
+		}
+
+		name, stmt = entityTypeInfo.onUpdateTriggerSQL()
+		err = applyTrigger(name, stmt, entityType)
+		if err != nil {
+			return err
+		}
+
+		name, stmt = entityTypeInfo.onInsertTriggerSQL()
+		err = applyTrigger(name, stmt, entityType)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -128,6 +128,15 @@ var updates = map[int]schema.Update{
 	82: updateFromV81,
 	83: updateFromV82,
 	84: updateFromV83,
+	85: updateFromV84,
+}
+
+func updateFromV84(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+DROP TRIGGER IF EXISTS identities_certificates_after_delete;
+`)
+
+	return err
 }
 
 func updateFromV83(ctx context.Context, tx *sql.Tx) error {

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -383,8 +383,10 @@ fine_grained: true"
 
   # The TLS identity can see and delete itself
   LXD_CONF="${LXD_CONF2}" lxc_remote auth identity list tls: --format csv | grep -wF "${tls_identity_fingerprint}"
+  [ "$(lxd sql global --format csv "SELECT COUNT(*) FROM certificates WHERE fingerprint = '${tls_identity_fingerprint}'")" = 1 ]
   LXD_CONF="${LXD_CONF2}" lxc_remote auth identity delete "tls:tls/${tls_identity_fingerprint}"
   ! lxc auth identity list --format csv | grep -F "${tls_identity_fingerprint}" || false
+  [ "$(lxd sql global --format csv "SELECT COUNT(*) FROM certificates WHERE fingerprint = '${tls_identity_fingerprint}'")" = 0 ]
 
   # The TLS identity is not trusted after deletion.
   LXD_CONF="${LXD_CONF2}" lxc_remote query tls:/1.0 | jq --exit-status '.auth == "untrusted"'


### PR DESCRIPTION
Moves the trigger out from the main schema and applies it in a similar way to other entity specific triggers.

I was not able to get this to work as part of the `identities` triggers and have instead applied it as a "global trigger" on the `identities_certificates` table.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
