### PR TITLE
OIDC device client

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2691,6 +2691,7 @@ Adds a `skip` mode to the restore request. This mode restores a cluster member's
 
 Adds the {config:option}`device-disk-device-conf:io.threads` option on `disk` devices which is used to control the `virtiofsd` thread pool size when sharing file systems into VMs. This can help improve I/O performance.
 
+(extension-oidc-client-secret)=
 ## `oidc_client_secret`
 
 This adds support for the {config:option}`server-oidc:oidc.client.secret` configuration key.
@@ -3099,3 +3100,16 @@ The following pool level configuration keys have been added:
 1. {config:option}`storage-powerstore-pool-conf:powerstore.user.password`
 1. {config:option}`storage-powerstore-pool-conf:powerstore.mode`
 1. {config:option}`storage-powerstore-pool-conf:powerstore.target`
+
+## `oidc_device_client_id`
+
+The {ref}`OIDC client secret configuration extension <extension-oidc-client-secret>` is used to configure LXD to send a
+secret to the identity provider for authentication. It is not secure to make this secret public for consumption by the
+LXD CLI (`lxc`). For this reason, if the client configured for LXD in the identity provider requires a secret, that
+client cannot be used by CLI users.
+
+This extension adds a new {config:option}`server-oidc:oidc.device.client.id` configuration key for the CLI to use. An
+administrator can create two clients in the identity provider, one for LXD UI requiring a secret (and {abbr}`PKCE <Proof Key for Code Exchange>`),
+and one for the CLI that enables the device authorization grant and does not require a secret. The device client ID will
+be public to the CLI, falling back to {config:option}`server-oidc:oidc.client.id`. This configuration option cannot be
+set unless {config:option}`server-oidc:oidc.client.id` is set.

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -131,18 +131,16 @@ A client with a CA-signed certificate that has been revoked, and is present in `
 LXD supports using [OpenID Connect](https://openid.net/developers/how-connect-works/) to authenticate users through an {abbr}`OIDC (OpenID Connect)` Identity Provider.
 
 To configure LXD to use OIDC authentication, set the [`oidc.*`](server-options-oidc) server configuration options.
-Your OIDC provider must be configured to enable the [Device Authorization Grant](https://oauth.net/2/device-flow/) type.
+See the {ref}`how-to guides <howto-oidc>` for more information.
 
-To add a remote pointing to a LXD server configured with OIDC authentication, run [`lxc remote add <remote_name> <remote_address>`](lxc_remote_add.md).
+Once configured, the LXD UI will display a {guilabel}`Log in with SSO` button which will redirect you to the Identity Provider to log in.
+
+To use OIDC authentication in the LXD CLI, run [`lxc remote add <remote_name> <remote_address>`](lxc_remote_add.md).
+This defaults to OIDC authentication if configured on the remote server.
 You are then prompted to authenticate through your web browser, where you must confirm that the device code displayed in the browser matches the device code that is displayed in the terminal window.
 The LXD client then retrieves and stores an access token, which it provides to LXD for all interactions.
 The identity provider might also provide a refresh token.
 In this case, the LXD client uses this refresh token to attempt to retrieve another access token when the current access token has expired.
-
-```{warning}
-Only set `oidc.client.secret` if required by the Identity Provider. Once set, this key allows the LXD UI client to authenticate.
-However, the secret is not shared with other LXD clients (such as the LXD CLI).
-```
 
 When an OIDC client initially authenticates with LXD, it does not have access to the majority of the LXD API.
 OIDC clients must be granted access by an administrator, see {ref}`fine-grained-authorization`.

--- a/doc/howto/oidc_auth0.md
+++ b/doc/howto/oidc_auth0.md
@@ -7,37 +7,55 @@ Auth0 is a flexible, drop-in solution to add authentication and authorization se
 
 1. Open a free account on [Auth0.com](https://auth0.com/).
 
-1. Once logged into the Auth0 web interface, from the main navigation's {guilabel}`Applications` section, select {guilabel}`Applications` > {guilabel}`Create application`.
-    - Use the default type of {guilabel}`Native` and click {guilabel}`Create`.
+1. Once logged into the Auth0 web interface, select {guilabel}`Applications` > {guilabel}`Applications` in the side panel.
+   - You need to create two applications. One is for the LXD UI and the other is for the LXD CLI.
+
+1. First, create an application that will be used for authentication in the LXD UI by selecting {guilabel}`+ Create Application`.
+   - Give the application a name, e.g. `LXD UI`.
+   - Select {guilabel}`Regular Web Application`.
+   - Click {guilabel}`Create`.
 
 1. Go to the {guilabel}`Settings` tab of your new application.
-    - Scroll to the {guilabel}`Allowed Callback URLs` field in this tab and enter your LXD UI address, followed by `/oidc/callback`.
-       - Example: `https://example.com:8443/oidc/callback`
-       - An IP address can be used instead of a domain name.
+   - Scroll to the {guilabel}`Allowed Callback URLs` field in this tab and enter your LXD UI address, followed by `/oidc/callback`.
+     - Example: `https://example.com:8443/oidc/callback`
+     - An IP address can be used instead of a domain name.
        - Note `:8443` is the default listening port for the LXD server. It might differ for your setup. You can verify the LXD configuration value `core.https_address` to find the correct port for your LXD server.
