### PR TITLE
shared/archive: Improve detection and error handling

### DIFF
--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/subprocess"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/logger"
 )
@@ -106,10 +107,14 @@ func CompressedTarReader(s *state.State, ctx context.Context, r io.ReadSeeker, u
 			return nil, cancelFunc, fmt.Errorf("Failed starting unpack: Failed running: %s: %w", unpacker[0], err)
 		}
 
-		// Close the pipe upon completion.
+		// Close the pipe and unload apparmor profile upon completion.
+		unPackerDone := cancel.New()
 		go func() {
 			_, err := p.Wait(context.Background())
 			_ = pipeWriter.CloseWithError(err)
+			_ = apparmor.ArchiveUnload(s.OS, outputPath)
+			_ = apparmor.ArchiveDelete(s.OS, outputPath)
+			unPackerDone.Cancel()
 		}()
 
 		ctxCancelFunc := cancelFunc
@@ -118,10 +123,7 @@ func CompressedTarReader(s *state.State, ctx context.Context, r io.ReadSeeker, u
 		// the unpacker process to complete.
 		cancelFunc = func() {
 			ctxCancelFunc()
-			_ = pipeWriter.Close()
-			_, _ = p.Wait(ctx)
-			_ = apparmor.ArchiveUnload(s.OS, outputPath)
-			_ = apparmor.ArchiveDelete(s.OS, outputPath)
+			<-unPackerDone.Done() // Wait for unpacker process to complete before returning.
 		}
 
 		tr = tar.NewReader(pipeReader)

--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -106,6 +106,12 @@ func CompressedTarReader(s *state.State, ctx context.Context, r io.ReadSeeker, u
 			return nil, cancelFunc, fmt.Errorf("Failed starting unpack: Failed running: %s: %w", unpacker[0], err)
 		}
 
+		// Close the pipe upon completion.
+		go func() {
+			_, err := p.Wait(context.Background())
+			_ = pipeWriter.CloseWithError(err)
+		}()
+
 		ctxCancelFunc := cancelFunc
 
 		// Now that unpacker process has started, wrap context cancel function with one that waits for

--- a/shared/archive.go
+++ b/shared/archive.go
@@ -27,33 +27,43 @@ func DetectCompressionFile(f io.Reader) ([]string, string, []string, error) {
 	// bz2 - 2 bytes, 'BZ' signature/magic number
 	// gz - 2 bytes, 0x1f 0x8b
 	// lzma - 6 bytes, { [0x000, 0xE0], '7', 'z', 'X', 'Z', 0x00 } -
-	// xy - 6 bytes,  header format { 0xFD, '7', 'z', 'X', 'Z', 0x00 }
+	// xz - 6 bytes,  header format { 0xFD, '7', 'z', 'X', 'Z', 0x00 }
 	// tar - 263 bytes, trying to get ustar from 257 - 262
+	// lz4 - 4 bytes 0x04 0x22 0x4d 0x18, magic number
 	header := make([]byte, 263)
-	_, err := f.Read(header)
+	n, err := f.Read(header)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	switch {
-	case bytes.Equal(header[0:2], []byte{'B', 'Z'}):
+	// Compressed tar handling.
+	case n >= 2 && bytes.Equal(header[0:2], []byte{'B', 'Z'}):
 		return []string{"-jxf"}, ".tar.bz2", []string{"bzip2", "-d"}, nil
-	case bytes.Equal(header[0:2], []byte{0x1f, 0x8b}):
+	case n >= 2 && bytes.Equal(header[0:2], []byte{0x1f, 0x8b}):
 		return []string{"-zxf"}, ".tar.gz", []string{"gzip", "-d"}, nil
-	case (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] == 0xFD):
+	case n >= 5 && (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] == 0xFD):
 		return []string{"-Jxf"}, ".tar.xz", []string{"xz", "-d"}, nil
-	case (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] != 0xFD):
+	case n >= 5 && (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] != 0xFD):
 		return []string{"--lzma", "-xf"}, ".tar.lzma", []string{"lzma", "-d"}, nil
-	case bytes.Equal(header[0:3], []byte{0x5d, 0x00, 0x00}):
+	case n >= 3 && bytes.Equal(header[0:3], []byte{0x5d, 0x00, 0x00}):
 		return []string{"--lzma", "-xf"}, ".tar.lzma", []string{"lzma", "-d"}, nil
-	case bytes.Equal(header[257:262], []byte{'u', 's', 't', 'a', 'r'}):
-		return []string{"-xf"}, ".tar", []string{}, nil
-	case bytes.Equal(header[0:4], []byte{'h', 's', 'q', 's'}):
-		return []string{"-xf"}, ".squashfs", []string{"sqfs2tar", "--no-skip"}, nil
-	case bytes.Equal(header[0:3], []byte{'Q', 'F', 'I'}):
-		return []string{""}, ".qcow2", []string{"qemu-img", "convert", "-O", "raw"}, nil
-	case bytes.Equal(header[0:4], []byte{0x28, 0xb5, 0x2f, 0xfd}):
+	case n >= 4 && bytes.Equal(header[0:4], []byte{0x28, 0xb5, 0x2f, 0xfd}):
 		return []string{"--zstd", "-xf"}, ".tar.zst", []string{"zstd", "-d"}, nil
+	case n >= 4 && bytes.Equal(header[0:4], []byte{0x04, 0x22, 0x4d, 0x18}):
+		return []string{"-Ilz4", "-xf"}, ".tar.lz4", []string{"lz4", "-d"}, nil
+
+	// Uncompressed tar handling.
+	case n >= 262 && bytes.Equal(header[257:262], []byte{'u', 's', 't', 'a', 'r'}):
+		return []string{"-xf"}, ".tar", []string{}, nil
+
+	// Other formats.
+	case n >= 4 && bytes.Equal(header[0:4], []byte{'h', 's', 'q', 's'}):
+		return []string{"-xf"}, ".squashfs", []string{"sqfs2tar", "--no-skip"}, nil
+	case n >= 3 && bytes.Equal(header[0:3], []byte{'Q', 'F', 'I'}):
+		return []string{""}, ".qcow2", []string{"qemu-img", "convert", "-O", "raw"}, nil
+	case n >= 4 && bytes.Equal(header[0:4], []byte{'K', 'D', 'M', 'V'}):
+		return []string{""}, ".vmdk", []string{"qemu-img", "convert", "-O", "raw"}, nil
 	default:
 		return nil, "", nil, errors.New("Unsupported compression")
 	}


### PR DESCRIPTION
Fuzzing by the 7asecurity team has discovered a few issues with our
handling of compressed images and backups.

This fixes 3 different issues:
 - We weren't checking that 0 bytes at the trailing end of a header were
   in fact 0 in the file itself (checking read length).
 - In case of unpacker error, the client may hang reading from the
   uncompressed pipe unless it implements its own timeout/context mechanism
   calling the canceler.
 - The signature of an uncompressed tarball is based on trailing bytes
   and so should be checked after all of those using leading bytes.

No crashes would result from such bad input but some of the consumers of
those archive functions would be left hanging indefinitely, wasting a
few goroutines.

Reported-by: https://7asecurity.com/