### PR TITLE
Storage: Add PowerFlex 5 support

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6340,6 +6340,15 @@ Must have at least SystemAdmin role to give LXD full control over managed storag
 
 ```
 
+```{config:option} powerflex.version storage-powerflex-pool-conf
+:defaultdesc: "Discovered version"
+:scope: "global"
+:shortdesc: "Software version of the PowerFlex array."
+:type: "string"
+This field is automatically populated after querying the PowerFlex version.
+It cannot be set by the user.
+```
+
 ```{config:option} rsync.bwlimit storage-powerflex-pool-conf
 :defaultdesc: "`0` (no limit)"
 :scope: "global"
@@ -6358,11 +6367,11 @@ to be placed on the socket I/O.
 ```
 
 ```{config:option} volume.size storage-powerflex-pool-conf
-:defaultdesc: "`8GiB`"
 :scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
-The size must be in multiples of 8 GiB.
+The size must be in multiples of 8 GiB for PowerFlex 4.
+Starting with PowerFlex 5, the size can be in multiples of 1 GiB.
 See {ref}`storage-powerflex-limitations` for more information.
 ```
 
@@ -6428,7 +6437,8 @@ Enable this option to allow the volume to be attached to multiple isolated insta
 :scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
-The size must be in multiples of 8 GiB.
+The size must be in multiples of 8 GiB for PowerFlex 4.
+Starting with PowerFlex 5, the size can be in multiples of 1 GiB.
 See {ref}`storage-powerflex-limitations` for more information.
 ```
 

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -108,9 +108,6 @@ Sharing custom volumes between instances
 Sharing the PowerFlex storage pool between installations
 : Sharing the same PowerFlex storage pool between multiple LXD installations is not supported.
 
-Recovering PowerFlex storage pools
-: Recovery of PowerFlex storage pools using `lxd recover` is not supported.
-
 Incompatible instance images
 : The Ubuntu Noble Numbat image cannot be used together with the {config:option}`storage-powerflex-pool-conf:powerflex.mode` set to `sdc`.
   This is due to a limitation of SDC not being able to manage volumes with more than 15 partitions.

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -13,6 +13,8 @@ LXD takes care of connecting to the respective subsystem.
 When using the SDC, LXD requires it to already be connected to the Dell Metadata Manager (MDM) beforehand.
 As LXD doesn't set up the SDC, follow the official guides from Dell for configuration details.
 
+LXD supports both PowerFlex 4 and 5.
+
 ## Terminology
 
 PowerFlex groups various so-called {abbr}`SDS (storage data servers)` under logical groups within a protection domain.
@@ -75,23 +77,29 @@ The `powerflex` driver has the following limitations:
 Limit of snapshots in a single vTree
 : An internal limitation in the PowerFlex vTree does not allow to take more than 126 snapshots of any volume in PowerFlex.
   This limit also applies to any child of any of the parent volume's snapshots.
-  A single vTree can only have 126 branches.
+  In PowerFlex 4 a single vTree can only have 126 branches.
+  PowerFlex 5 supports having 1022 snapshots per volume family (formerly vTree).
 
 Non-optimized image storage
-: Due to the limit of 126 snapshots in the vTree, the PowerFlex driver doesn't come with support for optimized image storage.
-  This would limit LXD to create only 126 instances from an image.
+: Due to the limit of snapshots in the vTree, the PowerFlex driver doesn't come with support for optimized image storage.
+  This would limit LXD to create only a finite number of instances from an image.
   Instead, when launching a new instance, the image's contents get copied to the instance's root volume.
 
 Copying volumes
 : PowerFlex does not support creating a copy of the volume so that it gets its own vTree.
   Therefore, LXD falls back to copying the volume on the local system.
   This implicates an increased use of bandwidth due to the volume's contents being transferred over the network twice.
+  Enabling {config:option}`storage-powerflex-pool-conf:powerflex.snapshot_copy` creates a PowerFlex snapshot when performing a copy.
+  Starting with PowerFlex 5, enabling {config:option}`storage-powerflex-pool-conf:powerflex.snapshot_copy` will cause any
+  volume copies to be performed on PowerFlex directly.
 
 Volume size constraints
-: In PowerFlex, the size (quota) of a volume must be in multiples of 8 GiB.
-  This results in the smallest possible volume size of 8 GiB.
+: In PowerFlex 4, the size (quota) of a volume must be in multiples of 8 GiB.
+  PowerFlex 5 requires the size to be in multiples of 1 GiB.
+  This results in the smallest possible volume size of 8 GiB or 1 GiB depending on the version of PowerFlex.
   However, if not specified otherwise, volumes are getting thin-provisioned by LXD.
   PowerFlex volumes can only be increased in size.
