### PR TITLE
shared/validate: reject descending IPv4 and IPv6 ranges

### DIFF
--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -381,7 +381,12 @@ func IsNetworkRangeV4(value string) error {
 		return err
 	}
 
-	return IsNetworkAddressV4(end)
+	err = IsNetworkAddressV4(end)
+	if err != nil {
+		return err
+	}
+
+	return IsNetworkRange(value)
 }
 
 // IsNetworkV6 validates an IPv6 CIDR string.
@@ -442,7 +447,12 @@ func IsNetworkRangeV6(value string) error {
 		return err
 	}
 
-	return IsNetworkAddressV6(end)
+	err = IsNetworkAddressV6(end)
+	if err != nil {
+		return err
+	}
+
+	return IsNetworkRange(value)
 }
 
 // IsNetworkVLAN validates a VLAN ID.

--- a/shared/validate/validate_test.go
+++ b/shared/validate/validate_test.go
@@ -618,6 +618,68 @@ func Test_IsNetworkV6(t *testing.T) {
 	}
 }
 
+func Test_IsNetworkRangeV4(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{
+			value:    "192.0.2.1-192.0.2.2",
+			expected: true,
+		},
+		{
+			value:    "192.0.2.2-192.0.2.1",
+			expected: false,
+		},
+		{
+			value:    "2001:db8::1-2001:db8::2",
+			expected: false,
+		},
+		{
+			value:    "192.0.2.1",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		err := validate.IsNetworkRangeV4(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsNetworkRangeV4(%q) = %v, want %v", test.value, err == nil, test.expected)
+		}
+	}
+}
+
+func Test_IsNetworkRangeV6(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{
+			value:    "2001:db8::1-2001:db8::2",
+			expected: true,
+		},
+		{
+			value:    "2001:db8::2-2001:db8::1",
+			expected: false,
+		},
+		{
+			value:    "192.0.2.1-192.0.2.2",
+			expected: false,
+		},
+		{
+			value:    "2001:db8::1",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		err := validate.IsNetworkRangeV6(test.value)
+		if (err == nil) != test.expected {
+			t.Errorf("IsNetworkRangeV6(%q) = %v, want %v", test.value, err == nil, test.expected)
+		}
+	}
+}
+
 func Test_IsNetworkMAC(t *testing.T) {
 	tests := []struct {
 		value    string


### PR DESCRIPTION
## Summary
This tightens `IsNetworkRangeV4` and `IsNetworkRangeV6` so they reject descending ranges too.

Right now they can accept stuff like `10.0.0.10-10.0.0.1` or `2001:db8::10-2001:db8::1`, which is kinda bogus. Downstream parsing rejects the same input later, so this is a small validation hole and a tiny footgun.

## Repro
Before this patch:

```go
validate.IsNetworkRangeV4("10.0.0.10-10.0.0.1") == nil
validate.IsNetworkRangeV6("2001:db8::10-2001:db8::1") == nil
```

But the same ranges fail once parsed for actual use:

```go
shared.ParseIPRanges("10.0.0.10-10.0.0.1", allowedNet)
// Start IP "10.0.0.10" must be less than End IP "10.0.0.1"

shared.ParseIPRanges("2001:db8::10-2001:db8::1", allowedNet)
// Start IP "2001:db8::10" must be less than End IP "2001:db8::1"
```

So yeah, same bad input, two different answers. This patch makes the first check stop lying a bit.

## Tests
`go test ./shared/validate`
