### PR TITLE
storage: Rename NVMe/TCP driver mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3113,3 +3113,7 @@ administrator can create two clients in the identity provider, one for LXD UI re
 and one for the CLI that enables the device authorization grant and does not require a secret. The device client ID will
 be public to the CLI, falling back to {config:option}`server-oidc:oidc.client.id`. This configuration option cannot be
 set unless {config:option}`server-oidc:oidc.client.id` is set.
+
+## `storage_nvme_tcp`
+
+Renames storage pool NVMe/TCP mode from `nvme` to `nvme/tcp`.

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -255,7 +255,7 @@ Create a storage pool named `pool3` that uses iSCSI to connect to Pure Storage a
 
 Create a storage pool named `pool4` that uses NVMe/TCP to connect to Pure Storage array via specific target addresses:
 
-    lxc storage create pool4 pure pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=nvme pure.target=<target_address_1>,<target_address_2>
+    lxc storage create pool4 pure pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=nvme/tcp pure.target=<target_address_1>,<target_address_2>
 
 ````
 ````{group-tab} alletra
@@ -270,7 +270,7 @@ Create a storage pool named `pool2` that uses a HPE Alletra gateway with a certi
 
 Create a storage pool named `pool3` that uses NVMe/TCP to connect to HPE Alletra array via specific target addresses:
 
-    lxc storage create pool3 alletra alletra.wsapi=https://<alletra-storage-address> alletra.user.name=<alletra-storage-username> alletra.user.password=<alletra-storage-password> alletra.mode=nvme alletra.target=<target_address_1>,<target_address_2>
+    lxc storage create pool3 alletra alletra.wsapi=https://<alletra-storage-address> alletra.user.name=<alletra-storage-username> alletra.user.password=<alletra-storage-password> alletra.mode=nvme/tcp alletra.target=<target_address_1>,<target_address_2>
 
 ````
 `````
@@ -671,7 +671,7 @@ Recover a pool named `pool2` using the existing pod `pool2` and iSCSI to connect
 
 Recover a pool named `pool3` using the existing pod `pool3` and NVMe/TCP to connect to Pure Storage array via specific target address:
 
-    lxc storage create pool3 pure source.recover=true pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=nvme pure.target=<target_address_1>,<target_address_2>
+    lxc storage create pool3 pure source.recover=true pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=nvme/tcp pure.target=<target_address_1>,<target_address_2>
 
 ````
 ````{group-tab} alletra
@@ -686,7 +686,7 @@ Recover a pool named `pool2` using the existing volume set `pool2` and accept a 
 
 Recover a pool named `pool3` using the existing volume set `pool3` and NVMe/TCP to connect to HPE Alletra array via specific target address:
 
-    lxc storage create pool3 alletra source.recover=true alletra.wsapi=https://<alletra-storage-address> alletra.user.name=<alletra-storage-username> alletra.user.password=<alletra-storage-password> alletra.mode=nvme alletra.target=<target_address_1>,<target_address_2>
+    lxc storage create pool3 alletra source.recover=true alletra.wsapi=https://<alletra-storage-address> alletra.user.name=<alletra-storage-username> alletra.user.password=<alletra-storage-password> alletra.mode=nvme/tcp alletra.target=<target_address_1>,<target_address_2>
 
 ````
 `````

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5119,7 +5119,7 @@ The minimum value is `1d` (1 day).
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode to use to map storage volumes to the local server.
-Supported values are `iscsi` and `nvme`.
+Supported values are `iscsi` and `nvme/tcp`.
 ```
 
 ```{config:option} alletra.target storage-alletra-pool-conf
