### PR TITLE
Events: Fix hung goroutine on ReadJSON

### DIFF
--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -113,8 +113,6 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 		cancel()
 	}
 
-	defer closer()
-
 	pingInterval := time.Second * 10
 	e.pongsPending = 0
 	const maxPongsPending = 2
@@ -148,8 +146,10 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 		return nil
 	})
 
+	var wg sync.WaitGroup
+
 	// Start reader from client.
-	go func() {
+	wg.Go(func() {
 		defer closer()
 
 		if recvFunc != nil {
@@ -168,37 +168,44 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 			// anything from the remote side, so this should remain blocked until disconnected.
 			_, _, _ = e.NextReader()
 		}
-	}()
+	})
 
-	t := time.NewTicker(pingInterval)
-	defer t.Stop()
+	// Start ping/pong handler.
+	wg.Go(func() {
+		defer closer()
 
-	for {
-		if ctx.Err() != nil {
-			return
-		}
+		t := time.NewTicker(pingInterval)
+		defer t.Stop()
 
-		e.lock.Lock()
-		if e.pongsPending > maxPongsPending {
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+
+			e.lock.Lock()
+			if e.pongsPending > maxPongsPending {
+				e.lock.Unlock()
+				return
+			}
+
+			err := e.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
+			if err != nil {
+				e.lock.Unlock()
+				return
+			}
+
+			e.pongsPending++
 			e.lock.Unlock()
-			return
-		}
 
-		err := e.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
-		if err != nil {
-			e.lock.Unlock()
-			return
+			select {
+			case <-t.C:
+			case <-ctx.Done():
+				return
+			}
 		}
+	})
 
-		e.pongsPending++
-		e.lock.Unlock()
-
-		select {
-		case <-t.C:
-		case <-ctx.Done():
-			return
-		}
-	}
+	wg.Wait() // Wait for both goroutines to clean up before returning.
 }
 
 // WriteJSON sends a JSON event to the websocket connection.

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -105,7 +105,11 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 			return
 		}
 
-		_ = e.Close()
+		err := e.Close()
+		if err != nil {
+			logger.Warn("Failed closing connection", logger.Ctx{"err": err, "remote": e.RemoteAddr()})
+		}
+
 		cancel()
 	}
 

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -117,11 +117,34 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 
 	pingInterval := time.Second * 10
 	e.pongsPending = 0
+	const maxPongsPending = 2
+
+	getNextReadDeadline := func() time.Time {
+		// This means that if we miss more than maxPongsPending pongs, the reading goroutine will end.
+		return time.Now().Add((maxPongsPending+1)*pingInterval + 5*time.Second)
+	}
+
+	// Set read deadline to prevent goroutine from blocking indefinitely.
+	// This ensures the goroutine will unblock even if e.Close() does not immediately
+	// interrupt the read operation due to buffering or network delays.
+	err := e.SetReadDeadline(getNextReadDeadline())
+	if err != nil {
+		logger.Warn("Failed setting read deadline on connection", logger.Ctx{"err": err, "remote": e.RemoteAddr()})
+		return
+	}
 
 	e.SetPongHandler(func(msg string) error {
 		e.lock.Lock()
+		defer e.lock.Unlock()
+
 		e.pongsPending = 0
-		e.lock.Unlock()
+
+		// Extend the read deadline each time we get a pong.
+		err := e.SetReadDeadline(getNextReadDeadline())
+		if err != nil {
+			return fmt.Errorf("Failed setting read deadline on connection: %w", err)
+		}
+
 		return nil
 	})
 
@@ -156,7 +179,7 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 		}
 
 		e.lock.Lock()
