### PR TITLE
Make `user.microcloud` visible when authenticated without `can_edit` on `server`

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -439,9 +439,13 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	// Only allow identities that can edit configuration to view it as sensitive information may be stored there.
 	err = s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanEdit)
-	if err != nil && !auth.IsDeniedError(err) {
-		return response.SmartError(err)
-	} else if err == nil {
+	if err != nil {
+		if !auth.IsDeniedError(err) {
+			return response.SmartError(err)
+		}
+
+		fullSrv.Config = s.GlobalConfig.DumpPublic()
+	} else {
 		daemonConfig, err := daemonConfigRender(s)
 		if err != nil {
 			return response.InternalError(err)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -273,15 +273,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	// If not authenticated, return now.
 	if !requestor.IsTrusted() {
-		daemonConfig, _ := daemonConfigRender(s)
-		_, flagExists := daemonConfig["user.microcloud"]
-		if flagExists {
-			// Unprivileged users may see the user.microcloud config key
-			srv.Config = map[string]any{
-				"user.microcloud": daemonConfig["user.microcloud"],
-			}
-		}
-
+		srv.Config = s.GlobalConfig.DumpPublic()
 		return response.SyncResponseETag(true, srv, nil)
 	}
 

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -279,6 +279,32 @@ func (c *Config) Dump() map[string]string {
 	return c.m.Dump()
 }
 
+// DumpPublic returns a map of publicly visible configuration keys and values ready to add to the public (or non-admin)
+// API response.
+func (c *Config) DumpPublic() map[string]any {
+	conf := make(map[string]any, 4)
+	issuer, _, _, _, audience, _, deviceClientID := c.OIDCServer()
+	if issuer != "" && deviceClientID != "" {
+		conf["oidc.issuer"] = issuer
+		conf["oidc.device.client.id"] = deviceClientID
+		if audience != "" {
+			conf["oidc.audience"] = audience
+		}
+	}
+
+	userMicrocloud := c.m.GetString("user.microcloud")
+	if userMicrocloud != "" {
+		conf["user.microcloud"] = userMicrocloud
+	}
+
+	// Return nil if no public configuration.
+	if len(conf) == 0 {
+		return nil
+	}
+
+	return conf
+}
+
 // Replace the current configuration with the given values.
 //
 // Return what has actually changed.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -104,7 +104,8 @@ test_authorization() {
   ! lxc auth identity group add "tls/${tls_user_fingerprint}" test-group || false # TLS identities cannot be added to groups (yet).
 
   spawn_oidc
-  lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=device"
+  oidc_issuer="http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/"
+  lxc config set "oidc.issuer=${oidc_issuer}" "oidc.client.id=device"
 
   set_oidc test-user test-user@example.com
   BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
@@ -791,11 +792,11 @@ fine_grained_authorization() {
 
   lxc auth group permission remove test-group server can_view_warnings
 
-  # Check we are not able to view any server config currently.
+  # Check we are only able to view public configuration.
   # Here we explicitly a setting that contains an actual password.
   lxc config set loki.auth.password bar
-  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config == null'
-  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."loki.auth.password" == null'
+  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 2'
+  curl -k "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata | .config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 2'
 
   # Check we are not able to set any server config currently.
   ! lxc_remote config set "${remote}:" loki.auth.password bar2 || false


### PR DESCRIPTION
Previously the key was only visible if unauthenticated. It is now populated when the caller does not have sufficient permission to view all config.

Additionally show `oidc.issuer`, `oidc.device.client.id`, and `oidc.audience` if configured.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
