### PR TITLE
Improve logging for crash consistent multi-volume snapshotting

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1004,12 +1004,24 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 
 	// Freeze the instance if the driver requires it or if there are snapshottable attached volumes to ensure crash-consistent snapshots.
 	if (pool.Driver().Info().RunningCopyFreeze || len(snapshottableVolumes) > 0) && inst.IsRunning() && !inst.IsFrozen() {
+		if len(snapshottableVolumes) > 0 {
+			d.logger.Info("Freezing instance to ensure crash-consistent multi-volume snapshot", logger.Ctx{"snapshot": snap.Name()})
+		} else {
+			d.logger.Debug("Freezing instance as required by the storage driver", logger.Ctx{"snapshot": snap.Name()})
+		}
+
 		err = inst.Freeze(ctx)
 		if err != nil {
 			return err
 		}
 
 		defer func() {
+			if len(snapshottableVolumes) > 0 {
+				d.logger.Info("Unfreezing instance after crash-consistent multi-volume snapshot", logger.Ctx{"snapshot": snap.Name()})
+			} else {
+				d.logger.Debug("Unfreezing instance after storage driver freeze", logger.Ctx{"snapshot": snap.Name()})
+			}
+
 			err := inst.Unfreeze(ctx)
 			if err != nil {
 				d.logger.Warn("Failed unfreezing instance after snapshot", logger.Ctx{"err": err})
@@ -1042,7 +1054,7 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 		instanceProject := inst.Project()
 		instanceType := inst.Type()
 		for deviceName, volume := range snapshottableVolumes {
-			d.logger.Debug("Creating attached volume snapshot", logger.Ctx{"pool": volume.Pool, "volume": volume.Name, "project": volume.Project})
+			d.logger.Info("Creating attached volume snapshot", logger.Ctx{"pool": volume.Pool, "volume": volume.Name, "project": volume.Project})
 
 			// Use shutdown context as we don't have access to the request context.
 			snapshotName, err := storagePools.VolumeDetermineNextSnapshotName(d.state.ShutdownCtx, d.state, volume.Pool, volume.Name, volume.Config)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1059,7 +1059,7 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 			// Use shutdown context as we don't have access to the request context.
 			snapshotName, err := storagePools.VolumeDetermineNextSnapshotName(d.state.ShutdownCtx, d.state, volume.Pool, volume.Name, volume.Config)
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed determining next snapshot name for attached volume %q in storage pool %q: %w", volume.Name, volume.Pool, err)
 			}
 
 			// Attached volume snapshot description.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -959,6 +959,18 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 		}
 	}
 
+	// Attached volumes to snapshot alongside the root, excluding ISO volumes whose
+	// snapshots are unsupported. An ISO-only attachment therefore does not need a
+	// crash-consistent freeze.
+	snapshottableVolumes := make(map[string]db.StorageVolume, len(attachedVolumes))
+	for deviceName, volume := range attachedVolumes {
+		if volume.ContentType == dbCluster.StoragePoolVolumeContentTypeNameISO {
+			continue
+		}
+
+		snapshottableVolumes[deviceName] = volume
+	}
+
 	// Setup the arguments.
 	args := db.InstanceArgs{
 		Project:      inst.Project().Name,
@@ -990,8 +1002,8 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 		return err
 	}
 
-	// Freeze the instance if the driver requires it or if there are attached volumes to ensure crash-consistent snapshots.
-	if (pool.Driver().Info().RunningCopyFreeze || len(attachedVolumes) > 0) && inst.IsRunning() && !inst.IsFrozen() {
+	// Freeze the instance if the driver requires it or if there are snapshottable attached volumes to ensure crash-consistent snapshots.
+	if (pool.Driver().Info().RunningCopyFreeze || len(snapshottableVolumes) > 0) && inst.IsRunning() && !inst.IsFrozen() {
 		err = inst.Freeze(ctx)
 		if err != nil {
 			return err
@@ -1029,12 +1041,7 @@ func (d *common) snapshotCommon(ctx context.Context, inst instance.Instance, nam
 		volatileAttachedVolumes := make(map[string]string)
 		instanceProject := inst.Project()
 		instanceType := inst.Type()
-		for deviceName, volume := range attachedVolumes {
-			// Skip ISO volumes (snapshots not supported).
-			if volume.ContentType == dbCluster.StoragePoolVolumeContentTypeNameISO {
-				continue
-			}
-
+		for deviceName, volume := range snapshottableVolumes {
 			d.logger.Debug("Creating attached volume snapshot", logger.Ctx{"pool": volume.Pool, "volume": volume.Name, "project": volume.Project})
 
 			// Use shutdown context as we don't have access to the request context.

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -562,8 +562,23 @@ test_snapshot_multi_volume() {
   lxc exec c1 -- touch /mnt/shared/snap2 /mnt/non-shared/snap2 snap2
 
   echo "Check multi-volume snapshot."
+  # Record the log position so the assertions below are scoped to this snapshot, not an earlier one.
+  local logLinesBefore=0
+  if [ -n "${SERVER_DEBUG:-}" ]; then
+    logLinesBefore=$(wc -l < "${LXD_DIR}/lxd.log")
+  fi
+
   lxc snapshot c1 c1-snap2 --disk-volumes=all-exclusive
   lxc info c1 # For debugging and coverage.
+
+  # The crash-consistency INFO logs only reach lxd.log when the daemon runs verbose.
+  if [ -n "${SERVER_DEBUG:-}" ]; then
+    local newLogs
+    newLogs="$(tail --lines="+$((logLinesBefore + 1))" "${LXD_DIR}/lxd.log")"
+    grep -qF "Freezing instance to ensure crash-consistent multi-volume snapshot" <<< "${newLogs}"
+    [ "$(grep -cF "Creating attached volume snapshot" <<< "${newLogs}")" = "2" ]
+    grep -qF "Unfreezing instance after crash-consistent multi-volume snapshot" <<< "${newLogs}"
+  fi
 
   # Remove created files.
   lxc exec c1 -- rm /mnt/shared/snap2 /mnt/non-shared/snap2 snap2


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description
When taking a crash-consistent multi-volume snapshot (`lxc snapshot <instance> --disk-volumes=all-exclusive`), LXD freezes the instance and snapshots the root volume together with every exclusively attached custom volume, so they are all captured at the same I/O point.

As noted in the issue, this path was silent at the info level. An operator reading the daemon log could not tell that the freeze happened for crash consistency across volumes (rather than a driver requirement), nor follow each volume being captured inside the freeze window.

This PR adds info logs around the freeze, the root volume snapshot, and each attached volume snapshot, and raises the existing per attached volume log from debug to info so it appears alongside the root. These are only emitted when attached volumes are present, so ordinary single-volume snapshots are unchanged. A shell test asserts the new lines, guarded so it only runs when the daemon is verbose.

It also refines the freeze condition to ignore attached ISO volumes. ISO volumes are read-only and are not snapshotted, so an instance whose only exclusive attachment is an ISO no longer freezes or logs a crash-consistent multi-volume snapshot.

Closes https://github.com/canonical/lxd/issues/18319