### PR TITLE
Cluster: Don't use the proxy for internal connections (from Incus)

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/canonical/lxd/client"
@@ -28,9 +29,15 @@ func connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 		UserAgent:     userAgent,
 	}
 
-	requestor, err := request.GetRequestorAuditor(ctx)
-	if err == nil {
-		args.Proxy = request.RequestorForwardProxy(requestor)
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		// Forward the requestor details if this is a user-initiated request.
+		requestor, err := request.GetRequestorAuditor(ctx)
+		if err == nil {
+			request.SetRequestorHeaders(requestor, req)
+		}
+
+		return nil, nil
 	}
 
 	url := "https://" + address
@@ -125,6 +132,11 @@ func SetupTrust(serverCert *shared.CertInfo, clusterPut api.ClusterPut) error {
 		UserAgent:     version.UserAgent,
 	}
 
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		return nil, nil
+	}
+
 	target, err := lxd.ConnectLXD("https://"+clusterPut.ClusterAddress, args)
 	if err != nil {
 		return fmt.Errorf("Failed connecting to target cluster node %q: %w", clusterPut.ClusterAddress, err)
@@ -164,6 +176,11 @@ func UpdateTrust(serverCert *shared.CertInfo, serverName string, targetAddress s
 		TLSClientKey:  string(serverCert.PrivateKey()),
 		TLSServerCert: targetCert,
 		UserAgent:     version.UserAgent,
+	}
+
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		return nil, nil
 	}
 
 	target, err := lxd.ConnectLXD("https://"+targetAddress, args)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -40,8 +40,8 @@ func connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 		return nil, nil
 	}
 
-	url := "https://" + address
-	return lxd.ConnectLXD(url, args)
+	clusterURL := "https://" + address
+	return lxd.ConnectLXD(clusterURL, args)
 }
 
 // Connect is a convenience around lxd.ConnectLXD that configures the client

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -44,6 +46,9 @@ type ImageDownloadArgs struct {
 	Budget            int64
 	SourceProjectName string
 	UserRequested     bool
+	// Proxy overrides the daemon-level proxy function when set.
+	// Use a no-op proxy function for intra-cluster connections to bypass the configured HTTP proxy.
+	Proxy func(req *http.Request) (*url.URL, error)
 }
 
 // imageOperationLock acquires a lock for operating on an image and returns the unlock function.
