### PR TITLE
Revert "Makefile: ignore const qualifiers being discarded in dqlite" (stable-5.21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ dqlite:
 
 	cd "$(DQLITE_PATH)" && \
 		autoreconf -i && \
-		./configure --enable-build-raft CFLAGS="-g -O2 -Wno-error=discarded-qualifiers" && \
+		./configure --enable-build-raft && \
 		make -j
 
 ifneq ($(shell command -v ldd),)


### PR DESCRIPTION
This reverts commit eafc474541b97e1cdfa59461e3d0a23aa7939fea.

https://github.com/canonical/dqlite/commit/9c0ac6f4d8a90ff77fd77dc88cfd372e19fa280d is the backport to `lts-1.17.x`.