-    - Enable {guilabel}`Allow Refresh Token Rotation`.
-    - Scroll down to {guilabel}`Advanced Settings` and select the {guilabel}`Grant Types` tab. Enable {guilabel}`Device code`.
-    The device code grant type is required for OIDC authentication using the LXD CLI.
-    - Select {guilabel}`Save Changes`.
+   - Enable {guilabel}`Allow Refresh Token Rotation`.
+   - Scroll down to {guilabel}`Advanced Settings` and select the {guilabel}`Grant Types` tab.
+   - Enable {guilabel}`Authorization code` and {guilabel}`Refresh Token`. Other grant types can be disabled.
+   - Select {guilabel}`Save`.
 
-1. Near the top of the {guilabel}`Settings` tab, locate the {guilabel}`Domain` field. Copy the value and add the `https://` prefix and the `/` suffix as in the example below. This is your OIDC issuer for LXD. Set this value in your LXD server configuration with the command:
+1. Navigate to {guilabel}`Basic Information` near the top of the {guilabel}`Settings` tab.
+   - Locate the {guilabel}`Domain` field. Copy the value and add the `https://` prefix and the `/` suffix as in the example below.
+     This is your OIDC issuer for LXD. Set this value in your LXD server configuration with the command:
 
-       lxc config set oidc.issuer=https://dev-example.us.auth0.com/
+         lxc config set oidc.issuer=https://dev-example.us.auth0.com/
+   - Locate the {guilabel}`Client ID` and {guilabel}`Client Secret` fields. Copy the values and use them in your LXD server configuration:
 
-1. From your Auth0 application's {guilabel}`Settings` tab, copy the {guilabel}`Client ID` and use it in your LXD server configuration:
+         lxc config set oidc.client.id=<Client ID>
+         lxc config set oidc.client.secret=<Client Secret>
 
-       lxc config set oidc.client.id=6f6f6f6f6f6f
+   - Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. Enter the credentials for Auth0.
 
-1. Finally, in the Auth0 interface's main navigation,  under {guilabel}`Applications`, select {guilabel}`Applications` > {guilabel}`APIs`. Copy the {guilabel}`API Audience` value, then use it as the OIDC audience in your LXD server configuration:
+1. Now create an application to be used by the LXD CLI. To do this, go back to {guilabel}`Applications` > {guilabel}`Applications` in the side panel and click {guilabel}`+ Create Application`.
+   - Give the application a name, e.g. `LXD CLI`.
+   - Select the default {guilabel}`Native` application type.
+   - Click {guilabel}`Create`.
 
-       lxc config set oidc.audience=https://dev-example.us.auth0.com/api/v2/
+1. Go to the {guilabel}`Settings` tab of your new application.
+   - Enable {guilabel}`Allow Refresh Token Rotation`.
+   - Scroll down to {guilabel}`Advanced Settings` and select the {guilabel}`Grant Types` tab.
+   - Enable {guilabel}`Device Code` and {guilabel}`Refresh Token`. Other grant types can be disabled.
+   - Select {guilabel}`Save`.
 
-Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. Enter the credentials for Auth0.
-You can also access LXD using the CLI with
+1. Navigate to {guilabel}`Basic Information` near the top of the {guilabel}`Settings` tab.
+   - Locate the {guilabel}`Client ID` field and use it in your LXD server configuration:
 
-    lxc remote add <remote-name> <LXD-address> --auth-type oidc
+         lxc config set oidc.device.client.id=<Client ID>
+   - You can now access LXD using the CLI with
 
-This will open a browser where you must confirm the device code displayed in the terminal window, and log in with the credentials for Auth0.
+         lxc remote add <remote-name> <LXD-address> --auth-type oidc
+     This will open a browser where you must confirm the device code displayed in the terminal window, and log in with the credentials for Auth0.
 
 Users will have no permissions by default. You must set up {ref}`LXD authorization groups <manage-permissions>` to grant access to projects and instances. For connecting the LXD authorization groups to a user you have two options:
 
@@ -49,14 +67,14 @@ Users will have no permissions by default. You must set up {ref}`LXD authorizati
 ## Set up automatic group mappings
 An admin can set up multiple users in Auth0 and allocate roles to those users. When a user logs in via OIDC, their allocated Auth0 roles can be mapped to LXD authorization groups through custom claims. This section details the steps for configuring roles in Auth0 and setting up a custom claim so that LXD can map those roles to its authorization groups.
 
-1. In Auth0 interface for the application used with LXD, select {guilabel}`User Management` > {guilabel}`Roles`, create some roles with suitable names.
+1. In the left panel of the Auth0 interface, select {guilabel}`User Management` > {guilabel}`Roles`, create some roles with suitable names. Note that these roles are global for the Auth0 tenant.
 
 1. Under {guilabel}`User Management` > {guilabel}`Users`, click {guilabel}`Create User`. Provide an email and password and create the user.
 
 1. Select on the {guilabel}`Roles` tab in the user detail page, then click the {guilabel}`Assign Roles` button. Select the roles you created in step 1.
 
-1. You must set up a custom action on Auth0 to set the custom claim on the id_token during the OIDC login flow.
-    - In the main navigation, under {guilabel}`Actions` > {guilabel}`Library`, click the {guilabel}`Create Action` button. Select {guilabel}`Build from scratch`.
+1. You must set up a custom action on Auth0 to set the custom claim on both the `id_token` and `access_token` during the OIDC login flow.
+    - In the main navigation, under {guilabel}`Actions` > {guilabel}`Library`, click the {guilabel}`Create Action` button. Select {guilabel}`Create Custom Action`.
        - **Name**: Give the action a suitable name like `roles-in-id-token`.
        - **Trigger**: Login / Post Login
        - **Runtime**: The recommended default
@@ -66,8 +84,8 @@ An admin can set up multiple users in Auth0 and allocate roles to those users. W
     ```javascript
     exports.onExecutePostLogin = async (event, api) => {
       if (event.authorization) {
-        api.idToken.setCustomClaim(`lxd-idp-groups`, event.authorization.roles);
-        api.accessToken.setCustomClaim(`lxd-idp-groups`, event.authorization.roles);
+        api.idToken.setCustomClaim(`global-roles`, event.authorization.roles);
+        api.accessToken.setCustomClaim(`global-roles`, event.authorization.roles);
       }
     };
     ```
@@ -77,11 +95,11 @@ An admin can set up multiple users in Auth0 and allocate roles to those users. W
 
 1. Navigate to the LXD UI. First authenticate with the UI using a trusted certificate so that you can configure server settings without permission issues.
 
-1. In the LXD UI, under {guilabel}`settings`, find `oidc.groups.claim`. Set it to the custom claim configured in step 4. Using the current example, the custom claim is `lxd-idp-groups`. Alternatively, use the command line: `lxc config set oidc.groups.claim=lxd-idp-groups`.
+1. In the LXD UI, under {guilabel}`settings`, find `oidc.groups.claim`. Set it to the custom claim configured in step 4. Using the current example, the custom claim is `global-roles`. Alternatively, use the command line: `lxc config set oidc.groups.claim=global-roles`.
 
 1. Continuing in the LXD UI, navigate to {guilabel}`Permissions` > {guilabel}`IDP groups` and click {guilabel}`Create IDP Group`. Here you can map roles from Auth0 to LXD authorization groups. For each {ref}`identity provider group <identity-provider-groups>` created in LXD, the name of the identity provider group must match a role you have created in Auth0, and it should also map to one or more LXD authorization groups. Alternatively, use the command line:
 
        lxc auth identity-provider-group create <auth0-role-name>
        lxc auth identity-provider-group group add <auth0-role-name> <LXD-group-name>
 
-1. Lastly, you log in as a user with roles assigned in Auth0. During the OIDC flow, LXD automatically extracts the custom claim from the user's `id_token` based on the LXD `oidc.groups.claim` configuration value. The extracted custom claim is an array of roles for your user from Auth0. Those roles are then mapped to LXD authorization groups using the identity provider group created in step 7.
+1. Lastly, you log in as a user with roles assigned in Auth0. During the OIDC flow, LXD extracts the roles set by Auth0 based on the LXD `oidc.groups.claim` configuration value. The extracted custom claim is an array of roles for your user from Auth0. Those roles are then mapped to LXD authorization groups using the identity provider group created in step 7.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5053,6 +5053,15 @@ This value is required by some providers.
 
 ```
 
