### PR TITLE
Refactor replication and project state handling

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -281,6 +281,7 @@ type InstanceServer interface {
 	GetProjects() (projects []api.Project, err error)
 	GetProject(name string) (project *api.Project, ETag string, err error)
 	GetProjectState(name string) (project *api.ProjectState, err error)
+	UpdateProjectState(name string, state api.ProjectStatePut, force bool) (op Operation, err error)
 	CreateProject(project api.ProjectsPost) (err error)
 	UpdateProject(name string, project api.ProjectPut, ETag string) (err error)
 	RenameProject(name string, project api.ProjectPost) (op Operation, err error)

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -82,6 +82,26 @@ func (r *ProtocolLXD) GetProjectState(name string) (*api.ProjectState, error) {
 	return &projectState, nil
 }
 
+// UpdateProjectState updates the project replica state (promote or demote).
+func (r *ProtocolLXD) UpdateProjectState(name string, state api.ProjectStatePut, force bool) (Operation, error) {
+	err := r.CheckExtension("project_replica_mode")
+	if err != nil {
+		return nil, err
+	}
+
+	u := api.NewURL().Path("projects", name, "state")
+	if force {
+		u = u.WithQuery("force", "true")
+	}
+
+	op, _, err := r.queryOperation(http.MethodPut, u.String(), state, "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
 // CreateProject defines a new container project.
 func (r *ProtocolLXD) CreateProject(project api.ProjectsPost) error {
 	err := r.CheckExtension("projects")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3117,3 +3117,7 @@ set unless {config:option}`server-oidc:oidc.client.id` is set.
 ## `storage_nvme_tcp`
 
 Renames storage pool NVMe/TCP mode from `nvme` to `nvme/tcp`.
+
+## `project_replica_mode`
+
+Adds a `replica_mode` field to projects and a new `PUT /1.0/projects/<name>/state` endpoint for promoting and demoting projects between leader and standby modes for replication.

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -15,7 +15,7 @@ Replicators are LXD entities that periodically copy instances from one cluster t
 Replication is configured at the project level. Both clusters have a project with the same name, and each project has a replica mode:
 
 - `leader`: The project is writable. Instances in this project are the source of replication. The replicator runs from this cluster.
-- `standby`: Instances in this project are replicas, kept in sync by the replicator. New instances cannot be created directly in this project; existing instances can still be managed. The project must be promoted to `leader` during a failover before instances can be started.
+- `standby`: Instances in this project are replicas, kept in sync by the replicator. New instances cannot be created directly in this project, and existing instances cannot be started. The project must be promoted to `leader` during a failover before instances can be started.
 
 Replica mode is managed via `lxc project promote-replica` and `lxc project demote-replica`. It is not a configuration key and cannot be set with `lxc project set`.
 

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -12,10 +12,14 @@ Replicators are LXD entities that periodically copy instances from one cluster t
 (exp-replicators-concepts)=
 ## Leader and standby projects
 
-Replication is configured at the project level. Both clusters have a project with the same name, and each project is assigned a {config:option}`project-replica:replica.mode`:
+Replication is configured at the project level. Both clusters have a project with the same name, and each project has a replica mode:
 
 - `leader`: The project is writable. Instances in this project are the source of replication. The replicator runs from this cluster.
 - `standby`: Instances in this project are replicas, kept in sync by the replicator. New instances cannot be created directly in this project; existing instances can still be managed. The project must be promoted to `leader` during a failover before instances can be started.
+
+Replica mode is managed via `lxc project promote-replica` and `lxc project demote-replica`. It is not a configuration key and cannot be set with `lxc project set`.
+
+Only the standby project needs the {config:option}`project-replica:replica.cluster` configuration key, which identifies the cluster link that is allowed to push replication data into it. The leader project does not need this key because the replicator defines the target cluster.
 
 The leader project pushes its instances to the standby project over the cluster link. The standby project mirrors the leader at the time of the last replicator run.
 
@@ -31,9 +35,9 @@ Replication can be triggered manually with `lxc replicator run`, or scheduled au
 (exp-replicators-failover)=
 ## Failover and recovery
 
-If the leader cluster fails, the standby project can be promoted by setting `replica.mode=leader` on the standby cluster. This makes the project writable and allows instances to be started.
+If the leader cluster fails, the standby project can be promoted with `lxc project promote-replica`. This makes the project writable and allows instances to be started. If the leader cluster is unreachable, validation against it is skipped automatically. Use `--force` to skip all validation without attempting to connect, which is useful when the leader is known to be down or during a planned takeover.
 
-When the original leader comes back online, it can be re-synced from the new leader by running the replicator in restore mode (`lxc replicator run --restore`), then returning both projects to their original roles. In restore mode, the remote leader's instance list is used as the authoritative source: instances that were created on the new leader after failover are also created on the recovering cluster, not just the instances that existed before the failure.
+When the original leader comes back online, it can be re-synced from the new leader by running the replicator in restore mode (`lxc replicator run --restore`), then returning both projects to their original roles with `lxc project demote-replica` and `lxc project promote-replica`. In restore mode, the remote leader's instance list is used as the authoritative source: instances that were created on the new leader after failover are also created on the recovering cluster, not just the instances that existed before the failure.
 
 See {ref}`howto-replicators-dr` for step-by-step instructions.
 
@@ -48,7 +52,7 @@ LXD supports two distinct approaches to cross-site disaster recovery:
 | **Mechanism** | Incremental instance refresh over cluster links | Vendor storage replication (Ceph RBD mirroring, PowerFlex RCG, etc.) |
 | **Scheduling** | Controlled by LXD ({config:option}`replicator-conf:schedule` config key) | Controlled by the storage vendor |
 | **Requires cluster link** | Yes | No |
-| **Recovery method** | Promote standby project with `replica.mode=leader` | Promote storage array, then run `lxd recover` |
+| **Recovery method** | Promote standby project with `lxc project promote-replica` | Promote storage array, then run `lxd recover` |
 | **Snapshot support** | Optional pre-replication snapshots | Depends on storage vendor |
 
 Use replicators when you want LXD to manage replication end-to-end across two clusters without dependency on a specific storage backend. Use {ref}`storage replication <disaster-recovery-replication>` when you need replication at the storage array level, or when you are not using cluster links.

--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -121,20 +121,27 @@ lxc replicator set <replicator_name> schedule="0 0 * * *"
 (howto-replicators-snapshot)=
 ## Snapshot before replication
 
-When you set `snapshot=true` on a replicator, LXD creates a point-in-time snapshot of each source
-instance before performing the incremental refresh to the standby cluster. This gives you a
-consistent rollback point on the source in case anything goes wrong during replication.
+Each replicator run performs an incremental instance sync to the standby cluster using
+the equivalent of `lxc copy --refresh`. This transfers only the data that has changed since the last sync,
+using any existing snapshots as a reference point to minimize the amount of data transferred.
 
-Snapshot naming and expiry are controlled entirely by the instance's own configuration (for example
-{config:option}`instance-snapshots:snapshots.pattern` and {config:option}`instance-snapshots:snapshots.expiry`), or by the profile applied to the instance. The
-replicator does not impose its own naming scheme.
+When you set `snapshot=true` on a replicator, LXD creates a point-in-time snapshot of each
+source instance before performing the incremental copy. This gives the copy operation a
+consistent reference point, which reduces the amount of data transferred on each sync and
+provides a rollback point on the source in case anything goes wrong during replication.
 
-If an instance already has a {config:option}`instance-snapshots:snapshots.schedule` set at the instance or profile level, the
-replicator skips creating a new snapshot and reuses the most recent existing snapshot for the
-incremental refresh instead.
+Snapshot naming and expiry are controlled entirely by the instance's own configuration (for
+example {config:option}`instance-snapshots:snapshots.pattern` and
+{config:option}`instance-snapshots:snapshots.expiry`), or by the profile applied to the
+instance. The replicator does not impose its own naming scheme.
 
-When `snapshot` is not set (or set to `false`), no new snapshot is created. If a previous snapshot
-already exists on the instance, it is reused naturally by the incremental refresh.
+If an instance already has a {config:option}`instance-snapshots:snapshots.schedule` set at
+the instance or profile level, the replicator skips creating a new snapshot and reuses the
+most recent existing snapshot as the reference point for the incremental copy instead.
+
+When `snapshot` is not set (or set to `false`), no new snapshot is created before the
+incremental copy runs. If existing snapshots are present on the instance, the copy operation
+uses them to transfer only the delta; if no snapshots exist, the full instance is transferred.
 
 ```{note}
 Snapshots created by replication accumulate over time. Use `snapshots.expiry` on the instance or

--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -44,37 +44,38 @@ Then create the cluster links with that authentication group, as described in {r
 (howto-replicators-project-setup)=
 ## Configure projects for replication
 
-Both clusters need a project configured with the {config:option}`project-replica:replica.cluster` and {config:option}`project-replica:replica.mode` settings.
+Both clusters need a project with the same name. Only the standby project requires the {config:option}`project-replica:replica.cluster` configuration key; the leader project does not need it because the replicator defines the target cluster.
 
-1. On the leader cluster, create a project and configure it to link to the standby cluster:
+1. On the leader cluster, create a project:
 
    ```bash
-   lxc project create <project_name> -c replica.cluster=<standby_cluster_link_name>
+   lxc project create <project_name>
    ```
 
-1. On the standby cluster, create a project with the same name and configure it to link to the leader cluster:
+1. On the standby cluster, create a project with the same name and configure it to accept replication from the leader cluster:
 
    ```bash
    lxc project create <project_name> -c replica.cluster=<leader_cluster_link_name>
    ```
 
-1. On the standby cluster, set the project's replica mode to `standby`. This prevents new instances from being created in the project directly; existing instances can still be managed until the project is promoted to `leader` during a failover.
+1. On the standby cluster, demote the project to standby mode. This prevents new instances from being created in the project directly; existing instances can still be managed until the project is promoted to `leader` during a failover.
 
    ```bash
-   lxc project set <project_name> replica.mode=standby
+   lxc project demote-replica <project_name>
    ```
 
-1. On the leader cluster, set the project's replica mode to `leader`.
+1. On the leader cluster, promote the project to leader mode:
 
    ```bash
-   lxc project set <project_name> replica.mode=leader
+   lxc project promote-replica <project_name>
    ```
 
-```{admonition} Setting the leader
+```{admonition} Promote validation
 :class: note
 
-Setting `replica.mode=leader` on the leader cluster requires the target project on the standby cluster to already have `replica.mode=standby` set.
+The `lxc project promote-replica` command validates that all target projects (on clusters referenced by the project's replicators) are in standby mode before allowing the promotion.
 This ensures that new instances are not created on a standby cluster between replicator runs.
+If a target cluster is unreachable, promotion still proceeds to allow disaster recovery scenarios where the target may be offline.
 ```
 
 (howto-replicators-create)=

--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -58,7 +58,7 @@ Both clusters need a project with the same name. Only the standby project requir
    lxc project create <project_name> -c replica.cluster=<leader_cluster_link_name>
    ```
 
-1. On the standby cluster, demote the project to standby mode. This prevents new instances from being created in the project directly; existing instances can still be managed until the project is promoted to `leader` during a failover.
+1. On the standby cluster, demote the project to standby mode. This prevents new instances from being created in the project and existing instances from being started. The project must be promoted to `leader` during a failover before instances can be started.
 
    ```bash
    lxc project demote-replica <project_name>

--- a/doc/howto/replicators_dr.md
+++ b/doc/howto/replicators_dr.md
@@ -16,7 +16,13 @@ If the leader cluster becomes unavailable, you can manually fail over to the sta
 On the standby cluster, promote the replica project to become the leader:
 
 ```bash
-lxc project set <project_name> replica.mode=leader
+lxc project promote-replica <project_name>
+```
+
+If the leader cluster is unreachable, promotion proceeds automatically without requiring validation. Use `--force` to skip validation when the leader cluster is still reachable but you want to promote anyway (for example, during a planned takeover before demoting the leader):
+
+```bash
+lxc project promote-replica <project_name> --force
 ```
 
 After this command, the project on the standby cluster becomes writable. Start the instances to resume your workloads:
@@ -27,9 +33,9 @@ lxc start --all --project <project_name>
 
 ## Recovering the original leader cluster
 
-When the original leader cluster comes back online, it will be out of sync with the new leader (the former standby). Scheduled replicator runs on the original leader cluster will fail because both projects have `replica.mode=leader`.
+When the original leader cluster comes back online, it will be out of sync with the new leader (the former standby). Scheduled replicator runs on the original leader cluster will fail because both projects are in leader mode.
 
-A replicator run requires the source project to have `replica.mode=leader` and the target project to have `replica.mode=standby`.
+A replicator run requires the source project to be in leader mode and the target project to be in standby mode.
 
 To restore the original leader cluster and resume the original replication direction:
 
@@ -42,10 +48,16 @@ The `--restore` action is rejected if any local instance is running, to prevent 
 lxc stop <instance_name> [<instance_name>...] --force
 ```
 
-Set the project on the original leader cluster to standby mode:
+Demote the project on the original leader cluster to standby mode:
 
 ```bash
-lxc project set <project_name> replica.mode=standby
+lxc project demote-replica <project_name>
+```
+
+If the new leader cluster is unreachable, use `--force` to skip the validation:
+
+```bash
+lxc project demote-replica <project_name> --force
 ```
 
 On the original leader cluster, run the replicator in restore mode to pull data from the new leader:
@@ -60,16 +72,16 @@ The original leader cluster is now a standby replica of the new leader cluster.
 
 ### 2. Resume original replication direction
 
-To return to the original setup where the original leader cluster replicates to the standby, stop any running instances in the project for the new leader cluster (former standby). Next, set the project on the new leader cluster back to standby mode:
+To return to the original setup where the original leader cluster replicates to the standby, stop any running instances in the project on the new leader cluster (former standby). Next, demote the project on the new leader cluster back to standby mode:
 
 ```bash
-lxc project set <project_name> replica.mode=standby
+lxc project demote-replica <project_name>
 ```
 
-Finally, set the project on the original leader cluster back to leader mode:
+Finally, promote the project on the original leader cluster back to leader mode:
 
 ```bash
-lxc project set <project_name> replica.mode=leader
+lxc project promote-replica <project_name>
 ```
 
 Your original active-passive disaster recovery setup is now restored. You can restart your instances on the leader cluster and resume your scheduled replicator runs.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4240,17 +4240,9 @@ This value is the maximum value for the sum of the individual {config:option}`in
 <!-- config group project-limits end -->
 <!-- config group project-replica start -->
 ```{config:option} replica.cluster project-replica
-:shortdesc: "Cluster link used for replication (source or target)."
+:shortdesc: "Cluster link allowed to replicate to this standby project."
 :type: "string"
-
-```
-
-```{config:option} replica.mode project-replica
-:shortdesc: "Replica project mode."
-:type: "string"
-The replica project mode. When set, the project acts as a replica project. Possible values are `standby` and `leader`.
-In `standby` mode, instances cannot be created in the project; existing instances may still be managed until the project is promoted to `leader` during a failover.
-In `leader` mode, the project is writable and is the source of replication.
+This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.
 ```
 
 <!-- config group project-replica end -->

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4975,6 +4975,12 @@ definitions:
                 readOnly: true
                 type: string
                 x-go-name: Name
+            replica_mode:
+                description: Replica mode for the project (leader, standby, or empty)
+                example: leader
+                readOnly: true
+                type: string
+                x-go-name: ReplicaMode
             used_by:
                 description: List of URLs of objects using this project
                 example:
@@ -5036,6 +5042,16 @@ definitions:
                 readOnly: true
                 type: object
                 x-go-name: Resources
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    ProjectStatePut:
+        description: ProjectStatePut represents the fields for updating project replica state
+        properties:
+            replica_mode:
+                description: 'Replica mode to set: "leader" or "standby"'
+                example: leader
+                type: string
+                x-go-name: ReplicaMode
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     ProjectStateResource:
@@ -16579,6 +16595,39 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Get the project state
+            tags:
+                - projects
+        put:
+            consumes:
+                - application/json
+            description: Promotes or demotes the project for replication.
+            operationId: project_state_put
+            parameters:
+                - description: Skip validation of remote project states
+                  example: false
+                  in: query
+                  name: force
+                  type: boolean
+                - description: Project state
+                  in: body
+                  name: state
+                  required: true
+                  schema:
+                    $ref: '#/definitions/ProjectStatePut'
+            produces:
+                - application/json
+            responses:
+                "202":
+                    $ref: '#/responses/Operation'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Update the project replica state
             tags:
                 - projects
     /1.0/projects?recursion=1:

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -79,6 +79,14 @@ func (c *cmdProject) command() *cobra.Command {
 	projectGetCurrentCmd := cmdProjectGetCurrent{global: c.global, project: c}
 	cmd.AddCommand(projectGetCurrentCmd.command())
 
+	// Promote
+	projectPromoteCmd := cmdProjectPromote{global: c.global, project: c}
+	cmd.AddCommand(projectPromoteCmd.command())
+
+	// Demote
+	projectDemoteCmd := cmdProjectDemote{global: c.global, project: c}
+	cmd.AddCommand(projectDemoteCmd.command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
@@ -491,6 +499,7 @@ func (c *cmdProjectList) columns() []cli.ShorthandColumn[api.Project] {
 		{Shorthand: 'z', Name: "NETWORK ZONES", Data: c.networkZonesColumnData},
 		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
 		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
+		{Shorthand: 'r', Name: "REPLICA MODE", Data: c.replicaModeColumnData},
 	}
 }
 
@@ -629,6 +638,14 @@ func (c *cmdProjectList) descriptionColumnData(project api.Project) string {
 
 func (c *cmdProjectList) usedByColumnData(project api.Project) string {
 	return strconv.Itoa(len(project.UsedBy))
+}
+
+func (c *cmdProjectList) replicaModeColumnData(project api.Project) string {
+	if project.ReplicaMode == "" {
+		return "-"
+	}
+
+	return strings.ToUpper(project.ReplicaMode)
 }
 
 // Rename.
@@ -1099,4 +1116,142 @@ func (c *cmdProjectInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return cli.RenderTable(c.flagFormat, header, data, projectState)
+}
+
+// Promote.
+type cmdProjectPromote struct {
+	global  *cmdGlobal
+	project *cmdProject
+
+	flagForce bool
+}
+
+func (c *cmdProjectPromote) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("promote-replica", "[<remote>:]<project>")
+	cmd.Short = "Promote project to leader mode for replication"
+	cmd.Long = cli.FormatSection("Description",
+		`Promotes the project to leader mode for replication.
+
+This validates that all replicator targets are in standby mode unless --force is specified.`)
+
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of remote project states")
+
+	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpTopLevelResource("project", toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+func (c *cmdProjectPromote) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New("Missing project name")
+	}
+
+	// Promote the project
+	op, err := resource.server.UpdateProjectState(resource.name, api.ProjectStatePut{ReplicaMode: api.ReplicatorProjectModeLeader}, c.flagForce)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf("Project %s promoted to leader mode\n", resource.name)
+	}
+
+	return nil
+}
+
+// Demote.
+type cmdProjectDemote struct {
+	global  *cmdGlobal
+	project *cmdProject
+
+	flagForce bool
+}
+
+func (c *cmdProjectDemote) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("demote-replica", "[<remote>:]<project>")
+	cmd.Short = "Demote project to standby mode for replication"
+	cmd.Long = cli.FormatSection("Description",
+		`Demotes the project to standby mode for replication.
+
+The project must have replica.cluster config set to identify which cluster can replicate to it, unless --force is specified.`)
+
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of replica.cluster config")
+
+	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpTopLevelResource("project", toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+func (c *cmdProjectDemote) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New("Missing project name")
+	}
+
+	// Demote the project
+	op, err := resource.server.UpdateProjectState(resource.name, api.ProjectStatePut{ReplicaMode: api.ReplicatorProjectModeStandby}, c.flagForce)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf("Project %s demoted to standby mode\n", resource.name)
+	}
+
+	return nil
 }

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -65,6 +65,7 @@ var projectStateCmd = APIEndpoint{
 	MetricsType: entity.TypeProject,
 
 	Get: APIEndpointAction{Handler: projectStateGet, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanView, "name")},
