### PR TITLE
lxd/db/dbgen: Fix govet "inline" error

### DIFF
--- a/lxd/db/dbgen/main.go
+++ b/lxd/db/dbgen/main.go
@@ -9,6 +9,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/fvbommel/sortorder"
-	"golang.org/x/exp/maps"
 )
 
 const (


### PR DESCRIPTION
The "inline" error is reported when a function should be replaced inline with another. This is typically when a function definition is moved (e.g. ioutil.ReadFile -> os.ReadFile). When this happens, the original function is annotated with "go:fix inline", which govet reports.

In this case, the maps.Copy function that was being used was mistakenly from the experimental package and needed to be replaced with the stdlib package.

Unblocks #18280.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
