### PR TITLE
workshop: add initial definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ doc/**/__pycache__
 # For Atom ctags
 .tags
 .tags1
+
+# Workshop
+.workshop.lock

--- a/.workshop/dev-tools/hooks/setup-base
+++ b/.workshop/dev-tools/hooks/setup-base
@@ -1,0 +1,31 @@
+set -ex
+
+export DEBIAN_FRONTEND=noninteractive
+
+pkgs=(
+  binutils-dev
+  build-essential
+  autoconf
+  pkg-config
+  automake
+  libtool
+  make
+  libuv1-dev
+  libsqlite3-dev
+  liblz4-dev
+  meson
+  libapparmor-dev
+  libcap-dev
+  libseccomp-dev
+  libacl1-dev
+  libudev-dev
+  git
+  ninja-build
+  shellcheck
+  jq
+  xdelta3
+  xfslibs-dev
+)
+
+apt-get update
+apt-get install -y --no-install-recommends "${pkgs[@]}"

--- a/.workshop/dev-tools/hooks/setup-project
+++ b/.workshop/dev-tools/hooks/setup-project
@@ -1,0 +1,4 @@
+set -ex
+
+cd /project
+make deps

--- a/.workshop/dev-tools/sdk.yaml
+++ b/.workshop/dev-tools/sdk.yaml
@@ -1,0 +1,2 @@
+name: dev-tools
+base: ubuntu@24.04

--- a/.workshop/lxd.yaml
+++ b/.workshop/lxd.yaml
@@ -1,0 +1,14 @@
+name: lxd
+base: ubuntu@24.04
+sdks:
+  - name: go
+    channel: 1.26/stable
+  - name: project-dev-tools
+
+actions:
+  build: |
+    make "${@:-all}"
+  tests: |
+    make check-unit
+  checks: |
+    make static-analysis

--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,11 @@ endif
 	find . -name 'AGENTS.md' -not -path './.git/*' -exec sed -i 's/^\(LXD requires Go \)[0-9.]\+ /\1$(NEW_GOMIN) /' {} +
 	sed -i 's/^\(LXD requires Go \)[0-9.]\+ /\1$(NEW_GOMIN) /' doc/requirements.md .github/copilot-instructions.md
 
+	@# Update Go SDK channel in .workshop/lxd.yaml
+	sed -i "s/^\( *channel: \)[0-9.]\+\/stable/\1$$(echo "$(NEW_GOMIN)" | sed 's/\.[0-9]*$$//')\/stable/" .workshop/lxd.yaml
+
 	@echo "Go minimum version updated to $(NEW_GOMIN)"
-	@./scripts/check-and-commit.sh "Makefile go.mod tools/go.mod doc/requirements.md $(shell find . -name 'AGENTS.md' -not -path './.git/*') .github/copilot-instructions.md" "go: Update Go minimum version to $(NEW_GOMIN)"
+	@./scripts/check-and-commit.sh "Makefile go.mod tools/go.mod doc/requirements.md $(shell find . -name 'AGENTS.md' -not -path './.git/*') .github/copilot-instructions.md .workshop/lxd.yaml" "go: Update Go minimum version to $(NEW_GOMIN)"
 
 .PHONY: update-gomod
 update-gomod:


### PR DESCRIPTION
This adds an initial definition of a workshop to build and test LXD. It currently wraps around the existing Makefile and installs the bare minimum of dependencies required.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
