### PR TITLE
lxd/storage/drivers: Fix LVM thin-pool usage calculation

### DIFF
--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -701,7 +701,7 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize
 		"--units", "b",
 		"--nosuffix",
 		"--separator", ",",
-		"-o", "lv_size,data_percent,metadata_percent",
+		"-o", "lv_size,data_percent,metadata_percent,lv_metadata_size",
 	}
 
 	out, err := shared.RunCommand(context.TODO(), "lvs", args...)
@@ -710,7 +710,7 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize
 	}
 
 	parts := shared.SplitNTrimSpace(out, ",", -1, true)
-	if len(parts) < 3 {
+	if len(parts) < 4 {
 		return 0, 0, errors.New("Unexpected output from lvs command")
 	}
 
@@ -739,7 +739,17 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize
 		}
 	}
 
-	usedSize = uint64(float64(totalSize) * ((dataPerc + metaPerc) / 100))
+	metadataSize := uint64(0)
+
+	// For thin volumes there is no metadata size. This is only for the thin pool volume itself.
+	if parts[3] != "" {
+		metadataSize, err = strconv.ParseUint(parts[3], 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("Failed parsing thin pool metadata size (%q): %w", parts[3], err)
+		}
+	}
+
+	usedSize = uint64(float64(totalSize)*dataPerc/100) + uint64(float64(metadataSize)*metaPerc/100)
 
 	return totalSize, usedSize, nil
 }


### PR DESCRIPTION
Fixes #18150 

`thinPoolVolumeUsage` queries `lvs` for `data_percent` and `metadata_percent` to calculate thin-pool usage. However, `metadata_percent` is relative to the metadata LV (typically a few MiB), not the data LV (`lv_size`). The old code applied both percentages to `totalSize` (the data LV), inflating the metadata component by ~1000x.

**Before:**
  usedSize = totalSize × (data_percent + metadata_percent) / 100

**After:**
  usedSize = (totalSize × data_percent / 100) + (lv_metadata_size × metadata_percent / 100)

## Reproduction

Empty pool (no containers):
  - `lvs` reports: `data_percent=0.00`, `metadata_percent=10.79`, `lv_metadata_size=8MiB`
  - Before fix: `lxc storage info` reported **883.92 MiB** used
  - After fix: **883.92 KiB** used ✓

With one Ubuntu 22.04 container:
  - Before fix: **2.75 GiB** reported
  - After fix: **1.37 GiB** reported ✓

## Notes

A unit test for `thinPoolVolumeUsage` would require either mocking `shared.RunCommand` or extracting the calculation into a pure function. The codebase currently has no infrastructure for the former, and the latter feels like scope creep for a bug fix. Happy to add one if maintainers have a preferred approach.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
