### PR TITLE
Generalised configuration

### DIFF
--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -177,7 +177,7 @@ func clusterLinksGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if recursion != 0 && len(clusterLinks) > 0 {
-			allConfigs, err = dbCluster.GetClusterLinkConfig(ctx, tx.Tx(), nil)
+			allConfigs, err = dbCluster.ClusterLinksConfigStore().GetAll(ctx, tx.Tx())
 			if err != nil {
 				return fmt.Errorf("Failed loading cluster link configs: %w", err)
 			}
@@ -270,7 +270,7 @@ func clusterLinkGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading cluster link: %w", err)
 		}
 
-		config, err := dbCluster.GetClusterLinkConfig(ctx, tx.Tx(), &dbClusterLink.ID)
+		config, err := dbCluster.ClusterLinksConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbClusterLink.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading cluster link config: %w", err)
 		}
@@ -308,7 +308,7 @@ func updateClusterLink(s *state.State, r *http.Request, isPatch bool) response.R
 			return fmt.Errorf("Failed loading cluster link: %w", err)
 		}
 
-		config, err := dbCluster.GetClusterLinkConfig(ctx, tx.Tx(), &dbClusterLink.ID)
+		config, err := dbCluster.ClusterLinksConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbClusterLink.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading cluster link config: %w", err)
 		}
@@ -384,7 +384,7 @@ func updateClusterLink(s *state.State, r *http.Request, isPatch bool) response.R
 			return err
 		}
 
-		err = dbCluster.UpdateClusterLinkConfig(ctx, tx.Tx(), dbClusterLink.ID, req.Config)
+		err = dbCluster.ClusterLinksConfigStore().Set(ctx, tx.Tx(), dbClusterLink.ID, req.Config)
 		if err != nil {
 			return err
 		}
@@ -808,7 +808,7 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 			return fmt.Errorf("Error inserting %q into database: %w", req.Name, err)
 		}
 
-		err = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, req.Config)
+		err = dbCluster.ClusterLinksConfigStore().Set(ctx, tx.Tx(), clusterLinkID, req.Config)
 		if err != nil {
 			return err
 		}
@@ -898,7 +898,7 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		}
 
 		req.Config["volatile.addresses"] = strings.Join(trustToken.Addresses, ",")
-		err = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, req.Config)
+		err = dbCluster.ClusterLinksConfigStore().Set(ctx, tx.Tx(), clusterLinkID, req.Config)
 		if err != nil {
 			return err
 		}
@@ -1046,20 +1046,15 @@ func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPo
 		}
 
 		clusterLinkName = clusterLink.Name
-
-		config, err := dbCluster.GetClusterLinkConfig(ctx, tx.Tx(), &clusterLink.ID)
+		configurator := dbCluster.ClusterLinksConfigStore()
+		config, err := configurator.GetByEntityID(ctx, tx.Tx(), clusterLink.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading cluster link config: %w", err)
 		}
 
-		currentConfig := config[clusterLink.ID]
-		if currentConfig == nil {
-			currentConfig = map[string]string{}
-		}
-
 		// Activate the pending cluster link by updating only volatile keys from the request.
 		// This preserves any user.* configuration set while the link was pending.
-		err = dbCluster.UpdateClusterLinkConfig(ctx, tx.Tx(), clusterLink.ID, mergeClusterLinkActivationConfig(currentConfig, req.Config))
+		err = configurator.Set(ctx, tx.Tx(), clusterLink.ID, mergeClusterLinkActivationConfig(config, req.Config))
 		if err != nil {
 			return fmt.Errorf("Failed activating cluster link %q: %w", clusterLink.Name, err)
 		}
@@ -1383,7 +1378,7 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		config, err := dbCluster.GetClusterLinkConfig(ctx, tx.Tx(), &dbClusterLink.ID)
+		config, err := dbCluster.ClusterLinksConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbClusterLink.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading cluster link config: %w", err)
 		}

--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1716,12 +1716,7 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, inst insta
 
 		if ok {
 			// Filter candidates by placement group.
-			placementGroup, err := pgCache.Get(ctx, tx, placementGroupName, inst.Project().Name)
-			if err != nil {
-				return err
-			}
-
-			apiPlacementGroup, err := placementGroup.ToAPI(ctx, tx.Tx())
+			apiPlacementGroup, err := pgCache.Get(ctx, tx, placementGroupName, inst.Project().Name)
 			if err != nil {
 				return err
 			}
@@ -1730,7 +1725,7 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, inst insta
 			if err != nil {
 				// If no candidates remain due to placement constraints, signal not found so caller can skip instance during evacuation.
 				if api.StatusErrorCheck(err, http.StatusConflict) {
-					return api.StatusErrorf(http.StatusNotFound, "No eligible target cluster members after applying placement group %q", placementGroup.Row.Name)
+					return api.StatusErrorf(http.StatusNotFound, "No eligible target cluster members after applying placement group %q", apiPlacementGroup.Name)
 				}
 
 				return err

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -206,7 +206,7 @@ func replicatorsGet(d *Daemon, r *http.Request) response.Response {
 			return nil
 		}
 
-		allConfigs, err := dbCluster.GetReplicatorConfig(ctx, tx.Tx(), nil)
+		allConfigs, err := dbCluster.ReplicatorsConfigStore().GetAll(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed loading replicator configs: %w", err)
 		}
@@ -311,7 +311,7 @@ func replicatorGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading replicator: %w", err)
 		}
 
-		config, err := dbCluster.GetReplicatorConfig(ctx, tx.Tx(), &dbReplicator.Row.ID)
+		config, err := dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbReplicator.Row.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
@@ -483,7 +483,7 @@ func replicatorsPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed creating replicator %q: %w", req.Name, err)
 		}
 
-		return dbCluster.CreateReplicatorConfig(ctx, tx.Tx(), id, req.Config)
+		return dbCluster.ReplicatorsConfigStore().Set(ctx, tx.Tx(), id, req.Config)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -634,7 +634,7 @@ func replicatorStatePut(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		config, err := dbCluster.GetReplicatorConfig(ctx, tx.Tx(), &dbReplicator.Row.ID)
+		config, err := dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbReplicator.Row.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
@@ -705,7 +705,7 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 			return fmt.Errorf("Failed loading replicator: %w", err)
 		}
 
-		config, err := dbCluster.GetReplicatorConfig(ctx, tx.Tx(), &dbReplicator.Row.ID)
+		config, err := dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbReplicator.Row.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
@@ -756,7 +756,7 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 			return err
 		}
 
-		return dbCluster.UpdateReplicatorConfig(ctx, tx.Tx(), dbReplicator.Row.ID, req.Config)
+		return dbCluster.ReplicatorsConfigStore().Set(ctx, tx.Tx(), dbReplicator.Row.ID, req.Config)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -1623,7 +1623,7 @@ func runScheduledReplicators(ctx context.Context, s *state.State) error {
 			return fmt.Errorf("Failed loading replicators: %w", err)
 		}
 
-		allConfigs, err := dbCluster.GetReplicatorConfig(ctx, tx.Tx(), nil)
+		allConfigs, err := dbCluster.ReplicatorsConfigStore().GetAll(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed loading replicator configs: %w", err)
 		}

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -121,7 +121,7 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 		return 0, nil, nil, fmt.Errorf("Failed loading cluster link %q: %w", name, err)
 	}
 
