### PR TITLE
Add security events documentation

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -376,6 +376,7 @@ unmanaged
 unmount
 unmounting
 unsets
+untrusted
 uplink
 uptime
 URI

--- a/doc/events.md
+++ b/doc/events.md
@@ -1,17 +1,26 @@
+---
+myst:
+  html_meta:
+    description: LXD events API reference covering logging, operation, lifecycle, ovn, and security events. Learn event types, structures, and how to access events via monitor or WebSocket.
+---
+
+(events)=
 # Events
 
 ## Introduction
 
 Events are messages about actions that have occurred over LXD. Using the API endpoint `/1.0/events` directly or via
-[`lxc monitor`](lxc_monitor.md) will connect to a WebSocket through which logs and life-cycle messages will be streamed.
+[`lxc monitor`](lxc_monitor.md) will connect to a WebSocket through which events of the selected types will be streamed.
 
 ## Event types
 
-LXD Currently supports three event types.
+LXD currently supports five event types.
 
 - `logging`: Shows all logging messages regardless of the server logging level.
 - `operation`: Shows all ongoing operations from creation to completion (including updates to their state and progress metadata).
 - `lifecycle`: Shows an audit trail for specific actions occurring over LXD.
+- `ovn`: Shows network-related events from OVN (Open Virtual Network).
+- `security`: Shows security-related events including authentication attempts, authorisation decisions, and administrative changes. Requires appropriate permissions to view.
 
 ## Event structure
 
@@ -31,7 +40,7 @@ type: lifecycle
 
 - `location`: The cluster member name (if clustered).
 - `timestamp`: Time that the event occurred in RFC3339 format.
-- `type`: The type of event this is (one of `logging`, `operation`, or `lifecycle`).
+- `type`: Type of event (one of `logging`, `operation`, `lifecycle`, `ovn`, or `security`).
 - `metadata`: Information about the specific event type.
 
 ### Logging event structure
@@ -175,3 +184,85 @@ type: lifecycle
 | `warning-acknowledged`                 | The warning's status has been set to "acknowledged".                  |                                                                                                      |
 | `warning-deleted`                      | The warning has been deleted.                                         |                                                                                                      |
 | `warning-reset`                        | The warning's status has been set to "new".                           |                                                                                                      |
