### PR TITLE
lxd/daemon: stop exporting `LVM_SUPPRESS_FD_WARNINGS=1`

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1194,12 +1194,6 @@ func (d *Daemon) init() error {
 		return err
 	}
 
-	/* Set the LVM environment */
-	err = os.Setenv("LVM_SUPPRESS_FD_WARNINGS", "1")
-	if err != nil {
-		return err
-	}
-
 	/* Print welcome message */
 	mode := "normal"
 	if d.os.MockMode {


### PR DESCRIPTION
This was introduced in 2015 by commit e6df9aa17cbc5024974e6273ccfbecd168da48f6:

> lvm: Hide fdleak messages

If there are any FD leaks left, they should be investigated. Also, TiCS seems to think this variable is some kind of secret value baked in the source code so it gives a bad score.