-	config, err := dbCluster.GetClusterLinkConfig(ctx, tx, &dbLink.ID)
+	config, err := dbCluster.ClusterLinksConfigStore().GetByEntityIDs(ctx, tx, dbLink.ID)
 	if err != nil {
 		return 0, nil, nil, fmt.Errorf("Failed loading cluster link config: %w", err)
 	}
@@ -228,7 +228,7 @@ func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, na
 
 	// Update the cluster link config in the database.
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		return dbCluster.UpdateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, clusterLink.Config)
+		return dbCluster.ClusterLinksConfigStore().Set(ctx, tx.Tx(), clusterLinkID, clusterLink.Config)
 	})
 	if err != nil {
 		return fmt.Errorf("Failed updating cluster link config: %w", err)

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -82,6 +82,15 @@ func (r *ClusterLinkRow) ToAPI(allConfigs map[int64]map[string]string) *api.Clus
 	}
 }
 
+// ClusterLinksConfigStore returns a [query.EntityConfigStore] for cluster links.
+func ClusterLinksConfigStore() *query.EntityConfigStore {
+	return &query.EntityConfigStore{
+		EntityTable:               "cluster_links",
+		ConfigTable:               "cluster_links_config",
+		ConfigTableEntityIDColumn: "cluster_link_id",
+	}
+}
+
 // GetClusterLinks returns all cluster links.
 func GetClusterLinks(ctx context.Context, tx *sql.Tx) ([]ClusterLinkRow, error) {
 	return query.Select[ClusterLinkRow](ctx, tx, "ORDER BY name")
@@ -121,57 +130,6 @@ func RenameClusterLink(ctx context.Context, tx *sql.Tx, name string, to string) 
 
 	link.Name = to
 	return query.UpdateByPrimaryKey(ctx, tx, *link)
-}
-
-// GetClusterLinkConfig returns the config for all cluster links, or only the config for the cluster link with the given ID if provided.
-func GetClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID *int64) (map[int64]map[string]string, error) {
-	var q string
-	var args []any
-	if clusterLinkID != nil {
-		q = `SELECT cluster_link_id, key, value FROM cluster_links_config WHERE cluster_link_id=?`
-		args = []any{*clusterLinkID}
-	} else {
-		q = `SELECT cluster_link_id, key, value FROM cluster_links_config`
-	}
-
-	allConfigs := map[int64]map[string]string{}
-	return allConfigs, query.Scan(ctx, tx, q, func(scan func(dest ...any) error) error {
-		var id int64
-		var key, value string
-
-		err := scan(&id, &key, &value)
-		if err != nil {
-			return err
-		}
-
-		if allConfigs[id] == nil {
-			allConfigs[id] = map[string]string{}
-		}
-
-		_, found := allConfigs[id][key]
-		if found {
-			return fmt.Errorf("Duplicate config row found for key %q for cluster link ID %d", key, id)
-		}
-
-		allConfigs[id][key] = value
-
-		return nil
-	}, args...)
-}
-
-// CreateClusterLinkConfig creates config for a new cluster link with the given ID.
-func CreateClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID int64, config map[string]string) error {
-	return createEntityConfig(ctx, tx, "cluster_links_config", "cluster_link_id", clusterLinkID, config)
-}
-
-// UpdateClusterLinkConfig updates the cluster link with the given ID, setting its config.
-func UpdateClusterLinkConfig(ctx context.Context, tx *sql.Tx, clusterLinkID int64, config map[string]string) error {
-	_, err := tx.ExecContext(ctx, "DELETE FROM cluster_links_config WHERE cluster_link_id=?", clusterLinkID)
-	if err != nil {
-		return err
-	}
-
-	return CreateClusterLinkConfig(ctx, tx, clusterLinkID, config)
 }
 
 // clusterConfigRef describes an entity type whose config table may reference a cluster link via the 'cluster' key.

--- a/lxd/db/cluster/config.go
+++ b/lxd/db/cluster/config.go
@@ -2,12 +2,6 @@
 
 package cluster
 
-import (
-	"context"
-	"database/sql"
-	"fmt"
-)
-
 // Code generation directives.
 //
 //go:generate -command mapper lxd-generate db mapper -t config.mapper.go
@@ -36,28 +30,4 @@ type Config struct {
 type ConfigFilter struct {
 	Key   *string
 	Value *string
-}
-
-// createEntityConfig inserts config rows for an entity. The table must have columns
-// (<idColumn>, key, value). Empty values are skipped.
-func createEntityConfig(ctx context.Context, tx *sql.Tx, table string, idColumn string, entityID int64, config map[string]string) error {
-	stmt, err := tx.Prepare(fmt.Sprintf("INSERT INTO %s (%s, key, value) VALUES(?, ?, ?)", table, idColumn))
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = stmt.Close() }()
-
-	for k, v := range config {
-		if v == "" {
-			continue
-		}
-
-		_, err = stmt.ExecContext(ctx, entityID, k, v)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/lxd/db/cluster/placement_groups.go
+++ b/lxd/db/cluster/placement_groups.go
@@ -42,6 +42,15 @@ type PlacementGroupFilter struct {
 	Name    *string
 }
 
+// PlacementGroupsConfigStore returns a [query.EntityConfigStore] for placement groups.
+func PlacementGroupsConfigStore() *query.EntityConfigStore {
+	return &query.EntityConfigStore{
+		EntityTable:               "placement_groups",
+		ConfigTable:               "placement_groups_config",
+		ConfigTableEntityIDColumn: "placement_group_id",
+	}
+}
+
 // GetPlacementGroup gets a [PlacementGroup] by name and project.
 func GetPlacementGroup(ctx context.Context, tx *sql.Tx, name string, projectName string) (*PlacementGroup, error) {
 	group, err := query.SelectOne[PlacementGroup](ctx, tx, "WHERE placement_groups.name = ? AND projects.name = ?", name, projectName)
@@ -87,46 +96,6 @@ func GetPlacementGroupsAndURLs(ctx context.Context, tx *sql.Tx, projectName *str
 	}
 
 	return placementGroups, placementGroupURLs, nil
-}
-
-// CreatePlacementGroupConfig creates config for a new placement group with the given ID.
-func CreatePlacementGroupConfig(ctx context.Context, tx *sql.Tx, placementGroupID int64, config map[string]string) error {
-	return createEntityConfig(ctx, tx, "placement_groups_config", "placement_group_id", placementGroupID, config)
-}
-
-// UpdatePlacementGroupConfig updates the placement group config with the given ID.
-func UpdatePlacementGroupConfig(ctx context.Context, tx *sql.Tx, placementGroupID int64, config map[string]string) error {
-	// Delete current entries.
-	_, err := tx.Exec("DELETE FROM placement_groups_config WHERE placement_group_id=?", placementGroupID)
-	if err != nil {
-		return err
-	}
-
-	// Insert new entries.
-	return CreatePlacementGroupConfig(ctx, tx, placementGroupID, config)
-}
-
-// GetPlacementGroupConfig returns the config for the placement group with the given ID.
-func GetPlacementGroupConfig(ctx context.Context, tx *sql.Tx, placementGroupID int64) (map[string]string, error) {
-	q := `SELECT key, value FROM placement_groups_config WHERE placement_group_id=?`
-
-	config := map[string]string{}
-	return config, query.Scan(ctx, tx, q, func(scan func(dest ...any) error) error {
-		var key, value string
-
-		err := scan(&key, &value)
-		if err != nil {
-			return err
-		}
-
-		_, found := config[key]
-		if found {
-			return fmt.Errorf("Duplicate config row found for key %q for placement group ID %d", key, placementGroupID)
-		}
-
-		config[key] = value
-		return nil
-	}, placementGroupID)
 }
 
 // ToAPI converts the [PlacementGroup] to an [api.PlacementGroup], querying for extra data as necessary.

--- a/lxd/db/cluster/placement_groups.go
+++ b/lxd/db/cluster/placement_groups.go
@@ -113,10 +113,12 @@ func (p *PlacementGroup) ToAPI(configs map[int64]map[string]string) *api.Placeme
 	}
 }
 
