### PR TITLE
lxd/instance/drivers/driver/qemu: missing secure boot firmware message

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2077,6 +2077,10 @@ func (d *qemu) setupNvram() error {
 		firmwares = edk2.GetArchitectureFirmwarePairsForUsage(d.architecture, edk2.CSM)
 	case instancetype.BootModeUEFISecureBoot:
 		firmwares = edk2.GetArchitectureFirmwarePairsForUsage(d.architecture, edk2.SECUREBOOT)
+		if len(firmwares) == 0 {
+			return errors.New("Secure boot firmware not available. Set boot.mode=uefi-nosecureboot")
+		}
+
 	default:
 		firmwares = edk2.GetArchitectureFirmwarePairsForUsage(d.architecture, edk2.GENERIC)
 	}


### PR DESCRIPTION
On RISC-V secure boot firmware is not yet available. The current error message when firmware is not found is

    Could not find one of the required VM firmware files: []

This message does not help the user to successfully launch a RISC-V VM.

Add a specific message if secure boot firmware is not available:

    Secure boot firmware not available. Set boot.mode=uefi-nosecureboot.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation. _(no change)_
