### PR TITLE
Set operation project on auto-created metadata entity URLs

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -268,7 +268,18 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		// Skip if the entity type is "server". This doesn't give any useful information to the requestor (since the url will just be "/1.0").
 		_, ok := metadata[api.MetadataEntityURL]
 		if !ok && operationEntityType != entity.TypeServer {
-			metadata[api.MetadataEntityURL] = op.entityURL.String()
+			// The project that is present in the operation entity URL is always the effective project (e.g. the actual
+			// project where the resource lives in the database). This means that if a user is updating a network within
+			// a project that has `features.networks=false`, the auto-generated metadata entity URL would incorrectly have
+			// `project=default`. For this reason, we always overwrite the project to be the project that the operation
+			// is contained within, which should always be the requested project.
+			requiresProject, _ := operationEntityType.RequiresProject()
+			metadataURL := *op.entityURL
+			if requiresProject {
+				metadataURL.Project(args.ProjectName)
+			}
+
+			metadata[api.MetadataEntityURL] = metadataURL.String()
 		}
 
 		op.metadata, err = validateMetadata(metadata)

--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -50,25 +50,31 @@ func (u *URL) Path(pathParts ...string) *URL {
 	return u
 }
 
-// Project sets the "project" query parameter in the URL if the projectName is not empty or "default".
+// Project sets the "project" query parameter in the URL based on the input project name.
+// If the input project name is empty or "default", then no project query parameter is set (and any existing are deleted).
 func (u *URL) Project(projectName string) *URL {
+	queryArgs := u.Query()
 	if projectName != "default" && projectName != "" {
-		queryArgs := u.Query()
-		queryArgs.Add("project", projectName)
-		u.RawQuery = queryArgs.Encode()
+		queryArgs.Set("project", projectName)
+	} else {
+		queryArgs.Del("project")
 	}
 
+	u.RawQuery = queryArgs.Encode()
 	return u
 }
 
-// Target sets the "target" query parameter in the URL if the clusterMemberName is not empty or "none".
+// Target sets the "target" query parameter in the URL based on the input cluster member name.
+// If the input cluster member name is empty or "none", then no target parameter is set (and any existing are deleted).
 func (u *URL) Target(clusterMemberName string) *URL {
+	queryArgs := u.Query()
 	if clusterMemberName != "" && clusterMemberName != "none" {
-		queryArgs := u.Query()
-		queryArgs.Add("target", clusterMemberName)
-		u.RawQuery = queryArgs.Encode()
+		queryArgs.Set("target", clusterMemberName)
+	} else {
+		queryArgs.Del("target")
 	}
 
+	u.RawQuery = queryArgs.Encode()
 	return u
 }
 

--- a/shared/api/url_test.go
+++ b/shared/api/url_test.go
@@ -1,18 +1,47 @@
 package api
 
 import (
-	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func ExampleURL() {
+func TestURL(t *testing.T) {
 	u := NewURL()
-	fmt.Println(u.Path("1.0", "networks", "name-with-/-in-it"))
-	fmt.Println(u.Project("default"))
-	fmt.Println(u.Project("project-with-%-in-it"))
-	fmt.Println(u.Target(""))
-	fmt.Println(u.Target("member-with-%-in-it"))
-	fmt.Println(u.Host("example.com"))
-	fmt.Println(u.Scheme("https"))
+	require.Empty(t, u.String())
+
+	u.Path("1.0", "networks", "name-with-/-in-it")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Project("default")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Project("project-with-%-in-it")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it", u.String())
+
+	u.Project("another-project-with-%-in-it")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it?project=another-project-with-%25-in-it", u.String())
+
+	u.Project("default")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Target("")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Target("member-with-%-in-it")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it?target=member-with-%25-in-it", u.String())
+
+	u.Target("another-member-with-%-in-it")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it?target=another-member-with-%25-in-it", u.String())
+
+	u.Target("none")
+	require.Equal(t, "/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Host("example.com")
+	require.Equal(t, "//example.com/1.0/networks/name-with-%2F-in-it", u.String())
+
+	u.Scheme("https")
+	require.Equal(t, "https://example.com/1.0/networks/name-with-%2F-in-it", u.String())
 
 	// Output: /1.0/networks/name-with-%2F-in-it
 	// /1.0/networks/name-with-%2F-in-it


### PR DESCRIPTION
To account for project features.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