@@ -6307,7 +6307,7 @@ This option is required only if {config:option}`storage-powerflex-pool-conf:powe
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode gets discovered automatically if the system provides the necessary kernel modules.
-This can be either `nvme` or `sdc`.
+This can be either `nvme/tcp` or `sdc`.
 ```
 
 ```{config:option} powerflex.pool storage-powerflex-pool-conf
@@ -6730,7 +6730,7 @@ API authorization token for Pure Storage gateway. Must have array_admin role to 
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode to use to map Pure Storage volumes to the local server.
-Supported values are `iscsi` and `nvme`.
+Supported values are `iscsi` and `nvme/tcp`.
 ```
 
 ```{config:option} pure.target storage-pure-pool-conf

--- a/doc/reference/storage_alletra.md
+++ b/doc/reference/storage_alletra.md
@@ -15,7 +15,7 @@ Each storage pool created in LXD using an HPE Alletra driver represents an HPE A
 
 LXD creates volumes within a volume set that is identified by the storage pool name.
 When the first volume needs to be mapped to a specific LXD host, a corresponding HPE Alletra host entity is created with the name of the LXD host and a suffix of the used protocol.
-For example, if the LXD host is `host01` and the mode is `nvme`, the resulting HPE Alletra host entity would be `host01-nvme`.
+For example, if the LXD host is `host01` and the mode is `nvme/tcp`, the resulting HPE Alletra host entity would be `host01-nvme-tcp`.
 
 The HPE Alletra host is then connected with the required volumes to allow attaching and accessing volumes from the LXD host.
 The HPE Alletra host is automatically removed once there are no volumes connected to it.

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -41,7 +41,7 @@ This driver behaves differently than some of the other drivers in that it provid
 As a result and depending on the internal network, storage access might be a bit slower than for local storage.
 On the other hand, using remote storage has big advantages in a cluster setup, because all cluster members have access to the same storage pools with the exact same contents, without the need to synchronize storage pools.
 
-When creating a new storage pool using the `powerflex` driver in `nvme` mode, LXD tries to discover one of the SDT from the given storage pool.
+When creating a new storage pool using the `powerflex` driver in `nvme/tcp` mode, LXD tries to discover one of the SDT from the given storage pool.
 Alternatively, you can specify which SDT to use with {config:option}`storage-powerflex-pool-conf:powerflex.sdt`.
 LXD instructs the NVMe initiator to connect to all the other SDT when first connecting to the subsystem.
 

--- a/doc/reference/storage_pure.md
+++ b/doc/reference/storage_pure.md
@@ -18,7 +18,7 @@ One benefit of using Pure Storage pods is that they can be linked with multiple 
 
 LXD creates volumes within a pod that is identified by the storage pool name.
 When the first volume needs to be mapped to a specific LXD host, a corresponding Pure Storage host is created with the name of the LXD host and a suffix of the used protocol.
-For example, if the LXD host is `host01` and the mode is `nvme`, the resulting Pure Storage host would be `host01-nvme`.
+For example, if the LXD host is `host01` and the mode is `nvme/tcp`, the resulting Pure Storage host would be `host01-nvme-tcp`.
 
 The Pure Storage host is then connected with the required volumes, to allow attaching and accessing volumes from the LXD host.
 The created Pure Storage host is automatically removed once there are no volumes connected to it.
@@ -36,7 +36,7 @@ This driver behaves differently than some of the other drivers in that it provid
 As a result, and depending on the internal network, storage access might be a bit slower compared to local storage.
 On the other hand, using remote storage has significant advantages in a cluster setup: all cluster members have access to the same storage pools with the exact same contents, without the need to synchronize them.
 
-When creating a new storage pool using the `pure` driver in either `iscsi` or `nvme` mode, LXD automatically discovers the array's qualified name and target address (portal).
+When creating a new storage pool using the `pure` driver in either `iscsi` or `nvme/tcp` mode, LXD automatically discovers the array's qualified name and target address (portal).
 Upon successful discovery, LXD attaches all volumes that are connected to the Pure Storage host that is associated with a specific LXD server.
 Pure Storage hosts and volume connections are fully managed by LXD.
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5707,7 +5707,7 @@
 					{
 						"alletra.mode": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "The mode to use to map storage volumes to the local server.\nSupported values are `iscsi` and `nvme`.",
+							"longdesc": "The mode to use to map storage volumes to the local server.\nSupported values are `iscsi` and `nvme/tcp`.",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"
 						}
@@ -6979,7 +6979,7 @@
 					{
 						"powerflex.mode": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nThis can be either `nvme` or `sdc`.",
+							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nThis can be either `nvme/tcp` or `sdc`.",
 							"scope": "global",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"
@@ -7432,7 +7432,7 @@
 					{
 						"pure.mode": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "The mode to use to map Pure Storage volumes to the local server.\nSupported values are `iscsi` and `nvme`.",
+							"longdesc": "The mode to use to map Pure Storage volumes to the local server.\nSupported values are `iscsi` and `nvme/tcp`.",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"
 						}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -34,6 +34,7 @@ import (
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
 	storagePools "github.com/canonical/lxd/lxd/storage"
+	"github.com/canonical/lxd/lxd/storage/connectors"
 	storageDrivers "github.com/canonical/lxd/lxd/storage/drivers"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
@@ -125,6 +126,7 @@ var patches = []patch{
 	{name: "storage_unset_ceph_source_setting", stage: patchPostDaemonStorage, run: patchUnsetCephSourceSetting},
 	{name: "clustering_event_hub_role_to_control_plane", stage: patchPreLoadClusterConfig, run: patchClusteringEventHubRoleToControlPlane},
 	{name: "storage_zfs_remove_local_bucket_datasets", stage: patchPostDaemonStorage, run: patchGenericStorage},
+	{name: "storage_rename_nvme_mode", stage: patchPreLoadClusterConfig, run: patchStoragePoolConnectorNVMeMode},
 }
 
 type patch struct {
@@ -2416,6 +2418,50 @@ DELETE FROM storage_pools_config
 	)
 	`)
 	return err
