### PR TITLE
lxd-agent/metrics: check for scan.Err()

### DIFF
--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -161,6 +161,10 @@ func getCPUMetrics() (map[string]metrics.CPUMetrics, error) {
 		out[fields[0]] = stats
 	}
 
+	if scanner.Err() != nil {
+		return nil, fmt.Errorf("Failed scanning /proc/stat: %w", scanner.Err())
+	}
+
 	return out, nil
 }
 
@@ -253,6 +257,10 @@ func getDiskMetrics() (map[string]metrics.DiskMetrics, error) {
 		out[fields[2]] = stats
 	}
 
+	if scanner.Err() != nil {
+		return nil, fmt.Errorf("Failed scanning /proc/diskstats: %w", scanner.Err())
+	}
+
 	return out, nil
 }
 
@@ -297,6 +305,10 @@ func getFilesystemMetrics() (map[string]metrics.FilesystemMetrics, error) {
 		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
 
 		out[fields[0]] = stats
+	}
+
+	if scanner.Err() != nil {
+		return nil, fmt.Errorf("Failed scanning /proc/mounts: %w", scanner.Err())
 	}
 
 	return out, nil
@@ -381,6 +393,10 @@ func getMemoryMetrics() (metrics.MemoryMetrics, error) {
 		// Formula: RSS = MemTotal - MemAvailable
 		// This is how modern tools like 'free' calculate used memory
 		out.RSSBytes = out.MemTotalBytes - out.MemAvailableBytes
+	}
+
+	if scanner.Err() != nil {
+		return metrics.MemoryMetrics{}, fmt.Errorf("Failed scanning /proc/meminfo: %w", scanner.Err())
 	}
 
 	return out, nil


### PR DESCRIPTION
Four scanner loops in `lxd-agent/metrics.go` never check `scanner.Err()` after finishing - if the scanner hits an error (e.g. `bufio.ErrTooLong` on a weirdly long line) it just silently returns empty/partial results with a nil error, which is sneaky.

Follows the same pattern from #18349 which fixed the same issue in other files.

**Affected functions:** `getCPUMetrics` (/proc/stat), `getDiskMetrics` (/proc/diskstats), `getFilesystemMetrics` (/proc/mounts), `getMemoryMetrics` (/proc/meminfo).

**To reproduce:**
```go
// scanner over bytes.NewReader - if a line exceeds bufio.MaxScanTokenSize (64KB)
// scanner.Scan() returns false but scanner.Err() == bufio.ErrTooLong
// without the check, the caller gets nil error + wrong data
```

In practice /proc lines are short so this wont bite you often, but the silent failure is the real issue - caller cant tell the diff between "file was empty" and "scanner blew up".