### PR TITLE
Storage: Add missing parent UUIDs

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3608,14 +3608,14 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, progressReporter iopr
 
 	revert.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, progressReporter) })
 
-	diskPath, err := b.getInstanceDisk(inst)
-	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
-		return nil, fmt.Errorf("Failed getting disk path: %w", err)
-	}
-
 	var mountInfo MountInfo
 
-	if diskPath != "" {
+	if inst.Type() == instancetype.VM {
+		diskPath, err := b.driver.GetVolumeDiskPath(vol)
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting disk path: %w", err)
+		}
+
 		mountInfo.DevSource = config.DevSourcePath{
 			Path: diskPath,
 		}
@@ -4163,14 +4163,14 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, progressRepor
 		return nil, err
 	}
 
-	diskPath, err := b.getInstanceDisk(inst)
-	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
-		return nil, fmt.Errorf("Failed getting disk path: %w", err)
-	}
-
 	var mountInfo MountInfo
 
-	if diskPath != "" {
+	if inst.Type() == instancetype.VM {
+		diskPath, err := b.driver.GetVolumeDiskPath(vol)
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting disk path: %w", err)
+		}
+
 		mountInfo.DevSource = config.DevSourcePath{
 			Path: diskPath,
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3680,39 +3680,6 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, progressReporter io
 	return err
 }
 
-// getInstanceDisk returns the location of the disk.
-func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
-	if inst.Type() != instancetype.VM {
-		return "", drivers.ErrNotSupported
-	}
-
-	// Check we can convert the instance to the volume type needed.
-	volType, err := InstanceTypeToVolumeType(inst.Type())
-	if err != nil {
-		return "", err
-	}
-
-	contentType := InstanceContentType(inst)
-	volStorageName := project.Instance(inst.Project().Name, inst.Name())
-
-	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
-	if err != nil {
-		return "", err
-	}
-
-	// Get the volume.
-	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
-
-	// Get the location of the disk block device.
-	diskPath, err := b.driver.GetVolumeDiskPath(vol)
-	if err != nil {
-		return "", err
-	}
-
-	return diskPath, nil
-}
-
 // CreateInstanceSnapshot creates a snapshot of an instance volume.
 func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, progressReporter ioprogress.ProgressReporter) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -596,10 +596,6 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
 
-		// Ensure parent UUID is retained for the filesystem volumes.
-		fsVol.SetParentUUID(vol.parentUUID)
-		srcFSVol.SetParentUUID(srcVol.parentUUID)
-
 		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
