### PR TITLE
Backports (stable-5.21)

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1236,6 +1236,23 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				req.Architecture = sourceImage.Architecture
 				req.Profiles = sourceImage.Profiles
 			}
+
+		case api.SourceTypeMigration:
+			// When performing a migration with refresh, route the request to the cluster member
+			// that owns the existing instance rather than triggering new placement logic.
+			if s.ServerClustered && !clusterNotification && req.Source.Refresh && targetMemberInfo == nil {
+				targetInst, err := instance.LoadInstanceDatabaseObject(ctx, tx, targetProjectName, req.Name)
+				if err != nil {
+					if !response.IsNotFoundError(err) {
+						return fmt.Errorf("Failed loading target instance %q: %w", req.Name, err)
+					}
+				} else {
+					targetMemberInfo = clusterMemberByName(allMembers, targetInst.Node)
+					if targetMemberInfo == nil {
+						return fmt.Errorf("Failed finding target cluster member %q", targetInst.Node)
+					}
+				}
+			}
 		}
 
 		// Use default profile if no profile list specified (not even an empty list).
@@ -1653,4 +1670,16 @@ func instanceCreateFinish(s *state.State, req *api.InstancesPost, args db.Instan
 	}
 
 	return inst.Start(false)
+}
+
+// clusterMemberByName returns a pointer to the db.NodeInfo entry in members
+// whose Name matches the given name, or nil if no match is found.
+func clusterMemberByName(members []db.NodeInfo, name string) *db.NodeInfo {
+	for i := range members {
+		if members[i].Name == name {
+			return &members[i]
+		}
+	}
+
+	return nil
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -478,6 +478,11 @@ test_clustering_containers() {
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc list -f csv -c L bar)" = "node1" ]
   LXD_DIR="${LXD_THREE_DIR}" lxc delete bar
 
+  echo "Refresh copy when target does not exist yet should create the target."
+  LXD_DIR="${LXD_ONE_DIR}" lxc copy foo refresh-new --refresh --target node3
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L refresh-new)" = "node3" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f refresh-new
+
   # Copy the container on node2 to node3, using a client connected to
   # node1.
   LXD_DIR="${LXD_ONE_DIR}" lxc copy foo bar --target node3


### PR DESCRIPTION
Route refresh migration requests (SourceTypeMigration) to the cluster member hosting the existing instance rather than letting placement logic pick an arbitrary member. Also refactor the equivalent SourceTypeCopy path to use a clusterMemberByName helper instead of inline loops.

Cherry-picks from https://github.com/canonical/lxd/pull/18207.