+	Put: APIEndpointAction{Handler: projectStatePut, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanEdit, "name")},
 }
 
 // swagger:operation GET /1.0/projects projects projects_get
@@ -1469,6 +1470,271 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponse(true, &state)
 }
 
+// swagger:operation PUT /1.0/projects/{name}/state projects project_state_put
+//
+//	Update the project replica state
+//
+//	Promotes or demotes the project for replication.
+//
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: force
+//	    description: Skip validation of remote project states
+//	    type: boolean
+//	    example: false
+//	  - in: body
+//	    name: state
+//	    description: Project state
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProjectStatePut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func projectStatePut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	name := r.PathValue("name")
+
+	req := api.ProjectStatePut{}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	force := shared.IsTrue(r.URL.Query().Get("force"))
+
+	var run func(ctx context.Context, op *operations.Operation) error
+	switch req.ReplicaMode {
+	case api.ReplicatorProjectModeLeader:
+		run = func(ctx context.Context, op *operations.Operation) error {
+			return projectPromote(ctx, s, name, force)
+		}
+
+	case api.ReplicatorProjectModeStandby:
+		run = func(ctx context.Context, op *operations.Operation) error {
+			return projectDemote(ctx, s, name, force)
+		}
+
+	default:
+		return response.BadRequest(fmt.Errorf("Unknown replica mode %q", req.ReplicaMode))
+	}
+
+	op, err := operations.ScheduleUserOperationFromRequest(s, r, operations.OperationArgs{
+		Type:      operationtype.ProjectReplicaModeUpdate,
+		Class:     operations.OperationClassTask,
+		EntityURL: entity.ProjectURL(name),
+		RunHook:   run,
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return operations.OperationResponse(op)
+}
+
+// validateProjectPromote validates that a project is ready to be promoted to leader mode.
+// It checks that the source cluster's project is no longer in leader mode, and that all
+// replicator target clusters have their project in standby mode.
+func validateProjectPromote(ctx context.Context, s *state.State, projectName string, project *api.Project, replicators []dbCluster.Replicator, allConfigs map[int64]map[string]string) error {
+	clusterCert := s.Endpoints.NetworkCert()
+
+	// Check the old leader (identified by replica.cluster config) is unreachable or already demoted.
+	sourceClusterLinkName := project.Config["replica.cluster"]
+	if sourceClusterLinkName != "" {
+		var clusterLink *api.ClusterLink
+		var targetCert *x509.Certificate
+		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), sourceClusterLinkName)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("Failed loading cluster link %q: %w", sourceClusterLinkName, err)
+		}
+
+		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+		sourceClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
+		if err != nil {
+			// Source cluster is unreachable, allow failover promotion.
+			logger.Warn("Failed connecting to source cluster, allowing failover promotion", logger.Ctx{"clusterLink": sourceClusterLinkName, "err": err})
+		} else {
+			defer sourceClient.Disconnect()
+
+			sourceProject, _, err := sourceClient.GetProject(projectName)
+			if err != nil {
+				return fmt.Errorf("Failed getting project %q from source cluster %q: %w", projectName, sourceClusterLinkName, err)
+			}
+
+			if sourceProject.ReplicaMode == api.ReplicatorProjectModeLeader {
+				return fmt.Errorf("Source project %q on cluster %q is still in leader mode, demote it first or use --force", projectName, sourceClusterLinkName)
+			}
+		}
+	}
+
+	// Check all replicator targets are in standby mode.
+	for _, replicator := range replicators {
+		config := allConfigs[replicator.Row.ID]
+		clusterLinkName := config["cluster"]
+		if clusterLinkName == "" {
+			continue
+		}
+
+		var clusterLink *api.ClusterLink
+		var targetCert *x509.Certificate
+		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("Failed loading cluster link %q: %w", clusterLinkName, err)
+		}
+
+		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+		targetClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
+		if err != nil {
+			// Skip unreachable clusters to allow for disaster recovery failover.
+			logger.Warn("Failed connecting to target cluster, skipping validation", logger.Ctx{"clusterLink": clusterLinkName, "err": err})
+			continue
+		}
+
+		targetProject, _, err := targetClient.GetProject(projectName)
+		if err != nil {
+			targetClient.Disconnect()
+			return fmt.Errorf("Failed getting target project %q from cluster %q: %w", projectName, clusterLinkName, err)
+		}
+
+		if targetProject.ReplicaMode != api.ReplicatorProjectModeStandby {
+			targetClient.Disconnect()
+			return fmt.Errorf("Target project %q on cluster %q is not in standby mode", projectName, clusterLinkName)
+		}
+
+		targetClient.Disconnect()
+	}
+
+	return nil
+}
+
+// projectPromote promotes the project to leader mode for replication.
+func projectPromote(ctx context.Context, s *state.State, projectName string, force bool) error {
+	var project *api.Project
+	var replicators []dbCluster.Replicator
+	var allConfigs map[int64]map[string]string
+
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		// Load all replicators for this project.
+		replicators, _, err = dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, func(_ dbCluster.Replicator) bool { return true })
+		if err != nil {
+			return fmt.Errorf("Failed loading replicators for project %q: %w", projectName, err)
+		}
+
+		replicatorIDList := make([]int64, 0, len(replicators))
+		for _, r := range replicators {
+			replicatorIDList = append(replicatorIDList, r.Row.ID)
+		}
+
+		allConfigs, err = dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), replicatorIDList...)
+		if err != nil {
+			return fmt.Errorf("Failed loading replicator configs: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if project.ReplicaMode == api.ReplicatorProjectModeLeader {
+		return fmt.Errorf("Project %q is already in leader mode", projectName)
+	}
+
+	if !force {
+		err = validateProjectPromote(ctx, s, projectName, project, replicators, allConfigs)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Update the replica mode to leader.
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.UpdateProjectReplicaMode(ctx, tx.Tx(), projectName, api.ReplicatorProjectModeLeader)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed updating project replica mode: %w", err)
+	}
+
+	s.Events.SendLifecycle(projectName, lifecycle.ProjectUpdated.Event(projectName, request.CreateRequestor(ctx), nil))
+
+	return nil
+}
+
+// projectDemote demotes the project to standby mode for replication.
+func projectDemote(ctx context.Context, s *state.State, projectName string, force bool) error {
+	var project *api.Project
+
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if project.ReplicaMode == api.ReplicatorProjectModeStandby {
+		return fmt.Errorf("Project %q is already in standby mode", projectName)
+	}
+
+	// Require replica.cluster config to be set so the standby knows which cluster can write to it.
+	if !force && project.Config["replica.cluster"] == "" {
+		return fmt.Errorf("Project %q must have replica.cluster config set before demoting to standby mode", projectName)
+	}
+
+	// Update the replica mode to standby.
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.UpdateProjectReplicaMode(ctx, tx.Tx(), projectName, api.ReplicatorProjectModeStandby)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed updating project replica mode: %w", err)
+	}
+
+	s.Events.SendLifecycle(projectName, lifecycle.ProjectUpdated.Event(projectName, request.CreateRequestor(ctx), nil))
+
+	return nil
+}
+
 // Check if a project is empty. When skipURLs are provided, those entities are ignored when checking if the project is empty.
 func projectIsEmpty(ctx context.Context, project *dbCluster.Project, tx *db.ClusterTx, skipURLs ...string) (bool, error) {
 	usedBy, err := projectUsedBy(ctx, tx, project)
@@ -1880,10 +2146,10 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 		"restricted.snapshots": isEitherAllowOrBlock,
 
 		// lxdmeta:generate(entities=project; group=replica; key=replica.cluster)
-		//
+		// This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.
 		// ---
 		//  type: string
-		//  shortdesc: Cluster link used for replication (source or target).
+		//  shortdesc: Cluster link allowed to replicate to this standby project.
 		"replica.cluster": validate.Optional(func(value string) error {
 			err := s.DB.Cluster.Transaction(ctx, func(dbCtx context.Context, tx *db.ClusterTx) error {
 				_, err := dbCluster.GetClusterLink(dbCtx, tx.Tx(), value)
@@ -1898,62 +2164,6 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 			}
 
 			return s.Authorizer.CheckPermission(ctx, entity.ClusterLinkURL(value), auth.EntitlementCanView)
-		}),
-
-		// lxdmeta:generate(entities=project; group=replica; key=replica.mode)
-		// The replica project mode. When set, the project acts as a replica project. Possible values are `standby` and `leader`.
-		// In `standby` mode, instances cannot be created in the project; existing instances may still be managed until the project is promoted to `leader` during a failover.
-		// In `leader` mode, the project is writable and is the source of replication.
-		// ---
-		//  type: string
-		//  shortdesc: Replica project mode.
-		"replica.mode": validate.Optional(func(value string) error {
-			if config["replica.cluster"] == "" {
-				return errors.New(`"replica.mode" can only be set when "replica.cluster" is set`)
-			}
-
-			switch value {
-			case "standby":
-				return nil
-			case "leader":
-				clusterLinkName := config["replica.cluster"]
-
-				var clusterLink *api.ClusterLink
-				var targetCert *x509.Certificate
-				err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-					var err error
-					_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
-					return err
-				})
-				if err != nil {
-					return err
-				}
-
-				// Skip the check if the target is unreachable to allow for disaster recovery failover.
-				clusterCert := s.Endpoints.NetworkCert()
-
-				args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
-				targetClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
-				if err != nil {
-					logger.Warn("Failed connecting to target cluster link, skipping replica.mode validation", logger.Ctx{"clusterLink": clusterLinkName, "err": err})
-					return nil
-				}
-
-				defer targetClient.Disconnect()
-
-				targetProject, _, err := targetClient.GetProject(projectName)
-				if err != nil {
-					return fmt.Errorf("Failed getting target project %q: %w", projectName, err)
-				}
-
-				if targetProject.Config["replica.mode"] != "standby" {
-					return errors.New(`Target project must have "replica.mode" set to standby when setting "replica.mode" to leader on the source project`)
-				}
-
-				return nil
-			default:
-				return fmt.Errorf(`Invalid "replica.mode" value %q, must be one of: leader, standby`, value)
-			}
 		}),
 	}
 

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1163,12 +1163,17 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Failed getting instance %q from current leader cluster: %w", instName, err)
 			}
 
