### PR TITLE
Replicator tests speedup

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -52,6 +52,7 @@ var apiInternal = []APIEndpoint{
 	internalClusterHandoverCmd,
 	internalClusterHealCmd,
 	internalClusterLinkRefreshVolatileAddressesCmd,
+	internalReplicatorRunSchedulerCmd,
 	internalClusterRaftNodeCmd,
 	internalClusterRebalanceCmd,
 	internalContainerOnStartCmd,
@@ -143,6 +144,12 @@ var internalClusterLinkRefreshVolatileAddressesCmd = APIEndpoint{
 	Path: "testing/cluster/link/refresh-volatile-addresses",
 
 	Post: APIEndpointAction{Handler: internalRefreshClusterLinkVolatileAddresses, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
+}
+
+var internalReplicatorRunSchedulerCmd = APIEndpoint{
+	Path: "testing/replicator/run-scheduler",
+
+	Post: APIEndpointAction{Handler: internalRunReplicatorScheduler, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
 var internalImageOptimizeCmd = APIEndpoint{
@@ -271,6 +278,19 @@ func internalRefreshClusterLinkVolatileAddresses(d *Daemon, r *http.Request) res
 	s := d.State()
 
 	err := autoRefreshClusterLinkVolatileAddresses(r.Context(), s)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}
+
+// internalRunReplicatorScheduler triggers the replicator scheduler task immediately.
+// It is used by tests to avoid waiting for the scheduler's one-minute tick.
+func internalRunReplicatorScheduler(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	err := runScheduledReplicators(r.Context(), s)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5879,45 +5879,36 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_ONE_DIR}" lxc config set c1 user.foo=bar --project replicator-project
 
   # Schedule the run after the instance exists. The replicator scheduler skips
-  # its first post-start tick, so use an every-minute cron and wait for the
-  # first active scheduler pass after daemon startup.
-  # Slow replications cannot accumulate: the replicator uses a ConflictReference on the
-  # operation so a scheduler tick that fires while a run is already in progress fails
-  # immediately with a conflict error rather than queuing another job.
+  # its first post-start tick, so use an every-minute cron expression.
+  # The internal trigger endpoint fires runScheduledReplicators synchronously,
+  # avoiding any real-time wait for the scheduler's one-minute tick.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator set my-replicator schedule "* * * * *" --project replicator-project
 
   sub_test "Wait for the scheduled replicator run"
 
-  local i scheduled_op
-  for i in $(seq 70); do
-    if grep -qxF 'c1,STOPPED' <<< "$(LXD_DIR="${LXD_TWO_DIR}" lxc list c1 --project replicator-project -f csv -c ns)" && \
-       grep -qF 'Status: Completed' <<< "$(LXD_DIR="${LXD_ONE_DIR}" lxc replicator info my-replicator --project replicator-project)"; then
-      break
-    fi
-
-    sleep 1
-  done
+  LXD_DIR="${LXD_ONE_DIR}" lxc query -X POST --raw --wait /internal/testing/replicator/run-scheduler
+  grep -F 'Status: Completed' <<< "$(LXD_DIR="${LXD_ONE_DIR}" lxc replicator info my-replicator --project replicator-project)"
 
   LXD_DIR="${LXD_TWO_DIR}" lxc list c1 --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc config get c1 user.foo --project replicator-project)" = "bar" ]
 
+  local scheduled_op
   scheduled_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 2 and .status == "Success" and ((.children // []) | length) == 1 and (all(.children[]; .status == "Success"))' <<< "${scheduled_op}"
 
   sub_test "Verify scheduler skips replicator when source project is not in leader mode"
 
-  local i ops_before
+  local ops_before
   ops_before="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | length')"
 
   # Unset replica.mode on the source; the scheduler must now skip this replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc project unset replicator-project replica.mode
 
-  # Poll for longer than one scheduler tick (the task fires every minute), failing immediately if a new operation appears.
-  for i in $(seq 70); do
-    LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' \
-      | jq --exit-status --argjson before "${ops_before}" '[.. | objects | select(.description == "Running replicator")] | length == $before'
-    sleep 1
-  done
+  # Trigger the scheduler synchronously; because replica.mode is unset the scheduler
+  # skips the replicator without creating a new operation.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query -X POST --raw --wait /internal/testing/replicator/run-scheduler
+  LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' \
+    | jq --exit-status --argjson before "${ops_before}" '[.. | objects | select(.description == "Running replicator")] | length == $before'
 
   # Restore leader mode before cleanup.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=standby

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5994,8 +5994,7 @@ test_clustering_replicator_dr() {
   # LXD_ONE is unreachable; replica.mode=leader validation skips when the target is unreachable.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.mode=leader
   # Both clusters now have replica.mode=leader. Verify instance creation is allowed on LXD_TWO.
-  LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage replicator-project
-  LXD_DIR="${LXD_TWO_DIR}" lxc launch testimage c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
   # Verify LXD_TWO can start a replicated instance as the new leader.
   LXD_DIR="${LXD_TWO_DIR}" lxc start c1 --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,RUNNING'


### PR DESCRIPTION
Goes from (full test: 28m 33s):
Test                                   |   btrfs |    ceph |     dir |     lvm |     zfs |  random
:------------------------------------- | ------: | ------: | ------: | ------: | ------: | ------:
clustering_replicator_basic            |   7.84s |  56.27s |   8.26s |  16.53s |  11.61s |  12.13s
clustering_replicator_dr               |   9.09s |  55.62s |   8.90s |  16.35s |  12.49s |  12.90s
clustering_replicator_evacuated_member |  35.89s |   0.01s |  36.28s |  44.11s |  41.92s |  35.73s
clustering_replicator_multi_member     |  10.44s |   0.01s |  11.58s |  20.16s |  14.91s |  10.59s
clustering_replicator_scheduled        | 134.34s | 144.26s | 134.36s | 135.39s | 135.14s | 138.78s
clustering_replicator_snapshot         |   5.54s |  35.08s |   5.86s |  10.05s |   7.85s |  21.73s
clustering_replicator_vm               |   5.26s |  59.14s |   6.37s |  15.62s |   8.68s |  39.11s
TOTAL                                  | 208.40s | 350.39s | 211.61s | 258.21s | 232.60s | 270.97s

To (full test: 14m 59s):

Test                                   |  btrfs |    ceph |    dir |     lvm |     zfs |  random
:------------------------------------- | -----: | ------: | -----: | ------: | ------: | ------:
clustering_replicator_basic            |  7.52s |  56.28s |  7.84s |  15.71s |  11.17s |  35.35s
clustering_replicator_dr               |  7.98s |  48.12s |  7.94s |  14.32s |  11.15s |   8.08s
clustering_replicator_evacuated_member | 35.72s |   0.00s | 36.03s |  43.89s |  41.92s |  35.58s
clustering_replicator_multi_member     | 10.20s |   0.00s | 10.82s |  19.79s |  14.29s |  10.19s
clustering_replicator_scheduled        |  5.27s |  30.09s |  5.22s |   8.84s |   7.07s |   7.40s
clustering_replicator_snapshot         |  5.39s |  35.11s |  5.66s |   9.69s |   7.61s |   8.05s
clustering_replicator_vm               |  5.08s |  59.14s |  6.21s |  14.88s |   8.42s |   8.39s
TOTAL                                  | 77.16s | 228.74s | 79.72s | 127.12s | 101.63s | 113.04s
