### PR TITLE
Move `ioprogress.ProgressReporter` to end of arg list for `instance.Start`

### DIFF
--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -1866,7 +1866,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 				// Start the instance.
 				reportEvacuationProgress(op, fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name))
 
-				err = inst.Start(ctx, op, false)
+				err = inst.Start(ctx, false, op)
 				if err != nil {
 					return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 				}
@@ -1990,7 +1990,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 
 				reportEvacuationProgress(op, fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name))
 
-				err = inst.Start(ctx, op, false)
+				err = inst.Start(ctx, false, op)
 				if err != nil {
 					return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 				}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -617,7 +617,7 @@ func (d *common) restartCommon(ctx context.Context, inst instance.Instance, time
 		return fmt.Errorf("Create restart (for start) operation: %w", err)
 	}
 
-	err = inst.Start(ctx, progressReporter, false)
+	err = inst.Start(ctx, false, progressReporter)
 	if err != nil {
 		op.Done(err)
 		return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2247,7 +2247,7 @@ func (d *lxc) detachInterfaceRename(netns string, ifName string, hostName string
 }
 
 // Start starts the instance.
-func (d *lxc) Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error {
+func (d *lxc) Start(ctx context.Context, stateful bool, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -2972,7 +2972,7 @@ func (d *lxc) onStop(ctx context.Context, args map[string]string) error {
 			// Start the container again
 			// Progress tracking here is not useful. We are in the on stop hook, which is called via lxc hook, so progress
 			// reporting would not be returned to the original client.
-			err = d.Start(ctx, nil, false)
+			err = d.Start(ctx, false, nil)
 			if err != nil {
 				op.Done(fmt.Errorf("Failed restarting instance: %w", err))
 				return
@@ -3401,7 +3401,7 @@ func (d *lxc) Restore(ctx context.Context, sourceContainer instance.Instance, st
 	// Restart the container.
 	if wasRunning {
 		d.logger.Debug("Starting instance after snapshot restore")
-		err = d.Start(ctx, progressReporter, false)
+		err = d.Start(ctx, false, progressReporter)
 		if err != nil {
 			op.Done(err)
 			return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -670,7 +670,7 @@ func (d *qemu) onStop(ctx context.Context, target string) error {
 	if target == "reboot" {
 		// Progress tracking here is not useful. We are in the on stop hook, which is called via lxc hook, so progress
 		// reporting would not be returned to the original client.
-		err = d.Start(ctx, nil, false)
+		err = d.Start(ctx, false, nil)
 		if err != nil {
 			op.Done(err)
 			return err
@@ -1096,7 +1096,7 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 }
 
 // Start starts the instance.
-func (d *qemu) Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error {
+func (d *qemu) Start(ctx context.Context, stateful bool, progressReporter ioprogress.ProgressReporter) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
 	if err != nil {
 		return err
@@ -5542,7 +5542,7 @@ func (d *qemu) Restore(ctx context.Context, source instance.Instance, stateful b
 	// Restart the instance.
 	if wasRunning || stateful {
 		d.logger.Debug("Starting instance after snapshot restore")
-		err := d.Start(ctx, progressReporter, stateful)
+		err := d.Start(ctx, stateful, progressReporter)
 		if err != nil {
 			op.Done(err)
 			return err

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -95,7 +95,7 @@ type Instance interface {
 	// Instance actions.
 	Freeze(ctx context.Context) error
 	Shutdown(ctx context.Context, timeout time.Duration) error
-	Start(ctx context.Context, progressReporter ioprogress.ProgressReporter, stateful bool) error
+	Start(ctx context.Context, stateful bool, progressReporter ioprogress.ProgressReporter) error
 	Stop(ctx context.Context, stateful bool) error
 	Restart(ctx context.Context, timeout time.Duration, progressReporter ioprogress.ProgressReporter) error
 	Rebuild(ctx context.Context, img *api.Image, op *operations.Operation) error

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -747,7 +747,7 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 	}
 
 	if statefulStart {
-		err = targetInst.Start(ctx, op, true)
+		err = targetInst.Start(ctx, true, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -306,7 +306,7 @@ func doInstanceStatePut(ctx context.Context, inst instance.Instance, req api.Ins
 			return inst.Unfreeze(ctx)
 		}
 
-		return inst.Start(ctx, op, req.Stateful)
+		return inst.Start(ctx, req.Stateful, op)
 	case instancetype.Stop:
 		if req.Stateful {
 			return inst.Stop(ctx, req.Stateful)

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -256,7 +256,7 @@ func instancesStart(ctx context.Context, s *state.State, instances []instance.In
 			attempt++
 
 			// Don't track progress here as there is no client to return the updates to.
-			err := inst.Start(ctx, nil, false)
+			err := inst.Start(ctx, false, nil)
 			if err != nil {
 				if api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
 					break // Don't log or retry instances that are not ready to start yet.

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -385,7 +385,7 @@ func prepareInstanceMigrationSink(ctx context.Context, s *state.State, projectNa
 
 		// Start up the instance if requested by the client.
 		if req != nil && req.Start {
-			err := inst.Start(ctx, op, false)
+			err := inst.Start(ctx, false, op)
 			if err != nil {
 				return fmt.Errorf("Failed starting instance %q: %w", inst.Name(), err)
 			}
@@ -1925,5 +1925,5 @@ func instanceCreateFinish(ctx context.Context, s *state.State, req *api.Instance
 		return fmt.Errorf("Failed loading the instance: %w", err)
 	}
 
-	return inst.Start(ctx, op, false)
+	return inst.Start(ctx, false, op)
 }


### PR DESCRIPTION
Addresses follow up comment https://github.com/canonical/lxd/pull/18057#discussion_r3094314971

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