-			// If the instance lives on another cluster member, forward the restore
+			// If the instance lives on a remote cluster member, forward the restore
 			// migration to that member so the refresh runs where the storage volume is.
+			// Instances on the local member (including unclustered servers) are handled
+			// directly below. This mirrors the logic in replicateInstance.
 			var memberAddress string
 			for _, inst := range allInsts {
 				if inst.Name() == instName {
-					memberAddress = nodeAddressByName[inst.Location()]
+					if inst.Location() != s.ServerName {
+						memberAddress = nodeAddressByName[inst.Location()]
+					}
+
 					break
 				}
 			}
@@ -1297,8 +1302,25 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Failed getting websocket secrets from local sink for instance %q: %w", instName, err)
 			}
 
-			// Build the operation URL using this node's cluster address.
+			// Build the operation URL using a reachable address for this server.
+			// For clustered members the address from the nodes table is already a
+			// concrete, registered address. For unclustered servers the nodes table
+			// stores the sentinel "0.0.0.0", so fall back to the configured HTTPS
+			// address. Return an error if we still cannot determine a concrete address,
+			// because the leader would not be able to reach us.
 			localAddress := nodeAddressByName[s.ServerName]
+			if util.IsWildCardAddress(localAddress) {
+				localAddress = s.LocalConfig.ClusterAddress()
+				if localAddress == "" {
+					localAddress = s.LocalConfig.HTTPSAddress()
+				}
+
+				if util.IsWildCardAddress(localAddress) || localAddress == "" {
+					sinkOp.Cancel()
+					return errors.New("Cannot restore to this server: configure a concrete address using cluster.https_address or core.https_address")
+				}
+			}
+
 			sinkOpURL := "https://" + localAddress + sinkOp.URL()
 
 			// Tell the current leader cluster to push-migrate the instance to our local sink.

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1040,7 +1040,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 		return operations.OperationArgs{}, fmt.Errorf("Failed getting target project: %w", err)
 	}
 