+  When no volume size is set, it's rounded to the next multiple which fits the instance image.
 
 Sharing custom volumes between instances
 : The PowerFlex driver "simulates" volumes with content type `filesystem` by putting a file system on top of a PowerFlex volume.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7021,6 +7021,15 @@
 						}
 					},
 					{
+						"powerflex.version": {
+							"defaultdesc": "Discovered version",
+							"longdesc": "This field is automatically populated after querying the PowerFlex version.\nIt cannot be set by the user.",
+							"scope": "global",
+							"shortdesc": "Software version of the PowerFlex array.",
+							"type": "string"
+						}
+					},
+					{
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
@@ -7040,8 +7049,7 @@
 					},
 					{
 						"volume.size": {
-							"defaultdesc": "`8GiB`",
-							"longdesc": "The size must be in multiples of 8 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"longdesc": "The size must be in multiples of 8 GiB for PowerFlex 4.\nStarting with PowerFlex 5, the size can be in multiples of 1 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
 							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
@@ -7113,7 +7121,7 @@
 					{
 						"size": {
 							"defaultdesc": "same as `volume.size`",
-							"longdesc": "The size must be in multiples of 8 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"longdesc": "The size must be in multiples of 8 GiB for PowerFlex 4.\nStarting with PowerFlex 5, the size can be in multiples of 1 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
 							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -17,8 +17,11 @@ import (
 // powerFlexDefaultUser represents the default PowerFlex user name.
 const powerFlexDefaultUser = "admin"
 
-// powerFlexDefaultSize represents the default PowerFlex volume size.
-const powerFlexDefaultSize = "8GiB"
+// powerFlex4DefaultSize represents the default PowerFlex volume size for PowerFlex 4.
+const powerFlex4DefaultSize = "8GiB"
+
+// powerFlex5DefaultSize represents the default PowerFlex volume size for PowerFlex 5.
+const powerFlex5DefaultSize = "1GiB"
 
 // powerFlexMinVolumeSizeBytes represents the minimal PowerFlex volume size in bytes.
 // This translates to 8 GiB.
@@ -165,11 +168,18 @@ func (d *powerflex) FillConfig() error {
 		}
 	}
 
-	// PowerFlex volumes have to be at least 8GiB in size.
-	if d.config["volume.size"] == "" {
-		d.config["volume.size"] = powerFlexDefaultSize
+	// Exit if there already is a PowerFlex version set as this field gets auto-populated.
+	if d.config["powerflex.version"] != "" {
+		return errors.New(`Cannot set "powerflex.version" manually`)
 	}
 
+	// Retrieve and store the PowerFlex system version.
+	version, err := d.client().getVersion()
+	if err != nil {
+		return err
+	}
+
+	d.config["powerflex.version"] = version
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -287,14 +287,14 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  scope: global
 		"powerflex.snapshot_copy": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=volume.size)
-		// The size must be in multiples of 8 GiB.
+		// The size must be in multiples of 8 GiB for PowerFlex 4.
+		// Starting with PowerFlex 5, the size can be in multiples of 1 GiB.
 		// See {ref}`storage-powerflex-limitations` for more information.
 		// ---
 		//  type: string
-		//  defaultdesc: `8GiB`
 		//  shortdesc: Size/quota of the storage volume
 		//  scope: global
-		"volume.size": validate.Optional(validate.IsMultipleOfUnit("8GiB")),
+		"volume.size": validate.Optional(validate.IsMultipleOfUnit("1GiB")),
 	}
 
 	err := d.validatePool(config, rules, d.commonVolumeRules())

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/ioprogress"
 	"github.com/canonical/lxd/shared/validate"
+	"github.com/canonical/lxd/shared/version"
 )
 
 // powerFlexDefaultUser represents the default PowerFlex user name.
@@ -91,6 +92,22 @@ func (d *powerflex) connector() (connectors.Connector, error) {
 // isRemote returns true indicating this driver uses remote storage.
 func (d *powerflex) isRemote() bool {
 	return true
+}
+
+// hasThinCloneSupport returns true if the PowerFlex system version supports thin clones.
+// This is true for all PowerFlex version starting with 5.0.
+func (d *powerflex) hasThinCloneSupport() bool {
+	powerFlexVersion, err := version.NewDottedVersion(d.config["powerflex.version"])
+	if err != nil {
+		return false
+	}
+
+	thinCloneSupportVersion, err := version.NewDottedVersion("5.0")
+	if err != nil {
+		return false
+	}
+
+	return powerFlexVersion.Compare(thinCloneSupportVersion) >= 0
 }
 
 // Info returns info about the driver and its environment.

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -109,8 +109,10 @@ func (d *powerflex) Info() Info {
 		DirectIO:                     true,
 		IOUring:                      true,
 		MountedRoot:                  false,
-		PopulateParentVolumeUUID:     false,
-		UUIDVolumeNames:              true,
+		// If parent volume UUID is present we know a snapshot [Volume] is an actual snapshot.
+		// In PowerFlex 5 when creating a thin clone of a snapshot, we unset the parent volume UUID to differentiate between snapshots and thin clones.
+		PopulateParentVolumeUUID: true,
+		UUIDVolumeNames:          true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -340,14 +340,20 @@ func (d *powerflex) Validate(config map[string]string) error {
 		return err
 	}
 
-	newMode := config["powerflex.mode"]
-	oldMode := d.config["powerflex.mode"]
-
 	// Ensure powerflex.mode cannot be changed to avoid leaving volume mappings
 	// and to prevent disturbing running instances.
-	if oldMode != "" && oldMode != newMode {
-		return errors.New("PowerFlex mode cannot be changed")
+	// Ensure powerflex.version cannot be changed.
+	immutableKeys := []string{"powerflex.mode", "powerflex.version"}
+	for _, key := range immutableKeys {
+		newVal := config[key]
+		oldVal := d.config[key]
+
+		if oldVal != "" && oldVal != newVal {
+			return fmt.Errorf("%q cannot be changed", key)
+		}
 	}
+
+	newMode := config["powerflex.mode"]
 
 	// Check if the selected PowerFlex mode is supported on this node.
 	// Also when forming the storage pool on a LXD cluster, the mode

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -23,9 +23,13 @@ const powerFlex4DefaultSize = "8GiB"
 // powerFlex5DefaultSize represents the default PowerFlex volume size for PowerFlex 5.
 const powerFlex5DefaultSize = "1GiB"
 
-// powerFlexMinVolumeSizeBytes represents the minimal PowerFlex volume size in bytes.
+// powerFlex4MinVolumeSizeBytes represents the minimal PowerFlex volume size in bytes for PowerFlex 4.
 // This translates to 8 GiB.
-const powerFlexMinVolumeSizeBytes = 8589934592
+const powerFlex4MinVolumeSizeBytes = 8589934592
+
+// powerFlex5MinVolumeSizeBytes represents the minimal PowerFlex volume size in bytes for PowerFlex 5.
+// This translates to 1 GiB.
+const powerFlex5MinVolumeSizeBytes = 1073741824
 
 var powerflexSupportedConnectors = []string{
 	connectors.TypeNVMeTCP,
@@ -463,7 +467,11 @@ func (d *powerflex) MigrationTypes(contentType ContentType, refresh bool, copySn
 }
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
-// multiple of 8 GiB, which is the minimum allocation unit on PowerFlex.
+// multiple of 1 or 8 GiB, which is the minimum allocation unit on PowerFlex.
 func (d *powerflex) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {
-	return roundAbove(powerFlexMinVolumeSizeBytes, sizeBytes)
+	if d.hasThinCloneSupport() {
+		return roundAbove(powerFlex5MinVolumeSizeBytes, sizeBytes)
+	}
+
+	return roundAbove(powerFlex4MinVolumeSizeBytes, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -406,16 +406,47 @@ func (d *powerflex) GetResources() (*api.ResourcesStoragePool, error) {
 		return nil, err
 	}
 
-	stats, err := d.client().getStoragePoolStatistics(pool.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	used := stats.NetCapacityInUseInKb * 1024
-
+	client := d.client()
 	res := &api.ResourcesStoragePool{}
-	res.Space.Total = stats.NetUnusedCapacityInKb*1024 + used
-	res.Space.Used = used
+
+	if !d.hasThinCloneSupport() {
+		// PowerFlex 4 allows querying stats from the pool directly.
+		stats, err := client.getStoragePoolStatistics(pool.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		used := stats.NetCapacityInUseInKb * 1024
+
+		res.Space.Total = stats.NetUnusedCapacityInKb*1024 + used
+		res.Space.Used = used
+	} else {
+		// PowerFlex 5 requires using the new metrics endpoint.
+		metrics, err := client.getStoragePoolMetrics(pool.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(metrics.Resources) != 1 {
+			return nil, fmt.Errorf("Unexpected number of resources in metrics response for pool %q", pool.ID)
+		}
+
+		for _, metric := range metrics.Resources[0].Metrics {
+			if len(metric.Values) != 1 {
+				return nil, fmt.Errorf("Unexpected number of values in metrics response for pool %q and metric %q", pool.ID, metric.Name)
+			}
+
+			if metric.Name == "physical_total" {
+				res.Space.Total = metric.Values[0]
+				continue
+			}
+
+			if metric.Name == "physical_used" {
+				res.Space.Used = metric.Values[0]
+				continue
+			}
+		}
+	}
 
 	return res, nil
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -297,6 +297,15 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  shortdesc: Size/quota of the storage volume
 		//  scope: global
 		"volume.size": validate.Optional(validate.IsMultipleOfUnit("1GiB")),
+		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.version)
+		// This field is automatically populated after querying the PowerFlex version.
+		// It cannot be set by the user.
+		// ---
+		//  type: string
+		//  defaultdesc: Discovered version
+		//  shortdesc: Software version of the PowerFlex array.
+		//  scope: global
+		"powerflex.version": validate.Optional(validate.IsDottedVersion),
 	}
 
 	err := d.validatePool(config, rules, d.commonVolumeRules())

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -132,6 +132,17 @@ type powerFlexStoragePoolStatistics struct {
 	NetCapacityInUseInKb uint64 `json:"netCapacityInUseInKb"`
 }
 
+// powerFlexStoragePoolMetrics represents the metrics of a storage pool in PowerFlex.
+type powerFlexStoragePoolMetrics struct {
+	Resources []struct {
+		ID      string `json:"id"`
+		Metrics []struct {
+			Name   string   `json:"name"`
+			Values []uint64 `json:"values"`
+		} `json:"metrics"`
+	} `json:"resources"`
+}
+
 // powerFlexProtectionDomain represents a protection domain in PowerFlex.
 type powerFlexProtectionDomain struct {
 	ID       string `json:"id"`
@@ -345,11 +356,33 @@ func (p *powerFlexClient) getStoragePool(poolID string) (*powerFlexStoragePool, 
 }
 
 // getStoragePoolStatistics returns the storage pools statistics.
+// Cannot be used with PowerFlex 5.
 func (p *powerFlexClient) getStoragePoolStatistics(poolID string) (*powerFlexStoragePoolStatistics, error) {
 	var actualResponse powerFlexStoragePoolStatistics
 	err := p.requestAuthenticated(http.MethodGet, "/api/instances/StoragePool::"+poolID+"/relationships/Statistics", nil, &actualResponse)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting storage pool statistics: %q: %w", poolID, err)
+	}
+
+	return &actualResponse, nil
+}
+
+// getStoragePoolMetrics returns the storage pools metrics.
+// Present starting with PowerFlex 5.
+func (p *powerFlexClient) getStoragePoolMetrics(poolID string) (*powerFlexStoragePoolMetrics, error) {
+	body := map[string]any{
+		"resource_type": "storage_pool",
+		"metrics": []string{
+			"physical_total",
+			"physical_used",
+		},
+		"ids": []string{poolID},
+	}
+
+	var actualResponse powerFlexStoragePoolMetrics
+	err := p.requestAuthenticated(http.MethodPost, "/dtapi/rest/v1/metrics/query", body, &actualResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting storage pool metrics: %q: %w", poolID, err)
 	}
 
 	return &actualResponse, nil

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -614,6 +614,43 @@ func (p *powerFlexClient) createVolumeSnapshot(systemID string, volumeID string,
 	return actualResponse.VolumeIDs[0], nil
 }
 
+// createVolumeThinClone creates a new thin clone for the volume behind volumeID under the given systemID.
+// The returned string represents the ID of the thin clone.
+func (p *powerFlexClient) createVolumeThinClone(systemID string, volumeID string, thinCloneName string) (string, error) {
+	body := map[string]any{
+		"snapshotDefs": []map[string]string{
+			{
+				"volumeId":     volumeID,
+				"snapshotName": thinCloneName,
+			},
+		},
+	}
+
+	var actualResponse struct {
+		VolumeIDs []string `json:"volumeIdList"`
+	}
+
+	err := p.requestAuthenticated(http.MethodPost, "/api/instances/System::"+systemID+"/action/createThinClone", body, &actualResponse)
+	if err != nil {
+		powerFlexError, ok := err.(*powerFlexError)
+		if ok {
+			// API returns 500 if the snapshot name is too long.
+			// To not confuse it with other 500 that might occur check the error code too.
+			if powerFlexError.HTTPStatusCode() == http.StatusInternalServerError && powerFlexError.ErrorCode() == powerFlexCodeNameTooLong {
+				return "", api.StatusErrorf(http.StatusNotFound, "Thin clone name exceeds the allowed length of 31 characters: %q", thinCloneName)
+			}
+		}
+
+		return "", fmt.Errorf("Failed creating thin clone: %q: %w", thinCloneName, err)
+	}
+
+	if len(actualResponse.VolumeIDs) == 0 {
+		return "", errors.New("Response does not contain a single thin clone ID")
+	}
+
+	return actualResponse.VolumeIDs[0], nil
+}
+
 // getVolumeSnapshots returns the snapshots of the volume behind volumeID.
 func (p *powerFlexClient) getVolumeSnapshots(volumeID string) ([]powerFlexVolume, error) {
 	volume, err := p.getVolume(volumeID)

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -110,6 +110,12 @@ func (p *powerFlexError) HTTPStatusCode() float64 {
 	return code
 }
 
+// powerFlexSystemInfo stores system information from PowerFlex.
+type powerFlexSystemInfo struct {
+	// Present starting with PowerFlex 5.
+	SystemNQN string `json:"systemNqn"`
+}
+
 // powerFlexStoragePool represents a storage pool in PowerFlex.
 type powerFlexStoragePool struct {
 	ID                 string `json:"id"`
@@ -370,6 +376,17 @@ func (p *powerFlexClient) getVersion() (string, error) {
 
 	// The API returns the version in quotes.
 	return strings.Trim(actualResponse, `"`), nil
+}
+
+// getSystemInfo returns system information from the PowerFlex system with the given systemID.
+func (p *powerFlexClient) getSystemInfo(systemID string) (*powerFlexSystemInfo, error) {
+	var actualResponse powerFlexSystemInfo
+	err := p.requestAuthenticated(http.MethodGet, "/api/instances/System::"+systemID, nil, &actualResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting system instances: %w", err)
+	}
+
+	return &actualResponse, nil
 }
 
 // getProtectionDomainID returns the ID of the protection domain behind domainName.
@@ -843,34 +860,56 @@ func (d *powerflex) getHostGUID() (string, error) {
 }
 
 // getNVMeTargetQN discovers the targetQN used for the given addresses.
-// The targetQN is unqiue per PowerFlex storage pool.
+// The targetQN is unique per PowerFlex system.
+// Starting with PowerFlex 5 the targetQN can be retrieved directly from the API.
 // Cache the targetQN as it doesn't change throughout the lifetime of the storage pool.
 func (d *powerflex) getNVMeTargetQN(targetAddresses ...string) (string, error) {
 	if d.nvmeTargetQN == "" {
-		connector, err := d.connector()
-		if err != nil {
-			return "", err
-		}
-
-		// The discovery log from the first reachable target address is returned.
-		discoveryLogRecords, err := connector.Discover(d.state.ShutdownCtx, targetAddresses...)
-		if err != nil {
-			return "", fmt.Errorf("Failed discovering SDT NQN: %w", err)
-		}
-
-		for _, recordAny := range discoveryLogRecords {
-			record, ok := recordAny.(connectors.NVMeDiscoveryLogRecord)
-			if !ok {
-				return "", fmt.Errorf("Invalid discovery log record entry type %T is not connectors.NVMeDiscoveryLogRecord", recordAny)
+		if !d.hasThinCloneSupport() {
+			connector, err := d.connector()
+			if err != nil {
+				return "", err
 			}
 
-			if record.SubType != connectors.SubtypeNVMESubsys {
-				continue
+			// The discovery log from the first reachable target address is returned.
+			discoveryLogRecords, err := connector.Discover(d.state.ShutdownCtx, targetAddresses...)
+			if err != nil {
+				return "", fmt.Errorf("Failed discovering SDT NQN: %w", err)
 			}
 
-			// The targetQN is listed together with every log record of type SubtypeNVMESubsys.
-			d.nvmeTargetQN = record.SubNQN
-			break
+			for _, recordAny := range discoveryLogRecords {
+				record, ok := recordAny.(connectors.NVMeDiscoveryLogRecord)
+				if !ok {
+					return "", fmt.Errorf("Invalid discovery log record entry type %T is not connectors.NVMeDiscoveryLogRecord", recordAny)
+				}
+
+				if record.SubType != connectors.SubtypeNVMESubsys {
+					continue
+				}
+
+				// The targetQN is listed together with every log record of type SubtypeNVMESubsys.
+				d.nvmeTargetQN = record.SubNQN
+				break
+			}
+		} else {
+			client := d.client()
+
+			pool, err := d.resolvePool()
+			if err != nil {
+				return "", err
+			}
+
+			domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
+			if err != nil {
+				return "", err
+			}
+
+			systemInfo, err := client.getSystemInfo(domain.SystemID)
+			if err != nil {
+				return "", err
+			}
+
+			d.nvmeTargetQN = systemInfo.SystemNQN
 		}
 	}
 

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -1437,8 +1437,10 @@ func (d *powerflex) getVolumeName(vol Volume) (string, error) {
 	// If volume is snapshot, prepend snapshot prefix to its name.
 	// This allows differentiating between snapshots which actually belong to its parent volume
 	// and snapshots which were being created as part of copying a volume using powerflex.snapshot_copy.
-	// The latter are snapshots of the original volume stand on their own and don't use the snapshot prefix.
-	if vol.IsSnapshot() {
+	// The latter are snapshots of the original volume which stand on their own and don't use the snapshot prefix.
+	// PowerFlex 5 tracks snapshots separately from the original volume but is still using the prefix for consistency.
+	// In case the snapshot doesn't have a parent UUID, it's a thin clone of the snapshot so we don't append the prefix.
+	if vol.IsSnapshot() && vol.parentUUID != "" {
 		volName = powerFlexSnapshotPrefix + volName
 	}
 

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -560,6 +560,21 @@ func (p *powerFlexClient) renameVolume(volumeID string, newName string) error {
 	return nil
 }
 
+// refreshVolume refreshes the volume behind volumeID with the given volume/snapshot behind sourceVolumeID.
+// Present starting with PowerFlex 5.
+func (p *powerFlexClient) refreshVolume(volumeID string, sourceVolumeID string) error {
+	body := map[string]any{
+		"srcVolumeId": sourceVolumeID,
+	}
+
+	err := p.requestAuthenticated(http.MethodPost, "/api/instances/Volume::"+volumeID+"/action/refresh", body, nil)
+	if err != nil {
+		return fmt.Errorf("Failed refreshing volume %q with volume %q: %w", volumeID, sourceVolumeID, err)
+	}
+
+	return nil
+}
+
 // createVolumeSnapshot creates a new volume snapshot under the given systemID for the volume behind volumeID.
 // The accessMode can be either ReadWrite or ReadOnly.
 // The returned string represents the ID of the snapshot.

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -360,6 +360,18 @@ func (p *powerFlexClient) getStoragePoolVolumes(poolID string) ([]powerFlexVolum
 	return actualResponse, nil
 }
 
+// getVersion returns the version of the PowerFlex system.
+func (p *powerFlexClient) getVersion() (string, error) {
+	var actualResponse string
+	err := p.requestAuthenticated(http.MethodGet, "/api/version", nil, &actualResponse)
+	if err != nil {
+		return "", fmt.Errorf("Failed getting system version: %w", err)
+	}
+
+	// The API returns the version in quotes.
+	return strings.Trim(actualResponse, `"`), nil
+}
+
 // getProtectionDomainID returns the ID of the protection domain behind domainName.
 func (p *powerFlexClient) getProtectionDomainID(domainName string) (string, error) {
 	body := map[string]any{

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -576,7 +576,7 @@ func (p *powerFlexClient) refreshVolume(volumeID string, sourceVolumeID string) 
 }
 
 // createVolumeSnapshot creates a new volume snapshot under the given systemID for the volume behind volumeID.
-// The accessMode can be either ReadWrite or ReadOnly.
+// The accessMode can be either ReadWrite or ReadOnly and is only relevant for PowerFlex 4.
 // The returned string represents the ID of the snapshot.
 func (p *powerFlexClient) createVolumeSnapshot(systemID string, volumeID string, snapshotName string, accessMode powerFlexSnapshotMode) (string, error) {
 	body := map[string]any{
@@ -586,14 +586,22 @@ func (p *powerFlexClient) createVolumeSnapshot(systemID string, volumeID string,
 				"snapshotName": snapshotName,
 			},
 		},
-		"accessModeLimit": accessMode,
 	}
 
 	var actualResponse struct {
 		VolumeIDs []string `json:"volumeIdList"`
 	}
 
-	err := p.requestAuthenticated(http.MethodPost, "/api/instances/System::"+systemID+"/action/snapshotVolumes", body, &actualResponse)
+	action := "createSnapshot"
+	if !p.driver.hasThinCloneSupport() {
+		// PowerFlex 4 uses a different endpoint to snapshot volumes.
+		action = "snapshotVolumes"
+		// PowerFlex 4 requires setting the access mode for the snapshot.
+		// This is an illegal parameter in PowerFlex 5.
+		body["accessModeLimit"] = accessMode
+	}
+
+	err := p.requestAuthenticated(http.MethodPost, "/api/instances/System::"+systemID+"/action/"+action, body, &actualResponse)
 	if err != nil {
 		powerFlexError, ok := err.(*powerFlexError)
 		if ok {

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -752,12 +752,22 @@ func (d *powerflex) ListVolumes() ([]Volume, error) {
 
 // DefaultVMBlockFilesystemSize returns the size of a VM root device block volume's associated filesystem volume.
 func (d *powerflex) defaultVMBlockFilesystemSize() string {
-	return powerFlexDefaultSize
+	if d.hasThinCloneSupport() {
+		return powerFlex5DefaultSize
+	}
+
+	return powerFlex4DefaultSize
 }
 
 // defaultBlockVolumeSize returns the default size for block volumes in this pool.
 func (d *powerflex) defaultBlockVolumeSize() string {
-	return powerFlexDefaultSize
+	if d.hasThinCloneSupport() {
+		// PowerFlex 5 allows multiples of 1GiB.
+		// Therefore return the same default block size (10GiB) as for the other drivers.
+		return defaultBlockSize
+	}
+
+	return powerFlex4DefaultSize
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -459,10 +459,238 @@ func (d *powerflex) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteC
 	return err
 }
 
+// refreshVolume updates an existing volume to match the state of another. For VMs, this function
+// refreshes either block or filesystem volume, depending on the volume type. Therefore, the caller
+// needs to ensure it is called twice - once for each volume type.
+func (d *powerflex) refreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, progressReporter ioprogress.ProgressReporter) (revert.Hook, error) {
+	client := d.client()
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Function to run once the volume is created, which will ensure appropriate permissions
+	// on the mount path inside the volume, and resize the volume to specified size.
+	postCreateTasks := func(v Volume) error {
+		if vol.contentType == ContentTypeFS {
+			mountTask := func(mountPath string, progressReporter ioprogress.ProgressReporter) error {
+				return v.EnsureMountPath()
+			}
+
+			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
+			err := v.MountTask(mountTask, progressReporter)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Resize volume to the size specified.
+		err := d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	srcVolName, err := d.getVolumeName(srcVol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	srcVolID, err := client.getVolumeID(srcVolName)
+	if err != nil {
+		return nil, err
+	}
+
+	volName, err := d.getVolumeName(vol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	volID, err := client.getVolumeID(volName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new reverter snapshot, which is used to revert the original volume in case of
+	// an error. Snapshots are also required to be first copied into destination volume,
+	// from which a new snapshot is created to effectively copy a snapshot. If any error
+	// occurs, the destination volume has been already modified and needs reverting.
+	reverterSnapshotName := "r" + volName
+
+	// Remove existing reverter snapshot.
+	reverterSnapshotID, err := client.getVolumeID(reverterSnapshotName)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return nil, err
+	}
+
+	if reverterSnapshotID != "" {
+		err = client.deleteVolume(reverterSnapshotID, "ONLY_ME")
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil, err
+		}
+	}
+
+	pool, err := d.resolvePool()
+	if err != nil {
+		return nil, err
+	}
+
+	domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new reverter snapshot.
+	reverterSnapshotID, err = client.createVolumeSnapshot(domain.SystemID, volID, reverterSnapshotName, "ReadWrite")
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() {
+		// Restore destination volume from reverter snapshot and remove the snapshot afterwards.
+		_ = client.overwriteVolume(volID, reverterSnapshotID)
+		_ = client.deleteVolume(reverterSnapshotID, "ONLY_ME")
+	})
+
+	if !srcVol.IsSnapshot() && len(refreshSnapshots) > 0 {
+		var refreshedSnapshots []string
+
+		// Refresh volume snapshots.
+		// PowerFlex does not allow copying snapshots along with the volume. Therefore,
+		// we copy the missing snapshots sequentially. Each snapshot is first copied into
+		// the destination volume, from which a new snapshot is created. The process is
+		// repeated until all of the missing snapshots are copied.
+		for _, snapshot := range vol.Snapshots {
+			// Remove volume name prefix from the snapshot name, and check whether it
+			// has to be refreshed.
+			_, snapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+			if !slices.Contains(refreshSnapshots, snapshotShortName) {
+				// Skip snapshot if it doesn't have to be refreshed.
+				continue
+			}
+
+			// Find the corresponding source snapshot.
+			var srcSnapshot *Volume
+			for _, srcSnap := range srcVol.Snapshots {
+				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
+				if snapshotShortName == srcSnapshotShortName {
+					srcSnapshot = &srcSnap
+					break
+				}
+			}
+
+			if srcSnapshot == nil {
+				return nil, fmt.Errorf("Failed refreshing snapshot %q: Source snapshot does not exist", snapshotShortName)
+			}
+
+			srcSnapshotName, err := d.getVolumeName(*srcSnapshot)
+			if err != nil {
+				return nil, err
+			}
+
+			srcSnapshotID, err := client.getVolumeID(srcSnapshotName)
+			if err != nil {
+				return nil, err
+			}
+
+			// Overwrite existing destination volume with snapshot.
+			err = client.refreshVolume(volID, srcSnapshotID)
+			if err != nil {
+				return nil, err
+			}
+
+			snapshotName, err := d.getVolumeName(snapshot)
+			if err != nil {
+				return nil, err
+			}
+
+			// Create a destination snapshot after refreshing the destination volume with the source snapshot.
+			snapshotID, err := client.createVolumeSnapshot(domain.SystemID, volID, snapshotName, "ReadWrite")
+			if err != nil {
+				return nil, err
+			}
+
+			revert.Add(func() { _ = client.deleteVolume(snapshotID, "ONLY_ME") })
+
+			// Append snapshot to the list of successfully refreshed snapshots.
+			refreshedSnapshots = append(refreshedSnapshots, snapshotShortName)
+		}
+
+		// Ensure all snapshots were successfully refreshed.
+		missing := shared.RemoveElementsFromSlice(refreshSnapshots, refreshedSnapshots...)
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("Failed refreshing snapshots %v", missing)
+		}
+	}
+
+	// Finally, copy the source volume (or snapshot) into destination volume snapshots.
+	err = client.refreshVolume(volID, srcVolID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = postCreateTasks(vol.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := revert.Clone().Fail
+	revert.Success()
+
+	// Remove temporary reverter snapshot.
+	_ = client.deleteVolume(reverterSnapshotID, "ONLY_ME")
+
+	return cleanup, err
+}
+
 // RefreshVolume updates an existing volume to match the state of another.
 func (d *powerflex) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, progressReporter ioprogress.ProgressReporter) error {
-	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
-	return err
+	thinCloneSupport := d.hasThinCloneSupport()
+
+	// For PowerFlex 4 or if powerflex.snapshot_copy is disabled on PowerFlex 5, run a generic refresh.
+	if !thinCloneSupport || (thinCloneSupport && shared.IsFalseOrEmpty(d.config["powerflex.snapshot_copy"])) {
+		_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, progressReporter)
+		return err
+	}
+
+	// For PowerFlex 5 with powerflex.snapshot_copy enabled, run optimized refresh.
+	revert := revert.New()
+	defer revert.Fail()
+
+	// For VMs, also copy the filesystem volume.
+	if vol.IsVMBlock() {
+		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
+		for _, snapshot := range vol.Snapshots {
+			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
+		for _, snapshot := range srcVol.Snapshots {
+			srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
+
+		cleanup, err := d.refreshVolume(fsVol, srcFSVol, refreshSnapshots, progressReporter)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(cleanup)
+	}
+
+	cleanup, err := d.refreshVolume(vol, srcVol, refreshSnapshots, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(cleanup)
+
+	revert.Success()
+	return nil
 }
 
 // DeleteVolume deletes a volume of the storage device.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -665,6 +665,14 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 
 // GetVolumeDiskPath returns the location of a root disk block device.
 func (d *powerflex) GetVolumeDiskPath(vol Volume) (string, error) {
+	if vol.IsSnapshot() && d.hasThinCloneSupport() {
+		// In PowerFlex 5 snapshots cannot be attached directly. The [powerflex.MountVolumeSnapshot]
+		// maps a temporary thin clone.
+		// Therefore ensure the snapshot's parent volume UUID is unset to indicate we are referring to the thin clone
+		// when deriving the volume name.
+		vol.SetParentUUID("")
+	}
+
 	if vol.IsVMBlock() || (vol.volType == VolumeTypeCustom && IsContentBlock(vol.contentType)) {
 		devPath, _, err := d.getMappedDevPath(vol, false)
 		return devPath, err

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -1118,16 +1118,158 @@ func (d *powerflex) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprog
 
 // MountVolumeSnapshot simulates mounting a volume snapshot.
 func (d *powerflex) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) error {
-	// A snapshot in PowerFlex is just another volume.
-	// We can reuse the volume mounting procedures.
-	return d.MountVolume(snapVol, progressReporter)
+	if !d.hasThinCloneSupport() {
+		// A snapshot in PowerFlex 4 is just another volume.
+		// We can reuse the volume mounting procedures.
+		return d.MountVolume(snapVol, progressReporter)
+	}
+
+	// In PowerFlex 5 we have to create a temporary thin clone from the snapshot.
+	// This thin clone can then be mounted like a regular volume.
+	revert := revert.New()
+	defer revert.Fail()
+
+	pool, err := d.resolvePool()
+	if err != nil {
+		return err
+	}
+
+	client := d.client()
+
+	domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
+	if err != nil {
+		return err
+	}
+
+	// Get the snapshot volume name.
+	snapVolName, err := d.getVolumeName(snapVol)
+	if err != nil {
+		return err
+	}
+
+	snapVolumeID, err := client.getVolumeID(snapVolName)
+	if err != nil {
+		return err
+	}
+
+	cachedSnapVolParentUUID := snapVol.parentUUID
+
+	// Unset parent vol UUID to indicate thin clone.
+	// Get the new thin clone volume name.
+	snapVol.SetParentUUID("")
+	thinCloneVolName, err := d.getVolumeName(snapVol)
+	if err != nil {
+		return err
+	}
+
+	thinCloneID, err := client.createVolumeThinClone(domain.SystemID, snapVolumeID, thinCloneVolName)
+	if err != nil {
+		return err
+	}
+
+	// Ensure temporary thin clone volume is removed in case of an error.
+	revert.Add(func() { _ = client.deleteVolume(thinCloneID, "ONLY_ME") })
+
+	// For VMs, also create the temporary filesystem volume snapshot.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+		snapFsVol.SetParentUUID(cachedSnapVolParentUUID)
+
+		snapFsVolName, err := d.getVolumeName(snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		snapFSVolumeID, err := client.getVolumeID(snapFsVolName)
+		if err != nil {
+			return err
+		}
+
+		// Unset parent vol UUID to indicate thin clone.
+		snapFsVol.SetParentUUID("")
+		thinCloneFsVolName, err := d.getVolumeName(snapFsVol)
+		if err != nil {
+			return err
+		}
+
+		thinCloneFsID, err := client.createVolumeThinClone(domain.SystemID, snapFSVolumeID, thinCloneFsVolName)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = client.deleteVolume(thinCloneFsID, "ONLY_ME") })
+	}
+
+	err = d.MountVolume(snapVol, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // UnmountVolumeSnapshot simulates unmounting a volume snapshot.
 func (d *powerflex) UnmountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.ProgressReporter) (bool, error) {
-	// A snapshot in PowerFlex is just another volume.
-	// We can reuse the volume mounting procedures.
-	return d.UnmountVolume(snapVol, false, progressReporter)
+	if !d.hasThinCloneSupport() {
+		// A snapshot in PowerFlex 4 is just another volume.
+		// We can reuse the volume mounting procedures.
+		return d.UnmountVolume(snapVol, false, progressReporter)
+	}
+
+	// Unset parent vol UUID to indicate thin clone.
+	snapVol.SetParentUUID("")
+
+	ourUnmount, err := d.UnmountVolume(snapVol, false, progressReporter)
+	if err != nil {
+		return false, err
+	}
+
+	if !ourUnmount {
+		return false, nil
+	}
+
+	snapVolName, err := d.getVolumeName(snapVol)
+	if err != nil {
+		return true, err
+	}
+
+	client := d.client()
+	volumeID, err := client.getVolumeID(snapVolName)
+	if err != nil {
+		return true, err
+	}
+
+	// Cleanup temporary snapshot volume.
+	err = d.client().deleteVolume(volumeID, "ONLY_ME")
+	if err != nil {
+		return true, err
+	}
+
+	// For VMs, also cleanup the temporary volume for a filesystem snapshot.
+	if snapVol.IsVMBlock() {
+		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
+
+		// Unset parent vol UUID to indicate thin clone.
+		snapFsVol.SetParentUUID("")
+
+		snapFsVolName, err := d.getVolumeName(snapFsVol)
+		if err != nil {
+			return true, err
+		}
+
+		snapFSVolumeID, err := client.getVolumeID(snapFsVolName)
+		if err != nil {
+			return true, err
+		}
+
+		err = d.client().deleteVolume(snapFSVolumeID, "ONLY_ME")
+		if err != nil {
+			return true, err
+		}
+	}
+
+	return ourUnmount, nil
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -191,62 +191,230 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 		return nil
 	}
 
-	// Copy without snapshots.
-	// If the pools config doesn't enforce creating clone copies of the volume, snapshot the volume
-	// in PowerFlex to create a new standalone volume.
+	thinCloneSupport := d.hasThinCloneSupport()
 	client := d.client()
-	if len(vol.Snapshots) == 0 && shared.IsTrue(d.config["powerflex.snapshot_copy"]) {
-		pool, err := d.resolvePool()
-		if err != nil {
-			return err
-		}
 
-		domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
-		if err != nil {
-			return err
-		}
-
-		srcVolName, err := d.getVolumeName(srcVol.Volume)
-		if err != nil {
-			return err
-		}
-
-		volumeID, err := client.getVolumeID(srcVolName)
-		if err != nil {
-			return err
-		}
-
-		volName, err := d.getVolumeName(vol.Volume)
-		if err != nil {
-			return err
-		}
-
-		_, err = client.createVolumeSnapshot(domain.SystemID, volumeID, volName, "ReadWrite")
-		if err != nil {
-			return err
-		}
-
-		revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
-
-		// For VMs, also copy the filesystem volume.
-		if vol.IsVMBlock() {
-			srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
-			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
-			err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
+	if shared.IsTrue(d.config["powerflex.snapshot_copy"]) {
+		if len(vol.Snapshots) == 0 && !thinCloneSupport {
+			// PowerFlex 4 only.
+			// Copy without snapshots.
+			// If the pools config doesn't enforce creating clone copies of the volume, snapshot the volume
+			// in PowerFlex to create a new standalone volume.
+			pool, err := d.resolvePool()
 			if err != nil {
 				return err
 			}
-		}
 
-		err = postCreateTasks(vol.Volume)
-		if err != nil {
-			return err
-		}
+			domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
+			if err != nil {
+				return err
+			}
 
-		revert.Success()
-		return nil
+			srcVolName, err := d.getVolumeName(srcVol.Volume)
+			if err != nil {
+				return err
+			}
+
+			volumeID, err := client.getVolumeID(srcVolName)
+			if err != nil {
+				return err
+			}
+
+			volName, err := d.getVolumeName(vol.Volume)
+			if err != nil {
+				return err
+			}
+
+			_, err = client.createVolumeSnapshot(domain.SystemID, volumeID, volName, "ReadWrite")
+			if err != nil {
+				return err
+			}
+
+			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
+
+			// For VMs, also copy the filesystem volume.
+			if vol.IsVMBlock() {
+				srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
+				fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+				err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
+				if err != nil {
+					return err
+				}
+			}
+
+			err = postCreateTasks(vol.Volume)
+			if err != nil {
+				return err
+			}
+
+			revert.Success()
+			return nil
+		} else if thinCloneSupport {
+			// PowerFlex 5 and later.
+			// Copy with snapshots.
+			// Volumes in the same vTree can now be refreshed from other volume snapshots in the same tree.
+			// This allows sequentially copying volumes and their snapshots directly on the array.
+
+			pool, err := d.resolvePool()
+			if err != nil {
+				return err
+			}
+
+			domain, err := client.getProtectionDomain(pool.ProtectionDomainID)
+			if err != nil {
+				return err
+			}
+
+			// For VMs, also copy the filesystem volume.
+			if vol.IsVMBlock() {
+				// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
+				fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
+				for _, snapshot := range vol.Snapshots {
+					fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+				}
+
+				srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
+				for _, snapshot := range srcVol.Snapshots {
+					srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+				}
+
+				fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
+				srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
+
+				// Ensure parent UUID is retained for the filesystem volumes.
+				fsVol.SetParentUUID(vol.parentUUID)
+				srcFSVol.SetParentUUID(srcVol.parentUUID)
+
+				err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
+				if err != nil {
+					return err
+				}
+
+				revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, progressReporter) })
+			}
+
+			volID := ""
+
+			volName, err := d.getVolumeName(vol.Volume)
+			if err != nil {
+				return err
+			}
+
+			srcVolName, err := d.getVolumeName(srcVol.Volume)
+			if err != nil {
+				return err
+			}
+
+			srcVolID, err := client.getVolumeID(srcVolName)
+			if err != nil {
+				return err
+			}
+
+			// Since snapshots are first copied into destination volume from which a new snapshot is created,
+			// we need to also remove the destination volume if an error occurs during copying of snapshots.
+			deleteVolCopy := true
+
+			// Copy volume snapshots.
+			// PowerFlex does copy snapshots along with the volume. Therefore, we copy the snapshots
+			// sequentially once the volume was copied. Each snapshot is first copied into destination
+			// volume from which a new snapshot is created. The process is repeated until all snapshots
+			// are copied.
+			if !srcVol.IsSnapshot() {
+				for _, snapshot := range vol.Snapshots {
+					_, snapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+
+					// Find the corresponding source snapshot.
+					var srcSnapshot *Volume
+					for _, srcSnap := range srcVol.Snapshots {
+						_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
+						if snapshotShortName == srcSnapshotShortName {
+							srcSnapshot = &srcSnap
+							break
+						}
+					}
+
+					if srcSnapshot == nil {
+						return fmt.Errorf("Failed copying snapshot %q: Source snapshot does not exist", snapshotShortName)
+					}
+
+					srcSnapshotName, err := d.getVolumeName(*srcSnapshot)
+					if err != nil {
+						return err
+					}
+
+					srcSnapshotID, err := client.getVolumeID(srcSnapshotName)
+					if err != nil {
+						return err
+					}
+
+					// Copy the snapshot.
+					if volID == "" {
+						// If this is a first snapshot, we need to clone it as the
+						// destination volume does not exist yet.
+						volID, err = client.createVolumeThinClone(domain.SystemID, srcSnapshotID, volName)
+						if err != nil {
+							return err
+						}
+
+						// Volume is created, make sure to remove it in case the operation fails.
+						revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
+						deleteVolCopy = false
+					} else {
+						// Otherwise, overwrite the destination volume.
+						err = client.refreshVolume(volID, srcSnapshotID)
+					}
+
+					if err != nil {
+						return fmt.Errorf("Failed copying snapshot %q into volume %q: %w", snapshot.name, vol.name, err)
+					}
+
+					// Set snapshot's parent UUID and retain source snapshot UUID.
+					snapshot.SetParentUUID(vol.config["volatile.uuid"])
+
+					snapshotName, err := d.getVolumeName(snapshot)
+					if err != nil {
+						return err
+					}
+
+					// Create snapshot from a new volume (that was created from the source snapshot).
+					// However, do not create VM's filesystem volume snapshot, as filesystem volume is
+					// copied before block volume.
+					_, err = client.createVolumeSnapshot(domain.SystemID, volID, snapshotName, powerFlexSnapshotRW)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			// Finally, copy the source volume (or snapshot) into destination volume snapshots.
+			if srcVol.IsSnapshot() || volID == "" {
+				// Copy the source volume/snapshot into destination volume.
+				_, err = client.createVolumeThinClone(domain.SystemID, srcVolID, volName)
+			} else {
+				// Destination volume already exists, so refresh it.
+				err = client.refreshVolume(volID, srcVolID)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			// Add reverter to delete destination volume, if not already added.
+			if deleteVolCopy {
+				revert.Add(func() { _ = d.DeleteVolume(vol.Volume, progressReporter) })
+			}
+
+			err = postCreateTasks(vol.Volume)
+			if err != nil {
+				return err
+			}
+
+			revert.Success()
+			return nil
+		}
 	}
 
+	// Fallback if none of the optimized copy options can be used.
 	srcVolumeSnapshots := make([]string, 0, len(vol.Snapshots))
 	for _, snapshot := range vol.Snapshots {
 		_, snapshotName, _ := api.GetParentAndSnapshotName(snapshot.name)

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -40,6 +40,9 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, progressRepor
 		return err
 	}
 
+	// Round up to accommodate at least the requested size.
+	sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+
 	sizeGiB := sizeBytes / factorGiB
 
 	client := d.client()
@@ -545,6 +548,9 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 	if sizeBytes <= 0 {
 		return nil
 	}
+
+	// Round up to accommodate at least the requested size.
+	sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
 
 	volName, err := d.getVolumeName(vol)
 	if err != nil {

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -454,14 +454,15 @@ func (d *powerflex) commonVolumeRules() map[string]func(value string) error {
 		//  scope: global
 		"block.type": validate.Optional(validate.IsOneOf("thin", "thick")),
 		// lxdmeta:generate(entities=storage-powerflex; group=volume-conf; key=size)
-		// The size must be in multiples of 8 GiB.
+		// The size must be in multiples of 8 GiB for PowerFlex 4.
+		// Starting with PowerFlex 5, the size can be in multiples of 1 GiB.
 		// See {ref}`storage-powerflex-limitations` for more information.
 		// ---
 		//  type: string
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage volume
 		//  scope: global
-		"size": validate.Optional(validate.IsMultipleOfUnit("8GiB")),
+		"size": validate.Optional(validate.IsMultipleOfUnit("1GiB")),
 	}
 }
 

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/units"
+	"github.com/canonical/lxd/shared/version"
 )
 
 // Required returns function that runs one or more validators, all must pass without error.
@@ -1011,4 +1012,10 @@ func IsEntityName(name string) error {
 	}
 
 	return nil
+}
+
+// IsDottedVersion validates that a string is a valid dotted version.
+func IsDottedVersion(dottedVersion string) error {
+	_, err := version.NewDottedVersion(dottedVersion)
+	return err
 }


### PR DESCRIPTION
Supersedes and fixes https://github.com/canonical/lxd/pull/17616.
Additions to `lxd-ci` in https://github.com/canonical/lxd-ci/pull/777.

### Overview

This PR adds support for PowerFlex 5 to the already existing driver.
In PowerFlex 5 the vTree dependency/child limits very raised from 126 to a little over 1000. Therefore a user might still hit a snapshot limit as some point. 
For this reason we continue to support the `powerflex.snapshot_copy` config key which by default is disabled.

If `powerflex.snapshot_copy` is enabled on a PowerFlex 5 pool, a user gets:
* Copy of volumes (including snapshots!) directly on the storage array. On PowerFlex 4 this is only possible if the volume doesn't have any snapshots. 
* No NVMe/TCP discovery. The target nqn can be fetched directly from the API
* Minimum vol size of 1GiB instead of 8GiB

A few more commits are added to align with changes done to the other more recent storage drivers.
Most this PRs changes are around the handling of the now existing thin clones and snapshots which are now nested directly under volumes.

What this PR does not include is optimized image support. 
This is done intentionally as it can be landed afterwards as an additional feature (gated by a config setting) but then added for both PowerFlex 4 and 5 (depending on the user needs and the vTree limits).

Also there is no patch that adds `powerflex.version` to existing storage pools. If the config key is not present, we always default to "no thin clone support" which is correct.

### TODO

- [x] Test changes with PowerFlex 4 array (`powerflex.snapshot_copy=(true|false)`)
  - [x] NVMe/TCP
  - [x] SDC
- [ ] Test changes with PowerFlex 5 array (`powerflex.snapshot_copy=(true|false)`)
  - [x] NVMe/TCP
  - [ ] SDC
- [x] Update docs (min vol size etc.)
- [x] Test `lxd recover`
