### PR TITLE
lxc/image: fix architecture filter to match displayed values

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1234,6 +1234,16 @@ func (c *cmdImageList) imageShouldShow(filters []string, state *api.Image) bool 
 			if ok && fmt.Sprint(val) == value {
 				found = true
 			}
+
+			// Also check against column shorthand display values so that
+			if !found {
+				for _, col := range c.columns() {
+					if string(col.Shorthand) == key && col.Data(*state) == value {
+						found = true
+						break
+					}
+				}
+			}
 		} else {
 			for _, alias := range state.Aliases {
 				if strings.Contains(alias.Name, filter) {


### PR DESCRIPTION
Fixes #17272

## Problem
Filtering with `a=x86_64` returned no results even though `x86_64` is what is shown in the ARCHITECTURE column. This is because the filter was only checking image properties (which use `amd64`) and not the column display values.

## Fix
Also check filter values against column shorthand display values, so `a=x86_64` matches what the user sees in the table.

## Testing
Verified on latest/edge that `lxc image list ubuntu:24.04 a=x86_64` returned empty before the fix and returns correct results after.
