### PR TITLE
lxd/metrics: Include `slab_reclaimable` in `MemAvailable`

### DIFF
--- a/doc/reference/provided_metrics.md
+++ b/doc/reference/provided_metrics.md
@@ -65,6 +65,8 @@ The following instance metrics are provided:
   - Amount of anonymous and swap cache memory
 * - `lxd_memory_Shmem_bytes`
   - Amount of cached file system data that is swap-backed
+* - `lxd_memory_SReclaimable_bytes`
+  - Amount of reclaimable slab memory
 * - `lxd_memory_Swap_bytes`
   - Amount of used swap memory
 * - `lxd_memory_Unevictable_bytes`

--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -365,6 +365,8 @@ func getMemoryMetrics() (metrics.MemoryMetrics, error) {
 			out.MemTotalBytes = value
 		case "Shmem":
 			out.ShmemBytes = value
+		case "SReclaimable":
+			out.SReclaimableBytes = value
 		case "SwapCached":
 			out.SwapBytes = value
 		case "Unevictable":

--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -849,6 +849,8 @@ func (cg *CGroup) GetMemoryStats() (map[string]uint64, error) {
 			out["shmem"], _ = strconv.ParseUint(value, 10, 64)
 		case "total_cache", "file":
 			out["cache"], _ = strconv.ParseUint(value, 10, 64)
+		case "total_slab_reclaimable", "slab_reclaimable":
+			out["slab_reclaimable"], _ = strconv.ParseUint(value, 10, 64)
 		}
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7249,6 +7249,7 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 	}
 
 	memoryCached := int64(0)
+	memorySReclaimable := int64(0)
 
 	// Get memory stats.
 	memStats, err := cg.GetMemoryStats()
@@ -7292,6 +7293,16 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 				} else {
 					memoryCached = int64(v)
 				}
+
+			case "slab_reclaimable":
+				metricType = metrics.MemorySReclaimableBytes
+
+				// Bound checking before converting from uint64 to int64.
+				if v > math.MaxInt64 {
+					memorySReclaimable = math.MaxInt64
+				} else {
+					memorySReclaimable = int64(v)
+				}
 			}
 
 			out.AddSamples(metricType, metrics.Sample{Value: float64(v)})
@@ -7306,7 +7317,9 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 
 	if memoryLimit > 0 {
 		out.AddSamples(metrics.MemoryMemTotalBytes, metrics.Sample{Value: float64(memoryLimit)})
-		out.AddSamples(metrics.MemoryMemAvailableBytes, metrics.Sample{Value: float64(memoryLimit - memoryUsage + memoryCached)})
+		// MemAvailable mirrors the kernel's /proc/meminfo definition: free plus reclaimable
+		// pages (page cache and reclaimable slab) that the kernel can release without swapping.
+		out.AddSamples(metrics.MemoryMemAvailableBytes, metrics.Sample{Value: float64(memoryLimit - memoryUsage + memoryCached + memorySReclaimable)})
 		out.AddSamples(metrics.MemoryMemFreeBytes, metrics.Sample{Value: float64(memoryLimit - memoryUsage)})
 	}
 

