### PR TITLE
Dbgen multi key followup

### DIFF
--- a/lxd/db/dbgen/main.go
+++ b/lxd/db/dbgen/main.go
@@ -20,6 +20,83 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+const (
+	// commentModel is what dbgen looks for to determine whether it should attempt to model the struct.
+	// It is only valid to write this comment above a struct type definition.
+	// The comment should be followed by a single string containing the name of the table that the struct models.
+	// 	e.g. // db:model auth_groups
+	commentModel = "// db:model "
+
+	// commentModel is what dbgen looks for to determine if the field is not a native column of the modelled table.
+	// It saves all the following text in the comment to use as a join clause during a select.
+	// There can only be one join clause per field.
+	// 	e.g. // db:join JOIN projects ON instances.project_id = projects.id
+	commentJoin = "// db:join "
+
+	// commentOmit can be used to omit a field from INSERT or UPDATE statements. This is useful for fields that have
+	// default values set by the database or that do not change over time. (e.g. a creation date).
+	// The comment is followed by one or more space-separated values that must be one of omitCreate, or omitUpdate.
+	// 	E.g. // db:omit create update
+	commentOmit = "// db:omit "
+
+	// omitCreate is used in conjunction with commentOmit to omit a column from INSERT statements.
+	omitCreate = "create"
+
+	// omitUpdate is used in conjunction with commentOmit to omit a column from UPDATE statements.
+	omitUpdate = "update"
+
+	// tagDB is the tag that is used to describe the column that a field represents.
+	// E.g. Given a table:
+	// 	```sql
+	// 	CREATE TABLE books (
+	// 	   id INTEGER NOT NULL AUTOINCREMENT PRIMARY KEY,
+	// 	   title TEXT NOT NULL,
+	// 	   UNIQUE (title)
+	// 	);
+	// 	```
+	// A struct can be created as:
+	// 	```go
+	// 	// BooksRow represents a row of the books table.
+	// 	// db:model books
+	// 	type BooksRow struct {
+	// 	    ID int64     `db:"id"`
+	// 	    Title string `db:"title"
+	// 	}
+	// 	```
+	tagDB = "db"
+
+	// tagSupplementalPrimary can be added to the `db` tag to indicate that the row modelled by a particular field is
+	// the primary key for the table (or is one of a set forming a composite primary key).
+	// If no primary keys are manually specified, `dbgen` assumes that the `id` column is the primary key.
+	// E.g.
+	// 	```sql
+	// 	CREATE TABLE books_authors (
+	// 	    book_id INTEGER NOT NULL,
+	// 	    author_id INTEGER NOT NULL,
+	// 	    FOREIGN KEY book_id REFERENCES books (id) ON DELETE CASCADE,
+	// 	    FOREIGN KEY author_id REFERENCES authors (id) ON DELETE CASCADE,
+	// 	    PRIMARY KEY (author_id, book_id)
+	// 	) WITHOUT ROWID;
+	// 	```
+	// A struct can be created as:
+	// 	```go
+	// 	// BooksAuthorsRow represents a row of the books_authors table.
+	// 	// db:model books_authors
+	// 	type BooksAuthorsRow struct {
+	//	    BookID int64 `db:"book_id,primary"
+	//	    AuthorID int64 `db:"author_id,primary"
+	// 	}
+	// 	```
+	tagSupplementalPrimary = "primary"
+
+	// columnID denotes the "special" id column. It is special because by convention, the "id" column is typically an
+	// auto-incrementing integer primary key. If no columns are manually marked as the primary key via
+	// tagSupplementalPrimary, `dbgen` will assume that the "id" column is the primary key (or will error if no id
+	// column is present). `dbgen` will never include the "id" column in "INSERT" or "UPDATE" statements (e.g. it is not
+	// necessary to use commentOmit to exclude it).
+	columnID = "id"
+)
+
 // unqualifiedColumnNameRegex matches a column name, without a prefixed `<table>.` qualifier.
 // It is used to check for shorthand column name labels. If a label matches this regular expression, it is
 // prepended with `<table>.` for generated select statements. Any other tag that does not match this expression is
