### PR TITLE
lxd/storage: Address review comments from #18266

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4317,14 +4317,12 @@ func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projec
 
 			// Reset img volume as we just deleted the old one.
 			imgDBVol = nil
+		} else {
+			// Adopt the persisted DB config so the driver looks up the on-disk image by its
+			// recorded volatile.uuid (UUIDVolumeNames drivers derive the backend name from it)
+			// and the returned volume carries volatile.rootfs.size for the caller's size check.
+			imgVol = existingVol
 		}
-	}
-
-	// Adopt the persisted DB config so the driver looks up the on-disk image by its
-	// recorded volatile.uuid (UUIDVolumeNames drivers derive the backend name from it)
-	// and the returned volume carries volatile.rootfs.size for the caller's size check.
-	if imgDBVol != nil {
-		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
 	}
 
 	// We have an unrecorded on-disk volume, assume it's a partial unpack and delete it.
@@ -4362,15 +4360,13 @@ func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projec
 
 	revert.Add(func() { _ = b.driver.DeleteVolume(imgVol, progressReporter) })
 
-	// If the volume filler has recorded the size of the unpacked volume, then store this in the image DB row.
+	// volFiller.Size is non-zero only when the driver actually unpacked the
+	// image: persist it in the image DB row. Otherwise the on-disk volume
+	// was already present and the DB record matches it, so there is nothing
+	// to reconcile.
 	if volFiller.Size != 0 {
 		imgVol.Config()["volatile.rootfs.size"] = strconv.FormatInt(volFiller.Size, 10)
-	}
-
-	// volFiller.Size is non-zero only when the driver actually unpacked the
-	// image. If the on-disk volume was already present and the DB record
-	// matches it, there is nothing to reconcile.
-	if imgDBVol != nil && volFiller.Size == 0 {
+	} else if imgDBVol != nil {
 		revert.Success()
 		return &imgVol, nil
 	}

--- a/lxd/storage/drivers/utils_image.go
+++ b/lxd/storage/drivers/utils_image.go
@@ -47,7 +47,7 @@ func CanUseOptimizedImage(vol Volume) (bool, error) {
 }
 
 // ensureImageVolume materialises the given image volume on disk for drivers
-// that keep one cached image dataset per fingerprint. If the dataset already
+// that keep one cached image volume per fingerprint. If the volume already
 // exists, the helper enforces the single-variant invariant: the on-disk
 // config must match pool defaults, otherwise ErrImageVariantNotSupported is
 // returned so the caller can slow-unpack a per-instance volume instead of


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.


## Summary

Addresses the three follow-up nits left on #18266 after merge. No behaviour change.

## Changes

* `ensureImageVolume`'s doc comment no longer refers to a cached image "dataset"; the helper is shared across drivers, so it now reads "volume".
* `EnsureImage` builds the cached volume from `imgDBVol.Config` once via `existingVol` and reuses it when the config matches pool defaults, instead of calling `GetVolume` a second time on the keep path.
* The two `volFiller.Size` branches in `EnsureImage` are collapsed into a single `if / else if`, since they partition the same value.