### PR TITLE
driver_qemu: don't use romfile for non-x86 architectures

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4718,6 +4718,12 @@ func (d *qemu) addNetDevConfig(busName string, busAllocate busAllocator, bootInd
 
 			if slices.Contains([]string{"pcie", "pci"}, busName) {
 				qemuDev["driver"] = "virtio-net-pci"
+				// QEMU hard codes using efi-virtio.rom.
+				// But that file contains only x86 code.
+				if d.architecture != osarch.ARCH_32BIT_INTEL_X86 &&
+					d.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+					qemuDev["romfile"] = ""
+				}
 			} else if busName == "ccw" {
 				qemuDev["driver"] = "virtio-net-ccw"
 			}
@@ -4856,6 +4862,12 @@ func (d *qemu) addNetDevConfig(busName string, busAllocate busAllocator, bootInd
 
 			if slices.Contains([]string{"pcie", "pci"}, busName) {
 				qemuDev["driver"] = "virtio-net-pci"
+				// QEMU hard codes using efi-virtio.rom.
+				// But that file contains only x86 code.
+				if d.architecture != osarch.ARCH_32BIT_INTEL_X86 &&
+					d.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+					qemuDev["romfile"] = ""
+				}
 			} else if busName == "ccw" {
 				qemuDev["driver"] = "virtio-net-ccw"
 			}


### PR DESCRIPTION
Lxd-pkg snap commit 0ad93fea298c ("qemu: use advanced grammar to prime just the needed FW") removed file efi-virtio.rom from the LXD snap except on x86. On non-x86 architectures this caused an error

        Failed setting up device via monitor:
        Failed setting up device "eth0":
        Failed adding NIC device:
        GenericError: failed to find romfile "efi-virtio.rom"

QEMU hard codes that the virtio-net-pci driver uses efi-virtio.rom as ROM file on all architectures though that file contains only x86 code.

Don't use it on other architectures.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation. _(no change)_