-// GetPlacementGroupUsedBy returns a list of URLs of all instances and profiles that reference placement groups matching the provider [PlacementGroupFilter].
-func GetPlacementGroupUsedBy(ctx context.Context, tx *sql.Tx, filter PlacementGroupFilter, firstOnly bool) ([]string, error) {
+// GetPlacementGroupsUsedBy returns a map of project name to map of placement group name (matching the given filter)
+// to list of URLs of instances and profiles that reference the placement group.
+func GetPlacementGroupsUsedBy(ctx context.Context, tx *sql.Tx, filter PlacementGroupFilter, firstOnly bool) (map[string]map[string][]string, error) {
 	var b strings.Builder
 	var args []any
+	urls := make(map[string]map[string][]string)
 
 	b.WriteString(`SELECT ` + strconv.FormatInt(entityTypeCodeInstance, 10) + `, instances.name, projects.name, instances_config.value FROM instances
 JOIN instances_config ON instances.id = instances_config.instance_id
@@ -131,6 +133,10 @@ WHERE instances_config.key = 'placement.group'`)
 	if filter.Project != nil {
 		b.WriteString(" AND projects.name = ?")
 		args = append(args, *filter.Project)
+
+		// Ensure returned map is populated for filter keys even if empty
+		// so that the caller can lookup results without worrying if the map is nil.
+		urls[*filter.Project] = make(map[string][]string)
 	}
 
 	b.WriteString(`
@@ -153,22 +159,24 @@ WHERE profiles_config.key = 'placement.group'`)
 		b.WriteString("LIMIT 1")
 	}
 
-	var urls []string
 	err := query.Scan(ctx, tx, b.String(), func(scan func(dest ...any) error) error {
 		var eType EntityType
-		var eName string
-		var pName string
-		var placementGroupName string
-		err := scan(&eType, &eName, &pName, &placementGroupName)
+		var entityName, projectName, placementGroupName string
+		err := scan(&eType, &entityName, &projectName, &placementGroupName)
 		if err != nil {
 			return err
 		}
 
+		_, ok := urls[projectName]
+		if !ok {
+			urls[projectName] = make(map[string][]string)
+		}
+
 		switch entity.Type(eType) {
 		case entity.TypeInstance:
-			urls = append(urls, api.NewURL().Project(pName).Path("1.0", "instances", eName).String())
+			urls[projectName][placementGroupName] = append(urls[projectName][placementGroupName], api.NewURL().Project(projectName).Path("1.0", "instances", entityName).String())
 		case entity.TypeProfile:
-			urls = append(urls, api.NewURL().Project(pName).Path("1.0", "profiles", eName).String())
+			urls[projectName][placementGroupName] = append(urls[projectName][placementGroupName], api.NewURL().Project(projectName).Path("1.0", "profiles", entityName).String())
 		default:
 			return errors.New("Unexpected entity type in placement group usage query")
 		}

--- a/lxd/db/cluster/placement_groups.go
+++ b/lxd/db/cluster/placement_groups.go
@@ -113,6 +113,19 @@ func (p *PlacementGroup) ToAPI(configs map[int64]map[string]string) *api.Placeme
 	}
 }
 
+// GetPlacementGroupUsedBy returns a list of URLs of entities that reference the placement group with the given name and project.
+func GetPlacementGroupUsedBy(ctx context.Context, tx *sql.Tx, projectName string, placementGroupName string, firstOnly bool) ([]string, error) {
+	usedByMap, err := GetPlacementGroupsUsedBy(ctx, tx, PlacementGroupFilter{
+		Project: &projectName,
+		Name:    &placementGroupName,
+	}, firstOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	return usedByMap[projectName][placementGroupName], nil
+}
+
 // GetPlacementGroupsUsedBy returns a map of project name to map of placement group name (matching the given filter)
 // to list of URLs of instances and profiles that reference the placement group.
 func GetPlacementGroupsUsedBy(ctx context.Context, tx *sql.Tx, filter PlacementGroupFilter, firstOnly bool) (map[string]map[string][]string, error) {

--- a/lxd/db/cluster/placement_groups.go
+++ b/lxd/db/cluster/placement_groups.go
@@ -99,11 +99,10 @@ func GetPlacementGroupsAndURLs(ctx context.Context, tx *sql.Tx, projectName *str
 }
 
 // ToAPI converts the [PlacementGroup] to an [api.PlacementGroup], querying for extra data as necessary.
-func (p *PlacementGroup) ToAPI(ctx context.Context, tx *sql.Tx) (*api.PlacementGroup, error) {
-	// Get config
-	config, err := GetPlacementGroupConfig(ctx, tx, p.Row.ID)
-	if err != nil {
-		return nil, fmt.Errorf("Failed getting placement group config: %w", err)
+func (p *PlacementGroup) ToAPI(configs map[int64]map[string]string) *api.PlacementGroup {
+	config := configs[p.Row.ID]
+	if config == nil {
+		config = map[string]string{}
 	}
 
 	return &api.PlacementGroup{
@@ -111,7 +110,7 @@ func (p *PlacementGroup) ToAPI(ctx context.Context, tx *sql.Tx) (*api.PlacementG
 		Description: p.Row.Description,
 		Project:     p.ProjectName,
 		Config:      config,
-	}, nil
+	}
 }
 
 // GetPlacementGroupUsedBy returns a list of URLs of all instances and profiles that reference placement groups matching the provider [PlacementGroupFilter].

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -37,6 +37,15 @@ type Replicator struct {
 	ProjectName string `db:"projects.name"`
 }
 
+// ReplicatorsConfigStore returns a [query.EntityConfigStore] for replicators.
+func ReplicatorsConfigStore() *query.EntityConfigStore {
+	return &query.EntityConfigStore{
+		EntityTable:               "replicators",
+		ConfigTable:               "replicators_config",
+		ConfigTableEntityIDColumn: "replicator_id",
+	}
+}
+
 // ToAPI converts the [Replicator] to an [api.Replicator].
 func (r *Replicator) ToAPI(allConfigs map[int64]map[string]string) *api.Replicator {
 	config := allConfigs[r.Row.ID]
@@ -130,57 +139,6 @@ func GetReplicatorsAndURLs(ctx context.Context, tx *sql.Tx, projectName *string,
 	}
 
 	return replicators, replicatorURLs, nil
-}
-
-// CreateReplicatorConfig creates config for a new replicator with the given ID.
-func CreateReplicatorConfig(ctx context.Context, tx *sql.Tx, replicatorID int64, config map[string]string) error {
-	return createEntityConfig(ctx, tx, "replicators_config", "replicator_id", replicatorID, config)
-}
-
-// UpdateReplicatorConfig updates the replicator with the given ID, setting its config.
-func UpdateReplicatorConfig(ctx context.Context, tx *sql.Tx, replicatorID int64, config map[string]string) error {
-	_, err := tx.ExecContext(ctx, "DELETE FROM replicators_config WHERE replicator_id=?", replicatorID)
-	if err != nil {
-		return err
-	}
-
-	return CreateReplicatorConfig(ctx, tx, replicatorID, config)
-}
-
-// GetReplicatorConfig returns the config for all replicators, or only the config for the replicator with the given ID if provided.
-func GetReplicatorConfig(ctx context.Context, tx *sql.Tx, replicatorID *int64) (map[int64]map[string]string, error) {
-	var q string
-	var args []any
-	if replicatorID != nil {
-		q = `SELECT replicator_id, key, value FROM replicators_config WHERE replicator_id=?`
-		args = []any{*replicatorID}
-	} else {
-		q = `SELECT replicator_id, key, value FROM replicators_config`
-	}
-
-	allConfigs := map[int64]map[string]string{}
-	return allConfigs, query.Scan(ctx, tx, q, func(scan func(dest ...any) error) error {
-		var id int64
-		var key, value string
-
-		err := scan(&id, &key, &value)
-		if err != nil {
-			return err
-		}
-
-		if allConfigs[id] == nil {
-			allConfigs[id] = map[string]string{}
-		}
-
-		_, found := allConfigs[id][key]
-		if found {
-			return fmt.Errorf("Duplicate config row found for key %q for replicator ID %d", key, id)
-		}
-
-		allConfigs[id][key] = value
-
-		return nil
-	}, args...)
 }
 
 // UpdateReplicatorLastRun updates the last_run_date and last_run_status fields of the replicator with the given ID.

--- a/lxd/db/config.go
+++ b/lxd/db/config.go
@@ -16,7 +16,7 @@ func (n *NodeTx) Config(ctx context.Context) (map[string]string, error) {
 // UpdateConfig updates the given LXD node-level configuration keys in the
 // config table. Config keys set to empty values will be deleted.
 func (n *NodeTx) UpdateConfig(values map[string]string) error {
-	return query.UpdateConfig(n.tx, "config", values)
+	return query.UpdateServerConfig(n.tx, values)
 }
 
 // Config fetches all LXD cluster config keys.
@@ -27,5 +27,5 @@ func (c *ClusterTx) Config(ctx context.Context) (map[string]string, error) {
 // UpdateClusterConfig updates the given LXD cluster configuration keys in the
 // config table. Config keys set to empty values will be deleted.
 func (c *ClusterTx) UpdateClusterConfig(values map[string]string) error {
-	return query.UpdateConfig(c.tx, "config", values)
+	return query.UpdateServerConfig(c.tx, values)
 }

--- a/lxd/db/query/config.go
+++ b/lxd/db/query/config.go
@@ -46,9 +46,8 @@ func SelectConfig(ctx context.Context, tx *sql.Tx, table string, where string, a
 	return values, nil
 }
 
-// UpdateConfig updates the given keys in the given table. Config keys set to
-// empty values will be deleted.
-func UpdateConfig(tx *sql.Tx, table string, values map[string]string) error {
+// UpdateServerConfig updates the given keys in the "config" table. Config keys set to empty values will be deleted.
+func UpdateServerConfig(tx *sql.Tx, values map[string]string) error {
 	changes := map[string]string{}
 	deletes := []string{}
 
@@ -61,12 +60,12 @@ func UpdateConfig(tx *sql.Tx, table string, values map[string]string) error {
 		changes[key] = value
 	}
 
-	err := upsertConfig(tx, table, changes)
+	err := upsertConfig(tx, changes)
 	if err != nil {
 		return fmt.Errorf("updating values failed: %w", err)
 	}
 
-	err = deleteConfig(tx, table, deletes)
+	err = deleteConfig(tx, deletes)
 	if err != nil {
 		return fmt.Errorf("deleting values failed: %w", err)
 	}
@@ -75,12 +74,12 @@ func UpdateConfig(tx *sql.Tx, table string, values map[string]string) error {
 }
 
 // Insert or updates the key/value rows of the given config table.
-func upsertConfig(tx *sql.Tx, table string, values map[string]string) error {
+func upsertConfig(tx *sql.Tx, values map[string]string) error {
 	if len(values) == 0 {
 		return nil // Nothing to update
 	}
 
-	query := "INSERT OR REPLACE INTO " + table + " (key, value) VALUES"
+	query := "INSERT OR REPLACE INTO config (key, value) VALUES"
 	exprs := []string{}
 	params := []any{}
 	for key, value := range values {
@@ -94,14 +93,14 @@ func upsertConfig(tx *sql.Tx, table string, values map[string]string) error {
 }
 
 // Delete the given key rows from the given config table.
-func deleteConfig(tx *sql.Tx, table string, keys []string) error {
+func deleteConfig(tx *sql.Tx, keys []string) error {
 	n := len(keys)
 
 	if n == 0 {
 		return nil // Nothing to delete.
 	}
 
-	query := "DELETE FROM " + table + " WHERE key IN " + Params(n)
+	query := "DELETE FROM config WHERE key IN " + Params(n)
 	values := make([]any, n)
 	for i, key := range keys {
 		values[i] = key

--- a/lxd/db/query/config.go
+++ b/lxd/db/query/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -108,4 +109,181 @@ func deleteConfig(tx *sql.Tx, keys []string) error {
 
 	_, err := tx.Exec(query, values...)
 	return err
+}
+
+// EntityConfigStore generalises configuration management for most entities.
+// It does not support entities whose configuration is node-specific (networks, storage pools).
+type EntityConfigStore struct {
+	EntityTable               string
+	ConfigTable               string
+	ConfigTableEntityIDColumn string
+}
+
+// Set deletes any existing configuration for an entity and creates the given configuration.
+// Empty configuration keys are skipped.
+func (c *EntityConfigStore) Set(ctx context.Context, tx *sql.Tx, entityID int64, config map[string]string) error {
+	var b strings.Builder
+	b.WriteString("DELETE FROM ")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(" WHERE ")
+	b.WriteString(c.ConfigTableEntityIDColumn)
+	b.WriteString(" = ?")
+	_, err := tx.ExecContext(ctx, b.String(), entityID)
+	if err != nil {
+		return fmt.Errorf("Failed resetting entity configuration: %w", err)
+	}
+
+	keys := make([]string, 0, len(config))
+	for k, v := range config {
+		// Ignore empty values.
+		if v == "" {
+			continue
+		}
+
+		keys = append(keys, k)
+	}
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	args := make([]any, 0, len(keys)*3)
+
+	b.Reset()
+	b.WriteString("INSERT INTO ")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(" (")
+	b.WriteString(c.ConfigTableEntityIDColumn)
+	b.WriteString(", key, value) VALUES ")
+	b.WriteString("(?, ?, ?)")
+	args = append(args, entityID, keys[0], config[keys[0]])
+	for _, key := range keys[1:] {
+		b.WriteString(", (?, ?, ?)")
+		args = append(args, entityID, key, config[key])
+	}
+
+	res, err := tx.ExecContext(ctx, b.String(), args...)
+	if err != nil {
+		return fmt.Errorf("Failed writing entity configuration: %w", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed verifying entity configuration: %w", err)
+	}
+
+	if int(n) != len(keys) {
+		return fmt.Errorf("Expected to write %d configuration entries but wrote %d", len(keys), n)
+	}
+
+	return nil
+}
+
+// GetByEntityID returns configuration for the entity with the given ID or an error if no entity exists with this ID.
+func (c *EntityConfigStore) GetByEntityID(ctx context.Context, tx *sql.Tx, entityID int64) (map[string]string, error) {
+	conf, err := c.GetByEntityIDs(ctx, tx, entityID)
+	if err != nil {
+		return nil, err
+	}
+
+	return conf[entityID], nil
+}
+
+// GetByEntityIDs returns configuration for entities with the given IDs or an error if one or more entities do not exist.
+func (c *EntityConfigStore) GetByEntityIDs(ctx context.Context, tx *sql.Tx, entityIDs ...int64) (map[int64]map[string]string, error) {
+	if len(entityIDs) == 0 {
+		return make(map[int64]map[string]string), nil
+	}
+
+	b := new(strings.Builder)
+	b.WriteString("WHERE ")
+	b.WriteString(c.EntityTable)
+	b.WriteString(".id IN (?")
+	args := make([]any, 0, len(entityIDs))
+	args = append(args, entityIDs[0])
+	for _, id := range entityIDs[1:] {
+		b.WriteString(", ?")
+		args = append(args, id)
+	}
+
+	b.WriteString(")")
+	entityConfigs, err := c.Select(ctx, tx, b.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if any IDs are missing.
+	missingIDs := make([]string, 0, len(entityIDs))
+	for _, entityID := range entityIDs {
+		_, ok := entityConfigs[entityID]
+		if !ok {
+			missingIDs = append(missingIDs, strconv.FormatInt(entityID, 10))
+		}
+	}
+
+	// If any IDs are missing there is an internal error (because IDs are internal).
+	if len(missingIDs) > 0 {
+		return nil, fmt.Errorf(`No rows in %q with ID %q`, c.EntityTable, strings.Join(missingIDs, `", "`))
+	}
+
+	return entityConfigs, nil
+}
+
+// GetAll returns all configuration available to the [EntityConfigStore].
+func (c *EntityConfigStore) GetAll(ctx context.Context, tx *sql.Tx) (map[int64]map[string]string, error) {
+	return c.Select(ctx, tx, "")
+}
+
+// Select gets all configuration for entities that match the given clause. The primary entity table is already part of the
+// default query, so this can be joined to other tables if required. The IDs of all entities matching the given clause are
+// returned. If the entity has no configuration, Select returns an empty map.
+func (c *EntityConfigStore) Select(ctx context.Context, tx *sql.Tx, clause string, args ...any) (map[int64]map[string]string, error) {
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	b.WriteString(c.EntityTable)
+	b.WriteString(".id, coalesce(")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(".key, ''), coalesce(")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(".value, '') FROM ")
+	b.WriteString(c.EntityTable)
+	b.WriteString(" LEFT JOIN ")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(" ON ")
+	b.WriteString(c.EntityTable)
+	b.WriteString(".id = ")
+	b.WriteString(c.ConfigTable)
+	b.WriteString(".")
+	b.WriteString(c.ConfigTableEntityIDColumn)
+	b.WriteString(" ")
+	b.WriteString(clause)
+
+	configs := make(map[int64]map[string]string)
+	err := Scan(ctx, tx, b.String(), func(scan func(dest ...any) error) error {
+		var entityID int64
+		var key, value string
+		err := scan(&entityID, &key, &value)
+		if err != nil {
+			return fmt.Errorf("Failed reading configuration: %w", err)
+		}
+
+		_, ok := configs[entityID]
+		if !ok {
+			configs[entityID] = make(map[string]string)
+		}
+
+		// Omit empty keys resulting from coalesced values.
+		// This indicates that an entity with this ID exists but does not have any config.
+		// For these entities we return an empty map.
+		if key != "" {
+			configs[entityID][key] = value
+		}
+
+		return nil
+	}, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading configuration: %w", err)
+	}
+
+	return configs, nil
 }

--- a/lxd/db/query/config_test.go
+++ b/lxd/db/query/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/canonical/lxd/lxd/db/query"
 )
@@ -67,4 +68,205 @@ func newTxForConfig(t *testing.T) *sql.Tx {
 	assert.NoError(t, err)
 
 	return tx
+}
+
+type entityConfigStoreSuite struct {
+	suite.Suite
+	runTx            func(func(ctx context.Context, tx *sql.Tx) error)
+	projectConfig    func() *query.EntityConfigStore
+	replicatorConfig func() *query.EntityConfigStore
+}
+
+func TestEntityConfigStore(t *testing.T) {
+	suite.Run(t, new(entityConfigStoreSuite))
+}
+
+func (s *entityConfigStoreSuite) SetupSuite() {
+	db, err := sql.Open("sqlite3", ":memory:")
+	s.Require().NoError(err)
+
+	_, err = db.ExecContext(s.T().Context(), "PRAGMA foreign_keys = ON;")
+	s.Require().NoError(err)
+
+	s.runTx = func(f func(ctx context.Context, tx *sql.Tx) error) {
+		tx, err := db.Begin()
+		s.Require().NoError(err)
+
+		err = f(s.T().Context(), tx)
+		s.Require().NoError(err)
+		err = tx.Commit()
+		s.Require().NoError(err)
+	}
+
+	s.projectConfig = func() *query.EntityConfigStore {
+		return &query.EntityConfigStore{
+			EntityTable:               "projects",
+			ConfigTable:               "projects_config",
+			ConfigTableEntityIDColumn: "project_id",
+		}
+	}
+
+	s.replicatorConfig = func() *query.EntityConfigStore {
+		return &query.EntityConfigStore{
+			EntityTable:               "replicators",
+			ConfigTable:               "replicators_config",
+			ConfigTableEntityIDColumn: "replicator_id",
+		}
+	}
+}
+
+func (s *entityConfigStoreSuite) SetupTest() {
+	s.runTx(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+CREATE TABLE "projects" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT NOT NULL,
+    UNIQUE (name)
+);
+CREATE TABLE "projects_config" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    project_id INTEGER NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES "projects" (id) ON DELETE CASCADE,
+    UNIQUE (project_id, key)
+);
+CREATE TABLE replicators (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	name TEXT NOT NULL,
+	project_id INTEGER NOT NULL,
+	UNIQUE(project_id, name),
+	FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+CREATE TABLE replicators_config (
+	replicator_id INTEGER NOT NULL,
+	key TEXT NOT NULL,
+	value TEXT NOT NULL,
+	FOREIGN KEY (replicator_id) REFERENCES replicators (id) ON DELETE CASCADE,
+	PRIMARY KEY (replicator_id,
+    key)
+) WITHOUT ROWID;
+
+INSERT INTO projects (name) VALUES ('p1'), ('p2'), ('p3');
+INSERT INTO projects_config (project_id, key, value) VALUES (1, 'user.foo', 'bar'), (1, 'user.fizz', 'buzz'), (1, 'user.ibble', 'dibble');
+INSERT INTO projects_config (project_id, key, value) VALUES (2, 'user.foo', 'bar');
+INSERT INTO replicators (name, project_id) VALUES ('r1', 1), ('r2', 1), ('r1', 2);
+INSERT INTO replicators_config (replicator_id, key, value) VALUES (1, 'user.foo', 'bar'), (1, 'user.fizz', 'buzz'), (1, 'user.ibble', 'dibble');
+INSERT INTO replicators_config (replicator_id, key, value) VALUES (3, 'user.foo', 'bar');
+`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (s *entityConfigStoreSuite) TearDownTest() {
+	s.runTx(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+DROP TABLE replicators_config;
+DROP TABLE replicators;
+DROP TABLE projects_config;
+DROP TABLE projects;
+`)
+		return err
+	})
+}
+
+func (s *entityConfigStoreSuite) TestGet() {
+	s.runTx(func(ctx context.Context, tx *sql.Tx) error {
+		projectConfig := s.projectConfig()
+
+		// Expect to get project1 config and no error.
+		project1Config, err := projectConfig.GetByEntityID(ctx, tx, 1)
+		s.Require().NoError(err)
+		s.Require().Equal(map[string]string{
+			"user.foo":   "bar",
+			"user.fizz":  "buzz",
+			"user.ibble": "dibble",
+		}, project1Config)
+
+		// Expect to get project2 config and no error.
+		project2Config, err := projectConfig.GetByEntityID(ctx, tx, 2)
+		s.Require().NoError(err)
+		s.Require().Equal(map[string]string{
+			"user.foo": "bar",
+		}, project2Config)
+
+		// Expect an empty map because project3 has no config but does exist.
+		project3Config, err := projectConfig.GetByEntityID(ctx, tx, 3)
+		s.Require().NoError(err)
+		s.Require().Equal(map[string]string{}, project3Config)
+
+		// Expect an error because there is no fourth project
+		_, err1 := projectConfig.GetByEntityID(ctx, tx, 4)
+		s.Require().Error(err1)
+
+		// Expect the same error because there is no fourth project
+		_, err2 := projectConfig.GetByEntityIDs(ctx, tx, 1, 2, 3, 4)
+		s.Require().Error(err2)
+		s.Require().Equal(err1, err2)
+
+		// Expect GetAll to return the same results and no map entry for fourth project (which doesn't exist).
+		projectConfigs, err := projectConfig.GetAll(ctx, tx)
+		s.Require().NoError(err)
+		s.Require().Equal(project1Config, projectConfigs[1])
+		s.Require().Equal(project2Config, projectConfigs[2])
+		s.Require().Equal(project3Config, projectConfigs[3])
+		_, ok := projectConfigs[4]
+		s.Require().False(ok)
+
+		// Get config for p1 and p2. Expect no map entry for p3 because we didn't select for it.
+		projectConfigs, err = projectConfig.Select(ctx, tx, "WHERE projects.name IN (?, ?)", "p1", "p2")
+		s.Require().NoError(err)
+		s.Require().Equal(projectConfigs[1], project1Config)
+		s.Require().Equal(projectConfigs[2], project2Config)
+		_, ok = projectConfigs[3]
+		s.Require().False(ok)
+
+		// Test that joining replicator config to projects works.
+		replicatorConfig := s.replicatorConfig()
+		replicatorConfigs, err := replicatorConfig.Select(ctx, tx, "JOIN projects ON replicators.project_id = projects.id WHERE projects.name = ?", "p1")
+		s.Require().NoError(err)
+		s.Require().Equal(map[string]string{
+			"user.foo":   "bar",
+			"user.fizz":  "buzz",
+			"user.ibble": "dibble",
+		}, replicatorConfigs[1])
+
+		// The second replicator is in p1 but has no config, so expect an empty map.
+		s.Require().Equal(map[string]string{}, replicatorConfigs[2])
+
+		// The third replicator is not present because it is not in project p1.
+		_, ok = replicatorConfigs[3]
+		s.Require().False(ok)
+
+		return nil
+	})
+}
+
+func (s *entityConfigStoreSuite) TestSet() {
+	projectConfig := s.projectConfig()
+	newConfig := map[string]string{
+		"user.foo":   "bar",
+		"user.fizz":  "buzz",
+		"user.ibble": "dibble",
+		"user.bacon": "eggs",
+	}
+
+	s.runTx(func(ctx context.Context, tx *sql.Tx) error {
+		err := projectConfig.Set(ctx, tx, 1, newConfig)
+		s.Require().NoError(err)
+		config, err := s.projectConfig().GetByEntityID(ctx, tx, 1)
+		s.Require().NoError(err)
+		s.Require().Equal(newConfig, config)
+		return nil
+	})
+
+	s.runTx(func(ctx context.Context, tx *sql.Tx) error {
+		err := projectConfig.Set(ctx, tx, 4, newConfig)
+		s.Require().Error(err)
+		return nil
+	})
 }

--- a/lxd/db/query/config_test.go
+++ b/lxd/db/query/config_test.go
@@ -13,14 +13,14 @@ import (
 
 func TestSelectConfig(t *testing.T) {
 	tx := newTxForConfig(t)
-	values, err := query.SelectConfig(context.Background(), tx, "test", "")
+	values, err := query.SelectConfig(context.Background(), tx, "config", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "x", "bar": "zz"}, values)
 }
 
 func TestSelectConfig_WithFilters(t *testing.T) {
 	tx := newTxForConfig(t)
-	values, err := query.SelectConfig(context.Background(), tx, "test", "key=?", "bar")
+	values, err := query.SelectConfig(context.Background(), tx, "config", "key=?", "bar")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"bar": "zz"}, values)
 }
@@ -30,10 +30,10 @@ func TestUpdateConfig_NewKeys(t *testing.T) {
 	tx := newTxForConfig(t)
 
 	values := map[string]string{"foo": "y"}
-	err := query.UpdateConfig(tx, "test", values)
+	err := query.UpdateServerConfig(tx, values)
 	require.NoError(t, err)
 
-	values, err = query.SelectConfig(context.Background(), tx, "test", "")
+	values, err = query.SelectConfig(context.Background(), tx, "config", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "y", "bar": "zz"}, values)
 }
@@ -43,10 +43,10 @@ func TestDeleteConfig_Delete(t *testing.T) {
 	tx := newTxForConfig(t)
 	values := map[string]string{"foo": ""}
 
-	err := query.UpdateConfig(tx, "test", values)
+	err := query.UpdateServerConfig(tx, values)
 
 	require.NoError(t, err)
-	values, err = query.SelectConfig(context.Background(), tx, "test", "")
+	values, err = query.SelectConfig(context.Background(), tx, "config", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"bar": "zz"}, values)
 }
@@ -57,10 +57,10 @@ func newTxForConfig(t *testing.T) *sql.Tx {
 	db, err := sql.Open("sqlite3", ":memory:")
 	assert.NoError(t, err)
 
-	_, err = db.Exec("CREATE TABLE test (key TEXT NOT NULL, value TEXT)")
+	_, err = db.Exec("CREATE TABLE config (key TEXT NOT NULL, value TEXT)")
 	assert.NoError(t, err)
 
-	_, err = db.Exec("INSERT INTO test VALUES ('foo', 'x'), ('bar', 'zz')")
+	_, err = db.Exec("INSERT INTO config VALUES ('foo', 'x'), ('bar', 'zz')")
 	assert.NoError(t, err)
 
 	tx, err := db.Begin()

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1770,10 +1770,12 @@ func instancesPostSelectClusterMember(ctx context.Context, tx *db.ClusterTx, pla
 		return nil, err
 	}
 
-	apiPlacementGroup, err := placementGroup.ToAPI(ctx, tx.Tx())
+	configs, err := dbCluster.PlacementGroupsConfigStore().GetByEntityIDs(ctx, tx.Tx(), placementGroup.Row.ID)
 	if err != nil {
 		return nil, err
 	}
+
+	apiPlacementGroup := placementGroup.ToAPI(configs)
 
 	filteredCandidates, err := placement.Filter(ctx, tx, candidateMembers, *apiPlacementGroup, false)
 	if err != nil {

--- a/lxd/placement/cache.go
+++ b/lxd/placement/cache.go
@@ -6,24 +6,25 @@ import (
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/shared/api"
 )
 
 // Cache stores placement groups loaded within a short-lived scope (eg: a DB transaction) to avoid reloading the same placement group multiple times.
 type Cache struct {
 	mu    sync.Mutex
-	items map[string]*cluster.PlacementGroup
+	items map[string]*api.PlacementGroup
 }
 
 // NewCache returns an initialized placement cache.
 func NewCache() *Cache {
 	return &Cache{
-		items: make(map[string]*cluster.PlacementGroup),
+		items: make(map[string]*api.PlacementGroup),
 	}
 }
 
 // Get returns the placement group for the given project/name, loading it via [cluster.GetPlacementGroup] if not present in the cache.
 // The provided [*db.ClusterTx] is used to perform the DB call.
-func (c *Cache) Get(ctx context.Context, tx *db.ClusterTx, name string, projectName string) (*cluster.PlacementGroup, error) {
+func (c *Cache) Get(ctx context.Context, tx *db.ClusterTx, name string, projectName string) (*api.PlacementGroup, error) {
 	key := projectName + "/" + name
 
 	c.mu.Lock()
@@ -40,9 +41,16 @@ func (c *Cache) Get(ctx context.Context, tx *db.ClusterTx, name string, projectN
 		return nil, err
 	}
 
+	configs, err := cluster.PlacementGroupsConfigStore().GetByEntityIDs(ctx, tx.Tx(), dbPg.Row.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	apiPg := dbPg.ToAPI(configs)
+
 	c.mu.Lock()
-	c.items[key] = dbPg
+	c.items[key] = apiPg
 	c.mu.Unlock()
 
-	return dbPg, nil
+	return apiPg, nil
 }

--- a/lxd/placement/filtering_test.go
+++ b/lxd/placement/filtering_test.go
@@ -96,7 +96,7 @@ func (s *filteringSuite) TestFilter() {
 					})
 					s.Require().NoError(err)
 
-					err = cluster.CreatePlacementGroupConfig(ctx, tx.Tx(), pgID, map[string]string{
+					err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), pgID, map[string]string{
 						"policy": api.PlacementPolicySpread,
 						"rigor":  api.PlacementRigorStrict,
 					})
@@ -215,7 +215,7 @@ func (s *filteringSuite) TestFilter() {
 					})
 					s.Require().NoError(err)
 
-					err = cluster.CreatePlacementGroupConfig(ctx, tx.Tx(), pgID, map[string]string{
+					err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), pgID, map[string]string{
 						"policy": api.PlacementPolicySpread,
 						"rigor":  api.PlacementRigorPermissive,
 					})
@@ -309,7 +309,7 @@ func (s *filteringSuite) TestFilter() {
 					})
 					s.Require().NoError(err)
 
-					err = cluster.CreatePlacementGroupConfig(ctx, tx.Tx(), pgID, map[string]string{
+					err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), pgID, map[string]string{
 						"policy": api.PlacementPolicyCompact,
 						"rigor":  api.PlacementRigorStrict,
 					})
@@ -463,7 +463,7 @@ func (s *filteringSuite) TestFilter() {
 					})
 					s.Require().NoError(err)
 
-					err = cluster.CreatePlacementGroupConfig(ctx, tx.Tx(), pgID, map[string]string{
+					err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), pgID, map[string]string{
 						"policy": api.PlacementPolicyCompact,
 						"rigor":  api.PlacementRigorPermissive,
 					})
@@ -609,13 +609,8 @@ func (s *filteringSuite) TestFilter() {
 		}
 
 		_ = testCluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-			// Fetch the placement group to get the full object with ID.
-			placementGroup, err := pgCache.Get(ctx, tx, tt.args.placementGroup.Row.Name, tt.args.placementGroup.ProjectName)
-			if err != nil {
-				return err
-			}
-
-			apiPlacementGroup, err := placementGroup.ToAPI(ctx, tx.Tx())
+			// Fetch the cached API placement group object needed for filtering, including its policy-related settings.
+			apiPlacementGroup, err := pgCache.Get(ctx, tx, tt.args.placementGroup.Row.Name, tt.args.placementGroup.ProjectName)
 			if err != nil {
 				return err
 			}

--- a/lxd/placement_groups.go
+++ b/lxd/placement_groups.go
@@ -168,16 +168,16 @@ func placementGroupsGet(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	var apiGroups []*api.PlacementGroup
+	var placementGroups []cluster.PlacementGroup
 	var placementGroupURLs []string
-	entitlementReportingMap := make(map[*api.URL]auth.EntitlementReporter)
+	var allConfigs map[int64]map[string]string
+	var usedByURLs map[string]map[string][]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var projectNameFilter *string
 		if !allProjects {
 			projectNameFilter = &projectName
 		}
 
-		var placementGroups []cluster.PlacementGroup
 		placementGroups, placementGroupURLs, err = cluster.GetPlacementGroupsAndURLs(ctx, tx.Tx(), projectNameFilter, func(group cluster.PlacementGroup) bool {
 			return canViewPlacementGroup(entity.PlacementGroupURL(group.ProjectName, group.Row.Name))
 		})
@@ -186,31 +186,25 @@ func placementGroupsGet(d *Daemon, r *http.Request) response.Response {
 			return nil
 		}
 
-		// Transaction local variable to prevent appending duplicates in case of transaction retry on sqlite.ErrBusy.
-		apiGroupsTx := make([]*api.PlacementGroup, 0, len(placementGroups))
-		for _, placementGroup := range placementGroups {
-			u := entity.PlacementGroupURL(placementGroup.ProjectName, placementGroup.Row.Name)
-			apiGroup, err := placementGroup.ToAPI(ctx, tx.Tx())
+		configStore := cluster.PlacementGroupsConfigStore()
+		if projectNameFilter == nil {
+			allConfigs, err = configStore.GetAll(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}
-
-			filter := cluster.PlacementGroupFilter{
-				Project: &placementGroup.ProjectName,
-				Name:    &placementGroup.Row.Name,
-			}
-
-			usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), filter, false)
+		} else {
+			allConfigs, err = configStore.Select(ctx, tx.Tx(), "JOIN projects ON placement_groups.project_id = projects.id WHERE projects.name = ?", *projectNameFilter)
 			if err != nil {
 				return err
 			}
-
-			apiGroup.UsedBy = usedBy
-			apiGroupsTx = append(apiGroupsTx, apiGroup)
-			entitlementReportingMap[u] = apiGroup
 		}
 
-		apiGroups = apiGroupsTx
+		usedByFilter := cluster.PlacementGroupFilter{Project: projectNameFilter}
+		usedByURLs, err = cluster.GetPlacementGroupsUsedBy(ctx, tx.Tx(), usedByFilter, false)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -221,8 +215,20 @@ func placementGroupsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SyncResponse(true, placementGroupURLs)
 	}
 
-	for _, pg := range apiGroups {
-		pg.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, pg.UsedBy)
+	entitlementReportingMap := make(map[*api.URL]auth.EntitlementReporter)
+	apiGroups := make([]*api.PlacementGroup, 0, len(placementGroups))
+	for _, placementGroup := range placementGroups {
+		u := entity.PlacementGroupURL(placementGroup.ProjectName, placementGroup.Row.Name)
+		apiGroup := placementGroup.ToAPI(allConfigs)
+
+		// If no placement groups in the project are in use, the usedByURLs map may have a nil value for the project.
+		usedBy, ok := usedByURLs[placementGroup.ProjectName]
+		if ok {
+			apiGroup.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, usedBy[placementGroup.Row.Name])
+		}
+
+		apiGroups = append(apiGroups, apiGroup)
+		entitlementReportingMap[u] = apiGroup
 	}
 
 	if len(withEntitlements) > 0 {

--- a/lxd/placement_groups.go
+++ b/lxd/placement_groups.go
@@ -45,6 +45,10 @@ var placementGroupCmd = APIEndpoint{
 	Post:   APIEndpointAction{Handler: placementGroupPost, AccessHandler: allowPermission(entity.TypePlacementGroup, auth.EntitlementCanEdit, "name")},
 }
 
+func placementGroupEtag(group api.PlacementGroup) any {
+	return []any{group.Name, group.Project, group.Description, group.Config}
+}
+
 // API endpoints.
 
 // swagger:operation GET /1.0/placement-groups placement-groups placement_groups_get
@@ -315,7 +319,7 @@ func placementGroupsPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		err = cluster.CreatePlacementGroupConfig(ctx, tx.Tx(), id, req.Config)
+		err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), id, req.Config)
 		if err != nil {
 			return err
 		}
@@ -380,12 +384,7 @@ func doPlacementGroupDelete(ctx context.Context, s *state.State, name string, pr
 			return err
 		}
 
-		filter := cluster.PlacementGroupFilter{
-			Project: &dbGroup.ProjectName,
-			Name:    &dbGroup.Row.Name,
-		}
-
-		usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), filter, true)
+		usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), dbGroup.ProjectName, dbGroup.Row.Name, true)
 		if err != nil {
 			return err
 		}
@@ -459,29 +458,29 @@ func placementGroupGet(d *Daemon, r *http.Request) response.Response {
 
 	s := d.State()
 
-	var placementGroup *api.PlacementGroup
+	var placementGroup *cluster.PlacementGroup
+	var configs map[int64]map[string]string
+	var usedBy map[string]map[string][]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbGroup, err := cluster.GetPlacementGroup(ctx, tx.Tx(), placementGroupName, projectName)
+		placementGroup, err = cluster.GetPlacementGroup(ctx, tx.Tx(), placementGroupName, projectName)
 		if err != nil {
 			return err
 		}
 
-		placementGroup, err = dbGroup.ToAPI(ctx, tx.Tx())
+		configs, err = cluster.PlacementGroupsConfigStore().GetByEntityIDs(ctx, tx.Tx(), placementGroup.Row.ID)
 		if err != nil {
 			return err
 		}
 
 		filter := cluster.PlacementGroupFilter{
-			Project: &dbGroup.ProjectName,
-			Name:    &dbGroup.Row.Name,
+			Project: &placementGroup.ProjectName,
+			Name:    &placementGroup.Row.Name,
 		}
 
-		usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), filter, false)
+		usedBy, err = cluster.GetPlacementGroupsUsedBy(ctx, tx.Tx(), filter, false)
 		if err != nil {
 			return err
 		}
-
-		placementGroup.UsedBy = usedBy
 
 		return nil
 	})
