### PR TITLE
Cluster: Don't use the proxy for cluster join requests

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -511,6 +511,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		TLSClientKey:  string(serverCert.PrivateKey()),
 		TLSServerCert: string(req.ClusterCertificate),
 		UserAgent:     version.UserAgent,
+		// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return nil, nil
+		},
 	}
 
 	// Asynchronously join the cluster.

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -194,8 +194,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			// Cluster URL
 			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
-			// Cluster certificate
-			cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
+			// Get cluster certificate bypassing any configured HTTP proxy.
+			cert, err := shared.GetRemoteCertificateNoProxy(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 			if err != nil {
 				fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 				continue

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"slices"
@@ -194,8 +196,8 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 			for _, clusterAddress := range joinToken.Addresses {
 				config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
-				// Cluster certificate
-				cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
+				// Get cluster certificate bypassing any configured HTTP proxy.
+				cert, err := shared.GetRemoteCertificateNoProxy(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 				if err != nil {
 					fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 					continue
@@ -249,6 +251,10 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 				TLSClientKey:  string(serverCert.PrivateKey()),
 				TLSServerCert: string(config.Cluster.ClusterCertificate),
 				UserAgent:     version.UserAgent,
+				// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+				Proxy: func(_ *http.Request) (*url.URL, error) {
+					return nil, nil
+				},
 			}
 
 			client, err := lxd.ConnectLXD("https://"+config.Cluster.ClusterAddress, args)

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -503,6 +504,19 @@ func CertFingerprintStr(c string) (string, error) {
 
 // GetRemoteCertificate returns the unverified peer certificate found at a remote address.
 func GetRemoteCertificate(ctx context.Context, address string, useragent string) (*x509.Certificate, error) {
+	return getRemoteCertificate(ctx, address, useragent, false)
+}
+
+// GetRemoteCertificateNoProxy returns the unverified peer certificate found at a remote address,
+// bypassing any configured HTTP proxy.
+func GetRemoteCertificateNoProxy(ctx context.Context, address string, useragent string) (*x509.Certificate, error) {
+	return getRemoteCertificate(ctx, address, useragent, true)
+}
+
+// getRemoteCertificate returns the unverified peer certificate found at a remote address.
+// If bypassProxy is true, the function bypasses any configured HTTP proxy.
+// Otherwise, the function uses the proxy from the environment to make a request.
+func getRemoteCertificate(ctx context.Context, address string, useragent string, bypassProxy bool) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
 	tlsConfig, err := GetTLSConfig(nil)
 	if err != nil {
@@ -518,6 +532,13 @@ func GetRemoteCertificate(ctx context.Context, address string, useragent string)
 		ExpectContinueTimeout: time.Second * 30,
 		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
+	}
+
+	// Bypass the environment proxy.
+	if bypassProxy {
+		tr.Proxy = func(_ *http.Request) (*url.URL, error) {
+			return nil, nil
+		}
 	}
 
 	// Connect

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -13,6 +13,7 @@ readonly test_group_cluster=(
     "clustering_profiles"
     "clustering_projects_force_delete"
     "clustering_join_api"
+    "clustering_join_proxy_bypass"
     "clustering_shutdown_nodes"
     "clustering_projects"
     "clustering_metrics"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2419,6 +2419,45 @@ test_clustering_image_proxy_bypass() {
   kill_lxd "${LXD_TWO_DIR}"
 }
 
+test_clustering_join_proxy_bypass() {
+  sub_test "Cluster join bypasses HTTP_PROXY and HTTPS_PROXY environment variables"
+
+  with_bad_proxy() {
+    HTTP_PROXY="http://127.0.0.1:1" HTTPS_PROXY="http://127.0.0.1:1" \
+    http_proxy="http://127.0.0.1:1" https_proxy="http://127.0.0.1:1" \
+    "$@"
+  }
+
+  # Bootstrap the first node with proxy env vars pointing to an unreachable proxy.
+  with_bad_proxy spawn_lxd_and_bootstrap_cluster
+
+  local cert
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Join a second node with proxy env vars still set.
+  with_bad_proxy spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}"
+
+  # Verify the cluster is functional by checking both nodes are present.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -wF node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -wF node2
+
+  # Verify both nodes are online.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF "status: Online"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -xF "status: Online"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+}
+
 test_clustering_dns() {
   # Because we do not want tests to only run on Ubuntu (due to cluster's fan network dependency)
   # instead we will just spawn forkdns directly and check DNS resolution.


### PR DESCRIPTION
Follow-up to the https://github.com/canonical/lxd/pull/18338.

This PR ensures that cluster join requests also bypass the configured proxy. This resolves cluster bootstrap failures when HTTP_PROXY or HTTPS_PROXY environment variables are set.

Fixes https://github.com/canonical/lxd/issues/17614.