@@ -1426,9 +1422,6 @@ func (d *alletra) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool
 	if snapVol.IsVMBlock() && snapshotVMfilesystem {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
 
-		// Set the parent volume's UUID.
-		fsVol.SetParentUUID(snapVol.parentUUID)
-
 		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
@@ -1489,7 +1482,6 @@ func (d *alletra) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogre
 	// For VM images, delete the filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		fsVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
@@ -1610,7 +1602,6 @@ func (d *alletra) RestoreVolume(vol Volume, snapVol Volume, progressReporter iop
 		fsVol := vol.NewVMBlockFilesystemVolume()
 
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFSVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -859,9 +859,6 @@ func (d *powerflex) CreateVolumeSnapshot(snapVol Volume, progressReporter ioprog
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
 
-		// Set the parent volume's UUID.
-		fsVol.SetParentUUID(snapVol.parentUUID)
-
 		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -434,10 +434,6 @@ func (d *powerstore) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, all
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
 
-		// Ensure parent UUID is retained for the filesystem volumes.
-		fsVol.SetParentUUID(vol.parentUUID)
-		srcFSVol.SetParentUUID(srcVol.parentUUID)
-
 		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
@@ -708,9 +704,7 @@ func (d *powerstore) RestoreVolume(vol Volume, snapVol Volume, progressReporter 
 	// For VMs, also restore the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFSVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {
@@ -1110,9 +1104,8 @@ func (d *powerstore) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem b
 	// For VMs, create a snapshot of the filesystem volume too.
 	// Skip if snapshotVMfilesystem is false to prevent overwriting separately copied volumes.
 	if snapVol.IsVMBlock() && snapshotVMfilesystem {
-		// Get FS volume and set parent volume UUID.
+		// Get FS volume.
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		fsVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
@@ -1166,7 +1159,6 @@ func (d *powerstore) DeleteVolumeSnapshot(snapVol Volume, progressReporter iopro
 	// For VM images, delete the filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		fsVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
@@ -1270,7 +1262,6 @@ func (d *powerstore) MountVolumeSnapshot(snapVol Volume, progressReporter ioprog
 	// For VMs, also clone the filesystem snapshot.
 	if snapVol.IsVMBlock() {
 		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFsVol.SetParentUUID(snapVol.parentUUID)
 
 		fsSnapVolClone, err := d.newMountableSnapshotVolume(snapFsVol)
 		if err != nil {
@@ -1349,7 +1340,6 @@ func (d *powerstore) UnmountVolumeSnapshot(snapVol Volume, progressReporter iopr
 	// For VMs, also delete the filesystem clone.
 	if snapVol.IsVMBlock() {
 		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFsVol.SetParentUUID(snapVol.parentUUID)
 
 		fsSnapVolClone, err := d.newMountableSnapshotVolume(snapFsVol)
 		if err != nil {

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -222,10 +222,6 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
 
-		// Ensure parent UUID is retained for the filesystem volumes.
-		fsVol.SetParentUUID(vol.parentUUID)
-		srcFSVol.SetParentUUID(srcVol.parentUUID)
-
 		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, progressReporter)
 		if err != nil {
 			return err
@@ -1070,9 +1066,7 @@ func (d *pure) RestoreVolume(vol Volume, snapVol Volume, progressReporter ioprog
 	// For VMs, also restore the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-
 		snapFSVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFSVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.RestoreVolume(fsVol, snapFSVol, progressReporter)
 		if err != nil {
@@ -1157,9 +1151,6 @@ func (d *pure) createVolumeSnapshot(snapVol Volume, snapshotVMfilesystem bool, p
 	if snapVol.IsVMBlock() && snapshotVMfilesystem {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
 
-		// Set the parent volume's UUID.
-		fsVol.SetParentUUID(snapVol.parentUUID)
-
 		err := d.CreateVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
 			return err
@@ -1230,7 +1221,6 @@ func (d *pure) DeleteVolumeSnapshot(snapVol Volume, progressReporter ioprogress.
 	// For VM images, delete the filesystem volume too.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		fsVol.SetParentUUID(snapVol.parentUUID)
 
 		err := d.DeleteVolumeSnapshot(fsVol, progressReporter)
 		if err != nil {
@@ -1273,8 +1263,6 @@ func (d *pure) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.P
 	// For VMs, also create the temporary filesystem volume snapshot.
 	if snapVol.IsVMBlock() {
 		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
-		snapFsVol.SetParentUUID(snapVol.parentUUID)
-
 		parentFsVol := snapFsVol.GetParent()
 
 		snapFsVolName, err := d.getVolumeName(snapFsVol)

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -429,6 +429,11 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 	// Propagate mount custom path of parent volume.
 	vol.SetMountCustomPath(v.mountCustomPath)
 
+	if v.IsSnapshot() {
+		// Propagate UUID of parent volume.
+		vol.SetParentUUID(v.parentUUID)
+	}
+
 	return vol
 }
 

--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -110,3 +110,34 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 		assert.Equal(t, test.err, err)
 	}
 }
+
+// Test NewVMBlockFilesystemVolume.
+func Test_NewVMBlockFilesystemVolume(t *testing.T) {
+	testDriver := dir{}
+
+	tests := []struct {
+		vol        Volume
+		parentUUID string
+	}{
+		{
+			// Check a FS volume derived from a regular volume doesn't have a parent UUID.
+			vol:        Volume{driver: &testDriver, config: map[string]string{}, name: "foo"},
+			parentUUID: "",
+		},
+		{
+			// Check a FS volume derived from a regular volume doesn't have a parent UUID even if the parent volume falsely has a parent UUID assigned.
+			vol:        Volume{driver: &testDriver, config: map[string]string{}, name: "foo", parentUUID: "b9e0b32f-5bb7-4782-8993-9f0c458fde75"},
+			parentUUID: "",
+		},
+		{
+			// Check a FS volume derived from a snapshot volume does have the parent's UUID.
+			vol:        Volume{driver: &testDriver, config: map[string]string{}, name: "foo/snap0", parentUUID: "b9e0b32f-5bb7-4782-8993-9f0c458fde75"},
+			parentUUID: "b9e0b32f-5bb7-4782-8993-9f0c458fde75",
+		},
+	}
+
+	for _, test := range tests {
+		vol := test.vol.NewVMBlockFilesystemVolume()
+		assert.Equal(t, test.parentUUID, vol.parentUUID)
+	}
+}


### PR DESCRIPTION
This PR adds missing parent UUIDs in places where it might be required by the storage driver. It also refactors and removes a func with additional DB lookup.
We should generally always populate the parent UUID when passing snapshots to storage driver level funcs.

This was surfaced whilst adding PowerFlex 5 support which requires the UUID to be present at theses places. PowerFlex is the only remote driver which can fall back to the generic copy funcs as it doesn't support array level copy.