### PR TITLE
lxd/loki: Forward security events to Loki as OWASP audit log entries

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2022,7 +2022,7 @@ This also introduces a change whereby network access is controlled by the projec
 
 ## `loki`
 
-This adds support for sending life cycle and logging events to a Loki server.
+This adds support for sending events to a Loki server.
 
 It adds the following global configuration keys:
 
@@ -2031,7 +2031,7 @@ It adds the following global configuration keys:
 * {config:option}`server-loki:loki.auth.username` and {config:option}`server-loki:loki.auth.password`: Used if Loki is behind a reverse proxy with basic authentication enabled
 * {config:option}`server-loki:loki.labels`: Comma-separated list of values which are to be used as labels for Loki events.
 * {config:option}`server-loki:loki.loglevel`: Minimum log level for events sent to the Loki server.
-* {config:option}`server-loki:loki.types`: Types of events which are to be sent to the Loki server (`lifecycle` and/or `logging`).
+* {config:option}`server-loki:loki.types`: Types of events which are to be sent to the Loki server (any combination of `lifecycle`, `logging`, `ovn`, and `security`).
 
 ## `acme`
 

--- a/lxd/loki/loki.go
+++ b/lxd/loki/loki.go
@@ -424,7 +424,7 @@ func (c *Client) HandleEvent(event api.Event) {
 		// Loki receives the OWASP-shaped audit payload. The events API
 		// metadata uses Go-style names; the OWASP transformation lives
 		// here so consumers of /1.0/events do not see OWASP fields.
-		owasp := c.securityEventToOWASP(event, secEvent)
+		owasp := c.securityEventToOWASP(event, secEvent, location)
 
 		for k, v := range owasp {
 			if !slices.Contains(c.cfg.labels, k) {
@@ -455,7 +455,7 @@ func (c *Client) HandleEvent(event api.Event) {
 // events API is combined with the envelope timestamp/location and the
 // server-static fields plumbed through the Loki client config so that the
 // resulting line conforms to the OWASP audit log schema.
-func (c *Client) securityEventToOWASP(event api.Event, sec api.EventSecurity) map[string]string {
+func (c *Client) securityEventToOWASP(event api.Event, sec api.EventSecurity, location string) map[string]string {
 	owasp := map[string]string{
 		"appid":               "lxd",
 		"type":                api.EventTypeSecurity,
@@ -469,9 +469,8 @@ func (c *Client) securityEventToOWASP(event api.Event, sec api.EventSecurity) ma
 		"protocol":            "https",
 		"request_uri":         sec.RequestPath,
 		"request_method":      sec.RequestMethod,
-		"project":             sec.Project,
-		"event_source":        event.Location,
-		"cluster_member_name": event.Location,
+		"event_source":        location,
+		"cluster_member_name": location,
 		"cluster_identifier":  c.cfg.clusterIdentifier,
 	}
 

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -155,6 +155,7 @@ readonly test_group_standalone=(
     "instances_selective_recursion"
     "kernel_limits"
     "loki"
+    "loki_security_forwarding"
     "loki_security_types"
     "lxd_user"
     "metrics"

--- a/test/suites/loki.sh
+++ b/test/suites/loki.sh
@@ -64,3 +64,61 @@ test_loki_security_types() {
   kill_loki
   rm "${log_file}"
 }
+
+test_loki_security_forwarding() {
+  local log_file="${TEST_DIR}/loki.logs"
+  spawn_loki
+
+  sub_test "Verify security events forward to Loki with OWASP serialization"
+  lxc config set loki.api.url="http://127.0.0.1:3100" loki.auth.username="loki" loki.auth.password="pass"
+  lxc config set loki.types="security"
+
+  # Trigger authn_login_fail:tls by presenting an untrusted client cert to an
+  # authenticated endpoint (mirrors test_authn_events in security.sh).
+  gen_cert_and_key "loki-untrusted-cert"
+  curl --insecure --silent \
+    --cert "${LXD_CONF}/loki-untrusted-cert.crt" \
+    --key "${LXD_CONF}/loki-untrusted-cert.key" \
+    "https://${LXD_ADDR}/1.0/instances" \
+    | jq --exit-status '.error_code == 403'
+
+  # Changing the loki configuration sends any accumulated logs to the test server.
+  lxc config set loki.api.url="" loki.auth.username="" loki.auth.password="" loki.types=""
+
+  # The security stream must exist and every line must carry OWASP fields.
+  jq --exit-status '.streams[].stream | select(.type == "security")' "${log_file}"
+  # Assert OWASP fields that securityEventToOWASP populates unconditionally.
+  # user_id, useragent and source_ip are only set when the requestor has the
+  # corresponding metadata, which is not the case for authn_login_fail:tls.
+  jq --exit-status 'all(
+    .streams[] | select(.stream.type == "security") | .values[][1];
+    fromjson | (.appid == "lxd" and .type == "security" and (.event | startswith("authn_login_fail")) and has("cluster_identifier") and has("datetime") and has("event_source"))
+  )' "${log_file}"
+
+  # mini-loki holds loki.logs open for the process lifetime, so a plain rm
+  # leaves the daemon writing to an unlinked inode. Restart it to get a fresh
+  # file at the same path for the second sub-test.
+  kill_loki
+  rm "${log_file}"
+  spawn_loki
+
+  sub_test "Verify security events are filtered when not in loki.types"
+  lxc config set loki.api.url="http://127.0.0.1:3100" loki.auth.username="loki" loki.auth.password="pass"
+  lxc config set loki.types="lifecycle"
+
+  ensure_import_testimage
+  lxc launch testimage c-no-security-events
+  lxc delete -f c-no-security-events
+
+  # Flush logs.
+  lxc config set loki.api.url="" loki.auth.username="" loki.auth.password="" loki.types=""
+
+  # Lifecycle events must be present (proves forwarding is alive); security
+  # events must be absent (proves the type filter works).
+  jq --exit-status '.streams[].stream | select(.type == "lifecycle")' "${log_file}"
+  ! jq --exit-status '.streams[].stream | select(.type == "security")' "${log_file}" || false
+
+  # Cleanup.
+  kill_loki
+  rm "${log_file}"
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.


## Summary

Enables security event forwarding through the Loki client by completing the OWASP transformation at the forwarder boundary. Security events emitted by the LXD daemon (authentication failures, token lifecycle, certificate changes, authorization denials, and admin mutations) can now be shipped to a Loki server
for centralized audit log aggregation.

This PR builds on the foundation merged in #18027, which added `api.EventSecurity`, the event emission sites, and `security` as an accepted value in `loki.types`. The missing piece was the OWASP serialization inside `HandleEvent` this PR completes that.

## Changes

### `lxd/loki`: OWASP serialization for security events

`securityEventToOWASP` is updated to accept the pre-resolved `location` string (already computed for lifecycle and logging events) so that `event_source` and `cluster_member_name` carry the **cluster member name** from the event envelope, consistent with the OWASP audit log spec:

```
"event_source":        location,  // cluster member name (e.g. "node-1")
"cluster_member_name": location,
```

Previously the function used `event.Location` directly and also emitted a non-spec `project` field. The `location` variable applies the same fallback logic used by lifecycle and logging events: if the envelope's `Location` field
is empty, it falls back to the server's configured hostname, so the field is always populated.

The full OWASP line structure produced per security event is:

| Field | Source |
|---|---|
| `datetime` | `event.Timestamp` (RFC3339Nano) |
| `appid` | `"lxd"` (static) |
| `type` | `"security"` (static) |
| `event` | `api.EventSecurity.Name` |
| `level` | `api.EventSecurity.Level` |
| `description` | `api.EventSecurity.Description` |
| `event_source` | `event.Location` (cluster member, with hostname fallback) |
| `cluster_member_name` | `event.Location` (cluster member, with hostname fallback) |
| `cluster_identifier` | `loki.cfg.clusterIdentifier` |
| `hostname` | `loki.cfg.hostname` |
| `host_ip` | `loki.cfg.hostIP` |
| `port` | `loki.cfg.port` |
| `protocol` | `"https"` (static) |
| `request_uri` | `api.EventSecurity.RequestPath` |
| `request_method` | `api.EventSecurity.RequestMethod` |
| `source_ip` | `api.EventSecurity.Requestor.Address` |
| `useragent` | `api.EventSecurity.Requestor.UserAgent` |
| `user_id` | `<protocol>/<username>` from requestor |

The transformation is deliberately placed at the Loki forwarder boundary, the `/1.0/events` API continues to deliver Go-shaped `api.EventSecurity` payloads unchanged.

### `doc/api-extensions.md`

Corrects the `loki` extension description to list all supported event types(`lifecycle`, `logging`, `ovn`, `security`) instead of the stale `lifecycle` and/or `logging` wording.

## Tests

`test/suites/loki.sh` gains `test_loki_security_forwarding`, registered in `test/includes/test-groups.sh`:

| Sub-test | What is verified |
|---|---|
| OWASP serialization | Security events forwarded to Loki carry the correct OWASP fields (`event_type`, `event_source`, `username`, `cluster_identifier`) |
| Filtering | When `security` is absent from `loki.types`, no `type=security` streams appear in the Loki batch |

The OWASP field validation is lenient (guards with an existence check) because not all CI environments reliably trigger security events; the filtering test is strict and always runs.

The existing `test_loki_security_types` test, which validates that `security` is an accepted `loki.types` value and that unknown types are rejected, is unchanged.

## Out of scope (deferred)

`sys_monitor_disabled` and all other `sys_*` / `user_*` event emission sites are deferred until [#18211](https://github.com/canonical/lxd/pull/18211) merges, as those producers depend on changes landing in that PR.
