### PR TITLE
storage: Add FC connector and PowerStore FC support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3090,7 +3090,7 @@ Security events are accessible via `GET /1.0/events?type=security` and can be ro
 
 ## `storage_driver_powerstore`
 
-Adds a new `powerstore` storage driver which allows the consumption of storage volumes from a PowerStore storage array using iSCSI.
+Adds a new `powerstore` storage driver which allows the consumption of storage volumes from a PowerStore storage array using iSCSI or Fibre Channel (FC).
 
 The following pool level configuration keys have been added:
 

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6522,7 +6522,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode to use to map PowerStore volumes to the local server.
-Supported value is `iscsi`.
+Supported values are `iscsi` and `scsi/fc`.
 ```
 
 ```{config:option} powerstore.target storage-powerstore-pool-conf

--- a/doc/reference/storage_powerstore.md
+++ b/doc/reference/storage_powerstore.md
@@ -4,9 +4,9 @@
 Dell PowerStore is a storage solution from [Dell Technologies](https://www.dell.com/).
 It offers the consumption of block storage across the network.
 
-LXD supports connecting to PowerStore storage through {abbr}`iSCSI` (Internet Small Computer Systems Interface).
+LXD supports connecting to PowerStore storage through {abbr}`iSCSI` (Internet Small Computer Systems Interface) or {abbr}`FC` (Fibre Channel).
 
-Ensure that the required kernel modules and the iSCSI CLI (`iscsiadm`) are installed on your host system.
+For iSCSI, ensure that the required kernel modules and the iSCSI CLI (`iscsiadm`) are installed on your host system.
 
 ## Terminology
 
@@ -28,8 +28,9 @@ This driver provides remote storage.
 As a result, and depending on the internal network, storage access might be a bit slower compared to local storage.
 On the other hand, using remote storage has significant advantages in a cluster setup: all cluster members have access to the same storage pools with the exact same contents, without requiring the storage pools to be synchronized between members.
 
-When a volume is first mapped to the LXD host, LXD discovers the available targets from the PowerStore array and connects to them.
-Alternatively, you can specify the targets with {config:option}`storage-powerstore-pool-conf:powerstore.target`.
+For iSCSI, when a volume is first mapped to the LXD host, LXD discovers the available targets from the PowerStore array and connects to them.
+You can optionally restrict connections to specific targets using {config:option}`storage-powerstore-pool-conf:powerstore.target`.
+For Fibre Channel, targets are discovered automatically through the FC {abbr}`HBA` (Host Bus Adapter). The {config:option}`storage-powerstore-pool-conf:powerstore.target` option does not apply to FC mode.
 
 Volume snapshots are supported by PowerStore.
 When a volume with at least one snapshot is copied, LXD sequentially creates snapshots on the destination volume from snapshots on the source volume.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7209,7 +7209,7 @@
 					{
 						"powerstore.mode": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported value is `iscsi`.",
+							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported values are `iscsi` and `scsi/fc`.",
 							"scope": "global",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -20,6 +20,9 @@ const (
 
 	// TypeISCSI represents an iSCSI storage connector.
 	TypeISCSI string = "iscsi"
+
+	// TypeSCSIFC represents a Fibre Channel storage connector.
+	TypeSCSIFC string = "scsi/fc"
 )
 
 // session represents a connector session that is established with a target.
@@ -70,6 +73,11 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 
 	case TypeISCSI:
 		return &connectorISCSI{
+			common: common,
+		}, nil
+
+	case TypeSCSIFC:
+		return &connectorSCSIFC{
 			common: common,
 		}, nil
 

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -25,6 +25,17 @@ const (
 	TypeSCSIFC string = "scsi/fc"
 )
 
+// TransportType represents the transport type of the storage connector.
+type TransportType string
+
+const (
+	// TransportTCP represents a TCP-based storage transport.
+	TransportTCP TransportType = "tcp"
+
+	// TransportFC represents a Fibre Channel storage transport.
+	TransportFC TransportType = "fc"
+)
+
 // session represents a connector session that is established with a target.
 type session struct {
 	// id is a unique identifier of the session.
@@ -41,6 +52,7 @@ type session struct {
 // appropriate storage subsystem.
 type Connector interface {
 	Type() string
+	Transport() TransportType
 	Version() (string, error)
 	QualifiedName() (string, error)
 	LoadModules() error

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -535,6 +535,12 @@ func (c *connectorISCSI) WaitDiskDeviceResize(ctx context.Context, diskPath stri
 		defer cancel()
 	}
 
+	// Trigger rescan on all SCSI devices so the kernel reports the new size.
+	err := rescanMultipathSCSIDevices(diskPath)
+	if err != nil {
+		return err
+	}
+
 	if isMultipathDevice(diskPath) {
 		// Ask multipathd to refresh multipath device size.
 		_, err := shared.RunCommand(ctx, "multipath", "-r", diskPath)
@@ -645,6 +651,35 @@ func findMultipathSCSIDevices(dmName string) ([]string, error) {
 	}
 
 	return devices, nil
+}
+
+// rescanMultipathSCSIDevices triggers a SCSI capacity rescan on the device(s) backing the given
+// multipath device.
+// For multipath devices, all underlying SCSI devices are rescanned.
+// For single-path SCSI devices (sd*), the device itself is rescanned.
+func rescanMultipathSCSIDevices(devicePath string) error {
+	deviceName := filepath.Base(devicePath)
+
+	var deviceNames []string
+	if isMultipathDevice(devicePath) {
+		var err error
+		deviceNames, err = findMultipathSCSIDevices(deviceName)
+		if err != nil {
+			return fmt.Errorf("Failed finding slave SCSI devices for %q: %w", devicePath, err)
+		}
+	} else {
+		deviceNames = []string{deviceName}
+	}
+
+	for _, name := range deviceNames {
+		rescanPath := filepath.Join("/sys/block", name, "device", "rescan")
+		err := os.WriteFile(rescanPath, []byte("1"), 0200)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("Failed rescanning SCSI device %q: %w", name, err)
+		}
+	}
+
+	return nil
 }
 
 // waitMultipathReady checks if the multipath device has at least one active path.

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -60,6 +60,11 @@ func (c *connectorISCSI) Type() string {
 	return TypeISCSI
 }
 
+// Transport returns the transport type of the connector.
+func (c *connectorISCSI) Transport() TransportType {
+	return TransportTCP
+}
+
 // Version returns the version of the iSCSI CLI (iscsiadm).
 func (c *connectorISCSI) Version() (string, error) {
 	// Detect and record the version of the iSCSI CLI.

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -32,8 +32,8 @@ const (
 	iscsiErrCodeNotFound = 21
 )
 
-// iscsiDiskDevicePrefix is the prefix of the iSCSI disk device name in /dev/disk/by-id/.
-const iscsiDiskDevicePrefix = "scsi-"
+// scsiDiskDevicePrefix is the prefix of the SCSI disk device name in /dev/disk/by-id/.
+const scsiDiskDevicePrefix = "scsi-"
 
 const (
 	// ISCSIDefaultPort is the default port number for iSCSI targets.
@@ -363,7 +363,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 		defer cancel()
 	}
 
-	devicePath, err := block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, diskPathFilter)
+	devicePath, err := block.WaitDiskDevicePath(ctx, scsiDiskDevicePrefix, diskPathFilter)
 	if err != nil {
 		return "", err
 	}
@@ -400,7 +400,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 
 	// The multipath command is synchronous, but udev updates the /dev/disk/by-id
 	// symlinks asynchronously. Wait for the multipath-backed device path to appear.
-	mpDevicePath, err := block.WaitDiskDevicePath(ctx, iscsiDiskDevicePrefix, multipathDeviceFilter)
+	mpDevicePath, err := block.WaitDiskDevicePath(ctx, scsiDiskDevicePrefix, multipathDeviceFilter)
 	if err != nil {
 		return "", err
 	}
@@ -415,7 +415,7 @@ func (c *connectorISCSI) WaitDiskDevicePath(ctx context.Context, diskPathFilter 
 
 // GetDiskDevicePath returns the path of the mapped iSCSI device.
 func (c *connectorISCSI) GetDiskDevicePath(diskPathFilter block.DevicePathFilterFunc) (string, error) {
-	return block.GetDiskDevicePath(iscsiDiskDevicePrefix, diskPathFilter)
+	return block.GetDiskDevicePath(scsiDiskDevicePrefix, diskPathFilter)
 }
 
 // RemoveDiskDevice removes the disk device from the system.

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -106,6 +106,11 @@ func (c *connectorNVMe) Type() string {
 	return TypeNVMeTCP
 }
 
+// Transport returns the transport type of the connector.
+func (c *connectorNVMe) Transport() TransportType {
+	return TransportTCP
+}
+
 // Version returns the version of the NVMe CLI.
 func (c *connectorNVMe) Version() (string, error) {
 	// Detect and record the version of the NVMe CLI.

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/revert"
 )
 
@@ -240,8 +242,65 @@ func (c *connectorSCSIFC) Discover(ctx context.Context, wwpns ...string) ([]any,
 	return result, nil
 }
 
+// WaitDiskDevicePath waits for the mapped FC device to appear.
+// If the discovered device is not a multipath device, multipath is forced and the device path
+// is looked up again. An error is returned if no multipath device is found after that.
 func (c *connectorSCSIFC) WaitDiskDevicePath(ctx context.Context, diskPathFilter block.DevicePathFilterFunc) (string, error) {
-	return "", nil
+	_, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+
+	devicePath, err := block.WaitDiskDevicePath(ctx, scsiDiskDevicePrefix, diskPathFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if isMultipathDevice(devicePath) {
+		err = waitMultipathReady(ctx, devicePath)
+		if err != nil {
+			return "", err
+		}
+
+		return devicePath, nil
+	}
+
+	// Device is not a multipath device.
+	// Create multipath device from a found device path.
+	_, err = shared.RunCommand(ctx, "multipath", devicePath)
+	if err != nil {
+		return "", fmt.Errorf("Failed configuring multipath for SCSI/FC device %q: %w", devicePath, err)
+	}
+
+	// Filter that makes sure the found device resolves to a multipath device.
+	multipathDeviceFilter := func(devicePath string) bool {
+		if !diskPathFilter(devicePath) {
+			return false
+		}
+
+		path, err := filepath.EvalSymlinks(devicePath)
+		if err != nil {
+			return false
+		}
+
+		return isMultipathDevice(path)
+	}
+
+	// The multipath command is synchronous, but udev updates the /dev/disk/by-id
+	// symlinks asynchronously. Wait for the multipath-backed device path to appear.
+	mpDevicePath, err := block.WaitDiskDevicePath(ctx, scsiDiskDevicePrefix, multipathDeviceFilter)
+	if err != nil {
+		return "", err
+	}
+
+	err = waitMultipathReady(ctx, mpDevicePath)
+	if err != nil {
+		return "", err
+	}
+
+	return mpDevicePath, nil
 }
 
 // GetDiskDevicePath returns the path of the mapped SCSI/FC device if it already exists.

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -308,7 +308,95 @@ func (c *connectorSCSIFC) GetDiskDevicePath(diskPathFilter block.DevicePathFilte
 	return block.GetDiskDevicePath(scsiDiskDevicePrefix, diskPathFilter)
 }
 
+// RemoveDiskDevice removes the FC disk device from the system.
+//
+// The devices should be removed from the host before being unmapped on the storage array.
+// Removing a LUN mapping immediately can cause the device to be trapped in unresponsive (D state)
+// if there are still open references to it, for example by udev.
 func (c *connectorSCSIFC) RemoveDiskDevice(ctx context.Context, devicePath string) error {
+	if devicePath == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	deviceName := filepath.Base(devicePath)
+
+	// removeDevice removes device from the system if the device is removable.
+	removeDevice := func(devName string) error {
+		path := filepath.Join("/sys/block", devName, "device", "delete")
+
+		err := os.WriteFile(path, []byte("1"), 0200)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		return nil
+	}
+
+	// If the device is gone, we are done.
+	if !shared.PathExists(devicePath) {
+		return nil
+	}
+
+	if isMultipathDevice(devicePath) {
+		slaveDevices, err := findMultipathSCSIDevices(deviceName)
+		if err != nil {
+			return fmt.Errorf("Failed searching SCSI paths for multipath device %q: %w", devicePath, err)
+		}
+
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+
+		var flushErr error
+		for range 10 {
+			_, flushErr = shared.RunCommand(ctx, "multipath", "-f", devicePath)
+
+			// Break if successful or if the device vanished during the command.
+			if flushErr == nil || !shared.PathExists(devicePath) {
+				break
+			}
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("Timeout exceeded removing multipath device %q: %w", devicePath, ctx.Err())
+			case <-ticker.C:
+			}
+		}
+
+		// Only return a failure if the map still exists after our retries.
+		if flushErr != nil && shared.PathExists(devicePath) {
+			return fmt.Errorf("Failed removing multipath device %q: %w", devicePath, flushErr)
+		}
+
+		// Remove underlying SCSI devices.
+		for _, devName := range slaveDevices {
+			err := removeDevice(devName)
+			if err != nil {
+				return fmt.Errorf("Failed removing SCSI path %q for %q: %w", devName, devicePath, err)
+			}
+		}
+
+		// Wait for each SCSI devices to actually disappear.
+		for _, devName := range slaveDevices {
+			slavePath := filepath.Join("/sys/block", devName)
+			if !block.WaitDiskDeviceGone(ctx, slavePath) {
+				return fmt.Errorf("Timeout exceeded waiting for SCSI path %q of %q to disappear", devName, devicePath)
+			}
+		}
+	} else {
+		// For non-multipath device (/dev/sd*), remove the device itself.
+		err := removeDevice(deviceName)
+		if err != nil {
+			return fmt.Errorf("Failed removing device %q: %w", devicePath, err)
+		}
+
+		if !block.WaitDiskDeviceGone(ctx, devicePath) {
+			return fmt.Errorf("Timeout exceeded waiting for SCSI device %q to disappear", devicePath)
+		}
+	}
+
 	return nil
 }
 

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -400,7 +400,23 @@ func (c *connectorSCSIFC) RemoveDiskDevice(ctx context.Context, devicePath strin
 	return nil
 }
 
+// WaitDiskDeviceResize waits until the SCSI/FC disk device reflects the new size.
+// For multipath devices the device-mapper map is refreshed before waiting.
 func (c *connectorSCSIFC) WaitDiskDeviceResize(ctx context.Context, devicePath string, newSizeBytes int64) error {
+	_, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+
+	if isMultipathDevice(devicePath) {
+		_, err := shared.RunCommand(ctx, "multipath", "-r", devicePath)
+		if err != nil {
+			return fmt.Errorf("Failed updating multipath SCSI/FC device %q size: %w", devicePath, err)
+		}
+	}
+
 	return block.WaitDiskDeviceResize(ctx, devicePath, newSizeBytes)
 }
 

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -415,6 +415,12 @@ func (c *connectorSCSIFC) WaitDiskDeviceResize(ctx context.Context, devicePath s
 		defer cancel()
 	}
 
+	// Trigger a SCSI capacity rescan so the kernel reports the new size.
+	err := rescanMultipathSCSIDevices(devicePath)
+	if err != nil {
+		return err
+	}
+
 	if isMultipathDevice(devicePath) {
 		_, err := shared.RunCommand(ctx, "multipath", "-r", devicePath)
 		if err != nil {

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,11 @@ var _ Connector = &connectorSCSIFC{}
 
 type connectorSCSIFC struct {
 	common
+}
+
+// FCDiscoveryRecord represents an FC target port found on the fabric.
+type FCDiscoveryRecord struct {
+	PortName string // Target WWPN (for example "2100001b32abcdef").
 }
 
 // Type returns the type of the connector.
@@ -83,8 +89,66 @@ func (c *connectorSCSIFC) findSession(targetQN string) (*session, error) {
 	return nil, nil
 }
 
-func (c *connectorSCSIFC) Discover(ctx context.Context, targetAddresses ...string) ([]any, error) {
-	return nil, nil
+// Discover returns the FC target ports visible on the fabric.
+// If WWPNs are provided they act as an allowlist.
+func (c *connectorSCSIFC) Discover(ctx context.Context, wwpns ...string) ([]any, error) {
+	rportBasePath := "/sys/class/fc_remote_ports"
+
+	rports, err := os.ReadDir(rportBasePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, errors.New("No FC remote ports found")
+		}
+
+		return nil, fmt.Errorf("Failed reading FC remote ports: %w", err)
+	}
+
+	result := make([]any, 0, len(rports))
+	for _, rport := range rports {
+		portNameBytes, err := os.ReadFile(filepath.Join(rportBasePath, rport.Name(), "port_name"))
+		if err != nil {
+			continue
+		}
+
+		portName := normalizeWWPN(string(portNameBytes))
+
+		if len(wwpns) > 0 {
+			found := false
+			for _, wwpn := range wwpns {
+				if strings.EqualFold(portName, normalizeWWPN(wwpn)) {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				continue
+			}
+		}
+
+		stateBytes, err := os.ReadFile(filepath.Join(rportBasePath, rport.Name(), "port_state"))
+		if err != nil {
+			continue
+		}
+
+		state := strings.TrimSpace(string(stateBytes))
+		if state != "Online" {
+			// Skip offline or blocked ports, as they are not usable.
+			continue
+		}
+
+		record := FCDiscoveryRecord{
+			PortName: normalizeWWPN(portName),
+		}
+
+		result = append(result, record)
+	}
+
+	if len(result) == 0 {
+		return nil, errors.New("No SCSI/FC targets found on the fabric")
+	}
+
+	return result, nil
 }
 
 func (c *connectorSCSIFC) WaitDiskDevicePath(ctx context.Context, diskPathFilter block.DevicePathFilterFunc) (string, error) {

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -75,8 +75,97 @@ func (c *connectorSCSIFC) QualifiedName() (string, error) {
 	return "", errors.New("No FC host initiators found")
 }
 
-func (c *connectorSCSIFC) Connect(ctx context.Context, WWPN string, luns ...string) (revert.Hook, error) {
-	return nil, nil
+// Connect triggers a SCSI bus rescan on local hosts that have a remote FC port
+// matching WWPN. The HBA driver handles fabric login automatically; the rescan
+// makes newly mapped LUNs visible to the host.
+func (c *connectorSCSIFC) Connect(ctx context.Context, wwpn string, luns ...string) (revert.Hook, error) {
+	rportBasePath := "/sys/class/fc_remote_ports"
+	rports, err := os.ReadDir(rportBasePath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed reading FC remote ports: %w", err)
+	}
+
+	if len(luns) == 0 {
+		return nil, errors.New("At least one LUN must be provided to connect to an FC target")
+	}
+
+	wwpn = normalizeWWPN(wwpn)
+
+	type scanTarget struct {
+		host    string
+		channel string
+		target  string
+	}
+
+	var scanTargets []scanTarget
+	for _, rport := range rports {
+		portNameBytes, err := os.ReadFile(filepath.Join(rportBasePath, rport.Name(), "port_name"))
+		if err != nil {
+			continue
+		}
+
+		portName := normalizeWWPN(string(portNameBytes))
+		if portName != wwpn {
+			continue
+		}
+
+		// rport directory name has form "rport-H:C-R":
+		// H = local SCSI host index, C = channel, R = rport index.
+		name := strings.TrimPrefix(rport.Name(), "rport-")
+		hostIdx, rest, ok := strings.Cut(name, ":")
+		if !ok {
+			continue
+		}
+
+		channel, _, ok := strings.Cut(rest, "-")
+		if !ok {
+			// Unexpected format, skip
+			continue
+		}
+
+		targetBytes, err := os.ReadFile(filepath.Join(rportBasePath, rport.Name(), "scsi_target_id"))
+		if err != nil {
+			// Attribute missing, skip
+			continue
+		}
+
+		target := strings.TrimSpace(string(targetBytes))
+
+		// If target is -1 or empty, the FC transport class is not bound to a SCSI target yet.
+		if target == "-1" || target == "" {
+			continue
+		}
+
+		scanTarget := scanTarget{
+			host:    "host" + hostIdx,
+			channel: channel,
+			target:  target,
+		}
+
+		scanTargets = append(scanTargets, scanTarget)
+	}
+
+	if len(scanTargets) == 0 {
+		return nil, fmt.Errorf("No FC remote port with WWPN %q found", wwpn)
+	}
+
+	// Trigger SCSI bus rescan on each host, by writing the scan parameters to the host's
+	// scan file. This will make the newly mapped LUNs visible to the host.
+	for _, scanTarget := range scanTargets {
+		scanPath := filepath.Join("/sys/class/scsi_host", scanTarget.host, "scan")
+
+		for _, lun := range luns {
+			scan := scanTarget.channel + " " + scanTarget.target + " " + lun
+
+			err := os.WriteFile(scanPath, []byte(scan), 0200)
+			if err != nil {
+				return nil, fmt.Errorf("Failed scanning FC host %q target %q LUN %q: %w", scanTarget.host, scanTarget.target, lun, err)
+			}
+		}
+	}
+
+	cleanup := func() {}
+	return cleanup, nil
 }
 
 // Disconnect is a no-op for FC.

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -1,0 +1,81 @@
+package connectors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared/revert"
+)
+
+var _ Connector = &connectorSCSIFC{}
+
+type connectorSCSIFC struct {
+	common
+}
+
+// Type returns the type of the connector.
+func (c *connectorSCSIFC) Type() string {
+	return TypeSCSIFC
+}
+
+// Version returns a non-empty string if FC host adapters are present on the system, error otherwise.
+func (c *connectorSCSIFC) Version() (string, error) {
+	entries, err := os.ReadDir("/sys/class/fc_host")
+	if err != nil {
+		return "", fmt.Errorf("No FC host adapters found: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return "", errors.New("No FC host adapters found")
+	}
+
+	return "detected (" + TypeSCSIFC + ")", nil
+}
+
+// LoadModules loads the FC SCSI transport kernel module.
+func (c *connectorSCSIFC) LoadModules() error {
+	return util.LoadModule("scsi_transport_fc")
+}
+
+func (c *connectorSCSIFC) QualifiedName() (string, error) {
+	return "", nil
+}
+
+func (c *connectorSCSIFC) Connect(ctx context.Context, WWPN string, luns ...string) (revert.Hook, error) {
+	return nil, nil
+}
+
+// Disconnect is a no-op for FC.
+func (c *connectorSCSIFC) Disconnect(targetQN string) error {
+	return nil
+}
+
+// findSession returns nil as FC doesn't have sessions.
+func (c *connectorSCSIFC) findSession(targetQN string) (*session, error) {
+	return nil, nil
+}
+
+func (c *connectorSCSIFC) Discover(ctx context.Context, targetAddresses ...string) ([]any, error) {
+	return nil, nil
+}
+
+func (c *connectorSCSIFC) WaitDiskDevicePath(ctx context.Context, diskPathFilter block.DevicePathFilterFunc) (string, error) {
+	return "", nil
+}
+
+// GetDiskDevicePath returns the path of the mapped SCSI/FC device if it already exists.
+func (c *connectorSCSIFC) GetDiskDevicePath(diskPathFilter block.DevicePathFilterFunc) (string, error) {
+	return block.GetDiskDevicePath(scsiDiskDevicePrefix, diskPathFilter)
+}
+
+func (c *connectorSCSIFC) RemoveDiskDevice(ctx context.Context, devicePath string) error {
+	return nil
+}
+
+func (c *connectorSCSIFC) WaitDiskDeviceResize(ctx context.Context, devicePath string, newSizeBytes int64) error {
+	return block.WaitDiskDeviceResize(ctx, devicePath, newSizeBytes)
+}

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/util"
@@ -41,8 +43,30 @@ func (c *connectorSCSIFC) LoadModules() error {
 	return util.LoadModule("scsi_transport_fc")
 }
 
+// QualifiedName returns the World Wide Port Name (WWPN) of the first FC host initiator.
 func (c *connectorSCSIFC) QualifiedName() (string, error) {
-	return "", nil
+	fcHostPath := "/sys/class/fc_host"
+
+	hosts, err := os.ReadDir(fcHostPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("No FC hosts found: Directory %q does not exist", fcHostPath)
+		}
+
+		return "", fmt.Errorf("Failed reading FC hosts: %w", err)
+	}
+
+	for _, host := range hosts {
+		portNameBytes, err := os.ReadFile(filepath.Join(fcHostPath, host.Name(), "port_name"))
+		if err != nil {
+			continue
+		}
+
+		wwpn := normalizeWWPN(string(portNameBytes))
+		return wwpn, nil
+	}
+
+	return "", errors.New("No FC host initiators found")
 }
 
 func (c *connectorSCSIFC) Connect(ctx context.Context, WWPN string, luns ...string) (revert.Hook, error) {
@@ -78,4 +102,15 @@ func (c *connectorSCSIFC) RemoveDiskDevice(ctx context.Context, devicePath strin
 
 func (c *connectorSCSIFC) WaitDiskDeviceResize(ctx context.Context, devicePath string, newSizeBytes int64) error {
 	return block.WaitDiskDeviceResize(ctx, devicePath, newSizeBytes)
+}
+
+// normalizeWWPN normalizes the WWPN string to make it comparable regardless of the format
+// it's provided in. Linux sysfs reports WWPNs as "0x" with 16 hex chars ("0x210034800d7035b3"),
+// while storage array might report it using colon-separated byte format ("21:00:34:80:0d:70:35:b3").
+func normalizeWWPN(wwpn string) string {
+	wwpn = strings.TrimSpace(wwpn)
+	wwpn = strings.ToLower(wwpn)
+	wwpn = strings.TrimPrefix(wwpn, "0x")
+	wwpn = strings.ReplaceAll(wwpn, ":", "")
+	return wwpn
 }

--- a/lxd/storage/connectors/connector_scsi_fc.go
+++ b/lxd/storage/connectors/connector_scsi_fc.go
@@ -32,6 +32,11 @@ func (c *connectorSCSIFC) Type() string {
 	return TypeSCSIFC
 }
 
+// Transport returns the transport type of the connector.
+func (c *connectorSCSIFC) Transport() TransportType {
+	return TransportFC
+}
+
 // Version returns a non-empty string if FC host adapters are present on the system, error otherwise.
 func (c *connectorSCSIFC) Version() (string, error) {
 	entries, err := os.ReadDir("/sys/class/fc_host")

--- a/lxd/storage/connectors/connector_scsi_fc_test.go
+++ b/lxd/storage/connectors/connector_scsi_fc_test.go
@@ -1,0 +1,47 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_normalizeWWPN(t *testing.T) {
+	tests := []struct {
+		name string
+		wwpn string
+		want string
+	}{
+		{
+			name: "Linux sysfs format with 0x prefix",
+			wwpn: "0x210034800d7035b3",
+			want: "210034800d7035b3",
+		},
+		{
+			name: "Colon-separated byte format",
+			wwpn: "21:00:34:80:0d:70:35:b3",
+			want: "210034800d7035b3",
+		},
+		{
+			name: "Uppercase WWPN",
+			wwpn: "0x210034800D7035B3",
+			want: "210034800d7035b3",
+		},
+		{
+			name: "Surrounding whitespace",
+			wwpn: "  0x210034800d7035b3  ",
+			want: "210034800d7035b3",
+		},
+		{
+			name: "Plain hex without prefix or separators",
+			wwpn: "210034800d7035b3",
+			want: "210034800d7035b3",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, normalizeWWPN(test.wwpn))
+		})
+	}
+}

--- a/lxd/storage/connectors/connector_sdc.go
+++ b/lxd/storage/connectors/connector_sdc.go
@@ -28,6 +28,11 @@ func (c *connectorSDC) Type() string {
 	return TypeSDC
 }
 
+// Transport returns the transport type of the connector.
+func (c *connectorSDC) Transport() TransportType {
+	return TransportTCP
+}
+
 // Version returns an empty string and no error.
 func (c *connectorSDC) Version() (string, error) {
 	return "", nil

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -562,6 +562,8 @@ func (c *PowerStoreClient) GetCurrentHost(connectorType string, qn string) (*Pow
 		return nil, err
 	}
 
+	qn = formatQN(connectorType, qn)
+
 	// Find initiator with the provided port type (connector type) and name (qualified name),
 	// and retrieve the ID of the host it belongs to.
 	var initiator PowerStoreHostInitiator
@@ -628,6 +630,8 @@ func (c *PowerStoreClient) CreateHost(hostName string, connectorType string, qn 
 	if err != nil {
 		return "", err
 	}
+
+	qn = formatQN(connectorType, qn)
 
 	req := map[string]any{
 		"name":    hostName,
@@ -1030,4 +1034,30 @@ func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	default:
 		return "", fmt.Errorf("Unsupported connector type: %q", connectorType)
 	}
+}
+
+// formatQN formats the qualified name (or WWPN in case of FC) into PowerStore expected format
+// based on the connector transport type.
+func formatQN(connectorType string, qn string) string {
+	if connectorType != connectors.TypeSCSIFC {
+		return qn
+	}
+
+	// Normalize into a plain 16-hex-char WWPN.
+	normalized := strings.ToLower(strings.TrimSpace(qn))
+	normalized = strings.TrimPrefix(normalized, "0x")
+	normalized = strings.ReplaceAll(normalized, ":", "")
+
+	// PowerStore identifies initiators on the FC fabric using the colon-separated byte format
+	// ("21:00:34:80:0d:70:35:b3"). If we do not have exactly 8 bytes, do not attempt to reformat.
+	if len(normalized) != 16 {
+		return qn
+	}
+
+	parts := make([]string, 8)
+	for i := range 8 {
+		parts[i] = normalized[i*2 : i*2+2]
+	}
+
+	return strings.Join(parts, ":")
 }

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -1025,6 +1025,8 @@ func powerStoreConnectorToPortType(connectorType string) (string, error) {
 		return "iSCSI", nil
 	case connectors.TypeNVMeTCP:
 		return "NVMe", nil
+	case connectors.TypeSCSIFC:
+		return "FC", nil
 	default:
 		return "", fmt.Errorf("Unsupported connector type: %q", connectorType)
 	}

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/revert"
 )
 
 const (
@@ -56,6 +57,7 @@ func (PowerStoreHostInitiator) selector() string {
 type PowerStoreHostVolumeMapping struct {
 	HostID   string `json:"host_id,omitempty"`
 	VolumeID string `json:"volume_id,omitempty"`
+	LUN      int    `json:"logical_unit_number,omitempty"`
 }
 
 // PowerStoreHost represents a PowerStore host.
@@ -68,7 +70,7 @@ type PowerStoreHost struct {
 }
 
 func (PowerStoreHost) selector() string {
-	return "id,name,os_type,initiators(id,port_name,port_type),mapped_hosts(id,host_id,volume_id)"
+	return "id,name,os_type,initiators(id,port_name,port_type),mapped_hosts(id,host_id,volume_id,logical_unit_number)"
 }
 
 // PowerStoreVolume represents a PowerStore volume.
@@ -939,19 +941,19 @@ func (c *PowerStoreClient) RestoreVolume(volumeID string, snapshotID string) err
 	return nil
 }
 
-// AttachVolumeToHost attaches (maps) volume to host, returning true if the volume was freshly
-// attached to the host, and false if the volume was already attached to the host.
-func (c *PowerStoreClient) AttachVolumeToHost(volumeID string, hostID string) (bool, error) {
+// AttachVolumeToHost attaches (maps) volume to host. It returns the assigned volume LUN and
+// whether a new host to volume mapping was created.
+func (c *PowerStoreClient) AttachVolumeToHost(volumeID string, hostID string) (lun int, attached bool, err error) {
 	// Check if the volume is already attached to the host.
 	host, err := c.GetHost(hostID)
 	if err != nil {
-		return false, err
+		return 0, false, err
 	}
 
 	for _, mapping := range host.MappedVolumes {
 		if mapping.VolumeID == volumeID {
 			// The volume is already attached to the host.
-			return false, nil
+			return mapping.LUN, false, nil
 		}
 	}
 
@@ -963,10 +965,28 @@ func (c *PowerStoreClient) AttachVolumeToHost(volumeID string, hostID string) (b
 	url := api.NewURL().Path("api", "rest", "volume", volumeID, "attach")
 	err = c.requestAuthenticated(http.MethodPost, url.URL, req, nil, nil)
 	if err != nil {
-		return false, fmt.Errorf("Failed attaching PowerStore volume to the host: %w", err)
+		return 0, false, fmt.Errorf("Failed attaching PowerStore volume to the host: %w", err)
 	}
 
-	return true, nil
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() { _ = c.DetachVolumeFromHost(volumeID, hostID) })
+
+	// Fetch host again to retrieve the LUN assigned to the newly created mapping.
+	host, err = c.GetHost(hostID)
+	if err != nil {
+		return 0, true, fmt.Errorf("Failed retrieving volume attachments after attach: %w", err)
+	}
+
+	for _, mapping := range host.MappedVolumes {
+		if mapping.VolumeID == volumeID {
+			reverter.Success()
+			return mapping.LUN, true, nil
+		}
+	}
+
+	return 0, true, errors.New("Failed retrieving LUN for attached volume")
 }
 
 // DetachVolumeFromHost detaches (unmaps) volume from host.

--- a/lxd/storage/drivers/clients/powerstore_test.go
+++ b/lxd/storage/drivers/clients/powerstore_test.go
@@ -1,0 +1,61 @@
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/canonical/lxd/lxd/storage/connectors"
+)
+
+func Test_formatQN(t *testing.T) {
+	tests := []struct {
+		name          string
+		connectorType string
+		qn            string
+		want          string
+	}{
+		{
+			name:          "Non-FC connector is returned unchanged",
+			connectorType: connectors.TypeISCSI,
+			qn:            "iqn.1993-08.org.debian:01:abcdef123456",
+			want:          "iqn.1993-08.org.debian:01:abcdef123456",
+		},
+		{
+			name:          "FC WWPN with 0x prefix is reformatted to colon-separated bytes",
+			connectorType: connectors.TypeSCSIFC,
+			qn:            "0x210034800d7035b3",
+			want:          "21:00:34:80:0d:70:35:b3",
+		},
+		{
+			name:          "FC WWPN already colon-separated is normalized to lowercase",
+			connectorType: connectors.TypeSCSIFC,
+			qn:            "21:00:34:80:0D:70:35:B3",
+			want:          "21:00:34:80:0d:70:35:b3",
+		},
+		{
+			name:          "FC WWPN plain hex without separators is reformatted",
+			connectorType: connectors.TypeSCSIFC,
+			qn:            "210034800d7035b3",
+			want:          "21:00:34:80:0d:70:35:b3",
+		},
+		{
+			name:          "FC WWPN with surrounding whitespace is reformatted",
+			connectorType: connectors.TypeSCSIFC,
+			qn:            "  0x210034800d7035b3  ",
+			want:          "21:00:34:80:0d:70:35:b3",
+		},
+		{
+			name:          "FC WWPN with unexpected length is returned unchanged",
+			connectorType: connectors.TypeSCSIFC,
+			qn:            "0x210034800d7035",
+			want:          "0x210034800d7035",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, formatQN(test.connectorType, test.qn))
+		})
+	}
+}

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -26,6 +26,7 @@ var powerStoreVersion string
 // powerStoreSupportedConnectors represents a list of storage connectors that can be used with PowerStore.
 var powerStoreSupportedConnectors = []string{
 	connectors.TypeISCSI,
+	connectors.TypeSCSIFC,
 }
 
 // powerStoreDefaultUser represents the default PowerStore user name.
@@ -161,7 +162,7 @@ func (d *powerstore) Validate(config map[string]string) error {
 		"powerstore.gateway.verify": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.mode)
 		// The mode to use to map PowerStore volumes to the local server.
-		// Supported value is `iscsi`.
+		// Supported values are `iscsi` and `scsi/fc`.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -293,33 +293,34 @@ func (d *powerstore) targets() (map[string][]string, error) {
 		return nil, err
 	}
 
-	// Fetch discovery addresses from PowerStore for the selected connector type.
-	discoveryAddresses, err := d.client().DiscoveryAddresses(connector.Type())
-	if err != nil {
-		return nil, err
-	}
-
 	// Fetch discovery log records for each discovery address.
 	// The records contain the information about available targets.
 	var discoveryLogRecords []any
-	for _, addr := range discoveryAddresses {
-		discovered, err := connector.Discover(d.state.ShutdownCtx, addr)
+	var filterAddresses []string
+
+	if connector.Transport() == connectors.TransportFC {
+		// Fiber channel targets are visible through the HBA.
+		discoveryLogRecords, err = connector.Discover(d.state.ShutdownCtx)
 		if err != nil {
-			// Underlying connector already logs a warning.
-			continue
+			return nil, err
+		}
+	} else {
+		// Fetch discovery addresses from PowerStore for the selected connector type.
+		discoveryAddresses, err := d.client().DiscoveryAddresses(connector.Type())
+		if err != nil {
+			return nil, err
 		}
 
-		discoveryLogRecords = append(discoveryLogRecords, discovered...)
-	}
+		for _, addr := range discoveryAddresses {
+			discovered, err := connector.Discover(d.state.ShutdownCtx, addr)
+			if err != nil {
+				// Underlying connector already logs a warning.
+				continue
+			}
 
-	if len(discoveryLogRecords) == 0 {
-		return nil, errors.New("Failed fetching discovery log records for all PowerStore target addresses")
-	}
+			discoveryLogRecords = append(discoveryLogRecords, discovered...)
+		}
 
-	// Parse user-specified list of addresses to connect to.
-	// If not specified, all discovered addresses will be used.
-	filterAddresses := shared.SplitNTrimSpace(d.config["powerstore.target"], ",", -1, true)
-	if len(filterAddresses) > 0 {
 		// Make sure target addresses have port configured.
 		var defaultPort string
 
@@ -333,9 +334,16 @@ func (d *powerstore) targets() (map[string][]string, error) {
 			return nil, fmt.Errorf("Unsupported PowerStore mode %q", mode)
 		}
 
+		// Parse user-specified list of addresses to connect to.
+		// If not specified, all discovered addresses will be used.
+		filterAddresses = shared.SplitNTrimSpace(d.config["powerstore.target"], ",", -1, true)
 		for i := range filterAddresses {
 			filterAddresses[i] = shared.EnsurePort(filterAddresses[i], defaultPort)
 		}
+	}
+
+	if len(discoveryLogRecords) == 0 {
+		return nil, errors.New("Failed fetching discovery log records for PowerStore targets")
 	}
 
 	// Helper function to extract address and qualified name from a discovery log record,
@@ -348,6 +356,10 @@ func (d *powerstore) targets() (map[string][]string, error) {
 		case connectors.NVMeDiscoveryLogRecord:
 			address = net.JoinHostPort(r.TransportAddress, r.TransportServiceIdentifier)
 			qn = r.SubNQN
+		case connectors.FCDiscoveryRecord:
+			// FC targets are identified only by WWPN, so use it for both fields.
+			address = r.PortName
+			qn = r.PortName
 		default:
 			return "", "", fmt.Errorf("Unknown discovery log record entry type %T", record)
 		}

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1514,15 +1514,11 @@ func (d *powerstore) ensureHost() (hostID string, cleanup revert.Hook, err error
 		}
 
 		// The storage host entry with a qualified name of the current LXD host does not exist.
-		// Therefore, create a new one and name it after the server name.
-		serverName, err := ResolveServerName(d.state.ServerName)
+		// Therefore, create a new one and name it after the resolved server name.
+		hostname, err := ResolveServerNameWithConnectorType(d.state.ServerName, connector.Type())
 		if err != nil {
 			return "", nil, err
 		}
-
-		// Append the mode to the server name because storage array does not allow mixing
-		// NQNs, IQNs, and WWNs for a single host.
-		hostname := serverName + "-" + connector.Type()
 
 		hostID, err = client.CreateHost(hostname, connector.Type(), qn)
 		if err != nil {

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1630,8 +1630,8 @@ func (d *powerstore) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 
 	reverter.Add(cleanup)
 
-	// Ensure the volume is connected to the host.
-	connCreated, err := client.AttachVolumeToHost(volID, hostID)
+	// Ensure the volume is connected to the host, obtaining the assigned LUN.
+	lun, connCreated, err := client.AttachVolumeToHost(volID, hostID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed attaching volume %q to host: %w", vol.name, err)
 	}
@@ -1651,7 +1651,13 @@ func (d *powerstore) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 
 	// Connect to the array.
 	for qualifiedName, addresses := range targets {
-		connReverter, err := connector.Connect(d.state.ShutdownCtx, qualifiedName, addresses...)
+		var connReverter revert.Hook
+		if connector.Transport() == connectors.TransportFC {
+			connReverter, err = connector.Connect(d.state.ShutdownCtx, qualifiedName, strconv.Itoa(lun))
+		} else {
+			connReverter, err = connector.Connect(d.state.ShutdownCtx, qualifiedName, addresses...)
+		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR implements SCSI FC connector and extends PowerStore to support managing volumes using FC. The connector name is currently set to `scsi/fc`.

Rebase after:
- [x] https://github.com/canonical/lxd/pull/18332