+}
+
+// patchStoragePoolConnectorNVMeMode renames the storage pool mode from value "nvme" to "nvme/tcp"
+// for all Pure Storage, PowerFlex, and Alletra storage pools.
+func patchStoragePoolConnectorNVMeMode(_ string, d *Daemon) error {
+	oldValue := "nvme"
+	newValue := connectors.TypeNVMeTCP
+
+	driverModeKeys := map[string]string{
+		"pure":      "pure.mode",
+		"powerflex": "powerflex.mode",
+		"alletra":   "alletra.mode",
+	}
+
+	return d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		pools, _, err := tx.GetStoragePools(ctx, nil)
+		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusNotFound) {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, pool := range pools {
+			modeKey, ok := driverModeKeys[pool.Driver]
+			if !ok {
+				continue
+			}
+
+			if pool.Config[modeKey] != oldValue {
+				continue
+			}
+
+			pool.Config[modeKey] = newValue
+
+			err = tx.UpdateStoragePool(ctx, pool.Name, pool.Description, pool.Config)
+			if err != nil {
+				return fmt.Errorf("Failed updating storage pool %q: %w", pool.Name, err)
+			}
+		}
+
+		return nil
+	})
 }
 
 // Patches end here

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -12,8 +12,8 @@ const (
 	// TypeUnknown represents an unknown storage connector.
 	TypeUnknown string = "unknown"
 
-	// TypeNVME represents an NVMe/TCP storage connector.
-	TypeNVME string = "nvme"
+	// TypeNVMeTCP represents an NVMe/TCP storage connector.
+	TypeNVMeTCP string = "nvme"
 
 	// TypeSDC represents Dell SDC storage connector.
 	TypeSDC string = "sdc"
@@ -58,7 +58,7 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 	}
 
 	switch connectorType {
-	case TypeNVME:
+	case TypeNVMeTCP:
 		return &connectorNVMe{
 			common: common,
 		}, nil

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -13,7 +13,7 @@ const (
 	TypeUnknown string = "unknown"
 
 	// TypeNVMeTCP represents an NVMe/TCP storage connector.
-	TypeNVMeTCP string = "nvme"
+	TypeNVMeTCP string = "nvme/tcp"
 
 	// TypeSDC represents Dell SDC storage connector.
 	TypeSDC string = "sdc"

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -51,9 +51,7 @@ type Connector interface {
 	findSession(targetQN string) (*session, error)
 }
 
-// NewConnector instantiates a new connector of the given type.
-// The caller needs to ensure connector type is validated before calling this
-// function, as common (empty) connector is returned for unknown type.
+// NewConnector instantiates a new connector of the given type, returning an error for unknown types.
 func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 	common := common{
 		serverUUID: serverUUID,

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -103,7 +103,7 @@ func nvmeNormalizeDiscoveryLog(log *nvmeDiscoveryLog) {
 
 // Type returns the type of the connector.
 func (c *connectorNVMe) Type() string {
-	return TypeNVME
+	return TypeNVMeTCP
 }
 
 // Version returns the version of the NVMe CLI.
@@ -322,7 +322,7 @@ func (c *connectorNVMe) findSession(targetQN string) (*session, error) {
 
 // Discover returns the targets found on the first reachable targetAddr.
 func (c *connectorNVMe) Discover(ctx context.Context, targetAddresses ...string) ([]any, error) {
-	if c.Type() != TypeNVME {
+	if c.Type() != TypeNVMeTCP {
 		return nil, errors.New("Discover() helper can only be used with NVMe connector type")
 	}
 

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -323,7 +323,7 @@ func (c *connectorNVMe) findSession(targetQN string) (*session, error) {
 // Discover returns the targets found on the first reachable targetAddr.
 func (c *connectorNVMe) Discover(ctx context.Context, targetAddresses ...string) ([]any, error) {
 	if c.Type() != TypeNVMeTCP {
-		return nil, errors.New("Discover() helper can only be used with NVMe connector type")
+		return nil, errors.New("Discover() helper can only be used with NVMe/TCP connector type")
 	}
 
 	hostNQN, err := c.QualifiedName()

--- a/lxd/storage/drivers/clients/alletra_wsapi1.go
+++ b/lxd/storage/drivers/clients/alletra_wsapi1.go
@@ -518,7 +518,7 @@ func (p *AlletraClient) GetCurrentHost(connectorType string, qn string) (*hpeHos
 			}
 		}
 
-		if connectorType == connectors.TypeNVME {
+		if connectorType == connectors.TypeNVMeTCP {
 			for _, nvmePath := range host.NVMETCPPaths {
 				if nvmePath.NQN == qn {
 					return &host, nil
@@ -544,7 +544,7 @@ func (p *AlletraClient) CreateHost(connectorType string, hostName string, qns []
 	switch connectorType {
 	case connectors.TypeISCSI:
 		req["iSCSINames"] = qns
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		req["NQN"] = qns[0]
 		req["transportType"] = hpeTransportTypeTCP
 	default:
@@ -706,7 +706,7 @@ func (p *AlletraClient) GetTargetAddrs(connectorType string) (targetAddrs []stri
 				targetAddrs = append(targetAddrs, member.IPAddr)
 			}
 
-		case connectors.TypeNVME:
+		case connectors.TypeNVMeTCP:
 			if member.Protocol != hpePortProtocolNVME {
 				continue
 			}

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -529,7 +529,7 @@ func (c *PowerStoreClient) DiscoveryAddresses(connectorType string) ([]string, e
 	switch connectorType {
 	case connectors.TypeISCSI:
 		purpose = "Storage_Iscsi_Target"
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		purpose = "Storage_NVMe_TCP_Port"
 	default:
 		return nil, fmt.Errorf("Unsupported connector type: %q", connectorType)
@@ -1023,7 +1023,7 @@ func powerStoreConnectorToPortType(connectorType string) (string, error) {
 	switch connectorType {
 	case connectors.TypeISCSI:
 		return "iSCSI", nil
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		return "NVMe", nil
 	default:
 		return "", fmt.Errorf("Unsupported connector type: %q", connectorType)

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -21,7 +21,7 @@ var alletraVersion = ""
 
 // alletraSupportedConnectors represents a list of storage connectors that can be used.
 var alletraSupportedConnectors = []string{
-	connectors.TypeNVME,
+	connectors.TypeNVMeTCP,
 	connectors.TypeISCSI,
 }
 
@@ -120,7 +120,7 @@ func (d *alletra) Info() Info {
 func (d *alletra) FillConfig() error {
 	// Use NVMe by default.
 	if d.config["alletra.mode"] == "" {
-		d.config["alletra.mode"] = connectors.TypeNVME
+		d.config["alletra.mode"] = connectors.TypeNVMeTCP
 	}
 
 	return nil
@@ -394,7 +394,7 @@ func (d *alletra) getTargetQN(targetAddresses ...string) (string, error) {
 			return "", err
 		}
 
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		targetQN, err = d.getNVMeTargetQN(targetAddresses...)
 		if err != nil {
 			return "", err

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -169,7 +169,7 @@ func (d *alletra) Validate(config map[string]string) error {
 		"alletra.target": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
 		// lxdmeta:generate(entities=storage-alletra; group=pool-conf; key=alletra.mode)
 		// The mode to use to map storage volumes to the local server.
-		// Supported values are `iscsi` and `nvme`.
+		// Supported values are `iscsi` and `nvme/tcp`.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -282,7 +282,7 @@ func (d *alletra) unmapVolume(vol Volume) error {
 	//
 	// For NVMe the host-side device is removed asynchronously after the array detaches the
 	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
-	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
+	if volumePath != "" && connector.Type() == connectors.TypeNVMeTCP && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
 		return fmt.Errorf("Timeout exceeded waiting for HPE Alletra volume %q to disappear on path %q", vol.name, volumePath)
 	}
 
@@ -365,7 +365,7 @@ func (d *alletra) getMappedDevPath(vol Volume, mapVolume bool) (string, revert.H
 	switch connector.Type() {
 	case connectors.TypeISCSI:
 		diskSuffix = strings.ToLower(hpeVol.WWN)
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		diskSuffix = strings.ToLower(hpeVol.NGUID)
 	default:
 		return "", nil, fmt.Errorf("Unsupported Alletra Storage mode %q", connector.Type())

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -118,15 +118,11 @@ func (d *alletra) ensureHost() (hostName string, cleanup revert.Hook, err error)
 		}
 
 		// The storage host entry with a qualified name of the current LXD host does not exist.
-		// Therefore, create a new one and name it after the server name.
-		serverName, err := ResolveServerName(d.state.ServerName)
+		// Therefore, create a new one and name it after the resolved server name.
+		hostname, err = ResolveServerNameWithConnectorType(d.state.ServerName, connector.Type())
 		if err != nil {
 			return "", nil, err
 		}
-
-		// Append the mode to the server name because storage array does not allow mixing
-		// NQNs, IQNs, and WWNs for a single host.
-		hostname = serverName + "-" + connector.Type()
 
 		err = d.client().CreateHost(connector.Type(), hostname, []string{qn})
 		if err != nil {

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -24,7 +24,7 @@ const powerFlexDefaultSize = "8GiB"
 const powerFlexMinVolumeSizeBytes = 8589934592
 
 var powerflexSupportedConnectors = []string{
-	connectors.TypeNVME,
+	connectors.TypeNVMeTCP,
 	connectors.TypeSDC,
 }
 
@@ -125,7 +125,7 @@ func (d *powerflex) FillConfig() error {
 	// Second try if the SDC kernel module is setup.
 	if d.config["powerflex.mode"] == "" {
 		// Create temporary connector to check if NVMe/TCP kernel modules can be loaded.
-		nvmeConnector, err := connectors.NewConnector(connectors.TypeNVME, "")
+		nvmeConnector, err := connectors.NewConnector(connectors.TypeNVMeTCP, "")
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (d *powerflex) FillConfig() error {
 		}
 
 		if nvmeConnector.LoadModules() == nil {
-			d.config["powerflex.mode"] = connectors.TypeNVME
+			d.config["powerflex.mode"] = connectors.TypeNVMeTCP
 		} else if sdcConnector.LoadModules() == nil {
 			d.config["powerflex.mode"] = connectors.TypeSDC
 		} else {
@@ -195,7 +195,7 @@ func (d *powerflex) ValidateSource() error {
 	if d.config["powerflex.mode"] == connectors.TypeSDC {
 		// In case the SDC mode is used the SDTs cannot be set.
 		if d.config["powerflex.sdt"] != "" {
-			return fmt.Errorf("The %q config key is specific to the %q mode", "powerflex.sdt", connectors.TypeNVME)
+			return fmt.Errorf("The %q config key is specific to the %q mode", "powerflex.sdt", connectors.TypeNVMeTCP)
 		}
 	}
 
@@ -269,7 +269,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  defaultdesc: the discovered mode
 		//  shortdesc: How volumes are mapped to the local server
 		//  scope: global
-		"powerflex.mode": validate.Optional(validate.IsOneOf("nvme", "sdc")),
+		"powerflex.mode": validate.Optional(validate.IsOneOf(connectors.TypeNVMeTCP, connectors.TypeSDC)),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.sdt)
 		//
 		// ---

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -263,7 +263,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		"powerflex.domain": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.mode)
 		// The mode gets discovered automatically if the system provides the necessary kernel modules.
-		// This can be either `nvme` or `sdc`.
+		// This can be either `nvme/tcp` or `sdc`.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -999,7 +999,7 @@ func (d *powerflex) mapVolume(vol Volume) (revert.Hook, error) {
 	}
 
 	switch d.config["powerflex.mode"] {
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		unlock, err := remoteVolumeMapLock(connector.Type(), d.Info().Name)
 		if err != nil {
 			return nil, err
@@ -1062,7 +1062,7 @@ func (d *powerflex) mapVolume(vol Volume) (revert.Hook, error) {
 	}
 
 	var cleanup revert.Hook
-	if d.config["powerflex.mode"] == connectors.TypeNVME {
+	if d.config["powerflex.mode"] == connectors.TypeNVMeTCP {
 		// Discover all SDTs from PowerFlex for the respective storage pool.
 		targetAddresses, err := d.getNVMeTargetAddresses()
 		if err != nil {
@@ -1100,7 +1100,7 @@ func (d *powerflex) mapVolume(vol Volume) (revert.Hook, error) {
 	// This ensures that ongoing connection attempts that haven't yet finished are cancelled
 	// before potentially running unmap volume.
 	// As the revert hooks are called in reverse order add the connection cleanup after unmap.
-	if d.config["powerflex.mode"] == connectors.TypeNVME {
+	if d.config["powerflex.mode"] == connectors.TypeNVMeTCP {
 		outerReverter.Add(cleanup)
 	}
 
@@ -1180,7 +1180,7 @@ func (d *powerflex) unmapVolume(vol Volume) error {
 
 	var host *powerFlexSDC
 	switch d.config["powerflex.mode"] {
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		hostNQN, err := connector.QualifiedName()
 		if err != nil {
 			return err
@@ -1226,7 +1226,7 @@ func (d *powerflex) unmapVolume(vol Volume) error {
 	// In case of SDC the driver doesn't manage the underlying connection to PowerFlex.
 	// Therefore if this was the last volume being unmapped from this system
 	// LXD will not try to cleanup the connection.
-	if d.config["powerflex.mode"] == connectors.TypeNVME {
+	if d.config["powerflex.mode"] == connectors.TypeNVMeTCP {
 		mappings, err := client.getHostVolumeMappings(host.ID)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -327,7 +327,7 @@ func (d *powerstore) targets() (map[string][]string, error) {
 		switch mode {
 		case connectors.TypeISCSI:
 			defaultPort = connectors.ISCSIDefaultPort
-		case connectors.TypeNVME:
+		case connectors.TypeNVMeTCP:
 			defaultPort = connectors.NVMeDefaultDiscoveryPort
 		default:
 			return nil, fmt.Errorf("Unsupported PowerStore mode %q", mode)

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1742,7 +1742,7 @@ func (d *powerstore) unmapVolume(vol Volume) error {
 	//
 	// For NVMe the host-side device is removed asynchronously after the array detaches the
 	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
-	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
+	if volumePath != "" && connector.Type() == connectors.TypeNVMeTCP && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
 		return fmt.Errorf("Timeout exceeded waiting for PowerStore volume %q to disappear on path %q", vol.name, volumePath)
 	}
 

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -25,7 +25,7 @@ var pureVersion = ""
 // pureSupportedConnectors represents a list of storage connectors that can be used with Pure Storage.
 var pureSupportedConnectors = []string{
 	connectors.TypeISCSI,
-	connectors.TypeNVME,
+	connectors.TypeNVMeTCP,
 }
 
 // pureMinVolumeSizeBytes defines the minimum size of a Pure Storage volume, which is 1MiB.
@@ -122,7 +122,7 @@ func (d *pure) Info() Info {
 func (d *pure) FillConfig() error {
 	// Use NVMe by default.
 	if d.config["pure.mode"] == "" {
-		d.config["pure.mode"] = connectors.TypeNVME
+		d.config["pure.mode"] = connectors.TypeNVMeTCP
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -160,7 +160,7 @@ func (d *pure) Validate(config map[string]string) error {
 		"pure.target": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
 		// lxdmeta:generate(entities=storage-pure; group=pool-conf; key=pure.mode)
 		// The mode to use to map Pure Storage volumes to the local server.
-		// Supported values are `iscsi` and `nvme`.
+		// Supported values are `iscsi` and `nvme/tcp`.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -31,8 +31,8 @@ const pureAPIVersion = "2.21"
 // pureServiceNameMapping maps Pure Storage mode in LXD to the corresponding Pure Storage
 // service name.
 var pureServiceNameMapping = map[string]string{
-	connectors.TypeISCSI: "iscsi",
-	connectors.TypeNVME:  "nvme-tcp",
+	connectors.TypeISCSI:   "iscsi",
+	connectors.TypeNVMeTCP: "nvme-tcp",
 }
 
 // pureVolTypePrefixes maps volume type to storage volume name prefix.
@@ -984,7 +984,7 @@ func (p *pureClient) getCurrentHost() (*pureHost, error) {
 			return &host, nil
 		}
 
-		if mode == connectors.TypeNVME && slices.Contains(host.NQNs, qn) {
+		if mode == connectors.TypeNVMeTCP && slices.Contains(host.NQNs, qn) {
 			return &host, nil
 		}
 	}
@@ -1005,7 +1005,7 @@ func (p *pureClient) createHost(hostName string, qns []string) error {
 	switch connector.Type() {
 	case connectors.TypeISCSI:
 		req["iqns"] = qns
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		req["nqns"] = qns
 	default:
 		return fmt.Errorf("Unsupported Pure Storage mode %q", connector.Type())
@@ -1036,7 +1036,7 @@ func (p *pureClient) updateHost(hostName string, qns []string) error {
 	switch connector.Type() {
 	case connectors.TypeISCSI:
 		req["iqns"] = qns
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		req["nqns"] = qns
 	default:
 		return fmt.Errorf("Unsupported Pure Storage mode %q", connector.Type())
@@ -1155,7 +1155,7 @@ func (p *pureClient) getTarget() (targetQN string, targetAddrs []string, err err
 			nq = port.IQN
 		}
 
-		if mode == connectors.TypeNVME {
+		if mode == connectors.TypeNVMeTCP {
 			nq = port.NQN
 		}
 
@@ -1353,7 +1353,7 @@ func (d *pure) unmapVolume(vol Volume) error {
 	//
 	// For NVMe the host-side device is removed asynchronously after the array detaches the
 	// volume. NVMe's [connectors.RemoveDiskDevice] is a no-op, so this is the only sync point.
-	if volumePath != "" && connector.Type() == connectors.TypeNVME && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
+	if volumePath != "" && connector.Type() == connectors.TypeNVMeTCP && !block.WaitDiskDeviceGone(d.state.ShutdownCtx, volumePath) {
 		return fmt.Errorf("Timeout exceeded waiting for Pure Storage volume %q to disappear on path %q", vol.name, volumePath)
 	}
 
@@ -1423,7 +1423,7 @@ func (d *pure) getMappedDevPath(vol Volume, mapVolume bool) (string, revert.Hook
 	switch connector.Type() {
 	case connectors.TypeISCSI:
 		diskSuffix = pureVol.Serial
-	case connectors.TypeNVME:
+	case connectors.TypeNVMeTCP:
 		// The disk device ID (e.g. "008726b5033af24324a9373d00014196") is constructed as:
 		// - "00"             - Padding
 		// - "8726b5033af243" - First 14 characters of serial number

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1200,15 +1200,11 @@ func (d *pure) ensureHost() (hostName string, cleanup revert.Hook, err error) {
 		}
 
 		// The Pure Storage host with a qualified name of the current LXD host does not exist.
-		// Therefore, create a new one and name it after the server name.
-		serverName, err := ResolveServerName(d.state.ServerName)
+		// Therefore, create a new one and name it after the resolved server name.
+		hostname, err = ResolveServerNameWithConnectorType(d.state.ServerName, connector.Type())
 		if err != nil {
 			return "", nil, err
 		}
-
-		// Append the mode to the server name because Pure Storage does not allow mixing
-		// NQNs, IQNs, and WWNs for a single host.
-		hostname = serverName + "-" + connector.Type()
 
 		err = d.client().createHost(hostname, []string{qn})
 		if err != nil {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -925,6 +925,21 @@ func ResolveServerName(serverName string) (string, error) {
 	return hostname, nil
 }
 
+// ResolveServerNameWithConnectorType returns the name used for storage array host entries.
+// It resolves the server name and appends the connector type as a suffix so the same server
+// has distinct host entries per connector type, as some storage arrays do not support
+// mixing NQNs, IQNs, and WWNs for the same host entry.
+//
+// Any "/" in connectorType is replaced with "-" because "/" is not valid in host names.
+func ResolveServerNameWithConnectorType(serverName string, connectorType string) (string, error) {
+	resolvedServerName, err := ResolveServerName(serverName)
+	if err != nil {
+		return "", err
+	}
+
+	return resolvedServerName + "-" + strings.ReplaceAll(connectorType, "/", "-"), nil
+}
+
 // remoteVolumeMapLock acquires a lock used when mapping or unmapping remote
 // storage volumes. This lock prevents conflicts between operations trying to
 // associate or disassociate volumes with the LXD host. If the lock is

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -491,6 +491,7 @@ var APIExtensions = []string{
 	"event_security",
 	"storage_driver_powerstore",
 	"oidc_device_client_id",
+	"storage_nvme_tcp",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR renames current storage connector type `nvme` into `nvme/tcp`. This is a breaking change and therefore an API extension named `storage_nvme_tcp` is added.

---

### Options

Below is the table with some alternative namings:

Option name | iSCSI | SCSI/FC | NVMe/TCP | NVMe/FC | SDC |
--- | --- | --- | --- | --- | --- |
Current | `iscsi`  | | `nvme` | | `sdc` |
Option 1 | `iscsi` | `fc` | `nvme/tcp` | `nvme/fc` | `sdc` |
Option 2 | `iscsi` | `scsi/fc` | `nvme/tcp` | `nvme/fc` | `sdc` |
Option 3 | `scsi/tcp` | `scsi/fc` | `nvme/tcp` | `nvme/fc` | `sdc/tcp` |

- Option 1: keeps existing names, but `fc` defines only the transport.
- Option 2: is explicit for Fibre Channel while keeping common names for iSCSI and SDC.
- Option 3: is the most consistent, but less natural for users because `iscsi` and probably `sdc` are the common protocol names.

I would personally be in favor of `Option 2`, where `iscsi` and `sdc` remain as they are. @roosterfish can provide more information if SDC could be used in the future with other transport modes.

### Open questions

1. Do we disallow new volumes to be created with old names? 

Current PR allows both values. Essentially, both values are accepted, but it always renders the `nvme/tcp` which includes transport. IMO this prevents having two pools, one with `nvme` and one with `nvme/tcp`, while both represent the same mode.

Old value | New value | Result
--- | --- | ---
`nvme` | `nvme` | `nvme/tcp`
`nvme` | `nvme/tcp` | `nvme/tcp`
`nvme/tcp` | `nvme` | `nvme/tcp`
`nvme/tcp` | `nvme/tcp` | `nvme/tcp`

If desired, we can prevent old values, such as `nvme`, for new storage pools. However, this becomes a breaking change.

2. Should we use delimiter `-` between protocol and transport? 

I would prefer using `/`, but that means the delimiter needs to be replaced when creating hosts on the appliance (`/` is not allowed). Other than that, it is mostly cosmetic.

## Resolution

We have agreed to proceed with Option 2 and use delimiter `/`.
However, we will not keep old name `nvme` and instead introduce an API extension that covers this change. 

---

TODO:
- [x] Include patch for existing storage pools