-		if e.pongsPending > 2 {
+		if e.pongsPending > maxPongsPending {
 			e.lock.Unlock()
 			return
 		}

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -97,15 +97,17 @@ func NewWebsocketListenerConnection(connection *websocket.Conn) EventListenerCon
 func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHandler) {
 	ctx, cancel := context.WithCancel(ctx)
 
+	// closer is used to clean up the connection and cancel the context when either
+	// the reader or ping/pong goroutine detects a problem and returns.
 	closer := func() {
 		e.lock.Lock()
 		defer e.lock.Unlock()
 
 		if ctx.Err() != nil {
-			return
+			return // Context already cancelled, no need to close again.
 		}
 
-		err := e.Close()
+		err := e.Close() // This may unblock the reader and ping/pong goroutines.
 		if err != nil {
 			logger.Warn("Failed closing connection", logger.Ctx{"err": err, "remote": e.RemoteAddr()})
 		}
@@ -135,7 +137,7 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 		e.lock.Lock()
 		defer e.lock.Unlock()
 
-		e.pongsPending = 0
+		e.pongsPending = 0 // Reset pending pongs on receiving a pong.
 
 		// Extend the read deadline each time we get a pong.
 		err := e.SetReadDeadline(getNextReadDeadline())
@@ -150,7 +152,7 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 
 	// Start reader from client.
 	wg.Go(func() {
-		defer closer()
+		defer closer() // Clean up connection and cancel context when reader exits.
 
 		if recvFunc != nil {
 			for {
@@ -172,35 +174,35 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
 
 	// Start ping/pong handler.
 	wg.Go(func() {
-		defer closer()
+		defer closer() // Clean up connection and cancel context when ping/pong handler exits.
 
 		t := time.NewTicker(pingInterval)
 		defer t.Stop()
 
 		for {
 			if ctx.Err() != nil {
-				return
+				return // Context cancelled, exit goroutine.
 			}
 
 			e.lock.Lock()
 			if e.pongsPending > maxPongsPending {
 				e.lock.Unlock()
-				return
+				return // Too many pongs pending, assume the connection is dead.
 			}
 
 			err := e.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
 			if err != nil {
 				e.lock.Unlock()
-				return
+				return // Failed to send ping, assume the connection is dead.
 			}
 
-			e.pongsPending++
+			e.pongsPending++ // Increment pending pongs after sending a ping.
 			e.lock.Unlock()
 
 			select {
 			case <-t.C:
 			case <-ctx.Done():
-				return
+				return // Context cancelled, exit goroutine.
 			}
 		}
 	})


### PR DESCRIPTION
This addresses a go routine leak that can occur if the remote cluster member does not respond in time:

```
goroutine 1968253700 [IO wait]:
internal/poll.runtime_pollWait(0x3ff641ba000, 0x72)
	runtime/netpoll.go:351 +0xec
internal/poll.(*pollDesc).wait(0x772d89b87500?, 0x772d8d018800?, 0x0)
	internal/poll/fd_poll_runtime.go:84 +0x34
internal/poll.(*pollDesc).waitRead(...)
	internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0x772d89b87500, {0x772d8d018800, 0x800, 0x800})
	internal/poll/fd_unix.go:165 +0x2f0
net.(*netFD).Read(0x772d89b87500, {0x772d8d018800?, 0x772d89c975e0?, 0x772d8d018805?})
	net/fd_posix.go:68 +0x36
net.(*conn).Read(0x772d84bc0500, {0x772d8d018800?, 0x107cf80?, 0x3000018?})
	net/net.go:196 +0x46
crypto/tls.(*atLeastReader).Read(0x772d8795ef48, {0x772d8d018800?, 0x31d3620?, 0x12c9808?})
	crypto/tls/conn.go:815 +0x4e
bytes.(*Buffer).ReadFrom(0x772d8beae2a8, {0x363e0e0, 0x772d8795ef48})
	bytes/buffer.go:229 +0xb2
crypto/tls.(*Conn).readFromUntil(0x772d8beae008, {0x363c900, 0x772d84bc0500}, 0x800?)
	crypto/tls/conn.go:837 +0xf8
crypto/tls.(*Conn).readRecordOrCCS(0x772d8beae008, 0x0)
	crypto/tls/conn.go:626 +0x3f6
crypto/tls.(*Conn).readRecord(...)
	crypto/tls/conn.go:588
crypto/tls.(*Conn).Read(0x772d8beae008, {0x772d8e23e000, 0x1000, 0x1d8d9a0?})
	crypto/tls/conn.go:1393 +0x184
bufio.(*Reader).fill(0x772d9112c7e0)
	bufio/bufio.go:113 +0x138
bufio.(*Reader).Peek(0x772d9112c7e0, 0x2)
	bufio/bufio.go:152 +0x6a
github.com/gorilla/websocket.(*Conn).read(0x772d8ca091e0, 0x1c93aa0?)
	github.com/gorilla/websocket@v1.5.1/conn.go:378 +0x30
github.com/gorilla/websocket.(*Conn).advanceFrame(0x772d8ca091e0)
	github.com/gorilla/websocket@v1.5.1/conn.go:824 +0x6e
github.com/gorilla/websocket.(*Conn).NextReader(0x772d8ca091e0)
	github.com/gorilla/websocket@v1.5.1/conn.go:1034 +0x134
github.com/gorilla/websocket.(*Conn).ReadJSON(0x0?, {0x3052520, 0x772d906ad260})
	github.com/gorilla/websocket@v1.5.1/json.go:50 +0x30
github.com/canonical/lxd/lxd/events.(*websockListenerConnection).Reader.func3()
	github.com/canonical/lxd/lxd/events/connections.go:131 +0xe2
created by github.com/canonical/lxd/lxd/events.(*websockListenerConnection).Reader in goroutine 1968243763
	github.com/canonical/lxd/lxd/events/connections.go:125 +0x208
```

Event though the connection should be being closed the `closer()` function if too many pong responses are missed (or if the context is cancelled), the `ReadJSON` call can still block.

Also switches to using a sync.WaitGroup so that `Reader` does not return until both go routines are definitely done.