### PR TITLE
lxc/operation: Add list-children subcommand and operation_child_count API extension

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -267,6 +267,7 @@ type InstanceServer interface {
 	GetOperations() (operations []api.Operation, err error)
 	GetOperationsAllProjects() (operations []api.Operation, err error)
 	GetOperation(uuid string) (op *api.Operation, ETag string, err error)
+	GetOperationFull(uuid string) (op *api.OperationFull, ETag string, err error)
 	GetOperationWait(uuid string, timeout int) (op *api.Operation, ETag string, err error)
 	GetOperationWaitSecret(uuid string, secret string, timeout int) (op *api.Operation, ETag string, err error)
 	GetOperationWebsocket(uuid string, secret string) (conn *websocket.Conn, err error)

--- a/client/lxd_operations.go
+++ b/client/lxd_operations.go
@@ -86,6 +86,23 @@ func (r *ProtocolLXD) GetOperation(uuid string) (*api.Operation, string, error) 
 	return &op, etag, nil
 }
 
+// GetOperationFull returns an OperationFull entry (with children) for the provided uuid.
+func (r *ProtocolLXD) GetOperationFull(uuid string) (*api.OperationFull, string, error) {
+	err := r.CheckExtension("bulk_operations")
+	if err != nil {
+		return nil, "", err
+	}
+
+	op := api.OperationFull{}
+
+	etag, err := r.queryStruct(http.MethodGet, api.NewURL().Path("operations", uuid).WithQuery("recursion", "1").String(), nil, "", &op)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &op, etag, nil
+}
+
 // GetOperationWait returns an Operation entry for the provided uuid once it's complete or hits the timeout.
 func (r *ProtocolLXD) GetOperationWait(uuid string, timeout int) (*api.Operation, string, error) {
 	op := api.Operation{}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3639,3 +3639,8 @@ New configuration options on the load balancer pool are added to further customi
 * {config:option}`network-load-balancer-pool-properties:healthcheck.failure_count`
 
 In addition a new endpoint [`GET /1.0/networks/{networkName}/load-balancer-pools/{poolName}/state`](swagger:/network-load-balancer-pools/network_load_balancer_pool_state_get) is added which returns the health check status for all instances in the pool.
+
+(extension-operation-child-count)=
+## `operation_child_count`
+
+Adds a `child_count` field to the `Operation` struct, indicating the number of child operations. This allows clients to determine whether an operation has children without requiring `recursion=2`.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5031,6 +5031,15 @@ definitions:
     Operation:
         description: Operation represents a LXD background operation
         properties:
+            child_count:
+                description: |-
+                    Number of child operations.
+
+                    API extension: operation_child_count
+                example: 2
+                format: int64
+                type: integer
+                x-go-name: ChildCount
             class:
                 description: Type of operation (task, token or websocket)
                 example: websocket
@@ -5128,6 +5137,15 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     OperationFull:
         properties:
+            child_count:
+                description: |-
+                    Number of child operations.
+
+                    API extension: operation_child_count
+                example: 2
+                format: int64
+                type: integer
+                x-go-name: ChildCount
             children:
                 description: Children is a list of child operations, if any exist.
                 items:

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,6 +31,10 @@ func (c *cmdOperation) command() *cobra.Command {
 	// List
 	operationListCmd := cmdOperationList{global: c.global, operation: c}
 	cmd.AddCommand(operationListCmd.command())
+
+	// List children
+	operationListChildrenCmd := cmdOperationListChildren{global: c.global, operation: c}
+	cmd.AddCommand(operationListChildrenCmd.command())
 
 	// Show
 	operationShowCmd := cmdOperationShow{global: c.global, operation: c}
@@ -106,6 +111,7 @@ func (c *cmdOperationList) columns() []cli.ShorthandColumn[api.Operation] {
 		{Shorthand: 's', Name: "STATUS", Data: c.statusColumnData},
 		{Shorthand: 'c', Name: "CANCELABLE", Data: c.cancelableColumnData},
 		{Shorthand: 'C', Name: "CREATED", Data: c.createdColumnData},
+		{Shorthand: 'n', Name: "CHILDREN", Data: c.childrenColumnData},
 	}
 }
 
@@ -217,6 +223,78 @@ func (c *cmdOperationList) createdColumnData(op api.Operation) string {
 
 func (c *cmdOperationList) locationColumnData(op api.Operation) string {
 	return op.Location
+}
+
+func (c *cmdOperationList) childrenColumnData(op api.Operation) string {
+	return strconv.FormatInt(op.ChildCount, 10)
+}
+
+// ListChildren.
+type cmdOperationListChildren struct {
+	global    *cmdGlobal
+	operation *cmdOperation
+
+	flagFormat  string
+	flagColumns string
+}
+
+func (c *cmdOperationListChildren) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("list-children", "[<remote>:]<operation>")
+	cmd.Short = "List child operations of a background operation"
+	cmd.Long = cli.FormatSection("Description", cmd.Short)
+	cmd.Example = cli.FormatSection("", `lxc operation list-children 019e9cad-3e66-79e0-ba80-6288755433a9
+    List child operations of the given operation UUID`)
+
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
+	listHelper := &cmdOperationList{}
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(listHelper.columns()), cli.FormatStringFlagLabel("Columns"))
+
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+func (c *cmdOperationListChildren) run(cmd *cobra.Command, args []string) error {
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	op, _, err := resource.server.GetOperationFull(resource.name)
+	if err != nil {
+		return err
+	}
+
+	listHelper := &cmdOperationList{global: c.global}
+	cols := listHelper.columns()
+	defaultColumns := cli.DefaultColumnString(cols)
+	if resource.server.IsClustered() {
+		cols = append(cols, cli.ShorthandColumn[api.Operation]{Shorthand: 'L', Name: "LOCATION", Data: listHelper.locationColumnData})
+		if c.flagColumns == defaultColumns {
+			c.flagColumns = cli.DefaultColumnString(cols)
+		}
+	} else if strings.ContainsAny(c.flagColumns, "L") {
+		return errors.New("Cannot use column shorthand char 'L' (LOCATION) when not clustered")
+	}
+
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
+	if err != nil {
+		return err
+	}
+
+	data := cli.ColumnData(columns, op.Children)
+	sort.Sort(cli.SortColumnsNaturally(data))
+	header := cli.ColumnHeaders(columns)
+
+	return cli.RenderTable(c.flagFormat, header, data, op.Children)
 }
 
 // Show.

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -395,3 +395,47 @@ func GetOperationsWithParent(ctx context.Context, tx *sql.Tx, parentID int64) ([
 func GetOperationsByNodeID(ctx context.Context, tx *sql.Tx, nodeID int64) ([]Operation, error) {
 	return query.Select[Operation](ctx, tx, "WHERE operations.node_id = ?", nodeID)
 }
+
+// CountOperationChildrenByParent returns a map of parent operation UUID to child count.
+// This is used to populate ChildCount on list responses without loading full child operations.
+func CountOperationChildrenByParent(ctx context.Context, tx *sql.Tx) (map[string]int64, error) {
+	stmt := `
+		SELECT parent_op.uuid, COUNT(*)
+		FROM operations child_op
+		JOIN operations parent_op ON child_op.parent = parent_op.id
+		WHERE child_op.parent IS NOT NULL
+		GROUP BY parent_op.id`
+
+	counts := make(map[string]int64)
+	err := query.Scan(ctx, tx, stmt, func(scan func(dest ...any) error) error {
+		var uuid string
+		var count int64
+		err := scan(&uuid, &count)
+		if err != nil {
+			return err
+		}
+
+		counts[uuid] = count
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed counting child operations by parent: %w", err)
+	}
+
+	return counts, nil
+}
+
+// CountOperationChildren returns the number of child operations for the given parent operation DB ID.
+func CountOperationChildren(ctx context.Context, tx *sql.Tx, parentID int64) (int64, error) {
+	stmt := `SELECT COUNT(*) FROM operations WHERE parent = ?`
+
+	var count int64
+	err := query.Scan(ctx, tx, stmt, func(scan func(dest ...any) error) error {
+		return scan(&count)
+	}, parentID)
+	if err != nil {
+		return 0, fmt.Errorf("Failed counting child operations: %w", err)
+	}
+
+	return count, nil
+}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -166,6 +166,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 
 	// Load the operation from the database.
 	var op *operations.Operation
+	var childCount int64
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbOp, err := dbCluster.GetOperation(ctx, tx.Tx(), id)
 		if err != nil {
@@ -183,9 +184,8 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Load children if needed
 		if recursion > 0 {
-			// Load all child operations.
+			// Load all child operations for embedding in the response.
 			childDbOps, err := dbCluster.GetOperationsWithParent(ctx, tx.Tx(), dbOp.Row.ID)
 			if err != nil {
 				return err
@@ -202,9 +202,16 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			op.AddChildren(children...)
+			childCount = int64(len(children))
+		} else {
+			// Count children from DB without loading full child operations.
+			childCount, err = dbCluster.CountOperationChildren(ctx, tx.Tx(), dbOp.Row.ID)
+			if err != nil {
+				return err
+			}
 		}
 
-		return err
+		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -216,6 +223,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	_, body := op.RenderFullWithoutProgress()
+	body.ChildCount = childCount
 
 	return response.SyncResponse(true, body)
 }
@@ -490,6 +498,10 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Map of parent operations keyed by the operation ID.
 	parentOps := make(map[int64]*operations.Operation)
+
+	// Child counts by parent UUID, populated via aggregate DB query for recursion < 2.
+	childCounts := make(map[string]int64)
+
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		projects, err := dbCluster.GetProjectIDsToNames(ctx, tx.Tx())
 		if err != nil {
@@ -511,26 +523,33 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		// Load the operations.
+		// For non-recursive responses, retrieve child counts via an aggregate query rather than
+		// loading and constructing every child operation just to compute counts.
+		if recursion < 2 {
+			childCounts, err = dbCluster.CountOperationChildrenByParent(ctx, tx.Tx())
+			if err != nil {
+				return fmt.Errorf("Failed getting child operation counts: %w", err)
+			}
+		}
+
+		// For non-recursive responses, only load parent operations from the DB.
+		// For recursive responses, load all operations so children can be embedded.
 		var dbOps []dbCluster.Operation
 		if recursion < 2 {
 			dbOps, err = dbCluster.GetParentOperations(ctx, tx.Tx())
+			if err != nil {
+				return fmt.Errorf("Failed getting operations: %w", err)
+			}
 		} else {
 			dbOps, err = query.Select[dbCluster.Operation](ctx, tx.Tx(), "")
+			if err != nil {
+				return fmt.Errorf("Failed getting operations: %w", err)
+			}
 		}
 
-		if err != nil {
-			return fmt.Errorf("Failed getting operations: %w", err)
-		}
-
-		// Map of child operations keyed by their parent operation ID.
+		// Map of child operations keyed by their parent operation ID (only used for recursion >= 2).
 		childOps := make(map[int64][]*operations.Operation)
 		for _, dbOp := range dbOps {
-			// Omit child operations if not requested.
-			if dbOp.Row.Parent != nil && recursion < 2 {
-				continue
-			}
-
 			// Get operation project name if it has one.
 			operationProject := ""
 			if dbOp.Row.ProjectID != nil {
@@ -561,8 +580,9 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			// If this is a child operations, add it to the list keyed by parent DB ID.
-			// We'll match these to actual parents later.
+			// If this is a child operation, add it to the list keyed by parent DB ID.
+			// We'll match these to actual parents later. This only occurs for recursion >= 2
+			// since child operations are excluded from the DB query for recursion < 2.
 			if dbOp.Row.Parent != nil {
 				_, ok := childOps[*dbOp.Row.Parent]
 				if !ok {
@@ -575,7 +595,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		// Now add the child operations to their parents.
+		// Now add the child operations to their parents (only for recursion >= 2).
 		for parentID, children := range childOps {
 			parentOp, ok := parentOps[parentID]
 			if !ok {
@@ -595,7 +615,15 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 	// Render the operations.
 	apiOps := make([]*api.OperationFull, 0, len(parentOps))
 	for _, op := range parentOps {
-		_, apiOp := op.RenderFullWithoutProgress()
+		var apiOp *api.OperationFull
+		if recursion >= 2 {
+			_, apiOp = op.RenderFullWithoutProgress()
+		} else {
+			_, retOp := op.RenderWithoutProgress()
+			retOp.ChildCount = childCounts[op.ID()]
+			apiOp = &api.OperationFull{Operation: *retOp}
+		}
+
 		apiOps = append(apiOps, apiOp)
 	}
 

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -778,6 +778,7 @@ func (op *Operation) Render() (string, *api.Operation) {
 		Location:    op.location,
 		Err:         op.err,
 		ErrCode:     op.errCode,
+		ChildCount:  int64(len(op.children)),
 	}
 
 	requestor := op.Requestor()

--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -80,6 +80,12 @@ type Operation struct {
 	// API extension: bulk_operations
 	ErrCode int64 `json:"err_code" yaml:"err_code"`
 
+	// Number of child operations.
+	// Example: 2
+	//
+	// API extension: operation_child_count
+	ChildCount int64 `json:"child_count" yaml:"child_count"`
+
 	// Which cluster member this record was found on
 	// Example: lxd01
 	//

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -499,6 +499,7 @@ var APIExtensions = []string{
 	"gpu_mig_cdi",
 	"cluster_links_unidirectional",
 	"network_load_balancer_pool_health_checks",
+	"operation_child_count",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -166,6 +166,7 @@ readonly test_group_standalone=(
     "duplicate_detection"
     "fdleak"
     "filtering"
+    "bulk_operation_children"
     "get_operations"
     "operations_conflict_reference"
     "instances_selective_recursion"

--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -52,6 +52,39 @@ test_get_operations() {
   )
 }
 
+test_bulk_operation_children() {
+  ensure_import_testimage
+
+  (
+    set -e
+
+    # Create two containers to generate a bulk operation with child operations.
+    lxc launch testimage c1
+    lxc launch testimage c2
+
+    # Trigger a bulk state change, which creates a parent operation with one child per instance.
+    bulk_op_id=$(lxc query -X PUT /1.0/instances -d '{"state": {"action": "stop"}}' | jq -r --exit-status '.id')
+
+    # Wait for the bulk operation to complete.
+    lxc query "/1.0/operations/${bulk_op_id}/wait?timeout=60" > /dev/null
+
+    # Assert the CHILDREN column in lxc operation list shows the correct child count.
+    child_count=$(lxc operation list --format json | jq --exit-status --arg id "${bulk_op_id}" '.[] | select(.id == $id) | .child_count')
+    [ "${child_count}" -eq 2 ]
+
+    # Assert child_count is accurate on a non-recursive single GET (no recursion=1 required).
+    api_child_count=$(lxc query "/1.0/operations/${bulk_op_id}" | jq --exit-status '.child_count')
+    [ "${api_child_count}" -eq 2 ]
+
+    # Assert lxc operation list-children shows the expected number of child operations.
+    list_children_count=$(lxc operation list-children "${bulk_op_id}" --format json | jq --exit-status 'length')
+    [ "${list_children_count}" -eq 2 ]
+
+    lxc delete c1 --force
+    lxc delete c2 --force
+  )
+}
+
 test_operations_conflict_reference() {
   conflictRef="test-conflict-ref"
 


### PR DESCRIPTION
## Summary

Fixes #18361

Bulk state changes (e.g. stopping all instances) create a parent operation with one child operation per instance. Previously there was no way to inspect these children from the CLI or know they existed from a list view.

This PR adds:

- `ChildCount int` field on `api.Operation` (API extension: `operation_child_count`) so clients can see at a glance whether an operation has children, without needing `recursion=2`
- Server-side population of `ChildCount` in all operation list and get responses
- `GetOperationFull` client method that fetches an operation with its children via `?recursion=1`
- `CHILDREN` column in `lxc operation list` showing the child count (`-` if none)
- `lxc operation list-children <uuid>` subcommand that displays child operations as a table in the same format as `lxc operation list`

## Results
<img width="1042" height="276" alt="image" src="https://github.com/user-attachments/assets/57c2ac69-99ba-4f37-abd6-b19d291fb339" />


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