--- a/lxd/metrics/api.go
+++ b/lxd/metrics/api.go
@@ -58,6 +58,7 @@ type MemoryMetrics struct {
 	MemTotalBytes       uint64 `json:"memory_mem_total_bytes" yaml:"memory_mem_total_bytes"`
 	RSSBytes            uint64 `json:"memory_rss_bytes" yaml:"memory_rss_bytes"`
 	ShmemBytes          uint64 `json:"memory_shmem_bytes" yaml:"memory_shmem_bytes"`
+	SReclaimableBytes   uint64 `json:"memory_sreclaimable_bytes" yaml:"memory_sreclaimable_bytes"`
 	SwapBytes           uint64 `json:"memory_swap_bytes" yaml:"memory_swap_bytes"`
 	UnevictableBytes    uint64 `json:"memory_unevictable_bytes" yaml:"memory_unevictable_bytes"`
 	WritebackBytes      uint64 `json:"memory_writeback_bytes" yaml:"memory_writeback_bytes"`

--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -243,6 +243,7 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 	set.AddSamples(MemoryMemTotalBytes, Sample{Value: float64(metrics.Memory.MemTotalBytes)})
 	set.AddSamples(MemoryRSSBytes, Sample{Value: float64(metrics.Memory.RSSBytes)})
 	set.AddSamples(MemoryShmemBytes, Sample{Value: float64(metrics.Memory.ShmemBytes)})
+	set.AddSamples(MemorySReclaimableBytes, Sample{Value: float64(metrics.Memory.SReclaimableBytes)})
 	set.AddSamples(MemorySwapBytes, Sample{Value: float64(metrics.Memory.SwapBytes)})
 	set.AddSamples(MemoryUnevictableBytes, Sample{Value: float64(metrics.Memory.UnevictableBytes)})
 	set.AddSamples(MemoryWritebackBytes, Sample{Value: float64(metrics.Memory.WritebackBytes)})

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -275,7 +275,7 @@ var MetricHeaders = map[MetricType]string{
 	MemoryMappedBytes:           "# HELP lxd_memory_Mapped_bytes The amount of mapped memory.",
 	MemoryMemAvailableBytes:     "# HELP lxd_memory_MemAvailable_bytes The amount of available memory.",
 	MemoryMemFreeBytes:          "# HELP lxd_memory_MemFree_bytes The amount of free memory.",
-	MemoryMemTotalBytes:         "# HELP lxd_memory_MemTotal_bytes The amount of used memory.",
+	MemoryMemTotalBytes:         "# HELP lxd_memory_MemTotal_bytes The total amount of memory or configured memory limit.",
 	MemoryRSSBytes:              "# HELP lxd_memory_RSS_bytes The amount of anonymous and swap cache memory.",
 	MemoryShmemBytes:            "# HELP lxd_memory_Shmem_bytes The amount of cached filesystem data that is swap-backed.",
 	MemorySReclaimableBytes:     "# HELP lxd_memory_SReclaimable_bytes The amount of reclaimable slab memory.",

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -120,6 +120,8 @@ const (
 	MemoryRSSBytes
 	// MemoryShmemBytes represents the amount of cached filesystem data that is swap-backed.
 	MemoryShmemBytes
+	// MemorySReclaimableBytes represents the amount of reclaimable slab memory.
+	MemorySReclaimableBytes
 	// MemorySwapBytes represents the amount of swap memory.
 	MemorySwapBytes
 	// MemoryUnevictableBytes represents the amount of unevictable memory.
@@ -204,6 +206,7 @@ var MetricNames = map[MetricType]string{
 	MemoryMemTotalBytes:         "lxd_memory_MemTotal_bytes",
 	MemoryRSSBytes:              "lxd_memory_RSS_bytes",
 	MemoryShmemBytes:            "lxd_memory_Shmem_bytes",
+	MemorySReclaimableBytes:     "lxd_memory_SReclaimable_bytes",
 	MemorySwapBytes:             "lxd_memory_Swap_bytes",
 	MemoryUnevictableBytes:      "lxd_memory_Unevictable_bytes",
 	MemoryWritebackBytes:        "lxd_memory_Writeback_bytes",
@@ -275,6 +278,7 @@ var MetricHeaders = map[MetricType]string{
 	MemoryMemTotalBytes:         "# HELP lxd_memory_MemTotal_bytes The amount of used memory.",
 	MemoryRSSBytes:              "# HELP lxd_memory_RSS_bytes The amount of anonymous and swap cache memory.",
 	MemoryShmemBytes:            "# HELP lxd_memory_Shmem_bytes The amount of cached filesystem data that is swap-backed.",
+	MemorySReclaimableBytes:     "# HELP lxd_memory_SReclaimable_bytes The amount of reclaimable slab memory.",
 	MemorySwapBytes:             "# HELP lxd_memory_Swap_bytes The amount of used swap memory.",
 	MemoryUnevictableBytes:      "# HELP lxd_memory_Unevictable_bytes The amount of unevictable memory.",
 	MemoryWritebackBytes:        "# HELP lxd_memory_Writeback_bytes The amount of memory queued for syncing to disk.",


### PR DESCRIPTION
> _Writeup by Claude Code on behalf of the author. Findings, reproduction, and patch verified against the repository. Author has signed the CCLA._

Fixes #18288.

`lxd_memory_MemAvailable_bytes` currently equals `memoryLimit - memoryUsage + Cached`. It does not include reclaimable slab (`slab_reclaimable` in cgroup `memory.stat` / `SReclaimable` in `/proc/meminfo`), so it diverges from the kernel's own MemAvailable by tens of GiB on workloads with heavy dentry/inode pressure (databases with frequent binlog rotation, etc.).

Symptoms on a real workload (MariaDB container, 128 GiB limit, fully warm 80 GiB InnoDB buffer pool, LXD 5.21.4):

| field | `/proc/meminfo` (inside) | `lxd_memory_*` (before) |
|---|---|---|
| MemTotal | 128.00 GiB | 128.00 GiB |
| MemFree | 14.16 GiB | 14.11 GiB |
| MemAvailable | **39.77 GiB** | **14.20 GiB** ← off by 25.6 GiB |
| Cached | 0.09 GiB | 0.09 GiB |
| SReclaimable | 25.53 GiB | *(not exposed)* |

### What this PR does

1. `lxd/cgroup`: parse `slab_reclaimable` (cgroup v2) / `total_slab_reclaimable` (cgroup v1) from `memory.stat` in `GetMemoryStats`.
2. `lxd/metrics`: add `MemorySReclaimableBytes` (= `lxd_memory_SReclaimable_bytes`) and the matching `SReclaimableBytes` field on `MemoryMetrics`.
3. `lxd/instance/drivers`: emit the new metric and include it in the MemAvailable calculation: `memoryLimit - memoryUsage + memoryCached + memorySReclaimable`.
4. `lxd-agent`: parse `SReclaimable` from `/proc/meminfo` so the metric is consistent across containers and VMs.
5. `doc`: add the new metric to `provided_metrics.md`.

### Behavior change

`lxd_memory_MemAvailable_bytes` will jump up on instances with significant reclaimable slab. This is a correctness fix bringing it in line with `/proc/meminfo`'s `MemAvailable`. Dashboards that derived "used %" from `(Total - MemAvailable) / Total` will start showing more honest (lower) figures.

### Analogous issue

Issue #18120 reports the same conceptual mistake in `lxd/resources/memory.go` (the `lxc info --resources` endpoint). That fix is more invasive and not addressed here.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.