### PR TITLE
riscv64: disable ACPI for RISC-V virtual machines

### DIFF
--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -76,6 +76,18 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
+			qemuBaseOpts{architecture: osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN},
+			`# Machine
+			[machine]
+			graphics = "off"
+			type = "virt"
+			accel = "kvm"
+			acpi = "off"
+			usb = "off"
+
+			[boot-opts]
+			strict = "on"`,
+		}, {
 			qemuBaseOpts{architecture: osarch.ARCH_64BIT_S390_BIG_ENDIAN},
 			`# Machine
 			[machine]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -96,12 +96,16 @@ func qemuBase(opts *qemuBaseOpts) []cfgSection {
 	machineType := qemuMachineType(opts.architecture)
 	gicVersion := ""
 	capLargeDecr := ""
+	acpi := ""
 
 	switch opts.architecture {
 	case osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
 		gicVersion = "max"
 	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
 		capLargeDecr = "off"
+	case osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN:
+		// Booting Linux 7.0 failed with acpi="on" (LP: #2153582)
+		acpi = "off"
 	}
 
 	sections := []cfgSection{{
@@ -113,6 +117,7 @@ func qemuBase(opts *qemuBaseOpts) []cfgSection {
 			{key: "gic-version", value: gicVersion},
 			{key: "cap-large-decr", value: capLargeDecr},
 			{key: "accel", value: "kvm"},
+			{key: "acpi", value: acpi},
 			{key: "usb", value: "off"},
 		},
 	}}


### PR DESCRIPTION
With kernel 7.0 an error

    sysfs: cannot create duplicate filename '/devices/pci0000:00/0000:00:01.1/resource0'

was observed when using ACPI ([LP #2153582](https://bugs.launchpad.net/ubuntu/+source/linux-riscv/+bug/2153582)). Let QEMU just pass a device-tree.

RISC-V test data for TestQemuConfigTemplates() is supplied.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation. *Machine options seem to be hard coded and not mentioned in the documentation. So no documentation change.*
