### PR TITLE
Cluster connect use context

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -44,7 +44,7 @@ func connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 	return lxd.ConnectLXDWithContext(ctx, clusterURL, args)
 }
 
-// Connect is a convenience around lxd.ConnectLXD that configures the client
+// Connect is a convenience around lxd.ConnectLXDWithContext that configures the client
 // with the correct parameters for node-to-node communication.
 //
 // If a request context is passed (as defined by request.IsRequestContext) then the

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -41,7 +41,7 @@ func connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 	}
 
 	clusterURL := "https://" + address
-	return lxd.ConnectLXD(clusterURL, args)
+	return lxd.ConnectLXDWithContext(ctx, clusterURL, args)
 }
 
 // Connect is a convenience around lxd.ConnectLXD that configures the client

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -57,9 +57,9 @@ func connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 func Connect(ctx context.Context, address string, networkCert *shared.CertInfo, serverCert *shared.CertInfo, notify bool) (lxd.InstanceServer, error) {
 	// Wait for a connection to the events API first for non-notify connections.
 	if !notify {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		err := EventListenerWait(ctx, address)
+		err := EventListenerWait(waitCtx, address)
 		if err != nil {
 			return nil, api.StatusErrorf(http.StatusServiceUnavailable, "Missing event connection with target cluster member")
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1414,7 +1414,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Sync the images between each node in the cluster on demand
-		err = imageSyncBetweenNodes(ctx, s, r, dbProject.Name, info.Fingerprint)
+		err = imageSyncBetweenNodes(ctx, s, dbProject.Name, info.Fingerprint)
 		if err != nil {
 			return fmt.Errorf("Failed syncing image between nodes: %w", err)
 		}
@@ -5075,7 +5075,7 @@ func autoSyncImages(ctx context.Context, s *state.State) error {
 	for fingerprint, projects := range imageProjectInfo {
 		ch := make(chan error)
 		go func(projectName string, fingerprint string) {
-			err := imageSyncBetweenNodes(ctx, s, nil, projectName, fingerprint)
+			err := imageSyncBetweenNodes(ctx, s, projectName, fingerprint)
 			if err != nil {
 				logger.Error("Failed synchronizing images", logger.Ctx{"err": err, "project": projectName, "fingerprint": fingerprint})
 			}
@@ -5093,7 +5093,7 @@ func autoSyncImages(ctx context.Context, s *state.State) error {
 	return nil
 }
 
-func imageSyncBetweenNodes(ctx context.Context, s *state.State, r *http.Request, project string, fingerprint string) error {
+func imageSyncBetweenNodes(ctx context.Context, s *state.State, project string, fingerprint string) error {
 	logger.Info("Syncing image to members started", logger.Ctx{"fingerprint": fingerprint, "project": project})
 	defer logger.Info("Syncing image to members finished", logger.Ctx{"fingerprint": fingerprint, "project": project})
 
@@ -5142,12 +5142,7 @@ func imageSyncBetweenNodes(ctx context.Context, s *state.State, r *http.Request,
 	// Pick a random node from that slice as the source.
 	syncNodeAddress := syncNodeAddresses[rand.Intn(len(syncNodeAddresses))]
 
-	reqContext := context.Background()
-	if r != nil {
-		reqContext = r.Context()
-	}
-
-	source, err := cluster.Connect(reqContext, syncNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+	source, err := cluster.Connect(ctx, syncNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 	if err != nil {
 		return fmt.Errorf("Failed connecting to source node for image synchronization: %w", err)
 	}
@@ -5194,7 +5189,7 @@ func imageSyncBetweenNodes(ctx context.Context, s *state.State, r *http.Request,
 		// Pick a random node from that slice as the target.
 		targetNodeAddress := addresses[rand.Intn(len(addresses))]
 
-		client, err := cluster.Connect(reqContext, targetNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+		client, err := cluster.Connect(ctx, targetNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 		if err != nil {
 			return fmt.Errorf("Failed connecting node for image synchronization: %w", err)
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -5073,20 +5073,13 @@ func autoSyncImages(ctx context.Context, s *state.State) error {
 	}
 
 	for fingerprint, projects := range imageProjectInfo {
-		ch := make(chan error)
-		go func(projectName string, fingerprint string) {
-			err := imageSyncBetweenNodes(ctx, s, projectName, fingerprint)
-			if err != nil {
-				logger.Error("Failed synchronizing images", logger.Ctx{"err": err, "project": projectName, "fingerprint": fingerprint})
-			}
+		if ctx.Err() != nil {
+			break // Stop once the context is cancelled.
+		}
 
-			ch <- nil
-		}(projects[0], fingerprint)
-
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ch:
+		err := imageSyncBetweenNodes(ctx, s, projects[0], fingerprint)
+		if err != nil {
+			logger.Error("Failed synchronizing images", logger.Ctx{"err": err, "project": projects[0], "fingerprint": fingerprint})
 		}
 	}
 

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -391,7 +391,7 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 					return
 				}
 
-				cs, err := doContainersFullGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
+				cs, err := doInstancesFullGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
 				if err != nil {
 					for _, inst := range instances {
 						resultErrListAppend(inst, err)
@@ -587,7 +587,7 @@ func doContainersGetFromNode(projects []string, node string, allProjects bool, n
 	return containers, err
 }
 
-func doContainersFullGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.InstanceFull, error) {
+func doInstancesFullGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.InstanceFull, error) {
 	f := func() ([]api.InstanceFull, error) {
 		client, err := cluster.Connect(r.Context(), node, networkCert, serverCert, true)
 		if err != nil {

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -534,17 +534,16 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponse(true, resultFullList)
 }
 
-// Fetch information about the containers on the given remote node, using the
-// rest API and with a timeout of 30 seconds.
+// Fetch information about the instances on the given remote node.
 func doInstancesGetFromNode(ctx context.Context, projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, instanceType instancetype.Type) ([]api.Instance, error) {
 	client, err := cluster.Connect(ctx, node, networkCert, serverCert, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to member %s: %w", node, err)
 	}
 
-	var containers []api.Instance
+	var instances []api.Instance
 	if allProjects {
-		containers, err = client.GetInstances(lxd.GetInstancesArgs{
+		instances, err = client.GetInstances(lxd.GetInstancesArgs{
 			InstanceType: api.InstanceType(instanceType.String()),
 			AllProjects:  true,
 		})
@@ -555,18 +554,18 @@ func doInstancesGetFromNode(ctx context.Context, projects []string, node string,
 		for _, project := range projects {
 			client = client.UseProject(project)
 
-			tmpContainers, err := client.GetInstances(lxd.GetInstancesArgs{
+			tmpInstances, err := client.GetInstances(lxd.GetInstancesArgs{
 				InstanceType: api.InstanceType(instanceType.String()),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
 			}
 
-			containers = append(containers, tmpContainers...)
+			instances = append(instances, tmpInstances...)
 		}
 	}
 
-	return containers, nil
+	return instances, nil
 }
 
 func doInstancesFullGetFromNode(ctx context.Context, projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, instanceType instancetype.Type) ([]api.InstanceFull, error) {

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -403,8 +403,8 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 					return
 				}
 
-				for _, c := range cs {
-					resultFullListAppend(&c)
+				for i := range cs {
+					resultFullListAppend(&cs[i])
 				}
 			}(memberAddress, instances)
 

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -374,8 +374,11 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 			go func(memberAddress string, instances []db.Instance) {
 				defer wg.Done()
 
+				ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+				defer cancel()
+
 				if recursion == 1 {
-					apiInsts, err := doInstancesGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
+					apiInsts, err := doInstancesGetFromNode(ctx, filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), instanceType)
 					if err != nil {
 						for _, inst := range instances {
 							resultErrListAppend(inst, err)
@@ -391,7 +394,7 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 					return
 				}
 
-				cs, err := doInstancesFullGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
+				cs, err := doInstancesFullGetFromNode(ctx, filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), instanceType)
 				if err != nil {
 					for _, inst := range instances {
 						resultErrListAppend(inst, err)
@@ -533,110 +536,68 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 
 // Fetch information about the containers on the given remote node, using the
 // rest API and with a timeout of 30 seconds.
-func doInstancesGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.Instance, error) {
-	f := func() ([]api.Instance, error) {
-		client, err := cluster.Connect(r.Context(), node, networkCert, serverCert, true)
-		if err != nil {
-			return nil, fmt.Errorf("Failed connecting to member %s: %w", node, err)
-		}
-
-		var containers []api.Instance
-		if allProjects {
-			containers, err = client.GetInstances(lxd.GetInstancesArgs{
-				InstanceType: api.InstanceType(instanceType.String()),
-				AllProjects:  true,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
-			}
-		} else {
-			for _, project := range projects {
-				client = client.UseProject(project)
-
-				tmpContainers, err := client.GetInstances(lxd.GetInstancesArgs{
-					InstanceType: api.InstanceType(instanceType.String()),
-				})
-				if err != nil {
-					return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
-				}
-
-				containers = append(containers, tmpContainers...)
-			}
-		}
-
-		return containers, nil
+func doInstancesGetFromNode(ctx context.Context, projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, instanceType instancetype.Type) ([]api.Instance, error) {
+	client, err := cluster.Connect(ctx, node, networkCert, serverCert, true)
+	if err != nil {
+		return nil, fmt.Errorf("Failed connecting to member %s: %w", node, err)
 	}
-
-	timeout := time.After(30 * time.Second)
-	done := make(chan struct{})
 
 	var containers []api.Instance
-	var err error
-
-	go func() {
-		containers, err = f()
-		done <- struct{}{}
-	}()
-
-	select {
-	case <-timeout:
-		err = fmt.Errorf("Timeout getting instances from member %s", node)
-	case <-done:
-	}
-
-	return containers, err
-}
-
-func doInstancesFullGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.InstanceFull, error) {
-	f := func() ([]api.InstanceFull, error) {
-		client, err := cluster.Connect(r.Context(), node, networkCert, serverCert, true)
+	if allProjects {
+		containers, err = client.GetInstances(lxd.GetInstancesArgs{
+			InstanceType: api.InstanceType(instanceType.String()),
+			AllProjects:  true,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("Failed connecting to member %s: %w", node, err)
+			return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
 		}
+	} else {
+		for _, project := range projects {
+			client = client.UseProject(project)
 
-		var instances []api.InstanceFull
-		if allProjects {
-			instances, err = client.GetInstancesFull(lxd.GetInstancesFullArgs{
+			tmpContainers, err := client.GetInstances(lxd.GetInstancesArgs{
 				InstanceType: api.InstanceType(instanceType.String()),
-				AllProjects:  true,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
 			}
-		} else {
-			for _, project := range projects {
-				client = client.UseProject(project)
 
-				tmpInstances, err := client.GetInstancesFull(lxd.GetInstancesFullArgs{
-					InstanceType: api.InstanceType(instanceType.String()),
-				})
-				if err != nil {
-					return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
-				}
-
-				instances = append(instances, tmpInstances...)
-			}
+			containers = append(containers, tmpContainers...)
 		}
-
-		return instances, nil
 	}
 
-	timeout := time.After(30 * time.Second)
-	done := make(chan struct{})
+	return containers, nil
+}
+
+func doInstancesFullGetFromNode(ctx context.Context, projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, instanceType instancetype.Type) ([]api.InstanceFull, error) {
+	client, err := cluster.Connect(ctx, node, networkCert, serverCert, true)
+	if err != nil {
+		return nil, fmt.Errorf("Failed connecting to member %s: %w", node, err)
+	}
 
 	var instances []api.InstanceFull
-	var err error
+	if allProjects {
+		instances, err = client.GetInstancesFull(lxd.GetInstancesFullArgs{
+			InstanceType: api.InstanceType(instanceType.String()),
+			AllProjects:  true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
+		}
+	} else {
+		for _, project := range projects {
+			client = client.UseProject(project)
 
-	go func() {
-		instances, err = f()
-		done <- struct{}{}
-	}()
+			tmpInstances, err := client.GetInstancesFull(lxd.GetInstancesFullArgs{
+				InstanceType: api.InstanceType(instanceType.String()),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Failed getting instances from member %s: %w", node, err)
+			}
 
-	select {
-	case <-timeout:
-		err = fmt.Errorf("Timeout getting instances from member %s", node)
-	case <-done:
+			instances = append(instances, tmpInstances...)
+		}
 	}
 
-	return instances, err
+	return instances, nil
 }

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -375,7 +375,7 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 				defer wg.Done()
 
 				if recursion == 1 {
-					apiInsts, err := doContainersGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
+					apiInsts, err := doInstancesGetFromNode(filteredProjects, memberAddress, allProjects, networkCert, s.ServerCert(), r, instanceType)
 					if err != nil {
 						for _, inst := range instances {
 							resultErrListAppend(inst, err)
@@ -533,7 +533,7 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 
 // Fetch information about the containers on the given remote node, using the
 // rest API and with a timeout of 30 seconds.
-func doContainersGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.Instance, error) {
+func doInstancesGetFromNode(projects []string, node string, allProjects bool, networkCert *shared.CertInfo, serverCert *shared.CertInfo, r *http.Request, instanceType instancetype.Type) ([]api.Instance, error) {
 	f := func() ([]api.Instance, error) {
 		client, err := cluster.Connect(r.Context(), node, networkCert, serverCert, true)
 		if err != nil {


### PR DESCRIPTION
This addresses a go routine leak that can occur if the remote cluster member does not respond in time.

```
goroutine 163918546 [chan send, 1119 minutes]:
main.doContainersFullGetFromNode.func2()
	github.com/canonical/lxd/lxd/instances_get.go:632 +0xd6
created by main.doContainersFullGetFromNode in goroutine 163918545
	github.com/canonical/lxd/lxd/instances_get.go:630 +0x218
```

Caused by Go not being able to deliver the empty struct to the unbuffered done channel as the outer consumer has already returned after the 30s timeout.

```go
	go func() {
		instances, err = f()
		done <- struct{}{}
	}()
```