### PR TITLE
Improve events websocket disconnection logic in the client

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -201,7 +201,7 @@ func (m *eventListenerManager) getEvents(ctxConnected context.Context, websocket
 			m.eventConnsLock.Lock()
 			if len(m.eventListeners[listener.projectName]) == 0 {
 				// We don't need the connection anymore, disconnect and clear.
-				if m.eventListeners[listener.projectName] != nil {
+				if m.eventConns[listener.projectName] != nil {
 					_ = m.eventConns[listener.projectName].Close()
 					delete(m.eventConns, listener.projectName)
 				}

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -46,9 +46,7 @@ type ProtocolLXD struct {
 
 // Disconnect gets rid of any background goroutines.
 func (r *ProtocolLXD) Disconnect() {
-	if r.ctxConnected.Err() != nil {
-		r.ctxConnectedCancel()
-	}
+	r.ctxConnectedCancel()
 }
 
 // GetConnectionInfo returns the basic connection information used to interact with the server.


### PR DESCRIPTION
The theory is that [`(lxd/cluster).EventsUpdateListeners`](https://github.com/canonical/lxd/blob/367a0a9ccf598aacd2dce80bb217152638eff43d/lxd/cluster/events.go#L206) is the ultimate cause of the leaky connections. This function is called on every heartbeat within `(*Daemon).nodeRefreshTask`. It checks that there is an event websocket connection to each cluster member that it should be connected to (which depends on event mode but is typically all members for full-mesh).

If there was a failed websocket read, then the listener context is cancelled but the websocket stays open (see first commit). `EventsUpdateListeners` then [sees that the listener is no longer active](https://github.com/canonical/lxd/blob/367a0a9ccf598aacd2dce80bb217152638eff43d/lxd/cluster/events.go#L268) and calls `Disconnect` on both the listener and the client, but this doesn't actually disconnect the websocket either (see second commit). 

The listener is then deleted from the global listeners map, so it should go out of scope and be cleaned up, but I guess there is a dangling reference somewhere due to the websocket still being open (e.g. ping/pong).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