+```{config:option} oidc.device.client.id server-oidc
+:defaultdesc: "The value of `oidc.client.id` if set."
+:scope: "global"
+:shortdesc: "OpenID Connect client ID (CLI)"
+:type: "string"
+The OIDC client ID used by the LXD CLI. This configuration value overrides the client ID that is made public
+to the LXD CLI.
+```
+
 ```{config:option} oidc.groups.claim server-oidc
 :scope: "global"
 :shortdesc: "A claim used for mapping identity provider groups to LXD groups."

--- a/doc/server.md
+++ b/doc/server.md
@@ -55,8 +55,10 @@ The following server options configure external user authentication through {ref
 ```
 
 ```{important}
-Setting `oidc.client.secret` may prevent CLI clients from authenticating depending on the Identity Provider policies.
-Set this key only if required by the Identity Provider.
+Setting `oidc.client.secret` might prevent LXD CLI clients from authenticating via the Identity Provider.
+This is because the client secret is used only for communication between LXD and the Identity Provider.
+LXD CLI clients, who do not have access to the client secret, authenticate separately with the Identity Provider and send their credentials to LXD for verification.
+You can create a separate client in the identity provider for the LXD CLI and configure this using the `oidc.device.client.id`
 ```
 
 (server-options-cluster)=

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1273,7 +1273,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			}
 
 			sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, d.globalConfig.OIDCSessionExpiry)
