### PR TITLE
client: Flush files on non-interactive exec

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -1356,10 +1357,20 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 					dones[0] = nil
 					_ = conns[0].Close()
 				case <-dones[1]:
+					f, ok := args.Stdout.(*os.File)
+					if ok {
+						_ = f.Sync()
+					}
+
 					dones[1] = nil
 					_ = conns[1].Close()
 					waitConns--
 				case <-dones[2]:
+					f, ok := args.Stderr.(*os.File)
+					if ok {
+						_ = f.Sync()
+					}
+
 					dones[2] = nil
 					_ = conns[2].Close()
 					waitConns--


### PR DESCRIPTION
Currently on `main` if you run:

```bash
for i in $(seq 50); do
    out="$(lxc exec tls:v1 -- whoami)"
    if [ "$out" = "" ]; then
        echo "empty" >> /tmp/v1
    else
        echo "$out" >> /tmp/v1
    fi
done
```

Then `/tmp/v1` will contain multiple "empty" lines.

This change forcefully flushes `(lxd.InstanceExecArgs).Std{out,err}` after write mirroring exits to ensure that what is read from the socket is written to file before the command exits.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
