### PR TITLE
Network: Clearly separate OVN nic add and start

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -890,19 +890,6 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 		}
 
-		// Remove old DHCP reservations and DNS records before re-adding with new IPs.
-		if ipv4Changed || ipv6Changed {
-			err := d.network.InstanceDevicePortRemove(d.inst.LocalConfig()["volatile.uuid"], d.name, oldConfig)
-			if err != nil {
-				return fmt.Errorf("Failed removing old instance device port config: %w", err)
-			}
-
-			err = d.network.InstanceDevicePortAdd(d.inst.LocalConfig()["volatile.uuid"], d.name, d.config)
-			if err != nil {
-				return fmt.Errorf("Failed adding updated instance device port config: %w", err)
-			}
-		}
-
 		// Load uplink network config.
 		uplinkNetworkName := d.network.Config()["network"]
 
@@ -919,16 +906,32 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			return fmt.Errorf("Failed loading uplink network %q: %w", uplinkNetworkName, err)
 		}
 
-		// Update OVN logical switch port for instance.
-		_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+		nicSetupOpts := &network.OVNInstanceNICSetupOpts{
 			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 			DNSName:      d.inst.Name(),
 			DeviceName:   d.name,
 			DeviceConfig: d.config,
 			UplinkConfig: uplink.Config,
-		}, removedACLs)
+		}
+
+		// Remove the port only when IP addresses have changed.
+		if ipv4Changed || ipv6Changed {
+			err = d.network.InstanceDevicePortRemove(d.inst.LocalConfig()["volatile.uuid"], d.name, oldConfig)
+			if err != nil {
+				return fmt.Errorf("Failed removing old instance device port config: %w", err)
+			}
+		}
+
+		// Always try to add the port to apply any ACL changes.
+		_, err = d.network.InstanceDevicePortAdd(nicSetupOpts, removedACLs)
 		if err != nil {
-			return fmt.Errorf("Failed updating OVN port: %w", err)
+			return fmt.Errorf("Failed adding updated instance device port config: %w", err)
+		}
+
+		// Signal a restart of the device.
+		err = d.network.InstanceDevicePortStart(d.inst)
+		if err != nil {
+			return fmt.Errorf("Failed starting up OVN port: %w", err)
 		}
 
 		if isRunning {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -38,8 +38,8 @@ type ovnNet interface {
 	network.Network
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
-	InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
-	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortAdd(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortStart(deviceInstance instance.Instance) error
 	InstanceDevicePortRemove(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -602,16 +602,21 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
 
-	// Add new OVN logical switch port for instance.
-	logicalPortName, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+	nicSetupOpts := &network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
 		DeviceConfig: d.config,
 		UplinkConfig: uplink.Config,
-	}, nil)
+	}
+
+	// Ensure the underlying OVN logical switch port exists.
+	// The operation is idempotent and safe to call even if the port already exists.
+	// It is required for the case when the switch port couldn't be created during Add().
+	// This might happen if there is an IP conflict with an existing port (e.g. caused by copying an instance).
+	logicalPortName, err := d.network.InstanceDevicePortAdd(nicSetupOpts, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed setting up OVN port: %w", err)
+		return nil, fmt.Errorf("Failed adding OVN port: %w", err)
 	}
 
 	// Associated host side interface to OVN logical switch port (if not nested).
@@ -622,6 +627,13 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 		}
 
 		reverter.Add(cleanup)
+	}
+
+	// Ensure to call this after setting up the host side interface.
+	// This allows triggering actions that require the logical port to be up.
+	err = d.network.InstanceDevicePortStart(d.inst)
+	if err != nil {
+		return nil, fmt.Errorf("Failed starting up OVN port: %w", err)
 	}
 
 	runConf := deviceConfig.RunConfig{}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -467,21 +467,18 @@ func (d *nicOVN) Add() error {
 		return fmt.Errorf("Failed loading uplink network %q: %w", uplinkNetworkName, err)
 	}
 
-	err = d.network.InstanceDevicePortAdd(d.inst.LocalConfig()["volatile.uuid"], d.name, d.config)
-	if err != nil {
-		return err
-	}
-
-	// Add new OVN logical switch port for instance.
-	_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+	nicSetupOpts := &network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
 		DeviceConfig: d.config,
 		UplinkConfig: uplink.Config,
-	}, nil)
+	}
+
+	// Add new OVN logical switch port for instance.
+	_, err = d.network.InstanceDevicePortAdd(nicSetupOpts, nil)
 	if err != nil {
-		return fmt.Errorf("Failed setting up OVN port: %w", err)
+		return fmt.Errorf("Failed adding OVN port: %w", err)
 	}
 
 	return nil

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4200,6 +4200,25 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 	return instancePortName, nil
 }
 
