### PR TITLE
Fix listing images with `--all-projects` flag

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1599,42 +1599,45 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 	}
 
 	for fingerprint, projects := range imagesProjectsMap {
-		hasAccess := false
-
-		image, err := doImageGet(ctx, tx, projects[0], fingerprint, public)
-		if err != nil {
-			continue
-		}
-
 		for _, project := range projects {
-			if image.Public || hasPermission(entity.ImageURL(project, fingerprint)) {
-				hasAccess = true
-				break
-			}
-		}
-
-		if !hasAccess {
-			continue
-		}
-
-		if !mustLoadObjects {
-			resultString = append(resultString, api.NewURL().Path(version.APIVersion, "images", fingerprint).String())
-		} else {
-			if clauses != nil && len(clauses.Clauses) > 0 {
-				match, err := filter.Match(*image, *clauses)
-				if err != nil {
-					return nil, err
-				}
-
-				if !match {
-					continue
-				}
+			image, err := doImageGet(ctx, tx, project, fingerprint, public)
+			if err != nil {
+				continue
 			}
 
-			if recursion {
-				resultMap = append(resultMap, image)
+			if !image.Public && !hasPermission(entity.ImageURL(project, fingerprint)) {
+				continue
+			}
+
+			if !mustLoadObjects {
+				url := api.NewURL().Path(version.APIVersion, "images", fingerprint)
+				if allProjects {
+					url = url.Project(project)
+				}
+
+				resultString = append(resultString, url.String())
 			} else {
-				resultString = append(resultString, api.NewURL().Path(version.APIVersion, "images", image.Fingerprint).String())
+				if clauses != nil && len(clauses.Clauses) > 0 {
+					match, err := filter.Match(*image, *clauses)
+					if err != nil {
+						return nil, err
+					}
+
+					if !match {
+						continue
+					}
+				}
+
+				if recursion {
+					resultMap = append(resultMap, image)
+				} else {
+					url := api.NewURL().Path(version.APIVersion, "images", image.Fingerprint)
+					if allProjects {
+						url = url.Project(project)
+					}
+
+					resultString = append(resultString, url.String())
+				}
 			}
 		}
 	}

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -104,6 +104,7 @@ readonly test_group_image=(
     "image_import_url"
     "image_import_existing_alias"
     "image_list_all_aliases"
+    "image_list_all_projects"
     "image_list_remotes"
     "image_prefer_cached"
     "image_refresh"

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -154,6 +154,34 @@ test_image_list_all_aliases() {
     lxc image alias delete zzz
 }
 
+test_image_list_all_projects() {
+    ensure_import_testimage
+
+    local fingerprint
+    fingerprint="$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
+    local fp_short
+    fp_short="$(echo "${fingerprint}" | cut -c1-12)"
+
+    sub_test "Same image in two projects appears twice in --all-projects output"
+
+    # Create a second project and copy the same image into it.
+    lxc project create p1 -c features.images=true -c features.profiles=false
+    lxc image copy "${fingerprint}" local: --target-project p1
+
+    # Verify both entries appear in the table.
+    local count
+    count="$(lxc image list --all-projects -f csv -c f | grep -cxF "${fp_short}")"
+    [ "${count}" -eq 2 ]
+
+    # Verify the project names are correct.
+    lxc image list --all-projects -f csv -c ef | grep -xF "default,${fp_short}"
+    lxc image list --all-projects -f csv -c ef | grep -xF "p1,${fp_short}"
+
+    # Clean up.
+    lxc image delete "${fingerprint}" --project p1
+    lxc project delete p1
+}
+
 test_image_list_remotes() {
     # list images from the `images:` and `ubuntu-minimal:` builtin remotes if they are reachable
     lxc remote list -f csv | while IFS=, read -r name url _; do


### PR DESCRIPTION
When the same image fingerprint exists in multiple projects, `lxc image list --all-projects` only showed it once (for the first project found) instead of once per project.

This PR fixes the `doImagesGet()` function to iterate over each `(project, fingerprint)` pair so that every project containing the image produces its own entry in the result. Permission checks are now per-project, and non-recursive URLs response includes the `?project=` parameter when `allProjects` is requested.

Fixes https://github.com/canonical/lxd/issues/17572.