-			d.oidcVerifier, err = oidc.NewVerifier(s.ShutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), s.CoreAuthSecrets, httpClientFunc, sessionHandler)
+			d.oidcVerifier, err = oidc.NewVerifier(s.ShutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), s.CoreAuthSecrets, httpClientFunc, sessionHandler)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -748,11 +748,13 @@ func validateStorageVolumes(s *state.State, ctx context.Context, nodeValues map[
 	return nil
 }
 
-// validateOIDCSessionExpiry enforces that "oidc.session.expiry" is not greater than "core.auth_secret_expiry".
-//
-// We cannot allow this, otherwise we might encounter OIDC session tokens that ought to be valid, but that we can't verify
-// because they have been signed by a key derived from a core secret that is too old and has been rotated out and deleted.
-func validateOIDCSessionExpiry(config *clusterConfig.Config, requestConfig map[string]string, patch bool) error {
+// validateOIDCConfiguration inspects the OIDC related values in a configuration update to enforce certain constraints.
+// This can't be handled by the config map, as the validation functions don't have access to other configuration values,
+// so we need to validate separately.
+func validateOIDCConfiguration(config *clusterConfig.Config, requestConfig map[string]string, patch bool) error {
+	// Enforce that "oidc.session.expiry" is not greater than "core.auth_secret_expiry". We cannot allow this, otherwise
+	// we might encounter OIDC session tokens that ought to be valid, but that we can't verify because they have been
+	// signed by a key derived from a core secret that is too old and has been rotated out and deleted.
 	coreAuthSecretExpiry := requestConfig["core.auth_secret_expiry"]
 	if coreAuthSecretExpiry == "" {
 		// If value is unset in request. For PATCH it is unchanged, but for PUT it will reset to the default.
@@ -790,6 +792,33 @@ func validateOIDCSessionExpiry(config *clusterConfig.Config, requestConfig map[s
 		return api.StatusErrorf(http.StatusBadRequest, "OIDC session expiry %q must not be greater than the auth secret expiry %q", oidcSessionExpiry, coreAuthSecretExpiry)
 	}
 
+	// Check that the oidc.device.client.id will not be set without oidc.client.id being set.
+	newClientID, hasNewClientID := requestConfig["oidc.client.id"]
+	newDeviceClientID, hasNewDeviceClientID := requestConfig["oidc.device.client.id"]
+	var clientIDWillBeUnset, deviceClientIDWillBeSet bool
+	if patch {
+		// Get the current client ID.
+		_, currentClientID, _, _, _, _, _ := config.OIDCServer()
+
+		// Get the current device client ID. Note that we are not using the value returned from config.OIDCServer here
+		// because that value defaults to the client ID if not set.
+		currentDeviceClientID := config.OIDCDeviceClientID()
+
+		// Client ID will be unset if the current value is not set and no new value was sent or if a new empty value was sent.
+		clientIDWillBeUnset = (!hasNewClientID && currentClientID == "") || (hasNewClientID && newClientID == "")
+
+		// Device client ID will be set if the current value is set and no new value was sent or if a new non-empty value was sent.
+		deviceClientIDWillBeSet = (!hasNewDeviceClientID && currentDeviceClientID != "") || (hasNewDeviceClientID && newDeviceClientID != "")
+	} else {
+		// For PUT we can just check the sent values.
+		clientIDWillBeUnset = newClientID == ""
+		deviceClientIDWillBeSet = newDeviceClientID != ""
+	}
+
+	if clientIDWillBeUnset && deviceClientIDWillBeSet {
+		return api.NewStatusError(http.StatusBadRequest, `"oidc.device.client.id" cannot be set if "oidc.client.id" is unset`)
+	}
+
 	return nil
 }
 
@@ -820,10 +849,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return response.BadRequest(errors.New("The cluster UUID cannot be changed"))
 	}
 
-	// Validate the OIDC session expiry is not greater than the core auth secret expiry.
-	// This can't be handled by the config map, as the validation functions don't have access
-	// to other configuration values, so we need to validate here.
-	err := validateOIDCSessionExpiry(d.globalConfig, stringReqConfig, patch)
+	err := validateOIDCConfiguration(d.globalConfig, stringReqConfig, patch)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1134,7 +1134,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			acmeCAURLChanged = true
 		case "acme.domain":
 			acmeDomainChanged = true
-		case "oidc.issuer", "oidc.client.id", "oidc.client.secret", "oidc.scopes", "oidc.audience", "oidc.groups.claim":
+		case "oidc.issuer", "oidc.client.id", "oidc.client.secret", "oidc.scopes", "oidc.audience", "oidc.groups.claim", "oidc.device.client.id":
 			oidcChanged = true
 		}
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -254,7 +254,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		api.AuthenticationMethodBearer,
 	}
 
-	oidcIssuer, oidcClientID, _, _, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -1261,7 +1261,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim := newClusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID := newClusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -60,6 +60,7 @@ type Verifier struct {
 	scopes         []string
 	audience       string
 	groupsClaim    string
+	deviceClientID string
 	secretsFunc    func(ctx context.Context) (cluster.AuthSecrets, error)
 	httpClientFunc func() (*http.Client, error)
 	clusterUUID    string
@@ -558,7 +559,7 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 // WriteHeaders writes the OIDC configuration as HTTP headers so the client can initatiate the device code flow.
 func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	w.Header().Set("X-LXD-OIDC-issuer", o.issuer)
-	w.Header().Set("X-LXD-OIDC-clientid", o.clientID)
+	w.Header().Set("X-LXD-OIDC-clientid", o.deviceClientID)
 	w.Header().Set("X-LXD-OIDC-audience", o.audience)
 
 	// Continue to sent groups claim header for compatibility with older clients
@@ -775,7 +776,7 @@ func (o *Verifier) secureCookieFromV7UUID(ctx context.Context, sessionID uuid.UU
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(ctx context.Context, issuer string, clientID string, clientSecret string, scopes []string, audience string, groupsClaim string, clusterUUID string, networkAddress string, secretsFunc func(ctx context.Context) (cluster.AuthSecrets, error), httpClientFunc func() (*http.Client, error), sessionHandler SessionHandler) (*Verifier, error) {
+func NewVerifier(ctx context.Context, issuer string, clientID string, clientSecret string, scopes []string, audience string, groupsClaim string, deviceClientID string, clusterUUID string, networkAddress string, secretsFunc func(ctx context.Context) (cluster.AuthSecrets, error), httpClientFunc func() (*http.Client, error), sessionHandler SessionHandler) (*Verifier, error) {
 	verifier := &Verifier{
 		issuer:         issuer,
 		clientID:       clientID,
@@ -783,6 +784,7 @@ func NewVerifier(ctx context.Context, issuer string, clientID string, clientSecr
 		scopes:         scopes,
 		audience:       audience,
 		groupsClaim:    groupsClaim,
+		deviceClientID: deviceClientID,
 		clusterUUID:    clusterUUID,
 		secretsFunc:    secretsFunc,
 		httpClientFunc: httpClientFunc,

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -229,8 +229,21 @@ func (c *Config) AuthSecretExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, clientSecret string, scopes []string, audience string, groupsClaim string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.client.secret"), strings.Fields(c.m.GetString("oidc.scopes")), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
+func (c *Config) OIDCServer() (issuer string, clientID string, clientSecret string, scopes []string, audience string, groupsClaim string, deviceClientID string) {
+	// The default value of oidc.device.client.id is oidc.client.id.
+	clientID = c.m.GetString("oidc.client.id")
+	deviceClientID = c.m.GetString("oidc.device.client.id")
+	if deviceClientID == "" {
+		deviceClientID = clientID
+	}
+
+	return c.m.GetString("oidc.issuer"), clientID, c.m.GetString("oidc.client.secret"), strings.Fields(c.m.GetString("oidc.scopes")), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim"), deviceClientID
+}
+
+// OIDCDeviceClientID returns the raw value of "oidc.device.client.id".
+// It is used to validate that unsetting "oidc.client.id" set will not leave the device client ID set.
+func (c *Config) OIDCDeviceClientID() string {
+	return c.m.GetString("oidc.device.client.id")
 }
 
 // OIDCSessionExpiry returns the expiry of an OIDC session. This is separate from OIDCServer as it is passed into the
@@ -777,6 +790,16 @@ var ConfigSchema = config.Schema{
 
 			return nil
 		}},
+
+		// lxdmeta:generate(entities=server; group=oidc; key=oidc.device.client.id)
+		// The OIDC client ID used by the LXD CLI. This configuration value overrides the client ID that is made public
+		// to the LXD CLI.
+		// ---
+		//  type: string
+		//  scope: global
+		//  shortdesc: OpenID Connect client ID (CLI)
+		//  defaultdesc: The value of `oidc.client.id` if set.
+		"oidc.device.client.id": {},
 
 		// OVN networking global keys.
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1798,7 +1798,7 @@ func (d *Daemon) init() error {
 		}
 
 		sessionHandler := dbOIDC.NewSessionHandler(d.db.Cluster, d.events, d.globalConfig.OIDCSessionExpiry)
-		d.oidcVerifier, err = oidc.NewVerifier(d.shutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
+		d.oidcVerifier, err = oidc.NewVerifier(d.shutdownCtx, oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID, d.globalConfig.ClusterUUID(), d.endpoints.NetworkAddress(), d.getCoreAuthSecrets, httpClientFunc, sessionHandler)
 		if err != nil {
 			logger.Warn("Failed setting up OIDC verifier", logger.Ctx{"err": err})
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1770,7 +1770,7 @@ func (d *Daemon) init() error {
 
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, oidcGroupsClaim, oidcDeviceClientID := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 
 	d.endpoints.NetworkUpdateTrustedProxy(d.globalConfig.HTTPSTrustedProxy())

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5649,6 +5649,15 @@
 						}
 					},
 					{
+						"oidc.device.client.id": {
+							"defaultdesc": "The value of `oidc.client.id` if set.",
+							"longdesc": "The OIDC client ID used by the LXD CLI. This configuration value overrides the client ID that is made public\nto the LXD CLI.",
+							"scope": "global",
+							"shortdesc": "OpenID Connect client ID (CLI)",
+							"type": "string"
+						}
+					},
+					{
 						"oidc.groups.claim": {
 							"longdesc": "Specify a custom token claim to denote groups defined at the identity provider.\nThe contents of this claim can be mapped to LXD groups for managing access control.\nThe value of the claim is expected to be a JSON string array.",
 							"scope": "global",

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1503,7 +1503,7 @@ func patchOIDCGroupsClaimScope(_ string, d *Daemon) error {
 		}
 
 		// Get the groups claim and scopes (these will just be the default values at the time of the patch)
-		_, _, _, scopes, _, groupsClaim := globalConfig.OIDCServer()
+		_, _, _, scopes, _, groupsClaim, _ := globalConfig.OIDCServer()
 
 		// If the groups claim is not set, or this patch was already run on another member and the groups claim is
 		// already present in the list of scopes, then there is nothing to do.

--- a/lxd/patches_test.go
+++ b/lxd/patches_test.go
@@ -154,7 +154,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)
 
-			_, _, _, scopes, _, groupsClaim := conf.OIDCServer()
+			_, _, _, scopes, _, groupsClaim, _ := conf.OIDCServer()
 			// Expect the groups claim to still be set.
 			assert.Equal(t, "groups", groupsClaim)
 
@@ -198,7 +198,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)
 
-			_, _, _, scopes, _, groupsClaim := conf.OIDCServer()
+			_, _, _, scopes, _, groupsClaim, _ := conf.OIDCServer()
 			// Expect the groups claim to still be set.
 			assert.Equal(t, "groups", groupsClaim)
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -490,6 +490,7 @@ var APIExtensions = []string{
 	"replicators",
 	"event_security",
 	"storage_driver_powerstore",
+	"oidc_device_client_id",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -21,13 +21,19 @@ test_oidc() {
   ! lxc config set oidc.issuer="http://127.0.0.1:22/" oidc.client.id="device" || false # Wrong port
   ! lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/wrong-path" "oidc.client.id=device" || false # Invalid path
   ! lxc config set "oidc.issuer=https://idp.example.com/" "oidc.client.id=device" || false # Invalid host
+  ! lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.device.client.id=device" || false # Cannot set device client ID without client ID.
 
 
   # Should remain empty as above tests failed.
   [ -z "$(lxc config get oidc.client.id || echo fail)" ]
   [ -z "$(lxc config get oidc.issuer || echo fail)" ]
 
-  lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=device" # Valid Configuration
+  lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=$(uuidgen)" "oidc.device.client.id=device" # Valid Configuration
+
+  ! lxc config unset oidc.client.id || false # Can't remove client ID without removing device client ID first.
+  ! lxc config set oidc.issuer="" oidc.client.id="" || false # Can't remove client ID without removing device client ID first.
+  curl -s -X PATCH --unix-socket "${LXD_DIR}/unix.socket" --data '{"config": {"oidc.client.id":""}}' lxd/1.0 | \
+    jq --exit-status '.error_code == 400 and .error == "\"oidc.device.client.id\" cannot be set if \"oidc.client.id\" is unset"' # Can't remove client ID without removing device client ID first.
 
   # Expect this to fail. No user set.
   ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
@@ -76,6 +82,6 @@ test_oidc() {
   # Cleanup OIDC
   lxc auth identity delete oidc/test-user@example.com
   lxc remote remove oidc
-  lxc config set oidc.issuer="" oidc.client.id=""
+  lxc config set oidc.issuer="" oidc.client.id="" oidc.device.client.id=""
   kill_oidc
 }


### PR DESCRIPTION
Adds the `oidc_device_client_id` API extension with the `oidc.device.client.id` configuration key. The default value of the key is `oidc.client.id`. This allows an administrator to configure a separate client in the IdP which does not require a client secret, disables authorization code flow, and enables device flow.

I have tested this manually using Auth0.

Closes #17871 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