+
+(events-security)=
+## Security events
+
+### Security event structure
+
+- `name`: The security event identifier (e.g., `authn_login_fail:tls`, `authz_fail:can_edit:/1.0/projects/foo`).
+- `level`: The severity level (`info`, `warning`).
+- `description`: A human-readable description of the event.
+- `requestor`: Who triggered the event (username, protocol, address, user agent). Omitted for daemon-level events.
+- `project`: The project the request targeted. Omitted for daemon-level events.
+- `request_path`: The REST API endpoint path. Omitted for daemon-level events.
+- `request_method`: The HTTP method used. Omitted for daemon-level events.
+
+### Security event types
+
+LXD emits events across four categories.
+
+**Authentication events**
+
+| Event | Description |
+|-------|-------------|
+| `authn_login_fail:tls` | Failed authentication attempt when an untrusted TLS client certificate is presented to a protected endpoint. |
+| `authn_token_created:<identity>` | A new bearer token was issued for an identity. The identity UUID is included in the event identifier. |
+| `authn_token_revoked:<identity>` | A bearer token was revoked for an identity. The identity UUID is included in the event identifier. |
+| `authn_token_reuse` | A bearer token was presented in an invalid, expired, or otherwise disallowed way, indicating possible token reuse, tampering, or other misuse. |
+| `authn_certificate_change:<fingerprint>` | A TLS client certificate was replaced. The old certificate fingerprint is included in the event identifier. |
+
+**Authorization events**
+
+| Event | Description |
+|-------|-------------|
+| `authz_fail:<entitlement>:<entity>` | An action was denied due to insufficient permissions. Includes the required entitlement and the entity path that was accessed. |
+| `authz_admin:group_create:<name>` | A new authentication group was created. |
+| `authz_admin:group_edit:<name>` | An authentication group was modified. |
+| `authz_admin:group_delete:<name>` | An authentication group was deleted. |
+| `authz_admin:idp_group_create:<name>` | A new identity provider group was created. |
+| `authz_admin:idp_group_edit:<name>` | An identity provider group was modified. |
+| `authz_admin:idp_group_delete:<name>` | An identity provider group was deleted. |
+| `authz_admin:identity_create:<method>/<identifier>` | A new identity was created (TLS certificates or bearer tokens only). OIDC identities are not created via API actions. |
+| `authz_admin:identity_edit:<method>/<identifier>` | An identity was modified. |
+| `authz_admin:identity_delete:<method>/<identifier>` | An identity was deleted. |
+
+**Daemon lifecycle events**
+
+| Event | Description |
+|-------|-------------|
+| `sys_startup` | The LXD daemon has started. Emitted once the event system is fully available. |
+| `sys_shutdown` | The LXD daemon is shutting down. |
+| `sys_monitor_disabled` | Security event monitoring (Loki) was disabled via a configuration change. This is a `warning`-level event. |
+
+**User lifecycle events**
+
+| Event | Description |
+|-------|-------------|
+| `user_created` | A new identity has been created (TLS, bearer, OIDC, or cluster-link methods). For OIDC, this fires on first login. |
+| `user_updated` | An identity has been modified. For OIDC, this fires when user metadata changes on subsequent logins. |
+| `user_deleted` | An identity has been deleted. |
+
+(events-security-loki-fields)=
+### Security event fields in Loki
+
+When security events are forwarded to Loki, they are stored in
+[OWASP (Open Worldwide Application Security Project)](https://owasp.org/)
+audit log format with the following key fields:
+
+| Field | Description |
+|-------|-------------|
+| `name` | The security event type identifier. |
+| `event_source` | The cluster member name where the event occurred. |
+| `cluster_identifier` | Unique identifier for the LXD cluster. |
+| `cluster_member_name` | Name of the cluster member. |
+| `project` | The project targeted by the request. Empty or omitted for daemon-level events. |
+| `request_method` | The HTTP method used. |
+| `request_uri` | The API endpoint path. |
+| `user_id` | The requestor identity in format `<auth_method>/<identifier>`. |
+| `source_ip` | The source IP address of the request. |
+| `useragent` | The HTTP user agent string. |
+| `level` | The event severity (`info`, `warning`). |
+| `description` | Human-readable event description. |
+
+For how to monitor and query security events, see {ref}`howto-security-events`.

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -1,5 +1,8 @@
 ---
 relatedlinks: "[Linux&#32;containers&#32;security](https://linuxcontainers.org/lxc/security/)"
+myst:
+  html_meta:
+    description: Understand LXD security architecture, access controls, daemon access, container security, and security event audit logging for compliance and incident investigation.
 ---
 
 (exp-security)=
@@ -165,6 +168,22 @@ In this networking mode, the LXD host functions as a router, and static routes a
 
 By default, the `veth` interface created on the host has its `accept_ra` setting disabled to prevent router advertisements from the container modifying the IPv6 routing table on the LXD host.
 In addition to that, the `rp_filter` on the host is set to `1` to prevent source address spoofing for IPs that the host does not know the container has.
+
+(security-audit-events)=
+## Security events and audit logging
+
+LXD emits security events that track important security-related actions in your system. These events provide a comprehensive audit trail of authentication attempts, authorization decisions, and administrative changes. This is essential for compliance, intrusion detection, and security incident investigation.
+
+Security events include:
+
+- **Authentication events**: Track login attempts, token lifecycle changes, and certificate modifications
+- **Authorization events**: Track permission denials and any changes to identities, groups, and their privileges.
+- **Daemon lifecycle events**: Track daemon startup/shutdown and changes to monitoring configuration
+- **User lifecycle events**: Track identity creation, modification, and deletion
+
+In a production environment, you can forward security events to a centralized logging system like Loki to maintain a persistent audit trail. Events are available through the `/1.0/events` API endpoint, the `lxc monitor` command, or integration with syslog.
+
+For detailed information on monitoring and configuring security events, see {ref}`howto-security-events`.
 
 ## Related topics
 

--- a/doc/howto/logs_loki.md
+++ b/doc/howto/logs_loki.md
@@ -1,10 +1,16 @@
+---
+myst:
+  html_meta:
+    description: Forward LXD logging, lifecycle, ovn, and security events to Loki for centralized log aggregation, analysis, and long-term retention.
+---
+
 (logs_loki)=
 # How to send logs to Loki
 
 <!-- Include start logs_loki intro -->
-LXD publishes information about its activity in the form of events. The `lxc monitor` command allows you to view this information in your shell. There are two categories of LXD events: logs and life cycle. The `lxc monitor --type=logging --pretty` command will filter and display log type events like activity of the raft cluster, for instance, while `lxc monitor --type=lifecycle --pretty` will only display life cycle events like instances starting or stopping.
+LXD publishes information about its activity in the form of events. The `lxc monitor` command allows you to view this information in your shell. There are several categories of LXD events: `logging`, `operation`, `lifecycle`, `ovn`, and `security`. The `lxc monitor --type=logging --pretty` command will filter and display log type events like activity of the raft cluster, for instance, while `lxc monitor --type=lifecycle --pretty` will only display lifecycle events like instances starting or stopping. The `lxc monitor --type=security --pretty` command shows security-related events such as authentication attempts and authorization decisions.
 
-In a production environment, you might want to keep a log of these events in a dedicated system. [Loki](https://grafana.com/oss/loki/) is one such system, and LXD provides a configuration option to forward its event stream to Loki.
+In a production environment, you might want to keep a log of these events in a dedicated system. [Loki](https://grafana.com/oss/loki/) is one such system, and LXD provides a configuration option to forward selected event types to Loki (`logging`, `lifecycle`, `ovn`, and `security`). Note that operation events are not forwarded to Loki.
 <!-- Include end logs_loki intro -->
 
 ## Configure LXD to send logs
@@ -19,6 +25,8 @@ Once you have a Loki server up and running, you can instruct LXD to send logs to
 
 ```{note}
 If Loki logs are to be viewed in the Grafana dashboard, ensure the `loki.instance` configuration key matches the name of the Prometheus job. See {ref}`grafana`.
+
+To forward security events to Loki, use: `lxc config set loki.types=logging,lifecycle,security`
 ```
 
 ## Query Loki logs
@@ -68,6 +76,6 @@ This will transform the above log entry into:
 ...
 ```
 
-Note the replacement of `-` by `_`, as `-` cannot be used in keys. As `requested_username` is now a key, you can query Loki using it like this:
+Note the replacement of `-` by `_`, as `-` cannot be used in keys. As `requester_username` is now a key, you can query Loki using it like this:
 
     logcli query -t '{requester_username="ubuntu"}'

--- a/doc/howto/security_events.md
+++ b/doc/howto/security_events.md
@@ -1,0 +1,94 @@
+---
+myst:
+  html_meta:
+    description: Monitor security events in LXD including authentication, authorisation, and administrative actions using the CLI, REST API, or Loki integration.
+---
+
+(howto-security-events)=
+# Monitor security events
+
+LXD emits security events that track authentication attempts, authorization
+decisions, and administrative changes. You can access these events through
+the CLI, the REST API, or by forwarding them to Loki for centralized log
+retention and analysis.
+
+For the full list of event types and field definitions, see {ref}`events-security`.
+
+## View security events with the CLI
+
+Use the `lxc monitor` command to stream security events in real time:
+
+```bash
+lxc monitor --type=security --format=yaml
+```
+
+You will see output like:
+
+```yaml
+type: security
+timestamp: 2026-05-08T14:32:15Z
+location: lxd1
+metadata:
+  name: authn_login_fail:tls
+  level: warning
+  description: "Authentication failure: untrusted client certificate"
+  requestor:
+    username: ""
+    protocol: tls
+    address: "192.168.1.100:45632"
+    user_agent: "curl/7.68.0"
+  request_path: /1.0/projects
+  request_method: GET
+```
+
+## View security events with the REST API
+
+Connect to the `/1.0/events` WebSocket endpoint with `type=security`.
+Access requires appropriate permissions on the server.
+
+For general event stream usage, see {ref}`events`.
+
+## Monitor security events with Loki
+
+In a production environment, forward security events to
+[Loki](https://grafana.com/oss/loki/) for centralised audit log
+aggregation and analysis.
+
+For general Loki setup, see {ref}`logs_loki`. The steps below cover
+security-event-specific configuration and queries.
+
+### Configure security event forwarding
+
+Ensure `security` is included in `loki.types`:
+
+```bash
+lxc config set loki.types=logging,lifecycle,security
+```
+
+LXD will forward security events to Loki in [OWASP (Open Worldwide Application Security Project)](https://owasp.org/) audit log format. See {ref}`events-security-loki-fields` for the full field mapping.
+
+### Query security events
+
+Use the LogCLI utility to query security events:
+
+```bash
+logcli query -t '{type="security"}'
+```
+
+Filter by a specific event type:
+
+```bash
+logcli query -t '{type="security"}' | grep 'authn_login_fail'
+```
+
+Filter by requestor identity (requires adding `user_id` to `loki.labels`):
+
+```bash
+logcli query -t '{type="security", user_id="tls/alice"}'
+```
+
+Alternatively, use a JSON parsing pipeline to filter without modifying labels:
+
+```bash
+logcli query -t '{type="security"} | json | user_id="tls/alice"'
+```

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -27,6 +27,7 @@ LXD collects metrics and logs that can be viewed as raw data or used with observ
 :titlesonly:
 
 Monitor metrics </metrics>
+Monitor security events </howto/security_events>
 Send logs to Loki </howto/logs_loki>
 Set up Grafana </howto/grafana>
 ```


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description

This PR adds comprehensive documentation for LXD security events audit logging, covering authentication, authorization, and administrative action tracking. Users can now access, configure, and query security events through the CLI, REST API, or Loki integration.

## What's included

- How to access and monitor security events
- 20 security event types across 4 categories
- Event structure and fields reference
- Loki forwarding configuration and query examples
- OWASP audit log field mapping for compliance

## Related PRs

Implements documentation for security events features from:
- #18027, #18144, #18159, #18211, #18251