@@ -174,7 +251,7 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 		}
 
 		// The table name is defined by the db:model tag (a bit like swagger).
-		tableName, ok := strings.CutPrefix(genDecl.Doc.List[len(genDecl.Doc.List)-1].Text, "// db:model ")
+		tableName, ok := strings.CutPrefix(genDecl.Doc.List[len(genDecl.Doc.List)-1].Text, commentModel)
 		if !ok {
 			continue
 		}
@@ -226,8 +303,8 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 				FieldName: field.Names[0].Name,
 			}
 
-			// Tags contain column names and the supplemental "primary" indicator.
-			tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`")).Get("db")
+			// Tags contain column names and supplemental data.
+			tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`")).Get(tagDB)
 			if tag == "" {
 				continue
 			}
@@ -235,7 +312,8 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 			var supplemental string
 			newFieldSpec.ColumnName, supplemental, ok = strings.Cut(tag, ",")
 			if ok {
-				if supplemental != "primary" {
+				// Only "primary" is currently supported as supplemental tag data.
+				if supplemental != tagSupplementalPrimary {
 					return nil, nil, fmt.Errorf("Invalid supplemental tag info %q for field %q in struct %q", supplemental, newFieldSpec.FieldName, newSpec.StructName)
 				}
 
@@ -251,7 +329,7 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 			// Check the field comment. Use "db:join" to specify joins required to get the value.
 			if field.Doc != nil {
 				for _, l := range field.Doc.List {
-					join, ok := strings.CutPrefix(l.Text, "// db:join ")
+					join, ok := strings.CutPrefix(l.Text, commentJoin)
 					if ok {
 						if strings.HasSuffix(newSpec.StructName, "Row") {
 							return nil, nil, fmt.Errorf("Invalid spec for struct %q: Structs with a `Row` suffix may not include joins", newSpec.StructName)
@@ -260,14 +338,14 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 						newSpec.Joins = append(newSpec.Joins, join)
 					}
 
-					omit, ok := strings.CutPrefix(l.Text, "// db:omit ")
+					omit, ok := strings.CutPrefix(l.Text, commentOmit)
 					if ok {
 						omits := strings.Fields(omit)
-						if slices.Contains(omits, "create") {
+						if slices.Contains(omits, omitCreate) {
 							newFieldSpec.SkipCreate = true
 						}
 
-						if slices.Contains(omits, "update") {
+						if slices.Contains(omits, omitUpdate) {
 							newFieldSpec.SkipUpdate = true
 						}
 					}
@@ -282,7 +360,12 @@ func getFileSpecs(f *ast.File) ([]Spec, map[*ast.StructType]*Spec, error) {
 			if !newSpec.hasPrimaryKey() {
 				var hasPrimary bool
 				for i, f := range newSpec.Fields {
-					if f.ColumnName == tableName+".id" {
+					unqualifiedColumnName, ok := newSpec.unqualifiedColumnName(f)
+					if !ok {
+						continue
+					}
+
+					if unqualifiedColumnName == columnID {
 						newSpec.Fields[i].Primary = true
 						hasPrimary = true
 						break

--- a/lxd/db/dbgen/spec.go
+++ b/lxd/db/dbgen/spec.go
@@ -28,6 +28,18 @@ func (s *Spec) hasPrimaryKey() bool {
 	return false
 }
 
+// unqualifiedColumnName returns the column name for the field spec without the `<table_name>.` prepended and boolean
+// indicating if the column is defined on the spec table (e.g. it is not joined or coalesced). If the column is not
+// defined on the spec table then an empty string is returned.
+func (s *Spec) unqualifiedColumnName(field FieldSpec) (string, bool) {
+	col, ok := strings.CutPrefix(field.ColumnName, s.TableName+".")
+	if !ok {
+		return "", false
+	}
+
+	return col, true
+}
+
 // FieldSpec is a simple mapping of struct field name to database column name.
 type FieldSpec struct {
 	FieldName  string
@@ -135,8 +147,8 @@ func (s *Spec) receiver() rune {
 func (s *Spec) createStmt() string {
 	cols := make([]string, 0, len(s.Fields))
 	for _, f := range s.Fields {
-		unqualifiedColName, ok := strings.CutPrefix(f.ColumnName, s.TableName+".")
-		if !ok || unqualifiedColName == "id" || f.SkipCreate {
+		unqualifiedColName, ok := s.unqualifiedColumnName(f)
+		if !ok || unqualifiedColName == columnID || f.SkipCreate {
 			continue
 		}
 
@@ -149,8 +161,8 @@ func (s *Spec) createStmt() string {
 func (s *Spec) updateStmt() string {
 	cols := make([]string, 0, len(s.Fields))
 	for _, f := range s.Fields {
-		unqualifiedColName, ok := strings.CutPrefix(f.ColumnName, s.TableName+".")
-		if !ok || unqualifiedColName == "id" || f.SkipUpdate {
+		unqualifiedColName, ok := s.unqualifiedColumnName(f)
+		if !ok || unqualifiedColName == columnID || f.SkipUpdate {
 			continue
 		}
 
@@ -192,12 +204,12 @@ func (s *Spec) scanColumns() string {
 func (s *Spec) createValues() string {
 	values := make([]string, 0, len(s.Fields))
 	for _, f := range s.Fields {
-		unqualifiedColName, ok := strings.CutPrefix(f.ColumnName, s.TableName+".")
+		unqualifiedColName, ok := s.unqualifiedColumnName(f)
 		if !ok {
 			continue
 		}
 
-		if unqualifiedColName == "id" || f.SkipCreate {
+		if unqualifiedColName == columnID || f.SkipCreate {
 			continue
 		}
 
@@ -210,12 +222,12 @@ func (s *Spec) createValues() string {
 func (s *Spec) updateValues() string {
 	values := make([]string, 0, len(s.Fields))
 	for _, f := range s.Fields {
-		unqualifiedColName, ok := strings.CutPrefix(f.ColumnName, s.TableName+".")
+		unqualifiedColName, ok := s.unqualifiedColumnName(f)
 		if !ok {
 			continue
 		}
 
-		if unqualifiedColName == "id" || f.SkipUpdate {
+		if unqualifiedColName == columnID || f.SkipUpdate {
 			continue
 		}
 

--- a/lxd/db/query/generic.go
+++ b/lxd/db/query/generic.go
@@ -123,10 +123,11 @@ func UpdateByPrimaryKey(ctx context.Context, tx *sql.Tx, u Updatable) error {
 	b.WriteString(u.UpdateStmt())
 	b.WriteString(" WHERE ")
 	cols := u.PKColumns()
+	lastColIdx := len(cols) - 1
 	for i, c := range cols {
 		b.WriteString(c)
 		b.WriteString(" = ?")
-		if i < len(cols)-1 {
+		if i < lastColIdx {
 			b.WriteString(" AND ")
 		}
 	}
@@ -315,10 +316,11 @@ func DeleteByPrimaryKey[T Referenceable](ctx context.Context, tx *sql.Tx, t T) e
 	b.WriteString(tableName)
 	b.WriteString(" WHERE ")
 	cols := t.PKColumns()
+	lastColIdx := len(cols) - 1
 	for i, c := range cols {
 		b.WriteString(c)
 		b.WriteString(" = ?")
-		if i < len(cols)-1 {
+		if i < lastColIdx {
 			b.WriteString(" AND ")
 		}
 	}


### PR DESCRIPTION
Follow up PR to add constants in dbgen to make it more readable and also skip repeated calls to `len` within a loop.

Also re-runs `make update-schema` as that seems to have been missed after a rebase. The Makefile is updated to include this in static-analysis.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
