### PR TITLE
Code quality and modernize fixes

### DIFF
--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -182,9 +182,8 @@ func (c *Config) connectRemote(remote Remote, args *lxd.ConnectionArgs) (lxd.Ins
 	if ok {
 		d, err := lxd.ConnectLXDUnix(strings.TrimPrefix(after, "//"), args)
 		if err != nil {
-			var netErr *net.OpError
-
-			if errors.As(err, &netErr) {
+			netErr, ok := errors.AsType[*net.OpError](err)
+			if ok {
 				if errors.Is(err, os.ErrNotExist) {
 					return nil, fmt.Errorf("LXD unix socket %q not found: Please check LXD is running", netErr.Addr)
 				}

--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -113,7 +113,7 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool, error) {
 	}
 
 	// Remove directly referenced arguments from @ARGS@
-	for i := len(atArgs) - 1; i >= 0; i-- {
+	for i := range slices.Backward(atArgs) {
 		_, ok := numberedArgsMap[i+1]
 		if ok {
 			atArgs = slices.Delete(atArgs, i, i+1)

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -335,8 +335,8 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 
 		// Attempt to extract the internal OpenFGA error for logging only, so that errors from the OpenFGA datastore implementation are logged (if any).
 		// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
-		var openFGAInternalError openFGAErrors.InternalError
-		if errors.As(err, &openFGAInternalError) {
+		openFGAInternalError, ok := errors.AsType[openFGAErrors.InternalError](err)
+		if ok {
 			errLogCtx["err"] = openFGAInternalError.Unwrap()
 		}
 
@@ -374,8 +374,8 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 
 				// Attempt to extract the internal error. This allows bubbling errors up from the OpenFGA datastore implementation.
 				// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
-				var openFGAInternalError openFGAErrors.InternalError
-				if errors.As(err, &openFGAInternalError) {
+				openFGAInternalError, ok := errors.AsType[openFGAErrors.InternalError](err)
+				if ok {
 					err = openFGAInternalError.Unwrap()
 				}
 
@@ -506,8 +506,8 @@ func (e *embeddedOpenFGA) getPermissionChecker(ctx context.Context, entitlement 
 
 		// Attempt to extract the internal OpenFGA error for logging only, so that errors from the OpenFGA datastore implementation are logged (if any).
 		// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
-		var openFGAInternalError openFGAErrors.InternalError
-		if errors.As(err, &openFGAInternalError) {
+		openFGAInternalError, ok := errors.AsType[openFGAErrors.InternalError](err)
+		if ok {
 			errLogCtx["err"] = openFGAInternalError.Unwrap()
 		}
 

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -263,8 +264,8 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 
 func (f *heartbeatFixture) Cleanup() {
 	// Run the cleanups in reverse order
-	for i := len(f.cleanups) - 1; i >= 0; i-- {
-		f.cleanups[i]()
+	for _, v := range slices.Backward(f.cleanups) {
+		v()
 	}
 
 	for _, server := range f.servers {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -904,8 +904,8 @@ func (d *Daemon) createCmd(restAPI *http.ServeMux, version string, c APIEndpoint
 		// Authentication
 		requestor, err := d.Authenticate(w, r, endpointAction.AllowUntrusted)
 		if err != nil {
-			var authError oidc.AuthError
-			if errors.As(err, &authError) {
+			_, ok := errors.AsType[oidc.AuthError](err)
+			if ok {
 				// Ensure the OIDC headers are set if needed.
 				if d.oidcVerifier != nil {
 					_ = d.oidcVerifier.WriteHeaders(w)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2786,7 +2786,7 @@ func pruneLeftoverImages(s *state.State) {
 
 			// Check and delete leftovers
 			for _, entry := range entries {
-				fp := strings.Split(entry.Name(), ".")[0]
+				fp, _, _ := strings.Cut(entry.Name(), ".")
 				if !slices.Contains(images, fp) {
 					err = os.Remove(filepath.Join(imagesDir, entry.Name()))
 					if err != nil {

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/auth"
@@ -638,8 +639,8 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 		// the new root disk device. Iterate in reverse order to respect profile
 		// precedence.
 		var profileRootDev map[string]string
-		for i := len(apiProfiles) - 1; i >= 0; i-- {
-			_, profileRootDev, err = api.GetRootDiskDevice(apiProfiles[i].Devices)
+		for _, apiProfile := range slices.Backward(apiProfiles) {
+			_, profileRootDev, err = api.GetRootDiskDevice(apiProfile.Devices)
 			if err == nil {
 				break
 			}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1185,10 +1185,12 @@ func operationWaitHandler(d *Daemon, r *http.Request) response.Response {
 
 	run := func(ctx context.Context, op *operations.Operation) error {
 		// Sleep for the duration, or until the run context is cancelled.
+		timer := time.NewTimer(duration)
+		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.Tick(duration):
+		case <-timer.C:
 		}
 
 		return nil

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/db"
@@ -58,8 +59,8 @@ func doProfileUpdate(ctx context.Context, s *state.State, p api.Project, profile
 
 			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				// Check what profile the device comes from by working backwards along the profiles list.
-				for i := len(inst.Profiles) - 1; i >= 0; i-- {
-					_, profile, err := tx.GetProfile(ctx, p.Name, inst.Profiles[i].Name)
+				for _, v := range slices.Backward(inst.Profiles) {
+					_, profile, err := tx.GetProfile(ctx, p.Name, v.Name)
 					if err != nil {
 						return err
 					}
@@ -68,7 +69,7 @@ func doProfileUpdate(ctx context.Context, s *state.State, p api.Project, profile
 					_, ok := profile.Devices[oldProfileRootDiskDeviceKey]
 					if ok {
 						// Found the profile.
-						if inst.Profiles[i].Name == profileName {
+						if v.Name == profileName {
 							// If it's the current profile, then we can't modify that root device.
 							return errors.New("At least one instance relies on this profile's root disk device")
 						}

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -209,7 +209,7 @@ func (d *alletra) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 	reverter.Add(connReverter)
 
 	// If connect succeeded it means we have at least one established connection.
-	// However, it's reverter does not cleanup the establised connections or a newly
+	// However, its reverter does not clean up the established connections or a newly
 	// created session. Therefore, if we created a mapping, add unmapVolume to the
 	// returned (outer) reverter. Unmap ensures the target is disconnected only when
 	// no other device is using it.

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -275,7 +275,7 @@ func (d *lvm) createDefaultThinPool(lvmVersion, thinPoolName string, thinpoolSiz
 
 // lvmVersionIsAtLeast checks whether the installed version of LVM is at least the specific version.
 func (d *lvm) lvmVersionIsAtLeast(sTypeVersion string, versionString string) (bool, error) {
-	lvmVersionString := strings.SplitN(sTypeVersion, "/", 2)[0]
+	lvmVersionString, _, _ := strings.Cut(sTypeVersion, "/")
 
 	lvmVersion, err := version.Parse(lvmVersionString)
 	if err != nil {

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1667,7 +1667,7 @@ func (d *powerstore) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 		}
 
 		// If connect succeeded it means we have at least one established connection.
-		// However, it's reverter does not cleanup the established connections or a newly
+		// However, its reverter does not clean up the established connections or a newly
 		// created session. Therefore, if we created a mapping, add unmapVolume to the
 		// returned (outer) reverter. Unmap ensures the target is disconnected only when
 		// no other device is using it.

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1289,7 +1289,7 @@ func (d *pure) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 	reverter.Add(connReverter)
 
 	// If connect succeeded it means we have at least one established connection.
-	// However, it's reverter does not cleanup the establised connections or a newly
+	// However, its reverter does not clean up the established connections or a newly
 	// created session. Therefore, if we created a mapping, add unmapVolume to the
 	// returned (outer) reverter. Unmap ensures the target is disconnected only when
 	// no other device is using it.

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1042,7 +1042,7 @@ func (p *pureClient) updateHost(hostName string, qns []string) error {
 		return fmt.Errorf("Unsupported Pure Storage mode %q", connector.Type())
 	}
 
-	// To destroy the volume, we need to patch it by setting the destroyed to true.
+	// Update the host by patching its qualified names (IQNs/NQNs).
 	url := api.NewURL().Path("hosts").WithQuery("names", hostName)
 	err = p.requestAuthenticated(http.MethodPatch, url.URL, req, nil)
 	if err != nil {

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -786,7 +786,7 @@ func (p *pureClient) createVolume(poolName string, volName string, sizeBytes int
 	return nil
 }
 
-// deleteVolume deletes an exisiting volume in the given storage pool.
+// deleteVolume deletes an existing volume in the given storage pool.
 func (p *pureClient) deleteVolume(poolName string, volName string) error {
 	req := map[string]any{
 		"destroyed": true,

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -220,7 +220,7 @@ func storagePoolVolumeBackupLoadByName(ctx context.Context, s *state.State, proj
 		return nil, err
 	}
 
-	volumeName := strings.Split(backupName, "/")[0]
+	volumeName, _, _ := strings.Cut(backupName, "/")
 	backup := backup.NewVolumeBackup(s, projectName, poolName, volumeName, b.ID, b.Name, b.CreationDate, b.ExpiryDate, b.VolumeOnly, b.OptimizedStorage)
 
 	return backup, nil

--- a/shared/api/error.go
+++ b/shared/api/error.go
@@ -69,9 +69,8 @@ func (e StatusError) Status() int {
 // status code matches one of the supplied status codes in matchStatus.
 // Returns the matched StatusError status code and true if match criteria are met, otherwise false.
 func StatusErrorMatch(err error, matchStatusCodes ...int) (int, bool) {
-	var statusErr StatusError
-
-	if errors.As(err, &statusErr) {
+	statusErr, ok := errors.AsType[StatusError](err)
+	if ok {
 		statusCode := statusErr.Status()
 
 		if len(matchStatusCodes) <= 0 {

--- a/shared/dnsutil/reverse.go
+++ b/shared/dnsutil/reverse.go
@@ -2,6 +2,7 @@ package dnsutil
 
 import (
 	"net"
+	"slices"
 )
 
 // Reverse takes an IPv4 or IPv6 address and returns the matching ARPA record.
@@ -19,8 +20,7 @@ func Reverse(ip net.IP) (arpa string) {
 	buf := make([]byte, 0, len(ip)*4+len(IP6arpa))
 
 	// Add it, in reverse, to the buffer.
-	for i := len(ip) - 1; i >= 0; i-- {
-		v := ip[i]
+	for _, v := range slices.Backward(ip) {
 		buf = append(buf, hexDigit[v&0xF],
 			'.',
 			hexDigit[v>>4],

--- a/shared/util.go
+++ b/shared/util.go
@@ -730,11 +730,10 @@ func StringPrefixInSlice(key string, list []string) bool {
 // The input slice is cloned to avoid modifying the original slice.
 func RemoveElementsFromSlice[T comparable](list []T, elements ...T) []T {
 	list = slices.Clone(list)
-	for i := len(elements) - 1; i >= 0; i-- {
-		element := elements[i]
+	for i, element := range slices.Backward(elements) {
 		match := false
-		for j := len(list) - 1; j >= 0; j-- {
-			if element == list[j] {
+		for j, l := range slices.Backward(list) {
+			if element == l {
 				match = true
 				list = slices.Delete(list, j, j+1)
 				break

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -406,10 +406,9 @@ func ExitStatus(err error) (int, error) {
 		return 0, err // No error exit status.
 	}
 
-	var exitErr *exec.ExitError
-
 	// Detect and extract ExitError to check the embedded exit status.
-	if errors.As(err, &exitErr) {
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	if ok {
 		// If the process was signaled, extract the signal.
 		status, isWaitStatus := exitErr.Sys().(syscall.WaitStatus)
 		if isWaitStatus && status.Signaled() {

--- a/test/mini-oidc/storage/user.go
+++ b/test/mini-oidc/storage/user.go
@@ -40,7 +40,7 @@ type userStore struct {
 
 // NewUserStore creates a new user store.
 func NewUserStore(issuer string) UserStore {
-	hostname := strings.Split(strings.Split(issuer, "://")[1], ":")[0]
+	hostname, _, _ := strings.Cut(strings.Split(issuer, "://")[1], ":")
 	return userStore{
 		users: map[string]*User{
 			"id1": {

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -8,7 +8,7 @@ test_storage_volume_snapshots() {
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
   spawn_lxd "${LXD_STORAGE_DIR}" false
 
-  local storage_pool storage_volume
+  local storage_pool storage_pool2 storage_volume
   storage_pool="lxdtest-$(basename "${LXD_STORAGE_DIR}")-pool"
   storage_pool2="${storage_pool}2"
   storage_volume="${storage_pool}-vol"


### PR DESCRIPTION
The changes with ` (modernize)` were applied mechanically with:

```
modernize -fix -errorsastype ./...
modernize -fix -slicesbackward ./...
modernize -fix -stringscut ./...
```

At the end, a general `modernize -fix` run came out clean.