### PR TITLE
Update `operationsGetByType`

### DIFF
--- a/lxd/api_cluster_member.go
+++ b/lxd/api_cluster_member.go
@@ -343,7 +343,7 @@ func clusterMembersPost(d *Daemon, r *http.Request) response.Response {
 	// Remove any existing join tokens for the requested cluster member, this way we only ever have one active
 	// join token for each potential new member, and it has the most recent active members list for joining.
 	// This also ensures any historically unused (but potentially published) join tokens are removed.
-	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken)
+	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken, false)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed getting cluster join token operations: %w", err))
 	}
@@ -1374,7 +1374,7 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Action {
 	case "evacuate":
-		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberRestore)
+		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberRestore, true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1474,7 +1474,7 @@ func clusterMemberStatePost(d *Daemon, r *http.Request) response.Response {
 
 		return operations.OperationResponse(op)
 	case "restore":
-		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberEvacuate)
+		ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterMemberEvacuate, true)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -205,7 +205,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 // clusterMemberJoinTokenValid searches for cluster join token that matches the join token provided.
 // Returns matching operation if found and cancels the operation, otherwise returns nil.
 func clusterMemberJoinTokenValid(s *state.State, r *http.Request, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
-	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken)
+	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken, false)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting cluster join token operations: %w", err)
 	}
@@ -279,7 +279,7 @@ func clusterMemberJoinTokenValid(s *state.State, r *http.Request, joinToken *api
 // If an operation is found it is cancelled and the request metadata is returned. If no operation is found then a nil value
 // is returned. An error is only returned if an internal error occurs, or if a token is found but is not valid.
 func certificateTokenValid(s *state.State, r *http.Request, addToken *api.CertificateAddToken) (*api.CertificatesPost, error) {
-	ops, err := operationsGetByType(r.Context(), s, api.ProjectDefaultName, operationtype.CertificateAddToken)
+	ops, err := operationsGetByType(r.Context(), s, api.ProjectDefaultName, operationtype.CertificateAddToken, false)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting certificate token operations: %w", err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3188,7 +3188,7 @@ func doImageGet(ctx context.Context, tx *db.ClusterTx, project, fingerprint stri
 // project that has a matching fingerprint and secret in its metadata.
 // If an operation is found it is returned and the operation is cancelled. Otherwise nil is returned if not found.
 func imageValidSecret(s *state.State, r *http.Request, projectName string, fingerprint string, secret string, tokenType operationtype.Type) (*api.Operation, error) {
-	ops, err := operationsGetByType(r.Context(), s, projectName, tokenType)
+	ops, err := operationsGetByType(r.Context(), s, projectName, tokenType, false)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting image token operations: %w", err)
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -639,13 +639,13 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 // operationsGetByType gets all operations for a project and type.
 // It does not populate operation resources.
-func operationsGetByType(ctx context.Context, s *state.State, projectName string, opType operationtype.Type) ([]*api.Operation, error) {
+func operationsGetByType(ctx context.Context, s *state.State, projectName string, opType operationtype.Type, excludeOffline bool) ([]*api.Operation, error) {
 	// Get all operations of the specified type in project.
 	var ops []dbCluster.Operation
 	var members []db.NodeInfo
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		if s.ServerClustered {
+		if s.ServerClustered && excludeOffline {
 			members, err = tx.GetNodes(ctx)
 			if err != nil {
 				return err
@@ -663,25 +663,19 @@ func operationsGetByType(ctx context.Context, s *state.State, projectName string
 		return nil, err
 	}
 
-	offlineThreshold := s.GlobalConfig.OfflineThreshold()
-	memberOnline := func(memberAddress string) bool {
+	// Map of online members. online[op.NodeAddress] is only true if the address exists and is online
+	// (if the address doesn't exist, the zero value for bool is false).
+	online := make(map[string]bool, len(members))
+	if excludeOffline {
+		offlineThreshold := s.GlobalConfig.OfflineThreshold()
 		for _, member := range members {
-			if member.Address == memberAddress {
-				if member.IsOffline(offlineThreshold) {
-					logger.Warn("Excluding offline member from operations by type list", logger.Ctx{"member": member.Name, "address": member.Address, "ID": member.ID, "lastHeartbeat": member.Heartbeat, "opType": opType})
-					return false
-				}
-
-				return true
-			}
+			online[member.Address] = !member.IsOffline(offlineThreshold)
 		}
-
-		return false
 	}
 
 	apiOps := make([]*api.Operation, 0, len(ops))
 	for _, op := range ops {
-		if s.ServerClustered && !memberOnline(op.NodeAddress) {
+		if s.ServerClustered && excludeOffline && !online[op.NodeAddress] {
 			continue
 		}
 


### PR DESCRIPTION
For some operations it doesn't matter if a cluster member is offline because all of the necessary information is now stored in the database. The function now accepts a parameter for excluding offline members and the logic for excluding them (if requested) is improved.

Depends on #18356 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
