### PR TITLE
storage: Address possible iSCSI race conditions

### DIFF
--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -169,9 +169,9 @@ func WaitDiskDeviceResize(ctx context.Context, diskPath string, newSizeBytes int
 	}
 }
 
-// WaitDiskDeviceGone waits for the disk device to disappear from /dev/disk/by-id.
-// It periodically checks for the device to disappear and returns once the device
-// is gone. If the device does not disappear within the timeout, an error is returned.
+// WaitDiskDeviceGone waits for the given disk device path to disappear.
+// It periodically checks for the device to disappear and returns true once the
+// device is gone. It returns false if the context times out or is canceled first.
 func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
 	_, ok := ctx.Deadline()
 	if !ok {

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -625,4 +626,31 @@ func findMultipathSCSIDevices(dmName string) ([]string, error) {
 	}
 
 	return devices, nil
+}
+
+// waitMultipathReady checks if the multipath device has at least one active path.
+func waitMultipathReady(ctx context.Context, devicePath string) error {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		out, err := exec.CommandContext(ctx, "multipath", "-ll", devicePath).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed checking multipath device %q status: %w", devicePath, err)
+		}
+
+		// The "multipath -ll" outputs the topology of a mapper. We look for a path that is:
+		// - running = Kernel SCSI device state is online.
+		// - ready   = Path checker confirms the device is usable.
+		// - active  = Path group is currently used by multipath.
+		if strings.Contains(string(out), "active ready running") {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Timeout waiting for multipath device %q to have active paths: %w", devicePath, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -434,16 +434,17 @@ func (c *connectorISCSI) RemoveDiskDevice(ctx context.Context, devicePath string
 	deviceName := filepath.Base(devicePath)
 
 	if isMultipathDevice(devicePath) {
-		// Collect the slave devices before removing the multipath map,
+		// Collect the underlying multipath devices before removing the multipath map,
 		// as /sys/block/dm-X/slaves/ will be gone after removal.
-		slavesPath := filepath.Join("/sys/block", deviceName, "slaves")
-		slaves, _ := os.ReadDir(slavesPath)
+		slaveDevices, err := findMultipathSCSIDevices(deviceName)
+		if err != nil {
+			return fmt.Errorf("Failed searching SCSI paths for multipath device %q: %w", devicePath, err)
+		}
 
 		// Remove the multipath map.
 		//
 		// This may fail transiently with "map in use" if the device is still
 		// briefly open (for example by udev), so retry a few times before giving up.
-		var err error
 		for range 10 {
 			ctxErr := ctx.Err()
 			if ctxErr != nil {
@@ -471,10 +472,18 @@ func (c *connectorISCSI) RemoveDiskDevice(ctx context.Context, devicePath string
 		// Remove the underlying SCSI devices that were part of the multipath map.
 		// If not removed, they remain on the system and cause I/O errors when the
 		// volume is disconnected from the storage array.
-		for _, slave := range slaves {
-			err := removeDevice(slave.Name())
+		for _, devName := range slaveDevices {
+			err := removeDevice(devName)
 			if err != nil {
-				return fmt.Errorf("Failed removing multipath slave device %q: %w", slave.Name(), err)
+				return fmt.Errorf("Failed removing multipath slave device %q: %w", devName, err)
+			}
+		}
+
+		// Wait for the underlying SCSI devices to disappear.
+		for _, devName := range slaveDevices {
+			devPath := filepath.Join("/sys/block", devName)
+			if !block.WaitDiskDeviceGone(ctx, devPath) {
+				return fmt.Errorf("Timeout exceeded waiting for multipath slave device %q to disappear", devPath)
 			}
 		}
 	} else {

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -369,6 +369,11 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 	}
 
 	if isMultipathDevice(devicePath) {
+		err := waitMultipathReady(ctx, devicePath)
+		if err != nil {
+			return "", err
+		}
+
 		return devicePath, nil
 	}
 
@@ -395,7 +400,17 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 
 	// The multipath command is synchronous, but udev updates the /dev/disk/by-id
 	// symlinks asynchronously. Wait for the multipath-backed device path to appear.
-	return block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, multipathDeviceFilter)
+	mpDevicePath, err := block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, multipathDeviceFilter)
+	if err != nil {
+		return "", err
+	}
+
+	err = waitMultipathReady(ctx, devicePath)
+	if err != nil {
+		return "", err
+	}
+
+	return mpDevicePath, nil
 }
 
 // GetDiskDevicePath returns the path of the mapped iSCSI device.

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -405,7 +405,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 		return "", err
 	}
 
-	err = waitMultipathReady(ctx, devicePath)
+	err = waitMultipathReady(ctx, mpDevicePath)
 	if err != nil {
 		return "", err
 	}
@@ -449,40 +449,43 @@ func (c *connectorISCSI) RemoveDiskDevice(ctx context.Context, devicePath string
 
 	deviceName := filepath.Base(devicePath)
 
+	// If the device is gone, we are done.
+	if !shared.PathExists(devicePath) {
+		return nil
+	}
+
 	if isMultipathDevice(devicePath) {
-		// Collect the underlying multipath devices before removing the multipath map,
-		// as /sys/block/dm-X/slaves/ will be gone after removal.
 		slaveDevices, err := findMultipathSCSIDevices(deviceName)
 		if err != nil {
 			return fmt.Errorf("Failed searching SCSI paths for multipath device %q: %w", devicePath, err)
 		}
 
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+
 		// Remove the multipath map.
 		//
 		// This may fail transiently with "map in use" if the device is still
 		// briefly open (for example by udev), so retry a few times before giving up.
+		var flushErr error
 		for range 10 {
-			ctxErr := ctx.Err()
-			if ctxErr != nil {
-				// Preserve the command error if we already have one.
-				// Otherwise return the generic context error.
-				if err == nil {
-					err = ctxErr
-				}
+			_, flushErr = shared.RunCommand(ctx, "multipath", "-f", devicePath)
 
+			// Break if the device disappeared.
+			if flushErr == nil || !shared.PathExists(devicePath) {
 				break
 			}
 
-			_, err = shared.RunCommand(ctx, "multipath", "-f", devicePath)
-			if err == nil {
-				break
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("Timeout exceeded removing multipath device %q: %w", devicePath, ctx.Err())
+			case <-ticker.C:
 			}
-
-			time.Sleep(500 * time.Millisecond)
 		}
 
-		if err != nil {
-			return fmt.Errorf("Failed removing multipath device %q: %w", devicePath, err)
+		// Only return a failure if the map still exists after our retries.
+		if flushErr != nil && shared.PathExists(devicePath) {
+			return fmt.Errorf("Failed removing multipath device %q: %w", devicePath, flushErr)
 		}
 
 		// Remove the underlying SCSI devices that were part of the multipath map.
@@ -508,14 +511,10 @@ func (c *connectorISCSI) RemoveDiskDevice(ctx context.Context, devicePath string
 		if err != nil {
 			return fmt.Errorf("Failed removing device %q: %w", devicePath, err)
 		}
-	}
 
-	// Wait until the device has disappeared.
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	if !block.WaitDiskDeviceGone(ctx, devicePath) {
-		return fmt.Errorf("Timeout exceeded waiting for device %q to disappear", devicePath)
+		if !block.WaitDiskDeviceGone(ctx, devicePath) {
+			return fmt.Errorf("Timeout exceeded waiting for device %q to disappear", devicePath)
+		}
 	}
 
 	return nil

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -520,3 +520,100 @@ func (c *connectorISCSI) WaitDiskDeviceResize(ctx context.Context, diskPath stri
 func isMultipathDevice(devicePath string) bool {
 	return strings.HasPrefix(filepath.Base(devicePath), "dm-")
 }
+
+// findMultipathSCSIDevices returns every /sys/block/sd* basename that
+// belongs to the multipath device-mapper device named by dmName.
+//
+// The returned value contains direct multipath slaves and any other device whose
+// device/wwid matches the multipath device's WWID, which includes devices that were
+// previously failed and dropped from the map by multipathd but still exist as kernel
+// SCSI devices. This is necessary to fully clean up all SCSI paths to the device when
+// removing multipath device, and avoid leaving zombie devices that trigger
+// "Logical unit not supported" probe storms on the next reuse of the same WWID after
+// the array detaches the underlying LUN.
+//
+// If the multipath WWID cannot be parsed, only direct multipath slaves are returned.
+func findMultipathSCSIDevices(dmName string) ([]string, error) {
+	var devices []string
+
+	addDeviceIfNotExist := func(name string) {
+		// Only collect unique device names.
+		if !slices.Contains(devices, name) {
+			devices = append(devices, name)
+		}
+	}
+
+	normalizeWWID := func(wwid string) string {
+		wwid = strings.TrimSpace(wwid)
+		wwid = strings.ToLower(wwid)
+
+		for _, prefix := range []string{"0x", "scsi-", "naa.", "eui."} {
+			wwid = strings.TrimPrefix(wwid, prefix)
+		}
+
+		return wwid
+	}
+
+	// Collect direct multipath slaves from /sys/block/dmName/slaves/*.
+	slavesPath := filepath.Join("/sys/block", dmName, "slaves")
+	slaves, err := os.ReadDir(slavesPath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("Failed reading slaves of %q: %w", dmName, err)
+	}
+
+	for _, dev := range slaves {
+		addDeviceIfNotExist(dev.Name())
+	}
+
+	// Extract the WWID from the multipath UUID.
+	mpUUIDBytes, err := os.ReadFile(filepath.Join("/sys/block", dmName, "dm", "uuid"))
+	if err != nil {
+		// No WWID found for multipath device.
+		return devices, nil
+	}
+
+	// Trim "mpath-" prefix from UUID to get the WWID.
+	mpUUID := strings.ToLower(strings.TrimSpace(string(mpUUIDBytes)))
+	mpUUID, ok := strings.CutPrefix(mpUUID, "mpath-")
+	if !ok {
+		return devices, nil
+	}
+
+	mpWWID := normalizeWWID(mpUUID)
+	if mpWWID == "" {
+		return devices, nil
+	}
+
+	entries, err := os.ReadDir("/sys/block")
+	if err != nil {
+		return nil, fmt.Errorf("Failed reading /sys/block: %w", err)
+	}
+
+	// Look for any /sys/block/sd* whose device/wwid matches the multipath WWID.
+	for _, dev := range entries {
+		if !strings.HasPrefix(dev.Name(), "sd") {
+			continue
+		}
+
+		devWWIDBytes, err := os.ReadFile(filepath.Join("/sys/block", dev.Name(), "device", "wwid"))
+		if err != nil {
+			continue
+		}
+
+		devWWID := normalizeWWID(string(devWWIDBytes))
+		if devWWID == "" {
+			continue
+		}
+
+		// Compare the SCSI device WWID with the multipath WWID.
+		//
+		// Some multipath WWIDs include the SCSI VPD designator type (3) as a prefix.
+		// For example, multipath may report WWID as "368cc...", while the SCSI device
+		// reports WWID as "68cc...".
+		if devWWID == mpWWID || "3"+devWWID == mpWWID {
+			addDeviceIfNotExist(dev.Name())
+		}
+	}
+
+	return devices, nil
+}

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"math"
@@ -10,7 +9,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
@@ -277,12 +275,15 @@ func (d *alletra) unmapVolume(vol Volume) error {
 		return err
 	}
 
-	// Wait until the volume has disappeared.
-	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
-	defer cancel()
-
-	if volumePath != "" && !block.WaitDiskDeviceGone(ctx, volumePath) {
-		return fmt.Errorf("Timeout exceeded waiting for HPE Alletra storage volume %q to disappear on path %q", vol.name, volumePath)
+	// iSCSI's [connectors.RemoveDiskDevice] implementation already waits for the device to
+	// disappear before returning. Re-checking the resolved /dev/dm-X path here is unsafe, as
+	// the kernel can reuse the dm device for a different mpath assembled concurrently, making
+	// the poll see an existing device that has nothing to do with the removed volume.
+	//
+	// For NVMe the host-side device is removed asynchronously after the array detaches the
+	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
+	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
+		return fmt.Errorf("Timeout exceeded waiting for HPE Alletra volume %q to disappear on path %q", vol.name, volumePath)
 	}
 
 	mappings, err := d.client().GetVLUNsForHost(host.Name)

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +10,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
@@ -20,6 +18,7 @@ import (
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -1736,11 +1735,14 @@ func (d *powerstore) unmapVolume(vol Volume) error {
 		return fmt.Errorf("Failed detaching volume %q from host %q: %w", vol.name, host.Name, err)
 	}
 
-	// Wait until the volume has disappeared.
-	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
-	defer cancel()
-
-	if volumePath != "" && !block.WaitDiskDeviceGone(ctx, volumePath) {
+	// iSCSI's and SCSI/FC's [connectors.RemoveDiskDevice] implementation already waits for the
+	// device to disappear before returning. Re-checking the resolved /dev/dm-X path here is
+	// unsafe, as the kernel can reuse the dm device for a different mpath assembled concurrently,
+	// making the poll see an existing device that has nothing to do with the removed volume.
+	//
+	// For NVMe the host-side device is removed asynchronously after the array detaches the
+	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
+	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
 		return fmt.Errorf("Timeout exceeded waiting for PowerStore volume %q to disappear on path %q", vol.name, volumePath)
 	}
 

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -14,7 +13,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -1348,11 +1346,14 @@ func (d *pure) unmapVolume(vol Volume) error {
 		return err
 	}
 
-	// Wait until the volume has disappeared.
-	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
-	defer cancel()
-
-	if volumePath != "" && !block.WaitDiskDeviceGone(ctx, volumePath) {
+	// iSCSI's [connectors.RemoveDiskDevice] implementation already waits for the device to
+	// disappear before returning. Re-checking the resolved /dev/dm-X path here is unsafe, as
+	// the kernel can reuse the dm device for a different mpath assembled concurrently, making
+	// the poll see an existing device that has nothing to do with the removed volume.
+	//
+	// For NVMe the host-side device is removed asynchronously after the array detaches the
+	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
+	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
 		return fmt.Errorf("Timeout exceeded waiting for Pure Storage volume %q to disappear on path %q", vol.name, volumePath)
 	}
 


### PR DESCRIPTION
This PR addresses several potential race conditions when using iSCSI. 
They were found when implementing SCSI/FC, but are applicable to iSCSI as well, although they are harder to reproduce due to slower scanning/discovery.

---

1.) Waiting for unassociated multipath device to disapper.

In NVMe, the device is first detached on the appliance side. Once detachment occurs, NVMe will detect disconnection and clear host devices, and we wait for them to disapper.

Using SCSI, the devices need to be deleted on the host first.
When SCSI devices are removed and volume is detached on the appliance side, we should not wait for the multipath path to disapper afterwards. Between disconnection on the applience side and waiting for the path to disapper, another volume might be attached to host and reuse the same (no longer present) multpath device. This can result in LXD waiting for a multipath device that is unrelated with the detached volume to disapper.

2.) Remove all SCSI devices associated with the multipath's WWID.

Currently, we remove all multipath slave devices. This is correct.
However, it can occur that the device is detached before all path are recognized.
For example, 4 devices appear on the host, but only 3/4 path were detected by multipathd at the time we are removing it. When we fetch multipath slave devices, we get 3 detected devices and remove them. 1 device remains zombie on the system, and can cause issues once new multipath devices reuse that path.

3.) Wait for multipath device to have at least one active path.

When we attach the volume, we find the device associated with it. If only one device is visible at the moment when we resolve the symlink, we force multipath and wait for multipath device to appear. Up to this point everything is fine.

Currently, we just wait for the multipath device to appear. In most cases this works seamlessly, but to be on a safe side, confirm that multipath has at least one active and usable path, as a failed path might be associated with multipath device, in which case we do not want to proceed with storage operations.

---

Tested on:
- [x] PowerStore iSCSI (also on FC)
- [x] PureStorage iSCSI