@@ -77,10 +82,17 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 
 	// Attempt to resolve the alias
 	if slices.Contains([]string{"lxd", "simplestreams"}, protocol) {
+		// Use the proxy from args if provided (e.g., a no-op proxy for intra-cluster connections),
+		// otherwise fall back to the daemon-level proxy.
+		proxy := args.Proxy
+		if proxy == nil {
+			proxy = s.Proxy
+		}
+
 		clientArgs := &lxd.ConnectionArgs{
 			TLSServerCert: args.Certificate,
 			UserAgent:     version.UserAgent,
-			Proxy:         s.Proxy,
+			Proxy:         proxy,
 			CachePath:     s.OS.CacheDir,
 			CacheExpiry:   time.Hour,
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -592,7 +592,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	return &info, nil
 }
 
-func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, profileProject string, imageProject string, budget int64) (*api.Image, error) {
+func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, profileProject string, imageProject string, budget int64, proxy func(req *http.Request) (*url.URL, error)) (*api.Image, error) {
 	var err error
 	var hash string
 
@@ -617,6 +617,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 		Budget:            budget,
 		SourceProjectName: req.Source.Project,
 		UserRequested:     true,
+		Proxy:             proxy,
 	})
 	if err != nil {
 		return nil, err
@@ -1324,8 +1325,17 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 			switch req.Source.Type {
 			case api.SourceTypeImage:
+				// For intra-cluster image copies, bypass the configured HTTP proxy
+				// since cluster members communicate directly.
+				var proxy func(req *http.Request) (*url.URL, error)
+				if isClusterNotification {
+					proxy = func(req *http.Request) (*url.URL, error) {
+						return nil, nil
+					}
+				}
+
 				/* Processing image copy from remote */
-				info, err = imgPostRemoteInfo(ctx, s, req, op, profileProject, imageProject, budget)
+				info, err = imgPostRemoteInfo(ctx, s, req, op, profileProject, imageProject, budget, proxy)
 			default:
 				/* Processing image creation from container */
 				imagePublishLock.Lock()

--- a/lxd/request/requestor.go
+++ b/lxd/request/requestor.go
@@ -5,12 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 	"time"
 
 	"github.com/canonical/lxd/lxd/identity"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -225,22 +223,19 @@ func (r *Requestor) IsForwarded() bool {
 	return r.forwardedOriginAddress != ""
 }
 
-// RequestorForwardProxy returns a proxy function that adds the requestor details as headers to be inspected by the receiving cluster member.
-func RequestorForwardProxy(r RequestorAuditor) func(req *http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		req.Header.Add(headerForwardedAddress, r.OriginAddress())
+// SetRequestorHeaders adds the requestor details as forwarded headers on the
+// given HTTP request so the receiving cluster member can identify the caller.
+func SetRequestorHeaders(r RequestorAuditor, req *http.Request) {
+	req.Header.Add(headerForwardedAddress, r.OriginAddress())
 
-		username := r.CallerUsername()
-		if username != "" {
-			req.Header.Add(headerForwardedUsername, username)
-		}
+	username := r.CallerUsername()
+	if username != "" {
+		req.Header.Add(headerForwardedUsername, username)
+	}
 
-		protocol := r.CallerProtocol()
-		if protocol != "" {
-			req.Header.Add(headerForwardedProtocol, protocol)
-		}
-
-		return shared.ProxyFromEnvironment(req)
+	protocol := r.CallerProtocol()
+	if protocol != "" {
+		req.Header.Add(headerForwardedProtocol, protocol)
 	}
 }
 
@@ -277,7 +272,7 @@ func (r *Requestor) setForwardingDetails(req *http.Request) error {
 	}
 
 	// If the forwarded address is set, the forwarded protocol and username must be both be set or both be unset
-	// (see RequestorForwardProxy).
+	// (see SetRequestorHeaders).
 	if (forwardedUsername == "" && forwardedProtocol != "") || (forwardedUsername != "" && forwardedProtocol == "") {
 		return errors.New("Received forwarded request with missing username or protocol")
 	}

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -54,6 +54,7 @@ readonly test_group_cluster=(
 readonly test_group_cluster_storage=(
     "clustering_image_refresh"
     "clustering_image_replication"
+    "clustering_image_proxy_bypass"
     "clustering_live_migration"
     "clustering_publish"
     "clustering_recovery"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2362,6 +2362,54 @@ test_clustering_image_replication() {
   kill_lxd "${LXD_THREE_DIR}"
 }
 
+test_clustering_image_proxy_bypass() {
+  spawn_lxd_and_bootstrap_cluster
+
+  local cert
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Spawn a second node
+  spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}"
+
+  sub_test "Image replication bypasses configured HTTP proxy"
+  # Set core.proxy_https to a non-existent proxy. Cluster traffic should bypass the proxy entirely.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.proxy_https "http://127.0.0.1:1"
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.proxy_http "http://127.0.0.1:1"
+
+  # Import the test image on node1
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage
+
+  # The image should be visible through both nodes
+  LXD_DIR="${LXD_ONE_DIR}" lxc image list | grep -wF testimage
+  LXD_DIR="${LXD_TWO_DIR}" lxc image list | grep -wF testimage
+
+  # The image tarball should be available on both nodes
+  fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info testimage | awk '/^Fingerprint/ {print $2}')
+  [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/images/${fingerprint}" ]
+
+  # Clean up the image
+  LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
+  [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
+
+  # Unset the proxy configuration
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset core.proxy_https
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset core.proxy_http
+
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+}
+
 test_clustering_dns() {
   # Because we do not want tests to only run on Ubuntu (due to cluster's fan network dependency)
   # instead we will just spawn forkdns directly and check DNS resolution.


### PR DESCRIPTION
Currently when `core.proxy_https` or `core.proxy_http` is configured, LXD uses the proxy for all HTTP connections including intra-cluster traffic. If the proxy denies connections to cluster member IPs, image sync between nodes fails.

This PR fixes this by always bypassing the configured proxy for cluster connections.

Inspired-by https://github.com/lxc/incus/pull/2437 and https://github.com/lxc/incus/pull/2528.

Fixes https://github.com/canonical/lxd/issues/16604.