@@ -489,16 +488,17 @@ func placementGroupGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	etag := *placementGroup
-	placementGroup.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, placementGroup.UsedBy)
+	apiGroup := placementGroup.ToAPI(configs)
+	apiGroup.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, usedBy[projectName][placementGroupName])
+
 	if len(withEntitlements) > 0 {
-		err = reportEntitlements(r.Context(), s.Authorizer, entity.TypePlacementGroup, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.PlacementGroupURL(projectName, placementGroupName): placementGroup})
+		err = reportEntitlements(r.Context(), s.Authorizer, entity.TypePlacementGroup, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.PlacementGroupURL(projectName, placementGroupName): apiGroup})
 		if err != nil {
 			return response.SmartError(err)
 		}
 	}
 
-	return response.SyncResponseETag(true, placementGroup, etag)
+	return response.SyncResponseETag(true, apiGroup, placementGroupEtag(*apiGroup))
 }
 
 // swagger:operation PATCH /1.0/placement-groups/{name} placement-groups placement_group_patch
@@ -586,14 +586,14 @@ func placementGroupPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	var placementGroup *cluster.PlacementGroup
-	var config map[string]string
+	var configs map[int64]map[string]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		placementGroup, err = cluster.GetPlacementGroup(ctx, tx.Tx(), placementGroupName, projectName)
 		if err != nil {
 			return err
 		}
 
