### PR TITLE
github: Simplify cluster test invocation for cross-track upgrades

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -742,14 +742,9 @@ jobs:
           TEST_SCRIPT="$(echo ${{ matrix.test }} | cut -d " " -f 1)"
           EXTRA_ARGS="$(echo ${{ matrix.test }} | cut -d " " -f 2- --only-delimited)"
           if [ "${TEST_SCRIPT}" = "cluster" ]; then
-            dst_track="${SNAP_TRACK}/${SNAP_RISK}"
-            src_track="${SNAP_TRACK}/stable"
-            # `*/stable` are not all working on 6.17 due to dqlite bug
-            # use `*/candidate` which has the fixed dqlite.
-            if [[ "$(uname -r)" =~ ^6\.17\.0 ]]; then
-              src_track="$(echo "${dst_track}" | cut -d/ -f1)/candidate"
-            fi
-            EXTRA_ARGS="${EXTRA_ARGS:-3} ${src_track} ${dst_track}"
+            # The cluster test script infers the upgrade chain (including
+            # cross-track upgrades) from the target channel automatically.
+            EXTRA_ARGS="${EXTRA_ARGS:-3}"
           elif [ "${TEST_SCRIPT}" = "network-ovn" ]; then
             if [ -n "${EXTRA_ARGS}" ]; then
               # Strip the `ovn:` prefix


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description
The cluster test script in lxd-ci now infers the full upgrade chain (including cross-track upgrades to latest/edge) from the target channel automatically. This simplifies the workflow by removing the manual `src_track`/`dst_track` computation and the kernel 6.17 workaround, as both are now handled within the script itself.

## Changes

1. Simplified the `cluster` case in the snap-tests job: only the count is passed as an extra argument (the channel is already set via `LXD_SNAP_CHANNEL` by `bin/local-run`).
2. Removed the kernel 6.17 dqlite workaround from the workflow (moved into the `tests/cluster` script).

## Testing

> **Note**: The lxd-ci checkout is temporarily pointed at
> `gajeshbhat/lxd-ci@cluster-cross-track-upgrades` to validate the
> changes end-to-end in CI. This will be reverted to
> `canonical/lxd-ci@main` once the companion PR is merged.

## References
1. Depends-on: https://github.com/canonical/lxd-ci/pull/758
2. Issue: #17175