+// InstanceDevicePortStart configures the security ACL port group memberships and default ACL rules for an
+// instance device port that has already been created by InstanceDevicePortAdd.
+// Accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
+// Returns the logical switch port name.
+func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) error {
+	if opts.InstanceUUID == "" {
+		return errors.New("Instance UUID is required")
+	}
+
+	instancePortName := n.getInstanceDevicePortName(opts.InstanceUUID, opts.DeviceName)
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	client, err := openvswitch.NewOVN(n.state.GlobalConfig.NetworkOVNNorthboundConnection(), n.state.GlobalConfig.NetworkOVNSSL)
+	if err != nil {
+		return fmt.Errorf("Failed getting OVN client: %w", err)
+	}
+
 	// Merge network and NIC assigned security ACL lists.
 	netACLNames := shared.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)
 	nicACLNames := shared.SplitNTrimSpace(opts.DeviceConfig["security.acls"], ",", -1, true)
@@ -4217,7 +4236,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 	// Get logical port UUID.
 	portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
 	if err != nil || portUUID == "" {
-		return "", fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
+		return fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
 	}
 
 	// Add NIC port to network port group (this includes the port in the @internal subject for ACL rules).
@@ -4234,7 +4253,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 			return err
 		})
 		if err != nil {
-			return "", fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
+			return fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
 		}
 
 		// Add port to ACLs requested.
@@ -4246,7 +4265,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 
 			cleanup, err := acl.OVNEnsureACLs(context.TODO(), n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, nicACLNames, false)
 			if err != nil {
-				return "", fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
+				return fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
 			}
 
 			revert.Add(cleanup)
@@ -4254,7 +4273,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 			for _, aclName := range nicACLNames {
 				aclID, found := aclNameIDs[aclName]
 				if !found {
-					return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+					return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 				}
 
 				// Add NIC port to ACL port group.
@@ -4274,7 +4293,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 
 			aclID, found := aclNameIDs[aclName]
 			if !found {
-				return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+				return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 			}
 
 			// Remove NIC port from ACL port group.
@@ -4290,7 +4309,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 	n.logger.Debug("Applying instance NIC port group member change sets")
 	err = client.PortGroupMemberChange(addChangeSet, removeChangeSet)
 	if err != nil {
-		return "", fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
+		return fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
 	}
 
 	// Set the automatic default ACL rule for the port.
@@ -4301,21 +4320,21 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 		logPrefix := fmt.Sprintf("%s-%s", opts.InstanceUUID, opts.DeviceName)
 		err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logPrefix, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
 		if err != nil {
-			return "", fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
+			return fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Set NIC default rule", logger.Ctx{"port": instancePortName, "ingressAction": ingressAction, "ingressLogged": ingressLogged, "egressAction": egressAction, "egressLogged": egressLogged})
 	} else {
 		err = client.PortGroupPortClearACLRules(acl.OVNIntSwitchPortGroupName(n.ID()), instancePortName)
 		if err != nil {
-			return "", fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
+			return fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Cleared NIC default rule", logger.Ctx{"port": instancePortName})
 	}
 
 	revert.Success()
-	return instancePortName, nil
+	return nil
 }
 
 // instanceDeviceACLDefaults returns the action and logging mode to use for the specified direction's default rule.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4314,6 +4314,12 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 	return instancePortName, nil
 }
 
+// InstanceDevicePortStart is called after the host side of the device has been configured and the logical switch port is up.
+// The passed deviceInstance can be used to trigger any post-start configuration.
+func (n *ovn) InstanceDevicePortStart(deviceInstance instance.Instance) error {
+	return nil
+}
+
 // instanceDeviceACLDefaults returns the action and logging mode to use for the specified direction's default rule.
 // If the security.acls.default.{in,e}gress.action or security.acls.default.{in,e}gress.logged settings are not
 // specified in the NIC device config, then the settings on the network are used, and if not specified there then

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4769,7 +4769,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 						// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
 						n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
-						_, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
+						_, err = n.InstanceDevicePortAdd(&OVNInstanceNICSetupOpts{
 							InstanceUUID: instanceUUID,
 							DNSName:      inst.Name,
 							DeviceName:   devName,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4196,29 +4196,6 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 		}
 	}
 
-	revert.Success()
-	return instancePortName, nil
-}
-
-// InstanceDevicePortStart configures the security ACL port group memberships and default ACL rules for an
-// instance device port that has already been created by InstanceDevicePortAdd.
-// Accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
-// Returns the logical switch port name.
-func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) error {
-	if opts.InstanceUUID == "" {
-		return errors.New("Instance UUID is required")
-	}
-
-	instancePortName := n.getInstanceDevicePortName(opts.InstanceUUID, opts.DeviceName)
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	client, err := openvswitch.NewOVN(n.state.GlobalConfig.NetworkOVNNorthboundConnection(), n.state.GlobalConfig.NetworkOVNSSL)
-	if err != nil {
-		return fmt.Errorf("Failed getting OVN client: %w", err)
-	}
-
 	// Merge network and NIC assigned security ACL lists.
 	netACLNames := shared.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)
 	nicACLNames := shared.SplitNTrimSpace(opts.DeviceConfig["security.acls"], ",", -1, true)
@@ -4236,7 +4213,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	// Get logical port UUID.
 	portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
 	if err != nil || portUUID == "" {
-		return fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
+		return "", fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
 	}
 
 	// Add NIC port to network port group (this includes the port in the @internal subject for ACL rules).
