### PR TITLE
Storage: Freeze instance before multi-volume snapshot

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -990,8 +990,8 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 		return err
 	}
 
-	if pool.Driver().Info().RunningCopyFreeze && inst.IsRunning() && !inst.IsFrozen() {
-		// Freeze the processes.
+	// Freeze the instance if the driver requires it or if there are attached volumes to ensure crash-consistent snapshots.
+	if (pool.Driver().Info().RunningCopyFreeze || len(attachedVolumes) > 0) && inst.IsRunning() && !inst.IsFrozen() {
 		err = inst.Freeze(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
Related to https://github.com/canonical/lxd/issues/18319

This is required for crash consistent multi-volume snapshots.

Tested as follows:

```
lxc config show c1
architecture: x86_64
config:
devices:
  foo:
    path: /mnt
    pool: zfs
    source: foo
    type: disk
  root:
    path: /
    pool: zfs
    type: disk
```

```
lxc snapshot c1 --disk-volumes=all-exclusive
```

Logs show instance freeze occurs before snapshots are taken even on ZFS (which has `RunningCopyFreeze: false`):
```
INFO   [2026-05-26T16:40:34+01:00] Created instance snapshot                     ephemeral=false instance=c1/snap1 instanceType=container project=default
INFO   [2026-05-26T16:40:34+01:00] instance-snapshot-created                     project=default requestor=unix/thomas.parrott@canonical.com source=/1.0/instances/c1/snapshots/snap1
INFO   [2026-05-26T16:40:34+01:00] Freezing container                            created="2026-05-26 12:33:47.347865925 +0000 UTC" ephemeral=false instance=c1 instanceType=container project=default used="2026-05-26 12:33:52.98825262 +0000 UTC"
INFO   [2026-05-26T16:40:34+01:00] Froze container                               created="2026-05-26 12:33:47.347865925 +0000 UTC" ephemeral=false instance=c1 instanceType=container project=default used="2026-05-26 12:33:52.98825262 +0000 UTC"
INFO   [2026-05-26T16:40:34+01:00] instance-paused                               name=c1 project=default requestor=unix/thomas.parrott@canonical.com source=/1.0/instances/c1
DEBUG  [2026-05-26T16:40:34+01:00] CreateInstanceSnapshot started                driver=zfs instance=c1/snap1 pool=zfs project=default src=c1
DEBUG  [2026-05-26T16:40:34+01:00] CreateInstanceSnapshot finished               driver=zfs instance=c1/snap1 pool=zfs project=default src=c1
DEBUG  [2026-05-26T16:40:34+01:00] Creating attached volume snapshot             instance=c1 instanceType=container pool=zfs project=default volume=foo
DEBUG  [2026-05-26T16:40:34+01:00] CreateCustomVolumeSnapshot started            driver=zfs newDescription="Created alongside container c1/snap1 snapshot in project default" newExpiryDate="0001-01-01 00:00:00 +0000 UTC" newSnapshotName=snap1 pool=zfs project=default volName=foo
DEBUG  [2026-05-26T16:40:34+01:00] UpdateCustomVolumeBackupFiles started         driver=zfs pool=zfs project=default snapshots=true volume=foo
DEBUG  [2026-05-26T16:40:34+01:00] UpdateInstanceBackupFile started              driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] Skipping unmount as in use                    driver=zfs pool=zfs refCount=1 volName=c1
DEBUG  [2026-05-26T16:40:34+01:00] UpdateInstanceBackupFile finished             driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] UpdateCustomVolumeBackupFiles finished        driver=zfs pool=zfs project=default snapshots=true volume=foo
INFO   [2026-05-26T16:40:34+01:00] storage-volume-snapshot-created               project=default requestor=unix/thomas.parrott@canonical.com source=/1.0/storage-pools/zfs/volumes/custom/default_foo/snapshots/snap1 type=custom
DEBUG  [2026-05-26T16:40:34+01:00] CreateCustomVolumeSnapshot finished           driver=zfs newDescription="Created alongside container c1/snap1 snapshot in project default" newExpiryDate="0001-01-01 00:00:00 +0000 UTC" newSnapshotName=snap1 pool=zfs project=default volName=foo
DEBUG  [2026-05-26T16:40:34+01:00] MountInstance started                         driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] MountInstance finished                        driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] UpdateInstanceBackupFile started              driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] Skipping unmount as in use                    driver=zfs pool=zfs refCount=2 volName=c1
DEBUG  [2026-05-26T16:40:34+01:00] UpdateInstanceBackupFile finished             driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] UnmountInstance started                       driver=zfs instance=c1 pool=zfs project=default
DEBUG  [2026-05-26T16:40:34+01:00] Skipping unmount as in use                    driver=zfs pool=zfs refCount=1 volName=c1
DEBUG  [2026-05-26T16:40:34+01:00] UnmountInstance finished                      driver=zfs instance=c1 pool=zfs project=default
INFO   [2026-05-26T16:40:34+01:00] Unfreezing container                          created="2026-05-26 12:33:47.347865925 +0000 UTC" ephemeral=false instance=c1 instanceType=container project=default used="2026-05-26 12:33:52.98825262 +0000 UTC"
INFO   [2026-05-26T16:40:34+01:00] Unfroze container                             created="2026-05-26 12:33:47.347865925 +0000 UTC" ephemeral=false instance=c1 instanceType=container project=default used="2026-05-26 12:33:52.98825262 +0000 UTC"
INFO   [2026-05-26T16:40:34+01:00] instance-resumed                              name=c1 project=default requestor=unix/thomas.parrott@canonical.com source=/1.0/instances/c1
DEBUG  [2026-05-26T16:40:34+01:00] Instance operation lock finished              action=create err="<nil>" instance=c1/snap1 project=default reusable=false
DEBUG  [2026-05-26T16:40:34+01:00] Success for operation                         class=task description="Snapshotting instance" operation=019e64f1-e3f0-78e5-914e-4530569e2540 project=default
```