### PR TITLE
Auth: Retry OIDC verifier initialization on start up

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1290,7 +1290,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID := newClusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
-			d.oidcVerifier = nil
+			d.oidcVerifier.Store(nil)
 		} else {
 			var err error
 
@@ -1299,10 +1299,12 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			}
 
 			sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, newClusterConfig.OIDCSessionExpiry)
-			d.oidcVerifier, err = oidc.NewVerifier(s.ShutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, newClusterConfig.ClusterUUID(), d.endpoints.NetworkAddress(), s.CoreAuthSecrets, httpClientFunc, sessionHandler)
+			oidcVerifier, err := oidc.NewVerifier(s.ShutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, newClusterConfig.ClusterUUID(), d.endpoints.NetworkAddress(), s.CoreAuthSecrets, httpClientFunc, sessionHandler)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}
+
+			d.oidcVerifier.Store(oidcVerifier)
 		}
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1298,7 +1298,13 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 				return util.HTTPClient("", d.proxy)
 			}
 
-			sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, newClusterConfig.OIDCSessionExpiry)
+			expiryFunc := func() string {
+				d.globalConfigMu.Lock()
+				defer d.globalConfigMu.Unlock()
+				return d.globalConfig.OIDCSessionExpiry()
+			}
+
+			sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, expiryFunc)
 			oidcVerifier, err := oidc.NewVerifier(s.ShutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, newClusterConfig.ClusterUUID(), d.endpoints.NetworkAddress(), s.CoreAuthSecrets, httpClientFunc, sessionHandler)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -250,8 +250,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		api.AuthenticationMethodBearer,
 	}
 