-	err = validateReplicatorModes(sourceProject.Config["replica.mode"], targetProject.Config["replica.mode"], restore)
+	err = validateReplicatorModes(sourceProject.ReplicaMode, targetProject.ReplicaMode, restore)
 	if err != nil {
 		return operations.OperationArgs{}, api.StatusErrorf(http.StatusBadRequest, "%s", err)
 	}
@@ -1618,7 +1618,7 @@ func runScheduledReplicators(ctx context.Context, s *state.State) error {
 		return err
 	}
 
-	// Build a per-project replica.mode map so the loop can skip standby projects
+	// Build a per-project replica mode map so the loop can skip standby projects
 	// without an extra DB round-trip per replicator.
 	projectModes := make(map[string]string, len(apiReplicators))
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
@@ -1628,12 +1628,12 @@ func runScheduledReplicators(ctx context.Context, s *state.State) error {
 				continue
 			}
 
-			config, err := dbCluster.GetProjectConfig(ctx, tx.Tx(), replicator.Project)
+			dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), replicator.Project)
 			if err != nil {
-				return fmt.Errorf("Failed loading project config for %q: %w", replicator.Project, err)
+				return fmt.Errorf("Failed loading project %q: %w", replicator.Project, err)
 			}
 
-			projectModes[replicator.Project] = config["replica.mode"]
+			projectModes[replicator.Project] = string(dbProject.ReplicaMode)
 		}
 
 		return nil
