### PR TITLE
lxd/storage/drivers: check for scanner.Err() in volume listing functions

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1514,6 +1514,11 @@ func (d *ceph) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("Failed scanning volume list: %w", err)
+	}
+
 	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -699,6 +699,11 @@ func (d *lvm) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("Failed scanning volume list: %w", err)
+	}
+
 	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err
@@ -1164,6 +1169,11 @@ func (d *lvm) VolumeSnapshots(vol Volume) ([]string, error) {
 		}
 
 		snapshots = append(snapshots, snapName)
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("Failed scanning snapshot list: %w", err)
 	}
 
 	errMsg, err := io.ReadAll(stderr)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2563,6 +2563,11 @@ func (d *zfs) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("Failed scanning volume list: %w", err)
+	}
+
 	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Three storage drivers (lvm, ceph, zfs) run a subprocess and scan its stdout line by line, but never check scanner.Err() after the loop. 
If the pipe read fails mid-way (e.g. bufio.ErrTooLong on an unusually long line, or an actual i/o error), the scan loop just exits silently - caller gets nil error + partial/empty volume list and has no way to tell something went wrong.

Same pattern was fixed in #18349 and #18363 for other files.

Affected functions: lvm.ListVolumes, lvm.VolumeSnapshots, ceph.ListVolumes, zfs.ListVolumes.

To trigger: feed a line exceeding bufio.MaxScanTokenSize (64 KB) into the pipe output - scanner.Scan() returns false and scanner.Err() returns bufio.ErrTooLong, which was previously swallowed.

Fix: add scanner.Err() check after each scan loop, before reading stderr and calling cmd.Wait().