### PR TITLE
storage/powerstore: Check host mapping using volume attachement

### DIFF
--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -979,13 +979,13 @@ func (c *PowerStoreClient) RestoreVolume(volumeID string, snapshotID string) err
 // attached to the host, and false if the volume was already attached to the host.
 func (c *PowerStoreClient) AttachVolumeToHost(volumeID string, hostID string) (bool, error) {
 	// Check if the volume is already attached to the host.
-	host, err := c.GetHost(hostID)
+	mappings, err := c.GetVolumeMappings(volumeID)
 	if err != nil {
 		return false, err
 	}
 
-	for _, mapping := range host.MappedVolumes {
-		if mapping.VolumeID == volumeID {
+	for _, mapping := range mappings {
+		if mapping.HostID == hostID {
 			// The volume is already attached to the host.
 			return false, nil
 		}

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -56,6 +56,11 @@ func (PowerStoreHostInitiator) selector() string {
 type PowerStoreHostVolumeMapping struct {
 	HostID   string `json:"host_id,omitempty"`
 	VolumeID string `json:"volume_id,omitempty"`
+	LUN      int    `json:"logical_unit_number,omitempty"`
+}
+
+func (PowerStoreHostVolumeMapping) selector() string {
+	return "host_id,volume_id,logical_unit_number"
 }
 
 // PowerStoreHost represents a PowerStore host.
@@ -756,6 +761,41 @@ func (c *PowerStoreClient) GetVolume(volumeID string) (*PowerStoreVolume, error)
 	}
 
 	return &resp, nil
+}
+
+// GetVolumeMappings retrieves host to volume mapping for a volume with the given ID.
+func (c *PowerStoreClient) GetVolumeMappings(volumeID string) ([]PowerStoreHostVolumeMapping, error) {
+	url := api.NewURL().Path("api", "rest", "host_volume_mapping")
+	url = url.WithQuery("volume_id", "eq."+volumeID)
+	url = url.WithQuery("select", PowerStoreHostVolumeMapping{}.selector())
+
+	var offset uint64
+	var attachments []PowerStoreHostVolumeMapping
+
+	for {
+		respBody := []PowerStoreHostVolumeMapping{}
+		respHeaders := make(http.Header)
+
+		pageURL := withPaginationQuery(url.URL, offset, powerStoreQueryResponseLimit)
+		err := c.requestAuthenticated(http.MethodGet, pageURL, nil, &respBody, respHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("Failed retrieving PowerStore volume attachments: %w", err)
+		}
+
+		nextOffset, hasMoreItems, err := parsePaginationOffset(respHeaders)
+		if err != nil {
+			return nil, err
+		}
+
+		attachments = append(attachments, respBody...)
+		offset = nextOffset
+
+		if !hasMoreItems {
+			break
+		}
+	}
+
+	return attachments, nil
 }
 
 // CreateVolume creates a new volume.

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -608,25 +608,6 @@ func (c *PowerStoreClient) GetCurrentHost(connectorType string, qn string) (*Pow
 	return &host, nil
 }
 
-// GetHost retrieves host using its ID.
-func (c *PowerStoreClient) GetHost(hostID string) (*PowerStoreHost, error) {
-	var host PowerStoreHost
-
-	url := api.NewURL().Path("api", "rest", "host", hostID)
-	url = url.WithQuery("select", host.selector())
-
-	err := c.requestAuthenticated(http.MethodGet, url.URL, nil, &host, nil)
-	if err != nil {
-		if isPowerStoreError(err, http.StatusNotFound) {
-			return nil, api.StatusErrorf(http.StatusNotFound, "Host with ID %q not found", hostID)
-		}
-
-		return nil, fmt.Errorf("Failed retrieving PowerStore host: %w", err)
-	}
-
-	return &host, nil
-}
-
 // CreateHost creates new host and returns its ID.
 func (c *PowerStoreClient) CreateHost(hostName string, connectorType string, qn string) (string, error) {
 	portType, err := powerStoreConnectorToPortType(connectorType)


### PR DESCRIPTION
Use volume attachments to determine whether volume is attached to host.
Functionality wise, nothing changes. This is preparation for FC where we will need to get volume LUN, which can be retrieved through volume attachments.