@@ -1744,19 +1744,19 @@ func triggerScheduledReplicator(ctx context.Context, s *state.State, replicator 
 func validateReplicatorModes(sourceMode string, targetMode string, restore bool) error {
 	if restore {
 		if sourceMode != api.ReplicatorProjectModeStandby {
-			return errors.New(`Source project must have "replica.mode" set to standby to run replicator in restore mode`)
+			return errors.New("Source project must be in standby mode to run replicator in restore mode")
 		}
 
 		if targetMode != api.ReplicatorProjectModeLeader {
-			return errors.New(`Target project must have "replica.mode" set to leader to run replicator in restore mode`)
+			return errors.New("Target project must be in leader mode to run replicator in restore mode")
 		}
 	} else {
 		if sourceMode != api.ReplicatorProjectModeLeader {
-			return errors.New(`Source project must have "replica.mode" set to leader to run replicator`)
+			return errors.New("Source project must be in leader mode to run replicator")
 		}
 
 		if targetMode != api.ReplicatorProjectModeStandby {
-			return errors.New(`Target project must have "replica.mode" set to standby to run replicator`)
+			return errors.New("Target project must be in standby mode to run replicator")
 		}
 	}
 

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -5,6 +5,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"net/http"
 
@@ -35,6 +36,57 @@ import (
 //go:generate mapper method -i -e project DeleteOne-by-Name
 //go:generate goimports -w projects.mapper.go
 //go:generate goimports -w projects.interface.mapper.go
+
+// ProjectReplicaMode represents the replica mode of a project stored as an integer in the database.
+//
+// This type implements the [sql.Scanner] and [driver.Valuer] interfaces to automatically handle
+// conversion between API constants and their int64 representation in the database.
+// When reading from the database, int64 values are converted back to their API constant.
+// When writing to the database, API constants are converted to their int64 representation.
+type ProjectReplicaMode string
+
+const (
+	projectReplicaModeNone    int64 = 0
+	projectReplicaModeLeader  int64 = 1
+	projectReplicaModeStandby int64 = 2
+)
+
+// ScanInteger implements [query.IntegerScanner] for [ProjectReplicaMode].
+func (p *ProjectReplicaMode) ScanInteger(code int64) error {
+	switch code {
+	case projectReplicaModeNone:
+		*p = ""
+	case projectReplicaModeLeader:
+		*p = api.ReplicatorProjectModeLeader
+	case projectReplicaModeStandby:
+		*p = api.ReplicatorProjectModeStandby
+	default:
+		return fmt.Errorf("Unknown project replica mode %d", code)
+	}
+
+	return nil
+}
+
+// Scan implements [sql.Scanner] for [ProjectReplicaMode]. This converts the database integer value
+// back into the correct API constant or returns an error.
+func (p *ProjectReplicaMode) Scan(value any) error {
+	return query.ScanValue(value, p, false)
+}
+
+// Value implements [driver.Valuer] for [ProjectReplicaMode]. This converts the API constant into
+// its integer database representation or returns an error.
+func (p ProjectReplicaMode) Value() (driver.Value, error) {
+	switch p {
+	case "":
+		return projectReplicaModeNone, nil
+	case api.ReplicatorProjectModeLeader:
+		return projectReplicaModeLeader, nil
+	case api.ReplicatorProjectModeStandby:
+		return projectReplicaModeStandby, nil
+	}
+
+	return nil, fmt.Errorf("Invalid project replica mode %q", p)
+}
 
 // ProjectFeature indicates the behaviour of a project feature.
 type ProjectFeature struct {
@@ -71,7 +123,8 @@ var ProjectFeatures = map[string]ProjectFeature{
 type Project struct {
 	ID          int
 	Description string
-	Name        string `db:"omit=update"`
+	Name        string             `db:"omit=update"`
+	ReplicaMode ProjectReplicaMode `db:"omit=update"`
 }
 
 // ProjectFilter specifies potential query parameter fields.

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -138,6 +138,7 @@ func (p *Project) ToAPI(ctx context.Context, tx *sql.Tx) (*api.Project, error) {
 	apiProject := &api.Project{
 		Name:        p.Name,
 		Description: p.Description,
+		ReplicaMode: string(p.ReplicaMode),
 	}
 
 	var err error

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -374,3 +374,22 @@ func GetAllProjectsConfig(ctx context.Context, tx *sql.Tx) (map[string]map[strin
 
 	return projectConfigs, nil
 }
+
+// UpdateProjectReplicaMode updates the replica_mode field for the project with the given name.
+func UpdateProjectReplicaMode(ctx context.Context, tx *sql.Tx, projectName string, replicaMode string) error {
+	result, err := tx.ExecContext(ctx, `UPDATE projects SET replica_mode = ? WHERE name = ?`, ProjectReplicaMode(replicaMode), projectName)
+	if err != nil {
+		return err
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if n != 1 {
+		return fmt.Errorf("Query updated %d rows instead of 1", n)
+	}
+
+	return nil
+}

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -19,28 +19,28 @@ import (
 var _ = api.ServerEnvironment{}
 
 var projectObjects = RegisterStmt(`
-SELECT projects.id, projects.description, projects.name
+SELECT projects.id, projects.description, projects.name, projects.replica_mode
   FROM projects
   ORDER BY projects.name
 `)
 
 var projectObjectsByName = RegisterStmt(`
-SELECT projects.id, projects.description, projects.name
+SELECT projects.id, projects.description, projects.name, projects.replica_mode
   FROM projects
   WHERE ( projects.name = ? )
   ORDER BY projects.name
 `)
 
 var projectObjectsByID = RegisterStmt(`
-SELECT projects.id, projects.description, projects.name
+SELECT projects.id, projects.description, projects.name, projects.replica_mode
   FROM projects
   WHERE ( projects.id = ? )
   ORDER BY projects.name
 `)
 
 var projectCreate = RegisterStmt(`
-INSERT INTO projects (description, name)
-  VALUES (?, ?)
+INSERT INTO projects (description, name, replica_mode)
+  VALUES (?, ?, ?)
 `)
 
 var projectID = RegisterStmt(`
@@ -68,7 +68,7 @@ func getProjects(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Project, e
 
 	dest := func(scan func(dest ...any) error) error {
 		p := Project{}
-		err := scan(&p.ID, &p.Description, &p.Name)
+		err := scan(&p.ID, &p.Description, &p.Name, &p.ReplicaMode)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func getProjectsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([
 
 	dest := func(scan func(dest ...any) error) error {
 		p := Project{}
-		err := scan(&p.ID, &p.Description, &p.Name)
+		err := scan(&p.ID, &p.Description, &p.Name, &p.ReplicaMode)
 		if err != nil {
 			return err
 		}
@@ -225,11 +225,12 @@ func GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error) 
 // CreateProject adds a new project to the database.
 // generator: project Create
 func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, error) {
-	args := make([]any, 2)
+	args := make([]any, 3)
 
 	// Populate the statement arguments.
 	args[0] = object.Description
 	args[1] = object.Name
+	args[2] = object.ReplicaMode
 
 	// Prepared statement to use.
 	stmt, err := Stmt(tx, projectCreate)

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -565,6 +565,7 @@ CREATE TABLE "projects" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name TEXT NOT NULL,
     description TEXT NOT NULL,
+    replica_mode INTEGER NOT NULL DEFAULT 0,
     UNIQUE (name)
 );
 CREATE TABLE "projects_config" (
@@ -789,5 +790,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (85, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (86, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -129,6 +129,45 @@ var updates = map[int]schema.Update{
 	83: updateFromV82,
 	84: updateFromV83,
 	85: updateFromV84,
+	86: updateFromV85,
+}
+
+func updateFromV85(ctx context.Context, tx *sql.Tx) error {
+	// Add replica_mode column to projects table as an integer.
+	// 0 = none (default), 1 = leader, 2 = standby.
+	_, err := tx.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN replica_mode INTEGER NOT NULL DEFAULT 0`)
+	if err != nil {
+		return err
+	}
+
+	// Migrate existing replica.mode config values into the new column.
+	// This preserves leader/standby configuration for projects that had
+	// replica.mode set via the legacy config key on previous versions.
+	_, err = tx.ExecContext(ctx, `
+UPDATE projects
+SET replica_mode = (
+	SELECT CASE projects_config.value
+		WHEN 'leader'  THEN 1
+		WHEN 'standby' THEN 2
+		ELSE 0
+	END
+	FROM projects_config
+	WHERE projects_config.project_id = projects.id
+		AND projects_config.key = 'replica.mode'
+)
+WHERE EXISTS (
+	SELECT 1
+	FROM projects_config
+	WHERE projects_config.project_id = projects.id
+		AND projects_config.key = 'replica.mode'
+)`)
+	if err != nil {
+		return err
+	}
+
+	// Remove the legacy replica.mode config key now that it is stored in the projects table.
+	_, err = tx.ExecContext(ctx, `DELETE FROM projects_config WHERE key = 'replica.mode'`)
+	return err
 }
 
 func updateFromV84(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -446,7 +446,7 @@ INSERT INTO profiles_devices_config VALUES(4, 2, 'pool', 'default');
 
 	// Create a new project.
 	_, err = tx.Exec(`
-INSERT INTO projects VALUES (2, 'staging', 'Staging environment')`)
+INSERT INTO projects (id, name, description) VALUES (2, 'staging', 'Staging environment')`)
 	require.NoError(t, err)
 
 	// Check that it's possible to have two containers with the same name

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -141,6 +141,7 @@ const (
 	NetworkZoneRecordDelete
 	ReplicatorRun
 	ReplicatorRunInstance
+	ProjectReplicaModeUpdate
 
 	// upperBound is used only to enforce consistency in the package on init.
 	// Make sure it's always the last item in this list.
@@ -384,6 +385,8 @@ func (t Type) Description() string {
 		return "Running replicator"
 	case ReplicatorRunInstance:
 		return "Replicating instance"
+	case ProjectReplicaModeUpdate:
+		return "Updating project replica mode"
 
 	// It should never be possible to reach the default clause.
 	// See the init function.
@@ -410,7 +413,7 @@ func (t Type) EntityType() entity.Type {
 	// (the entity being created is not yet referenceable).
 	case VolumeCreate, ProjectRename, InstanceCreate, ImageDownload, ImageUploadToken, CustomVolumeBackupRestore,
 		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, NetworkCreate, NetworkACLCreate, StorageBucketCreate,
-		NetworkZoneCreate, ReplicatorRunInstance:
+		NetworkZoneCreate, ReplicatorRunInstance, ProjectReplicaModeUpdate:
 		return entity.TypeProject
 
 	// Storage bucket operations.

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/canonical/lxd/lxd/db"
+	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
@@ -171,6 +173,28 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	// Check if the cluster member is evacuated.
 	if s.DB.Cluster.LocalNodeIsEvacuated() && req.Action != "stop" {
 		return response.Forbidden(errors.New("Cluster member is evacuated"))
+	}
+
+	// Block starting instances in a standby replica project.
+	// Instances must not be started until the project is promoted to leader mode.
+	if req.Action == "start" {
+		var replicaMode string
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+			if err != nil {
+				return err
+			}
+
+			replicaMode = string(dbProject.ReplicaMode)
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		if replicaMode == api.ReplicatorProjectModeStandby {
+			return response.Forbidden(errors.New("Cannot start instances in a standby replica project"))
+		}
 	}
 
 	// Don't mess with instances while in setup mode.

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1406,7 +1406,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		// Only replicator runs from the configured cluster link (or internal cluster
 		// notifications forwarded by the coordinator) can create instances in a standby
 		// replica project.
-		if targetProject.Config["replica.mode"] == "standby" && !clusterNotification {
+		if targetProject.ReplicaMode == api.ReplicatorProjectModeStandby && !clusterNotification {
 			expectedCluster := targetProject.Config["replica.cluster"]
 
 			// Verify the request comes from the configured cluster link identity.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4771,15 +4771,8 @@
 				"keys": [
 					{
 						"replica.cluster": {
-							"longdesc": "",
-							"shortdesc": "Cluster link used for replication (source or target).",
-							"type": "string"
-						}
-					},
-					{
-						"replica.mode": {
-							"longdesc": "The replica project mode. When set, the project acts as a replica project. Possible values are `standby` and `leader`.\nIn `standby` mode, instances cannot be created in the project; existing instances may still be managed until the project is promoted to `leader` during a failover.\nIn `leader` mode, the project is writable and is the source of replication.",
-							"shortdesc": "Replica project mode.",
+							"longdesc": "This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.",
+							"shortdesc": "Cluster link allowed to replicate to this standby project.",
 							"type": "string"
 						}
 					}

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -75,6 +75,14 @@ type Project struct {
 	// Read only: true
 	// Example: ["/1.0/images/0e60015346f06627f10580d56ac7fffd9ea775f6d4f25987217d5eed94910a20", "/1.0/instances/c1", "/1.0/networks/lxdbr0", "/1.0/profiles/default", "/1.0/storage-pools/default/volumes/custom/blah"]
 	UsedBy []string `json:"used_by" yaml:"used_by"`
+
+	// Replica mode for the project (leader, standby, or empty)
+	// Read only: true
+	// This field is updated via PUT /1.0/projects/<name>/state
+	// Example: leader
+	//
+	// API extension: project_replica_mode
+	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
 }
 
 // Writable converts a full Project struct into a ProjectPut struct (filters read-only fields)

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -132,3 +132,14 @@ type ProjectStateResource struct {
 	// Example: 4
 	Usage int64
 }
+
+// ProjectStatePut represents the fields for updating project replica state
+//
+// swagger:model
+//
+// API extension: project_replica_mode.
+type ProjectStatePut struct {
+	// Replica mode to set: "leader" or "standby"
+	// Example: leader
+	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -492,6 +492,7 @@ var APIExtensions = []string{
 	"storage_driver_powerstore",
 	"oidc_device_client_id",
 	"storage_nvme_tcp",
+	"project_replica_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -71,6 +71,7 @@ readonly test_group_replicator_storage=(
     "clustering_replicator_multi_member"
     "clustering_replicator_evacuated_member"
     "clustering_replicator_vm"
+    "clustering_replicator_unclustered"
 )
 
 readonly test_group_instance=(

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5716,10 +5716,6 @@ test_clustering_replicator_basic() {
 
   LXD_ONE_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --quiet --auth-group replicator-group)"
 
-  sub_test "Verify replica.mode cannot be set without replica.cluster"
-
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader 2>&1)" = 'Error: Invalid project configuration key "replica.mode" value: "replica.mode" can only be set when "replica.cluster" is set' ]
-
   sub_test "Verify replica.cluster rejects invalid cluster link names"
 
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=invalid-link 2>&1)" = 'Error: Invalid project configuration key "replica.cluster" value: Cluster link "invalid-link" not found' ]
@@ -5733,16 +5729,20 @@ test_clustering_replicator_basic() {
 
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  sub_test "Verify replica.mode=leader cannot be set before target is standby"
+  sub_test "Verify promote fails before target is in standby mode"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
+  # Set replica.cluster on standby side only (leader doesn't need it since replicator defines targets).
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
 
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader 2>&1)" = 'Error: Invalid project configuration key "replica.mode" value: Target project must have "replica.mode" set to standby when setting "replica.mode" to leader on the source project' ]
+  # Create replicator on LXD_ONE first (defines target cluster).
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
 
-  # Set replica.mode on both clusters.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
+  # Attempt to promote should fail because target is not in standby mode.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Target project "replicator-project" on cluster "lxd_two" is not in standby mode' ]
+
+  # Demote standby side, then promote leader side.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage on both clusters.
   local pool_one pool_two
@@ -5751,8 +5751,6 @@ test_clustering_replicator_basic() {
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
-  # Create replicator on LXD_ONE.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator list --project replicator-project | grep -F 'my-replicator'
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator show my-replicator --project replicator-project
 
@@ -5885,7 +5883,7 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project create replicator-project
 
-  # Setup auth groups and cluster links so replica.mode validation can read the
+  # Setup auth groups and cluster links so promote validation can read the
   # target project through the cluster-link identity, just like the basic test.
   LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
   LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
@@ -5897,9 +5895,11 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage on both clusters.
   local pool_one pool_two
@@ -5907,9 +5907,6 @@ test_clustering_replicator_scheduled() {
   pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
-
-  # Create the replicator.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
 
   # Launch one instance on the source project and set a config key that should
   # be replicated to the target side.
@@ -5940,18 +5937,17 @@ test_clustering_replicator_scheduled() {
   local ops_before
   ops_before="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | length')"
 
-  # Unset replica.mode on the source; the scheduler must now skip this replicator.
-  LXD_DIR="${LXD_ONE_DIR}" lxc project unset replicator-project replica.mode
+  # Demote the source with --force (skips validation); the scheduler must now skip this replicator.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
 
-  # Trigger the scheduler synchronously; because replica.mode is unset the scheduler
+  # Trigger the scheduler synchronously; because the project is not in leader mode the scheduler
   # skips the replicator without creating a new operation.
   LXD_DIR="${LXD_ONE_DIR}" lxc query -X POST --raw --wait /internal/testing/replicator/run-scheduler
   LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' \
     | jq --exit-status --argjson before "${ops_before}" '[.. | objects | select(.description == "Running replicator")] | length == $before'
 
   # Restore leader mode before cleanup.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Cleanup
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project
@@ -5976,7 +5972,7 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project create replicator-project
 
-  # Setup auth groups and cluster links so replica.mode validation can read the
+  # Setup auth groups and cluster links so promote validation can read the
   # target project through the cluster-link identity, just like the basic test.
   LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
   LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
@@ -5988,9 +5984,11 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage on both clusters.
   local pool_one pool_two
@@ -5998,9 +5996,6 @@ test_clustering_replicator_dr() {
   pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
-
-  # Create the replicator.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
 
   sub_test "Initial replication: replicate c1 and c2 to LXD_TWO"
 
@@ -6030,9 +6025,9 @@ test_clustering_replicator_dr() {
 
   grep -F 'UNREACHABLE' <<< "${link_info}"
 
-  # LXD_ONE is unreachable; replica.mode=leader validation skips when the target is unreachable.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=leader
-  # Both clusters now have replica.mode=leader. Verify instance creation is allowed on LXD_TWO.
+  # LXD_ONE is unreachable; promote-replica --force skips standby validation when the target is unreachable.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project promote-replica replicator-project --force
+  # Both clusters now have leader mode set. Verify instance creation is allowed on LXD_TWO.
   LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
   # Verify LXD_TWO can start a replicated instance as the new leader.
   LXD_DIR="${LXD_TWO_DIR}" lxc start c1 --project replicator-project
@@ -6069,15 +6064,15 @@ test_clustering_replicator_dr() {
 
   grep -F 'ACTIVE' <<< "${link_info}"
 
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Target project must have "replica.mode" set to standby to run replicator' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Target project must be in standby mode to run replicator' ]
 
   sub_test "Verify --restore is rejected when local instances are running"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected with a clear error.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 
-  sub_test "Restore: set LXD_ONE to standby and restore c1, c2, and c3 from LXD_TWO"
+  sub_test "Restore: LXD_ONE is standby and restore c1, c2, and c3 from LXD_TWO"
 
   # c1 is running and must be stopped: the server rejects --restore if any local instance
   # is running to prevent partial restores. c2 is empty and already stopped.
@@ -6092,15 +6087,15 @@ test_clustering_replicator_dr() {
 
   sub_test "Resume: demote LXD_TWO, promote LXD_ONE, verify replication resumes"
 
-  # Stop instances on LXD_TWO before setting standby.
+  # Stop instances on LXD_TWO before demoting.
   for i in c1 c2 c3; do
     if [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc list "${i}" --project replicator-project --format csv -c s 2>/dev/null)" = "RUNNING" ]; then
       LXD_DIR="${LXD_TWO_DIR}" lxc stop "${i}" --force --project replicator-project
     fi
   done
 
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 4 and .status == "Success" and ((.children // []) | length) == 3 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
@@ -6142,9 +6137,11 @@ test_clustering_replicator_snapshot() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two snapshot=true --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage on both clusters.
   local pool_one pool_two
@@ -6158,7 +6155,6 @@ test_clustering_replicator_snapshot() {
   sub_test "Verify snapshot=true creates a snapshot when instance has no snapshot schedule"
 
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two snapshot=true --project replicator-project
 
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run snap-replicator --project replicator-project
 
@@ -6224,9 +6220,11 @@ test_clustering_replicator_multi_member() {
   LXD_DIR="${LXD_THREE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  LXD_DIR="${LXD_THREE_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage: the bootstrapped clusters already have a "data" pool;
   # add a root device to the default profile in the replicator project.
@@ -6245,8 +6243,7 @@ test_clustering_replicator_multi_member() {
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c1,node1'
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c2,node2'
 
-  # Create replicator and run.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  # Run replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
 
   # Both instances must appear on the target cluster.
@@ -6288,8 +6285,8 @@ test_clustering_replicator_multi_member() {
   sub_test "Verify --restore rejects running instances on other members"
 
   # Simulate failover: source becomes standby, target becomes leader.
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=leader
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  LXD_DIR="${LXD_THREE_DIR}" lxc project promote-replica replicator-project --force
 
   # c1 is still running on node1 — restore must refuse to proceed.
   if LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1; then
@@ -6368,9 +6365,11 @@ test_clustering_replicator_evacuated_member() {
   LXD_DIR="${LXD_FOUR_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_FOUR_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage profiles.
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool=data --project replicator-project
@@ -6396,8 +6395,7 @@ test_clustering_replicator_evacuated_member() {
   c1_location="$(LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c L c1)"
   [ "${c1_location}" != "node2" ]
 
-  # Create replicator and run.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
+  # Run replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
 
   # Both instances must appear on the target cluster.
@@ -6415,8 +6413,8 @@ test_clustering_replicator_evacuated_member() {
   sub_test "Restore with evacuated member"
 
   # Simulate failover: source becomes standby, target becomes leader.
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a replica.mode=leader
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project promote-replica replicator-project --force
 
   # Run restore with node2 still evacuated.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
@@ -6432,8 +6430,8 @@ test_clustering_replicator_evacuated_member() {
   sub_test "Forward replication with down member"
 
   # Flip back to leader mode.
-  LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.mode=leader
+  LXD_DIR="${LXD_FOUR_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Bring node2 back online. Use --action=skip because instances were already
   # restored to their post-evacuation locations by the replicator restore.
@@ -6513,9 +6511,11 @@ test_clustering_replicator_vm() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings.
-  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one replica.mode=standby
-  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two replica.mode=leader
+  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create vm-replicator cluster=lxd_two --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
   # Setup storage on both clusters.
   local pool_one pool_two
@@ -6529,8 +6529,7 @@ test_clustering_replicator_vm() {
   # Create an empty VM (no image needed).
   LXD_DIR="${LXD_ONE_DIR}" lxc init --vm --empty v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}" --project replicator-project
 
-  # Create replicator and run.
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create vm-replicator cluster=lxd_two --project replicator-project
+  # Run replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
 
   # VM must appear on the target cluster.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6573,3 +6573,127 @@ test_clustering_replicator_vm() {
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_ONE_DIR}"
 }
+
+test_clustering_replicator_unclustered() {
+  # Create two standalone LXD daemons.  Neither enables clustering so each
+  # node's DB address remains the unclustered sentinel "0.0.0.0".  This
+  # exercises the wildcard-address fallback that was added to make both
+  # replicator run and replicator run --restore work against unclustered
+  # standby clusters.
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_ONE_DIR}" true
+
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  spawn_lxd "${LXD_TWO_DIR}" true
+
+  # Both daemons are intentionally left unclustered (no lxc cluster enable).
+
+  # Create projects on both.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project create replicator-project
+
+  # Setup auth groups and cluster links so that promote validation can reach
+  # the target project through the cluster-link identity.
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_ONE_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --quiet --auth-group replicator-group)"
+
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group create replicator-group
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project operator
+  LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
+
+  # Configure replica project: LXD_ONE is leader, LXD_TWO is standby.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
+
+  # Setup storage on both clusters.
+  local pool_one pool_two
+  pool_one="lxdtest-$(basename "${LXD_ONE_DIR}")"
+  pool_two="lxdtest-$(basename "${LXD_TWO_DIR}")"
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
+
+  sub_test "Forward replication: unclustered leader replicates c1 and c2 to unclustered standby"
+
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --empty c2 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+
+  sub_test "Disaster: kill LXD_ONE and promote LXD_TWO to leader"
+
+  kill_go_proc "$(< "${LXD_ONE_DIR}/lxd.pid")"
+
+  # Wait for LXD_TWO to observe LXD_ONE as unreachable before promoting.
+  local i link_info
+  for i in $(seq 30); do
+    link_info="$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster link info lxd_one 2>/dev/null || true)"
+    if grep -qF 'UNREACHABLE' <<< "${link_info}"; then
+      break
+    fi
+
+    sleep 1
+  done
+
+  grep -F 'UNREACHABLE' <<< "${link_info}"
+
+  # promote-replica --force skips standby validation when the target is unreachable.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project promote-replica replicator-project --force
+  # Create c3 on LXD_TWO (new leader) during the failover window.
+  LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
+
+  sub_test "Recovery: LXD_ONE comes back online; forward replicator run is rejected"
+
+  # respawn_lxd calls lxd waitready so LXD_ONE is responsive on return.
+  respawn_lxd "${LXD_ONE_DIR}" true
+
+  # Wait for LXD_ONE to observe LXD_TWO as ACTIVE via the cluster link.
+  for i in $(seq 30); do
+    link_info="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link info lxd_two 2>/dev/null || true)"
+    if grep -qF 'ACTIVE' <<< "${link_info}"; then
+      break
+    fi
+
+    sleep 1
+  done
+
+  grep -F 'ACTIVE' <<< "${link_info}"
+
+  # LXD_ONE still has leader mode set; forward run must be rejected because LXD_TWO
+  # (the target) is now also leader.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Target project must be in standby mode to run replicator' ]
+
+  sub_test "Verify --restore is rejected when local instances are running"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  # c1 is still running on LXD_ONE after respawn; --restore must be rejected.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
+
+  sub_test "Restore: unclustered standby LXD_ONE restores c1, c2, and c3 from LXD_TWO"
+
+  # Stop c1 before restore; c2 is already stopped.
+  LXD_DIR="${LXD_ONE_DIR}" lxc stop c1 --force --project replicator-project
+  # LXD_ONE is an unclustered standby (DB address = "0.0.0.0"). The restore path
+  # must fall back to core.https_address rather than the sentinel address.
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
+  bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
+  jq --exit-status '([., (.children? // [])[]] | length) == 4 and .status == "Success" and ((.children // []) | length) == 3 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  # c1 and c2 are restored from LXD_TWO; c3 was created during failover and is also restored.
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c3,STOPPED'
+
+  # Cleanup
+  LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc profile device remove default root --project replicator-project
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5797,13 +5797,15 @@ test_clustering_replicator_basic() {
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c3,STOPPED'
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc config get c1 user.foo --project replicator-project)" = "bar" ]
 
-  sub_test "Verify instance start is allowed on standby project"
+  sub_test "Verify instance start is blocked on standby project"
 
-  # Standby mode only blocks instance *creation*; existing instances may still be managed
-  # (e.g. started/stopped) to support failover workflows.
-  LXD_DIR="${LXD_TWO_DIR}" lxc start c1 --project replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc list c1 --project replicator-project -f csv -c ns | grep -xF 'c1,RUNNING'
-  LXD_DIR="${LXD_TWO_DIR}" lxc stop c1 --force --project replicator-project
+  # Starting instances in a standby replica project is blocked to prevent split-brain
+  # scenarios where the same instance runs on both the leader and standby clusters.
+  # Instances must not be started until the project is promoted to leader mode.
+  if CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_TWO_DIR}" lxc start c1 --project replicator-project 2>/dev/null; then
+    echo "ERROR: Starting instance in standby project unexpectedly succeeded" >&2
+    exit 1
+  fi
 
   sub_test "Verify replicator is idempotent when instances already exist on target"
 


### PR DESCRIPTION
This pull request introduces a new mechanism for managing project replication modes in LXD, replacing direct configuration key manipulation with explicit promote/demote actions. It adds a new API endpoint and CLI commands for promoting or demoting a project's replica state, updates documentation to reflect these changes, and improves visibility of replica mode in project listings.

Key changes include:

**API and Client Enhancements**
- Introduced a new `PUT /1.0/projects/<name>/state` API endpoint for promoting or demoting a project's replica mode, with support for a `force` parameter to override validation in disaster recovery scenarios. (`doc/rest-api.yaml` [[1]](diffhunk://#diff-216fa85d6fc7c80b69a6c22e22f0bd383806df995d6801b67ba4990eacff9e55R16600-R16632) [[2]](diffhunk://#diff-216fa85d6fc7c80b69a6c22e22f0bd383806df995d6801b67ba4990eacff9e55R5047-R5056) [[3]](diffhunk://#diff-e8462827145114b5518adf1ebb2aaa207d0f0e3d3913c4263e748bb47e00801aR85-R105) [[4]](diffhunk://#diff-17fcb0110ba89de5cc463080ca07022a507374f29f1cfbd9af40b2714b143ab0R284) [[5]](diffhunk://#diff-906870407147ce5fd1c4850626a492df3cd564c6981706e8ef8f7247e9200637R3102-R3105)
- Added the `replica_mode` field (read-only) to the project API schema for better status visibility. (`doc/rest-api.yaml` [doc/rest-api.yamlR4978-R4983](diffhunk://#diff-216fa85d6fc7c80b69a6c22e22f0bd383806df995d6801b67ba4990eacff9e55R4978-R4983))

**CLI Improvements**
- Added `lxc project promote-replica` and `lxc project demote-replica` commands for managing project replication roles, including support for the `--force` flag. (`lxc/project.go` [lxc/project.goR82-R89](diffhunk://#diff-f70c7039f5b041e422a3447e526367c0a22232841f99c45c9437506369acf49aR82-R89))
- Updated `lxc project list` to display the replica mode of each project. (`lxc/project.go` [[1]](diffhunk://#diff-f70c7039f5b041e422a3447e526367c0a22232841f99c45c9437506369acf49aR502) [[2]](diffhunk://#diff-f70c7039f5b041e422a3447e526367c0a22232841f99c45c9437506369acf49aR643-R650)

**Documentation Updates**
- Revised all relevant documentation to replace direct setting of `replica.mode` with the new promote/demote commands, and clarified the role of the `replica.cluster` key (now only required on standby projects). (`doc/explanation/replicators.md` [[1]](diffhunk://#diff-f4926ab9980b43ca4b9a56bd92d424e39d9f2e7966d0cb9ae57c697b6b6e3363L15-R23) [[2]](diffhunk://#diff-f4926ab9980b43ca4b9a56bd92d424e39d9f2e7966d0cb9ae57c697b6b6e3363L34-R40) [[3]](diffhunk://#diff-f4926ab9980b43ca4b9a56bd92d424e39d9f2e7966d0cb9ae57c697b6b6e3363L51-R55); `doc/howto/replicators_create.md` [[4]](diffhunk://#diff-dc000de081b275f9c6f72619c8fa58581873ae4e7c01c7cd1d6e1808e8f7a3e1L47-R78); `doc/howto/replicators_dr.md` [[5]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L19-R25) [[6]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L30-R38) [[7]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L45-R60) [[8]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L63-R84); `doc/metadata.txt` [[9]](diffhunk://#diff-f41fff49be2af7a5ad7c7e7632347ac8fb2f5fd8ed8bc72ddd749f10ee35bd42L4243-R4245)

**Replication Workflow and Behavior**
- Promotion and demotion now validate the state of remote projects and allow forced transitions for disaster recovery, improving safety and usability during failover and restoration. (`doc/howto/replicators_dr.md` [[1]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L19-R25) [[2]](diffhunk://#diff-12b32c0e8db4d67207afc9e481f34885626aa171237aa99072acb4952dcefa84L45-R60); `doc/explanation/replicators.md` [[3]](diffhunk://#diff-f4926ab9980b43ca4b9a56bd92d424e39d9f2e7966d0cb9ae57c697b6b6e3363L34-R40)

**Extension Registration**
- Documented the new `project_replica_mode` API extension to signal support for these features. (`doc/api-extensions.md` [doc/api-extensions.mdR3102-R3105](diffhunk://#diff-906870407147ce5fd1c4850626a492df3cd564c6981706e8ef8f7247e9200637R3102-R3105))

Closes https://github.com/canonical/lxd/issues/18364.