-		config, err = cluster.GetPlacementGroupConfig(ctx, tx.Tx(), placementGroup.Row.ID)
+		configs, err = cluster.PlacementGroupsConfigStore().GetByEntityIDs(ctx, tx.Tx(), placementGroup.Row.ID)
 		if err != nil {
 			return fmt.Errorf("Failed getting placement group config: %w", err)
 		}
@@ -604,13 +604,14 @@ func placementGroupPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = util.EtagCheck(r, placementGroup)
+	apiGroup := placementGroup.ToAPI(configs)
+	err = util.EtagCheck(r, placementGroupEtag(*apiGroup))
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	updatedPlacementGroup := *placementGroup
-	updatedConfig := config
+	updatedConfig := configs[placementGroup.Row.ID]
 	var descriptionChanged bool
 	switch r.Method {
 	case http.MethodPut:
@@ -651,7 +652,7 @@ func placementGroupPut(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		err = cluster.UpdatePlacementGroupConfig(ctx, tx.Tx(), updatedPlacementGroup.Row.ID, updatedConfig)
+		err = cluster.PlacementGroupsConfigStore().Set(ctx, tx.Tx(), updatedPlacementGroup.Row.ID, updatedConfig)
 		if err != nil {
 			return err
 		}
@@ -717,12 +718,7 @@ func placementGroupPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		filter := cluster.PlacementGroupFilter{
-			Project: &dbGroup.ProjectName,
-			Name:    &dbGroup.Row.Name,
-		}
-
-		usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), filter, true)
+		usedBy, err := cluster.GetPlacementGroupUsedBy(ctx, tx.Tx(), dbGroup.ProjectName, dbGroup.Row.Name, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#18237 will introduce composite primary keys to `dbgen`. This is required for tables that use `WITHOUT ROWID` but is also at odds with the approach to generic configuration taken in #18004.

This PR introduces a standard pattern for handling entity configuration and updates cluster links, placement groups, and replicators to use it.

The idea is that this pattern encourages good practice for handling configuration, so that we don't do things like `ToAPI(ctx, tx)` within a for loop when a single query can be performed.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
