### PR TITLE
doc: update links following removal of MyST cheat sheet

### DIFF
--- a/doc/.wokeignore
+++ b/doc/.wokeignore
@@ -1,4 +1,0 @@
-# the cheat sheets contain a link to a repository with a block word which we
-# cannot avoid for now, ie
-# https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-doc-cheat-sheet*

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,9 +13,9 @@ GitHub provides a basic rendering of the documentation as well, but important fe
 LXD's documentation is built with [Sphinx](https://www.sphinx-doc.org) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
 It is written in [Markdown](https://commonmark.org/) with [MyST](https://myst-parser.readthedocs.io/) extensions.
-For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/latest/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).
+For syntax help and guidelines, see the [MyST syntax guide](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/) in the [Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/).
 
-For structuring, the documentation uses the [Diátaxis](https://diataxis.fr/) approach.
+The documentation structure follows the [Diátaxis](https://diataxis.fr/) framework.
 
 ### Build the documentation
 


### PR DESCRIPTION
This PR follows up on #18310:

1. It updates the links in the documentation README to direct contributors to the MyST syntax guide in the updated Sphinx Stack documentation.
2. It removes the documentation `.wokeignore`, which is no longer needed following the removal of the MyST cheat sheet.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.