### PR TITLE
doc: update PureStorage, HPE Alletra references

### DIFF
--- a/doc/reference/storage_alletra.md
+++ b/doc/reference/storage_alletra.md
@@ -38,7 +38,9 @@ When creating a new storage pool using the `alletra` driver, LXD automatically d
 Upon successful discovery, LXD attaches all volumes that are connected to the HPE Alletra host that is associated with a specific LXD server.
 HPE Alletra hosts and volume connections ({abbr}`vLUNs (virtual Logical Unit Numbers)`) are fully managed by LXD.
 
-Volume snapshots are also supported by HPE Alletra. When a volume with at least one snapshot is copied, LXD sequentially copies snapshots into the destination volume, from which a new snapshot is created. Finally, once all snapshots are copied, the source volume is copied into the destination volume.
+Volume snapshots are also supported by HPE Alletra.
+When a volume with at least one snapshot is copied, LXD sequentially creates snapshots on the destination volume from snapshots on the source volume.
+Finally, once all snapshots are copied, the source volume is copied into the destination volume.
 
 (storage-alletra-volume-names)=
 ### Volume names

--- a/doc/reference/storage_pure.md
+++ b/doc/reference/storage_pure.md
@@ -40,9 +40,10 @@ When creating a new storage pool using the `pure` driver in either `iscsi` or `n
 Upon successful discovery, LXD attaches all volumes that are connected to the Pure Storage host that is associated with a specific LXD server.
 Pure Storage hosts and volume connections are fully managed by LXD.
 
-Volume snapshots are also supported by Pure Storage. However, each snapshot is associated with a parent volume and cannot be directly attached to the host.
-Therefore, when a snapshot is being exported, LXD creates a temporary volume behind the scenes. This volume is attached to the LXD host and removed once the operation is completed.
-Similarly, when a volume with at least one snapshot is being copied, LXD sequentially copies snapshots into destination volume, from which a new snapshot is created.
+Volume snapshots are also supported by Pure Storage.
+When a volume with at least one snapshot is copied, LXD sequentially creates snapshots on the destination volume from snapshots on the source volume.
+Each snapshot is associated with a parent volume and cannot be directly attached to the host; therefore, when a snapshot is exported, LXD creates a temporary volume behind the scenes.
+This volume is attached to the LXD host and removed once the operation is complete.
 Finally, once all snapshots are copied, the source volume is copied into the destination volume.
 
 (storage-pure-volume-names)=


### PR DESCRIPTION
This PR updates the description of the processes whereby the PureStorage and HPE Alletra storage drivers copy volumes with snapshots. The aim is to bring the descriptions into alignment with the description of the PowerStore driver introduced in PR #18316 .

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
