### PR TITLE
lxd/instance/drivers: Fix race condition in Rename

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3571,6 +3571,14 @@ func (d *lxc) Rename(ctx context.Context, newName string, applyTemplateTrigger b
 		return errors.New("Renaming of running instance not allowed")
 	}
 
+	// Wait for any pending file operations to complete so the rootfs can be
+	// unmounted safely before the storage rename, otherwise the rename may
+	// race with the unmount and fail. Snapshots cannot have file operations
+	// in flight, so this is not required for them.
+	if !d.IsSnapshot() {
+		d.stopForkfile(false)
+	}
+
 	// Clean things up.
 	d.cleanup()
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description
Fixes a race condition where Rename fails with "device or resource busy" on  ZFS when file operations have occurred on a stopped instance.

## Root Cause
Forkfile mounts the rootfs asynchronously in a goroutine when file operations run on stopped instances. If Rename executes before async unmount completes, storage rename operations fail.

## Solution
Call `d.stopForkfile(false)` in Rename before storage operations, mirroring the pattern already used in Snapshot, Restore, and Delete.

## Testing
Tested with exact reproduction steps from #18224; rename now succeeds  consistently after file operations.

Fixes #18224