### PR TITLE
Use `strconv.Atoi` instead of `strconv.ParseInt(..., 10, 32)`

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -675,7 +675,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 
 			maxWidth := -1
 			if len(cc) > 2 {
-				temp, err := strconv.ParseInt(cc[2], 10, 32)
+				temp, err := strconv.Atoi(cc[2])
 				if err != nil {
 					return nil, false, fmt.Errorf("Invalid max width (must be an integer) %q in %q", cc[2], columnEntry)
 				}

--- a/lxd/bgp/server.go
+++ b/lxd/bgp/server.go
@@ -87,7 +87,7 @@ func (s *Server) start(address string, asn uint32, routerID net.IP) error {
 		addrHost = "::"
 	}
 
-	addrPortInt, err := strconv.ParseInt(addrPort, 10, 32)
+	addrPortInt, err := strconv.Atoi(addrPort)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3457,7 +3457,7 @@ func (d *qemu) deviceBootPriorities(base int) (map[string]int, error) {
 	for _, dev := range d.expandedDevices.Filter(filters.Or(filters.IsDisk, filters.IsNIC)).Sorted() {
 		bootPrio := uint32(0) // Default to lowest priority.
 		if dev.Config["boot.priority"] != "" {
-			prio, err := strconv.ParseInt(dev.Config["boot.priority"], 10, 32)
+			prio, err := strconv.Atoi(dev.Config["boot.priority"])
 			if err != nil {
 				return nil, fmt.Errorf("Invalid boot.priority for device %q: %w", dev.Name, err)
 			}

--- a/lxd/main_forkconsole.go
+++ b/lxd/main_forkconsole.go
@@ -61,7 +61,7 @@ func (c *cmdForkconsole) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	escapeNum := strings.TrimPrefix(args[4], "escape=")
-	escape, err := strconv.ParseInt(escapeNum, 10, 32)
+	escape, err := strconv.Atoi(escapeNum)
 	if err != nil {
 		return fmt.Errorf("Failed retrieving escape character: %q", err)
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -287,13 +287,13 @@ type LXDFileHeaders struct {
 //   - `X-LXD-modify-perm`
 //     Comma separated list; 0 or more of `mode`, `uid`, `gid`
 func ParseLXDFileHeaders(headers http.Header) (*LXDFileHeaders, error) {
-	var uid, gid int64 = -1, -1
+	var uid, gid int = -1, -1
 	var mode = -1
 	var err error
 
 	rawUID := headers.Get("X-LXD-uid")
 	if rawUID != "" {
-		uid, err = strconv.ParseInt(rawUID, 10, 32)
+		uid, err = strconv.Atoi(rawUID)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid UID: %w", err)
 		}
@@ -301,7 +301,7 @@ func ParseLXDFileHeaders(headers http.Header) (*LXDFileHeaders, error) {
 
 	rawGID := headers.Get("X-LXD-gid")
 	if rawGID != "" {
-		gid, err = strconv.ParseInt(rawGID, 10, 32)
+		gid, err = strconv.Atoi(rawGID)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid GID: %w", err)
 		}
@@ -361,8 +361,8 @@ func ParseLXDFileHeaders(headers http.Header) (*LXDFileHeaders, error) {
 	}
 
 	return &LXDFileHeaders{
-		UID:  uid,
-		GID:  gid,
+		UID:  int64(uid),
+		GID:  int64(gid),
 		Mode: mode,
 
 		UIDModifyExisting:  UIDModifyExisting,


### PR DESCRIPTION
`strconv.Atoi` is advertised as:
> Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.

However, there is a fast path that's not in `ParseInt`: https://cs.opensource.google/go/go/+/refs/tags/go1.26.3:src/internal/strconv/atoi.go;l=220