@@ -4253,7 +4230,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
+			return "", fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
 		}
 
 		// Add port to ACLs requested.
@@ -4265,7 +4242,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 			cleanup, err := acl.OVNEnsureACLs(context.TODO(), n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, nicACLNames, false)
 			if err != nil {
-				return fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
+				return "", fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
 			}
 
 			revert.Add(cleanup)
@@ -4273,7 +4250,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			for _, aclName := range nicACLNames {
 				aclID, found := aclNameIDs[aclName]
 				if !found {
-					return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+					return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 				}
 
 				// Add NIC port to ACL port group.
@@ -4293,7 +4270,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 			aclID, found := aclNameIDs[aclName]
 			if !found {
-				return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+				return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 			}
 
 			// Remove NIC port from ACL port group.
@@ -4309,7 +4286,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	n.logger.Debug("Applying instance NIC port group member change sets")
 	err = client.PortGroupMemberChange(addChangeSet, removeChangeSet)
 	if err != nil {
-		return fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
+		return "", fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
 	}
 
 	// Set the automatic default ACL rule for the port.
@@ -4320,21 +4297,21 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		logPrefix := fmt.Sprintf("%s-%s", opts.InstanceUUID, opts.DeviceName)
 		err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logPrefix, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
 		if err != nil {
-			return fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
+			return "", fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Set NIC default rule", logger.Ctx{"port": instancePortName, "ingressAction": ingressAction, "ingressLogged": ingressLogged, "egressAction": egressAction, "egressLogged": egressLogged})
 	} else {
 		err = client.PortGroupPortClearACLRules(acl.OVNIntSwitchPortGroupName(n.ID()), instancePortName)
 		if err != nil {
-			return fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
+			return "", fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Cleared NIC default rule", logger.Ctx{"port": instancePortName})
 	}
 
 	revert.Success()
-	return nil
+	return instancePortName, nil
 }
 
 // instanceDeviceACLDefaults returns the action and logging mode to use for the specified direction's default rule.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4212,8 +4212,12 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsR
 
 	// Get logical port UUID.
 	portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
-	if err != nil || portUUID == "" {
+	if err != nil {
 		return "", fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
+	}
+
+	if portUUID == "" {
+		return "", errors.New("Empty logical port UUID for security ACL removal")
 	}
 
 	// Add NIC port to network port group (this includes the port in the @internal subject for ACL rules).

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3812,34 +3812,12 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 	return nil
 }
 
-// InstanceDevicePortAdd adds empty DNS record (to indicate port has been added) and any DHCP reservations for
-// instance device port.
-func (n *ovn) InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error {
-	instancePortName := n.getInstanceDevicePortName(instanceUUID, deviceName)
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	client, err := openvswitch.NewOVN(n.state.GlobalConfig.NetworkOVNNorthboundConnection(), n.state.GlobalConfig.NetworkOVNSSL)
-	if err != nil {
-		return fmt.Errorf("Failed getting OVN client: %w", err)
-	}
-
-	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, "", nil)
-	if err != nil {
-		return fmt.Errorf("Failed adding DNS record: %w", err)
-	}
-
-	revert.Add(func() { _ = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID, true) })
-
-	revert.Success()
-	return nil
-}
-
-// InstanceDevicePortStart sets up an instance device port to the internal logical switch.
-// Accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
+// InstanceDevicePortAdd creates the logical switch port for an instance NIC, configures its IPs, DNS records,
+// routes, and DNAT/SNAT rules. It is idempotent and can be called multiple times safely.
+// In addition it also configures the security ACL port group memberships and default ACL rules.
+// It accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
 // Returns the logical switch port name.
-func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error) {
+func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error) {
 	if opts.InstanceUUID == "" {
 		return "", errors.New("Instance UUID is required")
 	}
@@ -3968,9 +3946,8 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			nestedPortVLAN = uint16(nestedPortVLANInt64)
 		}
 
-		// Add port with mayExist set to true, so that if instance port exists, we don't fail and continue below
-		// to configure the port as needed. This is required because the port is created when the NIC is added, but
-		// we need to ensure it is present at start up as well in case it was deleted since the NIC was added.
+		// Add port with mayExist set to true, so that if instance port already exists, we don't fail and
+		// continue below to configure the port as needed.
 		err = client.LogicalSwitchPortAdd(n.getIntSwitchName(), instancePortName, &openvswitch.OVNSwitchPortOpts{
 			DHCPv4OptsID: dhcpV4ID,
 			DHCPv6OptsID: dhcpv6ID,
@@ -4218,6 +4195,10 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			return "", err
 		}
 	}
+
+	revert.Success()
+	return instancePortName, nil
+}
 
 	// Merge network and NIC assigned security ACL lists.
 	netACLNames := shared.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)


### PR DESCRIPTION
This PR aims to draw a line between OVN nic add and start operations.

It will help updating load balancers as part of the nic start operation as it is now guaranteed that the start func gets triggered only after the host side nic is connected to the integration bridge.