-	oidcIssuer, oidcClientID, _, _, _, _, _ := s.GlobalConfig.OIDCServer()
-	if oidcIssuer != "" && oidcClientID != "" {
+	if d.oidcVerifier.Load() != nil {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
 

--- a/lxd/api_root.go
+++ b/lxd/api_root.go
@@ -158,7 +158,7 @@ func rootGet(d *Daemon, r *http.Request) response.Response {
 // A method expression promotes the receiver to the first explicit argument, allowing
 // oidcHandler to call fn(verifier, w, r) uniformly for any [oidc.Verifier] method.
 func oidcHandler(d *Daemon, r *http.Request, fn func(*oidc.Verifier, http.ResponseWriter, *http.Request)) response.Response {
-	verifier := d.oidcVerifier
+	verifier := d.oidcVerifier.Load()
 	if verifier == nil {
 		return response.NotFound(nil)
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dqliteClient "github.com/canonical/go-dqlite/v3/client"
@@ -115,7 +116,7 @@ type Daemon struct {
 
 	proxy func(req *http.Request) (*url.URL, error)
 
-	oidcVerifier *oidc.Verifier
+	oidcVerifier atomic.Pointer[oidc.Verifier]
 
 	// Stores last heartbeat node information to detect node changes.
 	lastNodeList *cluster.APIHeartbeat
@@ -494,7 +495,7 @@ func extractEntitlementsFromQuery(r *http.Request, entityType entity.Type, allow
 // authentication. Errors returned from this function never trigger the
 // event because they may originate from a server-side fault (e.g. an
 // unreachable IdP).
-func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request, allowUntrusted bool) (*request.RequestorArgs, error) {
+func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request, oidcVerifier *oidc.Verifier, allowUntrusted bool) (*request.RequestorArgs, error) {
 	if r.TLS == nil {
 		// For a socket, the server is listening on a file, but the client does not have an address.
 		// Since there is no address, the kernel uses an unnamed unix socket address.
@@ -653,8 +654,8 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request, allowUntru
 	}
 
 	// Lastly, check OIDC authentication using the verifier.
-	if d.oidcVerifier != nil && d.oidcVerifier.IsRequest(r) {
-		result, err := d.oidcVerifier.Auth(w, r)
+	if oidcVerifier != nil && oidcVerifier.IsRequest(r) {
+		result, err := oidcVerifier.Auth(w, r)
 		if err != nil {
 			return nil, fmt.Errorf("Failed OIDC Authentication: %w", err)
 		}
@@ -909,13 +910,14 @@ func (d *Daemon) createCmd(restAPI *http.ServeMux, version string, c APIEndpoint
 		}
 
 		// Authentication
-		requestor, err := d.Authenticate(w, r, endpointAction.AllowUntrusted)
+		oidcVerifier := d.oidcVerifier.Load()
+		requestor, err := d.Authenticate(w, r, oidcVerifier, endpointAction.AllowUntrusted)
 		if err != nil {
 			_, ok := errors.AsType[oidc.AuthError](err)
 			if ok {
 				// Ensure the OIDC headers are set if needed.
-				if d.oidcVerifier != nil {
-					_ = d.oidcVerifier.WriteHeaders(w)
+				if oidcVerifier != nil {
+					_ = oidcVerifier.WriteHeaders(w)
 				}
 
 				// Return 401 Unauthorized error. This indicates to the client that it needs to use the
@@ -958,8 +960,8 @@ func (d *Daemon) createCmd(restAPI *http.ServeMux, version string, c APIEndpoint
 		} else if untrustedOk && r.Header.Get("X-LXD-authenticated") == "" {
 			logger.Debug("Allowing untrusted "+r.Method, logger.Ctx{"url": r.URL.RequestURI(), "ip": r.RemoteAddr})
 		} else {
-			if d.oidcVerifier != nil {
-				_ = d.oidcVerifier.WriteHeaders(w)
+			if oidcVerifier != nil {
+				_ = oidcVerifier.WriteHeaders(w)
 			}
 
 			logger.Warn("Rejecting request from untrusted client", logger.Ctx{"ip": r.RemoteAddr})
@@ -1828,10 +1830,12 @@ func (d *Daemon) init() error {
 		}
 
 		sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, d.globalConfig.OIDCSessionExpiry)
-		d.oidcVerifier, err = oidc.NewVerifier(d.shutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
+		oidcVerifier, err := oidc.NewVerifier(d.shutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
 		if err != nil {
 			logger.Warn("Failed setting up OIDC verifier", logger.Ctx{"err": err})
 		}
+
+		d.oidcVerifier.Store(oidcVerifier)
 	}
 
 	// Setup BGP listener.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -22,6 +22,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Rican7/retry"
+	"github.com/Rican7/retry/backoff"
+	"github.com/Rican7/retry/strategy"
 	dqliteClient "github.com/canonical/go-dqlite/v3/client"
 	"github.com/canonical/go-dqlite/v3/driver"
 	"golang.org/x/sys/unix"
@@ -1802,7 +1805,6 @@ func (d *Daemon) init() error {
 
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 
 	d.endpoints.NetworkUpdateTrustedProxy(d.globalConfig.HTTPSTrustedProxy())
@@ -1823,20 +1825,8 @@ func (d *Daemon) init() error {
 		}
 	}
 
-	// Setup OIDC authentication.
-	if oidcIssuer != "" && oidcClientID != "" {
-		httpClientFunc := func() (*http.Client, error) {
-			return util.HTTPClient("", d.proxy)
-		}
-
-		sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, d.globalConfig.OIDCSessionExpiry)
-		oidcVerifier, err := oidc.NewVerifier(d.shutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
-		if err != nil {
-			logger.Warn("Failed setting up OIDC verifier", logger.Ctx{"err": err})
-		}
-
-		d.oidcVerifier.Store(oidcVerifier)
-	}
+	// Setup OIDC verifier
+	initializeOIDCVerifier(d)
 
 	// Setup BGP listener.
 	d.bgp = bgp.NewServer()
@@ -2450,6 +2440,99 @@ func initializeDbObject(d *Daemon) error {
 	}
 
 	return nil
+}
+
+// initializeOIDCVerifier attempts to initialise the [oidc.Verifier] in the background and set it on the [Daemon].
+// OIDC initialization can fail because it calls out to the IdP to get endpoint information and JWKs (discovery).
+// This is prone to failure, especially if the IdP is deployed within LXD as a VM (e.g. on reboot we need to wait for
+// the VM to start).
+func initializeOIDCVerifier(d *Daemon) {
+	// If no issuer or client ID, then nothing to set up.
+	d.globalConfigMu.Lock()
+	issuer, clientID, _, _, _, _, _ := d.globalConfig.OIDCServer()
+	if issuer == "" || clientID == "" {
+		d.globalConfigMu.Unlock()
+		return
+	}
+
+	d.globalConfigMu.Unlock()
+
+	// Anonymous function to initialize the verifier.
+	setupOIDC := func() error {
+		// Don't attempt to configure the verifier if the daemon is shutting down.
+		if d.shutdownCtx.Err() != nil {
+			return nil
+		}
+
+		// If running in the background, an admin might update the config via /1.0 and the verifier might already be set.
+		// If so, nothing to do.
+		verifier := d.oidcVerifier.Load()
+		if verifier != nil {
+			return nil
+		}
+
+		// If no issuer or client ID, then nothing to set up. These values may have been unset via /1.0, if so, cancel retries by returning nil.
+		d.globalConfigMu.Lock()
+		issuer, clientID, clientSecret, scopes, audience, groupsClaim, deviceClientID := d.globalConfig.OIDCServer()
+		if issuer == "" || clientID == "" {
+			d.globalConfigMu.Unlock()
+			return nil
+		}
+
+		d.globalConfigMu.Unlock()
+
+		// Proxy set up (for LXD to reach the IdP).
+		httpClientFunc := func() (*http.Client, error) {
+			return util.HTTPClient("", d.proxy)
+		}
+
+		// Set up session handler and verifier. This will perform OIDC discovery and may fail.
+		expiryFunc := func() string {
+			d.globalConfigMu.Lock()
+			defer d.globalConfigMu.Unlock()
+			return d.globalConfig.OIDCSessionExpiry()
+		}
+
+		sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, expiryFunc)
+
+		var err error
+		verifier, err = oidc.NewVerifier(d.shutdownCtx, issuer, clientID, clientSecret, scopes, audience, groupsClaim, deviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
+		if err != nil {
+			return err
+		}
+
+		d.oidcVerifier.Store(verifier)
+		return nil
+	}
+
+	// Start goroutine to handle set up.
+	go func() {
+		var attemptLimit uint = 14
+		algorithm := backoff.Fibonacci(time.Second)
+		err := retry.Retry(func(attempt uint) error {
+			err := setupOIDC()
+			if err != nil {
+				if attempt < attemptLimit {
+					logger.Warn("Failed applying OIDC configuration", logger.Ctx{"err": err, "attempt": attempt, "retrying_in": algorithm(attempt)})
+				} else {
+					logger.Error("Failed applying OIDC configuration", logger.Ctx{"err": err, "attempt": attempt})
+				}
+
+				return err
+			}
+
+			return nil
+		}, strategy.Backoff(algorithm), strategy.Limit(attemptLimit))
+
+		if err != nil {
+			err = d.db.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, "", "", -1, warningtype.OIDCAuthenticationUnavailable, "Failed applying OIDC configuration")
+			})
+			if err != nil {
+				logger.Error("Failed creating warning after failing to apply OIDC configuration", logger.Ctx{"err": err})
+			}
+		}
+	}()
 }
 
 // hasMemberStateChanged returns true if the number of members, their addresses or state has changed.

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -43,7 +43,8 @@ func daemonConfigSetProxy(d *Daemon, config *clusterConfig.Config) {
 		config.ProxyIgnoreHosts(),
 	)
 
-	if d.oidcVerifier != nil {
-		d.oidcVerifier.ExpireConfig()
+	oidcVerifier := d.oidcVerifier.Load()
+	if oidcVerifier != nil {
+		oidcVerifier.ExpireConfig()
 	}
 }

--- a/lxd/db/warningtype/warning_type.go
+++ b/lxd/db/warningtype/warning_type.go
@@ -58,6 +58,9 @@ const (
 	StoragePoolUnvailable
 	// UnableToUpdateClusterCertificate represents the unable to update cluster certificate warning.
 	UnableToUpdateClusterCertificate
+	// OIDCAuthenticationUnavailable warnings are created when OIDC is configured on LXD but LXD is unable to use those
+	// settings to initialize the OIDC verifier.
+	OIDCAuthenticationUnavailable
 )
 
 // TypeNames associates a warning code to its name.
@@ -88,6 +91,7 @@ var TypeNames = map[Type]string{
 	InstanceTypeNotOperational:             "Instance type not operational",
 	StoragePoolUnvailable:                  "Storage pool unavailable",
 	UnableToUpdateClusterCertificate:       "Cannot update cluster certificate",
+	OIDCAuthenticationUnavailable:          "Failed applying OIDC settings",
 }
 
 // Severity returns the severity of the warning type.
@@ -145,6 +149,8 @@ func (t Type) Severity() Severity {
 		return SeverityHigh
 	case UnableToUpdateClusterCertificate:
 		return SeverityLow
+	case OIDCAuthenticationUnavailable:
+		return SeverityModerate
 	}
 
 	return SeverityLow

--- a/test/includes/oidc.sh
+++ b/test/includes/oidc.sh
@@ -1,12 +1,17 @@
 # mini-oidc related test helpers.
 
 spawn_oidc() {
+  local port=${1:-}
+
   # Return if OIDC is already set up.
   [ -e "${TEST_DIR}/oidc.pid" ] && return
 
-  PORT="$(local_tcp_port)"
-  echo "${PORT}" > "${TEST_DIR}/oidc.port"
-  mini-oidc "${PORT}" "${TEST_DIR}/oidc.user" &
+  if [ "${port}" = "" ]; then
+    port="$(local_tcp_port)"
+  fi
+
+  echo "${port}" > "${TEST_DIR}/oidc.port"
+  mini-oidc "${port}" "${TEST_DIR}/oidc.user" &
   echo $! > "${TEST_DIR}/oidc.pid"
 
   sleep 3

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -12,14 +12,14 @@ test_oidc() {
 
   # Setup OIDC
   spawn_oidc
-
+  oidc_port="$(< "${TEST_DIR}/oidc.port")"
   # Ensure a clean state before testing validation & rollback
   lxc config unset oidc.issuer
   lxc config unset oidc.client.id
 
   # Should be failed on wrong issuer.
-  ! lxc config set oidc.issuer="http://127.0.0.1:22/" oidc.client.id="device" || false # Wrong port
-  ! lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/wrong-path" "oidc.client.id=device" || false # Invalid path
+  ! lxc config set oidc.issuer="http://127.0.0.1:22" oidc.client.id="device" || false # Wrong port
+  ! lxc config set "oidc.issuer=http://127.0.0.1:${oidc_port}/wrong-path" "oidc.client.id=device" || false # Invalid path
   ! lxc config set "oidc.issuer=https://idp.example.com/" "oidc.client.id=device" || false # Invalid host
   ! lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.device.client.id=device" || false # Cannot set device client ID without client ID.
 
@@ -28,7 +28,7 @@ test_oidc() {
   [ -z "$(lxc config get oidc.client.id || echo fail)" ]
   [ -z "$(lxc config get oidc.issuer || echo fail)" ]
 
-  lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=$(uuidgen)" "oidc.device.client.id=device" # Valid Configuration
+  lxc config set "oidc.issuer=http://127.0.0.1:${oidc_port}/" "oidc.client.id=$(uuidgen)" "oidc.device.client.id=device" # Valid Configuration
 
   ! lxc config unset oidc.client.id || false # Can't remove client ID without removing device client ID first.
   ! lxc config set oidc.issuer="" oidc.client.id="" || false # Can't remove client ID without removing device client ID first.
@@ -78,6 +78,29 @@ test_oidc() {
   cluster_uuid="$(lxc config get volatile.uuid)"
   session_uuid="$(lxc auth oidc-session list --format csv test-user@example.com | cut -d, -f3)"
   jq -e --arg cluster_uuid "${cluster_uuid}" --arg session_uuid "${session_uuid}" '.iss == "lxd:"+$cluster_uuid and .sub == $session_uuid and (.aud | length) == 1 and .aud[0] == "lxd:"+$cluster_uuid' <<< "${payload}"
+
+  # Shutdown mini-oidc and restart LXD.
+  kill_oidc
+  shutdown_lxd "${LXD_DIR}"
+  respawn_lxd "${LXD_DIR}" true
+
+  # LXD was not able to instantiate an OIDC verifier at startup.
+  lxc query /1.0 | jq --exit-status '.auth_methods == ["tls", "bearer"]'
+
+  # The user should not be able to authenticate even though their session is still valid
+  # because the OIDC verifier is not available. Via the CLI, the user cannot even call endpoints that allow untrusted
+  # requests because the X-LXD-authenticated header is being set by the client.
+  [ "$("${_LXC}" query oidc:/1.0 2>&1 1>/dev/null)" = "Error: Forbidden" ]
+
+  # Restart mini-oidc using the same port. This function already sleeps for 3 seconds to ensure everything is up.
+  # LXD is attempting to perform discovery in the background and should succeed by the time the function exits.
+  spawn_oidc "${oidc_port}"
+
+  # OIDC authentication should now be available.
+  lxc_remote query /1.0 | jq --exit-status '.auth_methods == ["tls", "bearer", "oidc"]'
+
+  # The user should now be logged in.
+  lxc_remote query oidc:/1.0 | jq --exit-status '.auth == "trusted"'
 
   # Cleanup OIDC
   lxc auth identity delete oidc/test-user@example.com


### PR DESCRIPTION
Runs `NewVerifier` once synchronously. If that fails, OIDC set up is run in the background for about 6 minutes using a Fibonacci backoff. Added a test for this.

Closes #17907 
Depends on #18300

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
