### PR TITLE
Nvidia: Switch `gputype=mig` to use CDI passthrough instead of legacy `nvidia.runtime`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3607,3 +3607,16 @@ This includes the following new endpoints (see {ref}`rest-api` for details):
 Adds a `force` field to `POST /1.0/cluster/members/{name}/state` when performing an `evacuate` action.
 
 When `force` is set to `true`, LXD skips the quorum safety check that otherwise would not allow you to evacuate an online raft voter when the remaining online voters would fall below the required majority.
+
+(extension-gpu-mig-cdi)=
+## `gpu_mig_cdi`
+
+Updates `gputype=mig` GPU devices to use the Container Device Interface (CDI) for device passthrough instead of the legacy `nvidia.runtime` approach.
+
+The following changes are included:
+
+- `mig.uuid`: The UUID is now resolved to a CDI identifier (`nvidia.com/mig=<uuid>`) internally. The `MIG-` prefix remains optional. Because a MIG UUID uniquely identifies the device, no parent GPU selector (`pci`, `vendorid`, `productid`, or `id`) is required alongside `mig.uuid`. If a parent GPU selector is provided, it is used to validate that the matching GPU exists and is an NVIDIA card, preserving backward compatibility.
+- `mig.gi` and `mig.ci`: The GPU instance ID and compute instance ID pair is now resolved to a MIG UUID via NVML, which is then used as a CDI identifier.
+- `id`: Now accepts either a CDI identifier for `gputype=mig` devices or a DRM card ID selector for the parent GPU. Supported CDI formats are `nvidia.com/mig=<uuid>` and `nvidia.com/mig=<dev_idx>:<mig_idx>`. When a CDI identifier is provided, it is used directly and is mutually exclusive with `mig.uuid`, `mig.gi`, and `mig.ci`.
+
+Because the legacy `nvidia.runtime` instance-level option is incompatible with CDI-based MIG passthrough, attaching a `gputype=mig` device to a container with {config:option}`instance-nvidia:nvidia.runtime` set to `true` is rejected. To preserve backward compatibility, an upgrade patch unsets `nvidia.runtime` on existing containers and snapshots that have a `gputype=mig` device attached.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -298,27 +298,38 @@ For example: `i915-GVTg_V5_4`
 <!-- config group device-gpu-mdev-device-conf end -->
 <!-- config group device-gpu-mig-device-conf start -->
 ```{config:option} id device-gpu-mig-device-conf
-:shortdesc: "DRM card ID of the GPU device"
+:shortdesc: "DRM card ID of the parent GPU, or CDI identifier of the MIG GPU device"
 :type: "string"
+The ID can either be the DRM card ID of the parent GPU device, or a fully-qualified Container Device Interface (CDI) name for the MIG device.
+Here are some examples of fully-qualified CDI names:
 
+- `nvidia.com/mig=0:2`: Instructs LXD to pass through the MIG device at index 2 on GPU 0. You can find the index using `nvidia-smi -L` on your host.
+- `nvidia.com/mig=MIG-74c6a31a-fde5-5c61-973b-70e12346c202`: Instructs LXD to pass through a MIG device with a given unique identifier. This identifier should also appear with `nvidia-smi -L`.
 ```
 
 ```{config:option} mig.ci device-gpu-mig-device-conf
 :shortdesc: "Existing MIG compute instance ID"
 :type: "integer"
-
+Use this together with {config:option}`device-gpu-mig-device-conf:mig.gi` to
+identify a MIG device by its GPU instance ID and compute instance ID.
+LXD resolves the pair to a MIG device UUID using NVML and then uses CDI
+to pass the device through to the container.
 ```
 
 ```{config:option} mig.gi device-gpu-mig-device-conf
 :shortdesc: "Existing MIG GPU instance ID"
 :type: "integer"
-
+Use this together with {config:option}`device-gpu-mig-device-conf:mig.ci` to
+identify a MIG device by its GPU instance ID and compute instance ID.
+LXD resolves the pair to a MIG device UUID using NVML and then uses CDI
+to pass the device through to the container.
 ```
 
 ```{config:option} mig.uuid device-gpu-mig-device-conf
 :shortdesc: "Existing MIG device UUID"
 :type: "string"
 You can omit the `MIG-` prefix when specifying this option.
+LXD uses CDI to pass the MIG device through to the container.
 ```
 
 ```{config:option} pci device-gpu-mig-device-conf

--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -133,13 +133,45 @@ GPU devices of type `mig` have the following device options:
     :end-before: <!-- config group device-gpu-mig-device-conf end -->
 ```
 
-You must set either {config:option}`device-gpu-mig-device-conf:mig.uuid` (NVIDIA drivers 470+) or both {config:option}`device-gpu-mig-device-conf:mig.ci` and {config:option}`device-gpu-mig-device-conf:mig.gi` (old NVIDIA drivers).
+You must use one of the following options to specify the MIG device to pass through:
+
+- {config:option}`device-gpu-mig-device-conf:mig.uuid`: Specify the MIG device UUID directly.
+  The `MIG-` prefix is optional.
+  The UUID uniquely identifies the MIG device, so no parent GPU selector is required.
+  You may optionally provide `pci`, `id` (as a DRM card ID), or both `vendorid` and `productid` to validate that the expected parent GPU is present.
+
+- {config:option}`device-gpu-mig-device-conf:mig.gi` and {config:option}`device-gpu-mig-device-conf:mig.ci`: Specify both the GPU instance ID and compute instance ID.
+  LXD resolves these to a MIG UUID via NVML.
+  On systems with multiple NVIDIA GPUs, also provide `pci`, `id` (as a DRM card ID), or both `vendorid` and `productid` to identify the parent GPU.
+
+- {config:option}`device-gpu-mig-device-conf:id` (CDI identifier only): Use CDI notation to pass the MIG device through directly.
+  Supported formats: `nvidia.com/mig=<uuid>` and `nvidia.com/mig=<dev_idx>:<mig_idx>`.
+  The CDI identifier is self-contained.
+  If you set `id` to a CDI identifier, then you cannot set `pci`, `vendorid`, `productid`, or a non-CDI `id` (DRM card ID).
+
+These three methods are mutually exclusive. All three use CDI internally to configure the device in the container.
 
 ### Configuration examples
 
-Add a `mig` GPU device to an instance by specifying its UUID and the PCI address of the GPU:
+Add a `mig` GPU device by specifying a UUID:
+
+    lxc config device add <instance_name> <device_name> gpu gputype=mig mig.uuid=<mig_uuid>
+
+Add a `mig` GPU device by specifying a UUID as well as a PCI address to validate the parent GPU:
 
     lxc config device add <instance_name> <device_name> gpu gputype=mig mig.uuid=<mig_uuid> pci=<pci_address>
+
+Add a `mig` GPU device by specifying GPU instance and compute instance IDs:
+
+    lxc config device add <instance_name> <device_name> gpu gputype=mig mig.gi=<gi_id> mig.ci=<ci_id> pci=<pci_address>
+
+Add a `mig` GPU device by specifying a CDI identifier (UUID):
+
+    lxc config device add <instance_name> <device_name> gpu gputype=mig id=nvidia.com/mig=<mig_uuid>
+
+Add a `mig` GPU device by specifying a CDI identifier (index):
+
+    lxc config device add <instance_name> <device_name> gpu gputype=mig id=nvidia.com/mig=<dev_idx>:<mig_idx>
 
 See {ref}`instances-configure-devices` for more information.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/canonical/lxd
 go 1.26.4
 
 require (
+	github.com/NVIDIA/go-nvml v0.13.0-1.0.20260212130905-92cf8c963449
 	github.com/NVIDIA/nvidia-container-toolkit v1.19.1
 	github.com/Rican7/retry v0.3.1
 	github.com/armon/go-proxyproto v0.1.0
@@ -66,7 +67,6 @@ require (
 require (
 	cel.dev/expr v0.25.2 // indirect
 	github.com/NVIDIA/go-nvlib v0.10.0 // indirect
-	github.com/NVIDIA/go-nvml v0.13.0-1.0.20260212130905-92cf8c963449 // indirect
 	github.com/Yiling-J/theine-go v0.6.2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/lxd/device/cdi/configure.go
+++ b/lxd/device/cdi/configure.go
@@ -341,12 +341,14 @@ func GenerateFromCDI(isCore bool, inst instance.Instance, cdiID ID) (*ConfigDevi
 	configDevices := &ConfigDevices{UnixCharDevs: make([]map[string]string, 0), BindMounts: make([]map[string]string, 0)}
 
 	// 2. Process the specific device configuration
+	found := false
 	for _, device := range spec.Devices {
 		// If cdiID.Name is 'all', then the edits for all the visible devices will be
 		// applied from the generated spec (it has a special case 'all' device entry).
 		// Otherwise, only the edits for the specific device identified by cdiID.Name
 		// will be applied.
 		if device.Name == cdiID.Name {
+			found = true
 			err := applyContainerEdits(device.ContainerEdits, configDevices, hooks)
 			if err != nil {
 				return nil, nil, err
@@ -355,6 +357,10 @@ func GenerateFromCDI(isCore bool, inst instance.Instance, cdiID ID) (*ConfigDevi
 			mounts = append(mounts, device.ContainerEdits.Mounts...)
 			break
 		}
+	}
+
+	if cdiID.Name != "all" && !found {
+		return nil, nil, fmt.Errorf("CDI device %q not found in generated spec", cdiID.String())
 	}
 
 	// 3. Process general container edits (device-independent)

--- a/lxd/device/cdi/configure_test.go
+++ b/lxd/device/cdi/configure_test.go
@@ -111,7 +111,7 @@ func TestGenerateFromCDI(t *testing.T) {
 	})
 
 	t.Run("Device Name Mismatch", func(t *testing.T) {
-		// If device name doesn't match, specific edits shouldn't be applied
+		// If device name doesn't match any device in the spec, GenerateFromCDI returns an error.
 		generateSpec = func(isCore bool, cdiID ID, inst instance.Instance) (*specs.Spec, error) {
 			return &specs.Spec{
 				Version: "0.5.0",
@@ -132,9 +132,9 @@ func TestGenerateFromCDI(t *testing.T) {
 		inst := &mockInstance{rootfsPath: "/tmp/rootfs"}
 		cdiID := ID{Vendor: NVIDIA, Class: GPU, Name: "gpu1"} // Mismatch
 
-		config, _, err := GenerateFromCDI(false, inst, cdiID)
-		assert.NoError(t, err)
-		assert.Empty(t, config.UnixCharDevs)
+		_, _, err := GenerateFromCDI(false, inst, cdiID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `CDI device "nvidia.com/gpu=gpu1" not found in generated spec`)
 	})
 
 	t.Run("GenerateSpec Failure", func(t *testing.T) {

--- a/lxd/device/cdi/mig_nvml.go
+++ b/lxd/device/cdi/mig_nvml.go
@@ -1,0 +1,77 @@
+//go:build cgo && !armhf && !arm && !arm32
+
+package cdi
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// MIGDeviceUUID returns the NVML UUID of the MIG device that matches the given GPU instance
+// ID (gi) and compute instance ID (ci) on the GPU at the specified PCI address.
+// The returned UUID is in the format "MIG-GPU-<uuid>/<gi>/<ci>" as reported by NVML,
+// and is suitable for use as the UUID part of a "nvidia.com/mig=<uuid>" CDI identifier.
+//
+// Concurrent calls are safe, go-nvml functions are mutex-protected.
+func MIGDeviceUUID(pciAddress string, gi, ci int) (string, error) {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("Failed initializing NVML: %v", ret)
+	}
+
+	defer func() { _ = nvml.Shutdown() }()
+
+	device, ret := nvml.DeviceGetHandleByPciBusId(pciAddress)
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("Failed getting GPU handle for PCI address %q: %v", pciAddress, ret)
+	}
+
+	currentMode, _, ret := device.GetMigMode()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("Failed getting MIG mode for GPU at %q: %v", pciAddress, ret)
+	}
+
+	if currentMode != nvml.DEVICE_MIG_ENABLE {
+		return "", fmt.Errorf("MIG mode is not enabled on GPU at %q", pciAddress)
+	}
+
+	count, ret := device.GetMaxMigDeviceCount()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("Failed getting MIG device count for GPU at %q: %v", pciAddress, ret)
+	}
+
+	for i := 0; i < count; i++ {
+		migDevice, ret := device.GetMigDeviceHandleByIndex(i)
+		if ret == nvml.ERROR_NOT_FOUND || ret == nvml.ERROR_INVALID_ARGUMENT {
+			continue
+		}
+
+		if ret != nvml.SUCCESS {
+			return "", fmt.Errorf("Failed getting MIG device handle at index %d on GPU at %q: %v", i, pciAddress, ret)
+		}
+
+		giID, ret := migDevice.GetGpuInstanceId()
+		if ret != nvml.SUCCESS {
+			return "", fmt.Errorf("Failed getting GPU instance ID for MIG device %d on GPU at %q: %v", i, pciAddress, ret)
+		}
+
+		ciID, ret := migDevice.GetComputeInstanceId()
+		if ret != nvml.SUCCESS {
+			return "", fmt.Errorf("Failed getting compute instance ID for MIG device %d on GPU at %q: %v", i, pciAddress, ret)
+		}
+
+		if giID != gi || ciID != ci {
+			continue
+		}
+
+		uuid, ret := migDevice.GetUUID()
+		if ret != nvml.SUCCESS {
+			return "", fmt.Errorf("Failed getting UUID for MIG device %d on GPU at %q: %v", i, pciAddress, ret)
+		}
+
+		return uuid, nil
+	}
+
+	return "", fmt.Errorf("No MIG device with gi=%d ci=%d found on GPU at %q", gi, ci, pciAddress)
+}

--- a/lxd/device/cdi/mig_nvml_unsupported.go
+++ b/lxd/device/cdi/mig_nvml_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !cgo || armhf || arm || arm32
+
+package cdi
+
+import (
+	"errors"
+)
+
+// MIGDeviceUUID is not supported on this platform.
+func MIGDeviceUUID(pciAddress string, gi, ci int) (string, error) {
+	return "", errors.New("MIG NVML operations not supported on this platform")
+}

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -47,11 +47,21 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 		//  type: string
 		//  shortdesc: ID of the GPU device
 
-		// lxdmeta:generate(entities=device-gpu-{mdev+mig}; group=device-conf; key=id)
+		// lxdmeta:generate(entities=device-gpu-mdev; group=device-conf; key=id)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: DRM card ID of the GPU device
+
+		// lxdmeta:generate(entities=device-gpu-mig; group=device-conf; key=id)
+		// The ID can either be the DRM card ID of the parent GPU device, or a fully-qualified Container Device Interface (CDI) name for the MIG device.
+		// Here are some examples of fully-qualified CDI names:
+		//
+		// - `nvidia.com/mig=0:2`: Instructs LXD to pass through the MIG device at index 2 on GPU 0. You can find the index using `nvidia-smi -L` on your host.
+		// - `nvidia.com/mig=MIG-74c6a31a-fde5-5c61-973b-70e12346c202`: Instructs LXD to pass through a MIG device with a given unique identifier. This identifier should also appear with `nvidia-smi -L`.
+		// ---
+		//  type: string
+		//  shortdesc: DRM card ID of the parent GPU, or CDI identifier of the MIG GPU device
 
 		// lxdmeta:generate(entities=device-gpu-sriov; group=device-conf; key=id)
 		//
@@ -96,19 +106,26 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 		//  shortdesc: Mode of the device in the container
 		"mode": unixValidOctalFileMode,
 		// lxdmeta:generate(entities=device-gpu-mig; group=device-conf; key=mig.gi)
-		//
+		// Use this together with {config:option}`device-gpu-mig-device-conf:mig.ci` to
+		// identify a MIG device by its GPU instance ID and compute instance ID.
+		// LXD resolves the pair to a MIG device UUID using NVML and then uses CDI
+		// to pass the device through to the container.
 		// ---
 		//  type: integer
 		//  shortdesc: Existing MIG GPU instance ID
 		"mig.gi": validate.IsUint8,
 		// lxdmeta:generate(entities=device-gpu-mig; group=device-conf; key=mig.ci)
-		//
+		// Use this together with {config:option}`device-gpu-mig-device-conf:mig.gi` to
+		// identify a MIG device by its GPU instance ID and compute instance ID.
+		// LXD resolves the pair to a MIG device UUID using NVML and then uses CDI
+		// to pass the device through to the container.
 		// ---
 		//  type: integer
 		//  shortdesc: Existing MIG compute instance ID
 		"mig.ci": validate.IsUint8,
 		// lxdmeta:generate(entities=device-gpu-mig; group=device-conf; key=mig.uuid)
 		// You can omit the `MIG-` prefix when specifying this option.
+		// LXD uses CDI to pass the MIG device through to the container.
 		// ---
 		//  type: string
 		//  shortdesc: Existing MIG device UUID

--- a/lxd/device/gpu_cdi.go
+++ b/lxd/device/gpu_cdi.go
@@ -1,0 +1,334 @@
+package device
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/device/cdi"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
+	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
+	"github.com/canonical/lxd/shared"
+)
+
+// cdiHooksFilePath returns the path to the CDI hooks file for the named device.
+func cdiHooksFilePath(devicesPath, devName string) string {
+	return filepath.Join(devicesPath, devName+cdi.CDIHooksFileSuffix)
+}
+
+// cdiConfigDevicesFilePath returns the path to the CDI config devices file for the named device.
+func cdiConfigDevicesFilePath(devicesPath, devName string) string {
+	return filepath.Join(devicesPath, devName+cdi.CDIConfigDevicesFileSuffix)
+}
+
+// startCDIDevices starts all the devices given in a CDI specification:
+// * `unix-char` (representing the card and non-card devices)
+// * `disk` (representing the mounts).
+func startCDIDevices(d *deviceCommon, configDevices cdi.ConfigDevices, runConf *deviceConfig.RunConfig) error {
+	srcFDHandlers := make([]*os.File, 0)
+	defer func() {
+		for _, f := range srcFDHandlers {
+			_ = f.Close()
+		}
+	}()
+
+	hooksFilePath := cdiHooksFilePath(d.inst.DevicesPath(), d.name)
+	deviceConfigFilePath := cdiConfigDevicesFilePath(d.inst.DevicesPath(), d.name)
+	devicesPath := d.inst.DevicesPath()
+
+	// Check if there are any remaining CDI devices in the instance devices directory.
+	// If there are, we need to remove them. These can be present in the case where the device stop hook was not called
+	// (e.g. due to an abrupt host shutdown).
+	err := filepath.WalkDir(devicesPath, func(path string, e fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if e.IsDir() {
+			return nil
+		}
+
+		// Remove the CDI device files (both unix-char and disk devices as long as JSON CDI metadata files).
+		if strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIUnixPrefix+"."+d.name+".")) ||
+			strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIDiskPrefix+"."+d.name+".")) ||
+			path == hooksFilePath || path == deviceConfigFilePath {
+			err = os.Remove(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, conf := range configDevices.UnixCharDevs {
+		if conf["source"] == "" {
+			return fmt.Errorf("The source of the unix-char device %v used for CDI is empty", conf)
+		}
+
+		if conf["major"] == "" || conf["minor"] == "" {
+			return fmt.Errorf("The major or minor of the unix-char device %v used for CDI is empty", conf)
+		}
+
+		major, err := strconv.ParseUint(conf["major"], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Failed parsing major number %q when starting CDI device: %w", conf["major"], err)
+		}
+
+		minor, err := strconv.ParseUint(conf["minor"], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Failed parsing minor number %q when starting CDI device: %w", conf["minor"], err)
+		}
+
+		uid := conf["uid"]
+		if uid != "" {
+			d.config["uid"] = uid
+		}
+
+		gid := conf["gid"]
+		if gid != "" {
+			d.config["gid"] = gid
+		}
+
+		// Here putting a `cdi.CDIUnixPrefix` prefix with 'd.name' as a device name will create an directory entry like:
+		// <lxd_var_path>/devices/<instance_name>/<cdi.CDIUnixPrefix>.<gpu_device_name>.<path_encoded_relative_dest_path>
+		// 'unixDeviceSetupCharNum' is already checking for dupe entries so we have no validation to do here.
+		err = unixDeviceSetupCharNum(d.state, devicesPath, cdi.CDIUnixPrefix, d.name, conf, uint32(major), uint32(minor), conf["path"], false, runConf)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create the devices directory if missing.
+	err = os.Mkdir(devicesPath, 0711)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		return err
+	}
+
+	for _, conf := range configDevices.BindMounts {
+		if conf["source"] == "" {
+			return fmt.Errorf("The source of the disk device %v used for CDI is empty", conf)
+		}
+
+		srcPath := shared.HostPath(conf["source"])
+		destPath := conf["path"]
+		relativeDestPath := strings.TrimPrefix(destPath, "/")
+
+		// Deduplicate CDI bind mounts by target path across devices.
+		// Multiple CDI GPU devices can require the same runtime files (e.g. /run/nvidia-persistenced/socket).
+		// Only create one mount entry per target path to avoid duplicate lxc.mount.entry conflicts.
+		duplicate := false
+		dents, err := os.ReadDir(devicesPath)
+		if err == nil {
+			for _, e := range dents {
+				decoded := filesystem.PathNameDecode(e.Name())
+				if strings.HasPrefix(decoded, cdi.CDIDiskPrefix+".") && strings.HasSuffix(decoded, "."+relativeDestPath) {
+					duplicate = true
+					break
+				}
+			}
+		}
+
+		if duplicate {
+			continue
+		}
+
+		// This time, the created path will be like:
+		// <lxd_var_path>/devices/<instance_name>/<cdi.CDIDiskPrefix>.<gpu_device_name>.<path_encoded_relative_dest_path>
+		deviceName := filesystem.PathNameEncode(deviceJoinPath(cdi.CDIDiskPrefix, d.name, relativeDestPath))
+		devPath := filepath.Join(devicesPath, deviceName)
+
+		ownerShift := deviceConfig.MountOwnerShiftNone
+		if idmap.CanIdmapMount(devPath, "") {
+			ownerShift = deviceConfig.MountOwnerShiftDynamic
+		}
+
+		options := []string{"bind"}
+		mntOptions := shared.SplitNTrimSpace(conf["raw.mount.options"], ",", -1, true)
+		fsName := "none"
+
+		fileInfo, err := os.Stat(srcPath)
+		if err != nil {
+			return fmt.Errorf("Failed accessing source path %q: %w", srcPath, err)
+		}
+
+		isFile := !fileInfo.Mode().IsDir()
+
+		f, err := os.OpenFile(srcPath, unix.O_PATH|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return fmt.Errorf("Failed opening source path %q: %w", srcPath, err)
+		}
+
+		srcPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+		srcFDHandlers = append(srcFDHandlers, f)
+
+		// Clean any existing entry.
+		err = os.Remove(devPath)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+
+		// Create the mount point.
+		if isFile {
+			f, err := os.Create(devPath)
+			if err != nil {
+				return err
+			}
+
+			srcFDHandlers = append(srcFDHandlers, f)
+		} else {
+			err := os.Mkdir(devPath, 0700)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Mount the fs.
+		err = DiskMount(srcPath, devPath, false, "", mntOptions, fsName)
+		if err != nil {
+			return err
+		}
+
+		if isFile {
+			options = append(options, "create=file")
+		} else {
+			options = append(options, "create=dir")
+		}
+
+		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
+			DevName:    deviceName,
+			DevSource:  deviceConfig.DevSourcePath{Path: devPath},
+			TargetPath: relativeDestPath,
+			FSType:     "none",
+			Opts:       options,
+			OwnerShift: ownerShift,
+		})
+
+		runConf.PostHooks = append(runConf.PostHooks, func() error {
+			return unix.Unmount(devPath, unix.MNT_DETACH)
+		})
+	}
+
+	// Serialize the config devices inside the devices directory.
+	f, err := os.Create(cdiConfigDevicesFilePath(devicesPath, d.name))
+	if err != nil {
+		return fmt.Errorf("Could not create the CDI config devices file: %w", err)
+	}
+
+	defer f.Close()
+	err = json.NewEncoder(f).Encode(configDevices)
+	if err != nil {
+		return fmt.Errorf("Could not write to the CDI config devices file: %w", err)
+	}
+
+	return nil
+}
+
+// stopCDIDevices removes unix-char devices and unmounts disk bind mounts described by configDevices.
+func stopCDIDevices(d *deviceCommon, configDevices cdi.ConfigDevices, runConf *deviceConfig.RunConfig) error {
+	// Remove ALL the underlying unix-char dev entries created when the CDI device started.
+	err := unixDeviceRemove(d.inst.DevicesPath(), cdi.CDIUnixPrefix, d.name, "", runConf)
+	if err != nil {
+		return err
+	}
+
+	for _, conf := range configDevices.BindMounts {
+		relativeDestPath := strings.TrimPrefix(conf["path"], "/")
+		devPath := filepath.Join(d.inst.DevicesPath(), filesystem.PathNameEncode(deviceJoinPath(cdi.CDIDiskPrefix, d.name, relativeDestPath)))
+		runConf.PostHooks = append(runConf.PostHooks, func() error {
+			// Clean any existing device mount entry. Should occur first before custom volume unmounts.
+			err := DiskMountClear(devPath)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		// The disk device doesn't exist do nothing.
+		if !shared.PathExists(devPath) {
+			return nil
+		}
+
+		// Request an unmount of the device inside the instance.
+		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
+			TargetPath: relativeDestPath,
+		})
+	}
+
+	return nil
+}
+
+// applyCDIDeviceToContainer runs the full CDI device setup for a container: it generates the CDI
+// spec from cdiID, sets up unix-char and disk devices, writes the hooks file, and registers a
+// PostHook to apply the hooks after the container starts.
+func applyCDIDeviceToContainer(d *deviceCommon, cdiID cdi.ID, runConf *deviceConfig.RunConfig) error {
+	c, ok := d.inst.(instance.Container)
+	if !ok {
+		return fmt.Errorf("Failed casting instance %q to container", d.inst.Name())
+	}
+
+	configDevices, hooks, err := cdi.GenerateFromCDI(d.state.OS.InUbuntuCore(), d.inst, cdiID)
+	if err != nil {
+		return err
+	}
+
+	err = startCDIDevices(d, *configDevices, runConf)
+	if err != nil {
+		return err
+	}
+
+	hooksFile := cdiHooksFilePath(d.inst.DevicesPath(), d.name)
+	f, err := os.Create(hooksFile)
+	if err != nil {
+		return fmt.Errorf("Could not create the CDI hooks file: %w", err)
+	}
+
+	defer f.Close()
+	err = json.NewEncoder(f).Encode(hooks)
+	if err != nil {
+		return fmt.Errorf("Could not write to the CDI hooks file: %w", err)
+	}
+
+	runConf.PostHooks = append(runConf.PostHooks, func() error {
+		return cdi.ApplyHooksToContainer(hooksFile, c)
+	})
+
+	return nil
+}
+
+// postStopCDIDevice cleans up CDI device files after a device is stopped.
+// If allowMissingFiles is true, missing hooks and config files are silently ignored.
+// This is needed for instances started before the CDI migration for gputype=mig.
+func postStopCDIDevice(d *deviceCommon, allowMissingFiles bool) error {
+	err := unixDeviceDeleteFiles(d.state, d.inst.DevicesPath(), cdi.CDIUnixPrefix, d.name, "")
+	if err != nil {
+		return fmt.Errorf("Failed deleting files for CDI device %q: %w", d.name, err)
+	}
+
+	hooksFile := cdiHooksFilePath(d.inst.DevicesPath(), d.name)
+	err = os.Remove(hooksFile)
+	if err != nil && (!allowMissingFiles || !errors.Is(err, fs.ErrNotExist)) {
+		return fmt.Errorf("Failed deleting CDI hooks file for device %q: %w", d.name, err)
+	}
+
+	configDevicesFile := cdiConfigDevicesFilePath(d.inst.DevicesPath(), d.name)
+	err = os.Remove(configDevicesFile)
+	if err != nil && (!allowMissingFiles || !errors.Is(err, fs.ErrNotExist)) {
+		return fmt.Errorf("Failed deleting CDI config devices file for device %q: %w", d.name, err)
+	}
+
+	return nil
+}

--- a/lxd/device/gpu_cdi.go
+++ b/lxd/device/gpu_cdi.go
@@ -257,9 +257,9 @@ func stopCDIDevices(d *deviceCommon, configDevices cdi.ConfigDevices, runConf *d
 			return nil
 		})
 
-		// The disk device doesn't exist do nothing.
+		// The disk device doesn't exist, do nothing.
 		if !shared.PathExists(devPath) {
-			return nil
+			continue
 		}
 
 		// Request an unmount of the device inside the instance.

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -21,9 +21,6 @@ type gpuMIG struct {
 	deviceCommon
 }
 
-// GPUNvidiaDeviceKey is the key used for NVIDIA devices through libnvidia-container.
-const GPUNvidiaDeviceKey = "nvidia.device"
-
 // validateConfig checks the supplied config for correctness.
 func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container) {

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -217,7 +217,7 @@ func (d *gpuMIG) migCDIID() (cdi.ID, error) {
 	return cdi.ID{Vendor: cdi.NVIDIA, Class: cdi.MIG, Name: migUUID}, nil
 }
 
-// CanHotPlug returns whether the device can be managed whilst the instance is running,.
+// CanHotPlug returns whether the device can be managed whilst the instance is running.
 func (d *gpuMIG) CanHotPlug() bool {
 	return false
 }

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -3,14 +3,17 @@ package device
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/canonical/lxd/lxd/device/cdi"
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	pcidev "github.com/canonical/lxd/lxd/device/pci"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/resources"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -54,14 +57,51 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 		d.config["pci"] = pcidev.NormaliseAddress(d.config["pci"])
 	}
 
+	// Validate the "id" field.
 	if d.config["id"] != "" {
 		for _, field := range []string{"pci", "productid", "vendorid"} {
 			if d.config[field] != "" {
 				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
 			}
 		}
+
+		// Validate "id" is either an integer DRM card ID or a CDI identifier.
+		_, err = strconv.ParseUint(d.config["id"], 10, 64)
+		if err != nil {
+			cdiID, err := cdi.ToCDI(d.config["id"])
+			if err != nil {
+				// Structurally incorrect CDI ID supplied.
+				if api.StatusErrorCheck(err, http.StatusBadRequest) {
+					return fmt.Errorf(`"id" must be an integer DRM card ID or a CDI ID: %w`, err)
+				}
+
+				// Structurally correct CDI ID supplied, but still invalid.
+				return err
+			}
+
+			// CDI "id" must be of MIG class.
+			if cdiID.Class != cdi.MIG {
+				return fmt.Errorf("CDI identifier %q is not a MIG device; use gputype=physical for non-MIG CDI devices", d.config["id"])
+			}
+
+			// CDI "id" must refer to a single MIG device.
+			if cdiID.Name == "all" {
+				return fmt.Errorf(`CDI identifier %q must refer to a single MIG device, not "all"`, d.config["id"])
+			}
+
+			// CDI "id" is mutually exclusive with mig.* fields.
+			for _, field := range []string{"mig.uuid", "mig.gi", "mig.ci"} {
+				if d.config[field] != "" {
+					return fmt.Errorf(`Cannot use %q when a CDI "id" is set`, field)
+				}
+			}
+
+			// CDI "id" is the only MIG selector needed.
+			return nil
+		}
 	}
 
+	// Without a CDI "id", require mig.uuid or mig.gi+mig.ci.
 	if d.config["mig.uuid"] != "" {
 		for _, field := range []string{"mig.gi", "mig.ci"} {
 			if d.config[field] != "" {
@@ -69,7 +109,7 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 			}
 		}
 	} else if d.config["mig.gi"] == "" || d.config["mig.ci"] == "" {
-		return errors.New(`Either "mig.uuid" or both "mig.gi" and "mig.ci" must be set`)
+		return errors.New(`Either "mig.uuid", both "mig.gi" and "mig.ci", or a CDI "id" must be set`)
 	}
 
 	return nil
@@ -77,24 +117,104 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *gpuMIG) validateEnvironment() error {
-	if shared.IsFalseOrEmpty(d.inst.ExpandedConfig()["nvidia.runtime"]) {
-		return errors.New("nvidia.runtime must be set to true for MIG GPUs to work")
-	}
-
 	return validatePCIDevice(d.config["pci"])
 }
 
-// buildMIGDeviceName builds the name of the MIG device based on old/new format.
-func (d *gpuMIG) buildMIGDeviceName(gpu api.ResourcesGPUCard) string {
-	if d.config["mig.uuid"] != "" {
-		if strings.HasPrefix(d.config["mig.uuid"], "MIG-") {
-			return d.config["mig.uuid"]
+// migCDIID resolves the CDI identifier for the MIG device from the device config.
+// It handles three cases: a direct CDI "id", a "mig.uuid", or a "mig.gi"+"mig.ci" pair.
+func (d *gpuMIG) migCDIID() (cdi.ID, error) {
+	// Case 1: direct CDI "id".
+	if d.config["id"] != "" {
+		cdiID, err := cdi.ToCDI(d.config["id"])
+		if err == nil && cdiID != nil {
+			return *cdiID, nil
 		}
-
-		return "MIG-" + d.config["mig.uuid"]
 	}
 
-	return fmt.Sprintf("MIG-%s/%s/%s", gpu.Nvidia.UUID, d.config["mig.gi"], d.config["mig.ci"])
+	// Case 2: "mig.uuid". The UUID uniquely identifies the MIG device, no parent GPU lookup is needed.
+	// However, if a parent GPU selector (id, pci, vendorid, productid) is present, perform the lookup
+	// for validation to preserve backward compatibility with existing configurations.
+	if d.config["mig.uuid"] != "" {
+		migUUID := d.config["mig.uuid"]
+		if !strings.HasPrefix(migUUID, "MIG-") {
+			migUUID = "MIG-" + migUUID
+		}
+
+		hasSelector := d.config["id"] != "" || d.config["pci"] != "" || d.config["vendorid"] != "" || d.config["productid"] != ""
+		if hasSelector {
+			gpus, err := resources.GetGPU()
+			if err != nil {
+				return cdi.ID{}, fmt.Errorf("Failed getting GPU resources: %w", err)
+			}
+
+			var parentGPU *api.ResourcesGPUCard
+			for i := range gpus.Cards {
+				if !gpuSelected(d.Config(), gpus.Cards[i]) {
+					continue
+				}
+
+				if parentGPU != nil {
+					return cdi.ID{}, errors.New("More than one GPU matched the MIG device")
+				}
+
+				parentGPU = &gpus.Cards[i]
+			}
+
+			if parentGPU == nil {
+				return cdi.ID{}, errors.New("Failed detecting requested GPU device")
+			}
+
+			if parentGPU.Nvidia == nil {
+				return cdi.ID{}, errors.New("Card is not an NVIDIA GPU or driver is not properly set up")
+			}
+		}
+
+		return cdi.ID{Vendor: cdi.NVIDIA, Class: cdi.MIG, Name: migUUID}, nil
+	}
+
+	// Case 3: "mig.gi"+"mig.ci". Resolve to UUID via NVML, which requires the parent GPU PCI address.
+	gpus, err := resources.GetGPU()
+	if err != nil {
+		return cdi.ID{}, fmt.Errorf("Failed getting GPU resources: %w", err)
+	}
+
+	var parentGPU *api.ResourcesGPUCard
+	for i := range gpus.Cards {
+		if !gpuSelected(d.Config(), gpus.Cards[i]) {
+			continue
+		}
+
+		if parentGPU != nil {
+			return cdi.ID{}, errors.New("More than one GPU matched the MIG device")
+		}
+
+		parentGPU = &gpus.Cards[i]
+	}
+
+	if parentGPU == nil {
+		return cdi.ID{}, errors.New("Failed detecting requested GPU device")
+	}
+
+	if parentGPU.Nvidia == nil {
+		return cdi.ID{}, errors.New("Card is not an NVIDIA GPU or driver is not properly set up")
+	}
+
+	gi, err := strconv.Atoi(d.config["mig.gi"])
+	if err != nil {
+		return cdi.ID{}, fmt.Errorf("Invalid mig.gi value %q: %w", d.config["mig.gi"], err)
+	}
+
+	ci, err := strconv.Atoi(d.config["mig.ci"])
+	if err != nil {
+		return cdi.ID{}, fmt.Errorf("Invalid mig.ci value %q: %w", d.config["mig.ci"], err)
+	}
+
+	migUUID, err := cdi.MIGDeviceUUID(parentGPU.PCIAddress, gi, ci)
+	if err != nil {
+		return cdi.ID{}, fmt.Errorf("Failed resolving MIG device UUID for gi=%d ci=%d: %w", gi, ci, err)
+	}
+
+	return cdi.ID{Vendor: cdi.NVIDIA, Class: cdi.MIG, Name: migUUID}, nil
 }
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running,.
@@ -110,60 +230,49 @@ func (d *gpuMIG) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := deviceConfig.RunConfig{}
-
-	// Get all the GPUs.
-	gpus, err := resources.GetGPU()
+	// Resolve the CDI identifier for the MIG device.
+	cdiID, err := d.migCDIID()
 	if err != nil {
 		return nil, err
 	}
 
-	var pciAddress string
-	for _, gpu := range gpus.Cards {
-		// Skip any cards that are not selected.
-		if !gpuSelected(d.Config(), gpu) {
-			continue
-		}
-
-		// We found a match.
-		if pciAddress != "" {
-			return nil, errors.New("More than one GPU matched the MIG device")
-		}
-
-		pciAddress = gpu.PCIAddress
-
-		// Validate the GPU.
-		if gpu.Nvidia == nil {
-			return nil, errors.New("Card is not a NVIDIA GPU or driver is not properly setup")
-		}
-
-		// Validate the MIG.
-		fields := strings.SplitN(gpu.Nvidia.CardDevice, ":", 2)
-		if len(fields) != 2 {
-			return nil, errors.New("Bad NVIDIA GPU (could not find ID)")
-		}
-
-		gpuID := fields[1]
-
-		if d.config["mig.uuid"] == "" {
-			if !shared.PathExists(fmt.Sprintf("/proc/driver/nvidia/capabilities/gpu%s/mig/gi%s/ci%s/access", gpuID, d.config["mig.gi"], d.config["mig.ci"])) {
-				return nil, fmt.Errorf("MIG device gi=%s ci=%s does not exist on GPU %s", d.config["mig.gi"], d.config["mig.ci"], gpuID)
-			}
-		}
-
-		runConf.GPUDevice = append(runConf.GPUDevice, []deviceConfig.RunConfigItem{
-			{Key: GPUNvidiaDeviceKey, Value: d.buildMIGDeviceName(gpu)},
-		}...)
-	}
-
-	if pciAddress == "" {
-		return nil, errors.New("Failed detecting requested GPU device")
+	runConf := deviceConfig.RunConfig{}
+	err = applyCDIDeviceToContainer(&d.deviceCommon, cdiID, &runConf)
+	if err != nil {
+		return nil, err
 	}
 
 	return &runConf, nil
 }
 
-// Stop is run when the device is removed from the instance.
+// Stop is run when the device is removed from the container.
 func (d *gpuMIG) Stop() (*deviceConfig.RunConfig, error) {
-	return nil, nil
+	runConf := deviceConfig.RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	configFilePath := cdiConfigDevicesFilePath(d.inst.DevicesPath(), d.name)
+	configDevices, err := cdi.ReloadConfigDevicesFromDisk(configFilePath)
+	if err != nil {
+		// Instances started before the CDI migration have no config file on disk.
+		// Treat missing file as a no-op to allow a clean stop.
+		if errors.Is(err, fs.ErrNotExist) {
+			return &runConf, nil
+		}
+
+		return nil, err
+	}
+
+	err = stopCDIDevices(&d.deviceCommon, configDevices, &runConf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runConf, nil
+}
+
+// postStop is run after the device is removed from the container.
+func (d *gpuMIG) postStop() error {
+	// missingFilesOK=true because instances started before the CDI migration have no files to clean up.
+	return postStopCDIDevice(&d.deviceCommon, true)
 }

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/resources"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -42,6 +43,14 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 	err := d.config.Validate(gpuValidationRules(requiredFields, optionalFields))
 	if err != nil {
 		return err
+	}
+
+	// MIG devices use CDI for passthrough, which is incompatible with the legacy "nvidia.runtime"
+	// LXC hook. The hook sets NVIDIA_VISIBLE_DEVICES=none and mounts driver files via
+	// nvidia-container-cli, which conflicts with the CDI-managed device nodes and prevents the
+	// MIG slices from appearing inside the container.
+	if shared.IsTrue(instConf.ExpandedConfig()["nvidia.runtime"]) {
+		return errors.New(`The "nvidia.runtime" instance option is incompatible with gputype=mig devices`)
 	}
 
 	if d.config["pci"] != "" {

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -1,10 +1,8 @@
 package device
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,11 +14,9 @@ import (
 	"github.com/canonical/lxd/lxd/device/cdi"
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	pcidev "github.com/canonical/lxd/lxd/device/pci"
-	"github.com/canonical/lxd/lxd/idmap"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/resources"
-	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -130,229 +126,6 @@ func (d *gpuPhysical) Start() (*deviceConfig.RunConfig, error) {
 	return d.startContainer()
 }
 
-// startCDIDevices starts all the devices given in a CDI specification:
-// * `unix-char` (representing the card and non-card devices)
-// * `disk` (representing the mounts)).
-func (d *gpuPhysical) startCDIDevices(configDevices cdi.ConfigDevices, runConf *deviceConfig.RunConfig) error {
-	srcFDHandlers := make([]*os.File, 0)
-	defer func() {
-		for _, f := range srcFDHandlers {
-			_ = f.Close()
-		}
-	}()
-
-	hooksFilePath := d.generateCDIHooksFilePath()
-	deviceConfigFilePath := d.generateCDIConfigDevicesFilePath()
-	devicesPath := d.inst.DevicesPath()
-
-	// Check if there are any remaining CDI devices in the instance devices directory.
-	// If there are, we need to remove them. These can be present in the case where the device stop hook was not called
-	// (e.g. due to an abrupt host shutdown).
-	err := filepath.WalkDir(devicesPath, func(path string, e fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if e.IsDir() {
-			return nil
-		}
-
-		// Remove the CDI device files (both unix-char and disk devices as long as JSON CDI metadata files).
-		if strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIUnixPrefix+"."+d.name+".")) ||
-			strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIDiskPrefix+"."+d.name+".")) ||
-			path == hooksFilePath || path == deviceConfigFilePath {
-			err = os.Remove(path)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, conf := range configDevices.UnixCharDevs {
-		if conf["source"] == "" {
-			return fmt.Errorf("The source of the unix-char device %v used for CDI is empty", conf)
-		}
-
-		if conf["major"] == "" || conf["minor"] == "" {
-			return fmt.Errorf("The major or minor of the unix-char device %v used for CDI is empty", conf)
-		}
-
-		major, err := strconv.ParseUint(conf["major"], 10, 32)
-		if err != nil {
-			return fmt.Errorf("Failed parsing major number %q when starting CDI device: %w", conf["major"], err)
-		}
-
-		minor, err := strconv.ParseUint(conf["minor"], 10, 32)
-		if err != nil {
-			return fmt.Errorf("Failed parsing minor number %q when starting CDI device: %w", conf["minor"], err)
-		}
-
-		uid := conf["uid"]
-		if uid != "" {
-			d.config["uid"] = uid
-		}
-
-		gid := conf["gid"]
-		if gid != "" {
-			d.config["gid"] = gid
-		}
-
-		// Here putting a `cdi.CDIUnixPrefix` prefix with 'd.name' as a device name will create an directory entry like:
-		// <lxd_var_path>/devices/<instance_name>/<cdi.CDIUnixPrefix>.<gpu_device_name>.<path_encoded_relative_dest_path>
-		// 'unixDeviceSetupCharNum' is already checking for dupe entries so we have no validation to do here.
-		err = unixDeviceSetupCharNum(d.state, devicesPath, cdi.CDIUnixPrefix, d.name, conf, uint32(major), uint32(minor), conf["path"], false, runConf)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Create the devices directory if missing.
-	err = os.Mkdir(devicesPath, 0711)
-	if err != nil && !errors.Is(err, fs.ErrExist) {
-		return err
-	}
-
-	for _, conf := range configDevices.BindMounts {
-		if conf["source"] == "" {
-			return fmt.Errorf("The source of the disk device %v used for CDI is empty", conf)
-		}
-
-		srcPath := shared.HostPath(conf["source"])
-		destPath := conf["path"]
-		relativeDestPath := strings.TrimPrefix(destPath, "/")
-
-		// Deduplicate CDI bind mounts by target path across devices.
-		// Multiple CDI GPU devices can require the same runtime files (e.g. /run/nvidia-persistenced/socket).
-		// Only create one mount entry per target path to avoid duplicate lxc.mount.entry conflicts.
-		duplicate := false
-		dents, err := os.ReadDir(devicesPath)
-		if err == nil {
-			for _, e := range dents {
-				decoded := filesystem.PathNameDecode(e.Name())
-				if strings.HasPrefix(decoded, cdi.CDIDiskPrefix+".") && strings.HasSuffix(decoded, "."+relativeDestPath) {
-					duplicate = true
-					break
-				}
-			}
-		}
-
-		if duplicate {
-			continue
-		}
-
-		// This time, the created path will be like:
-		// <lxd_var_path>/devices/<instance_name>/<cdi.CDIDiskPrefix>.<gpu_device_name>.<path_encoded_relative_dest_path>
-		deviceName := filesystem.PathNameEncode(deviceJoinPath(cdi.CDIDiskPrefix, d.name, relativeDestPath))
-		devPath := filepath.Join(devicesPath, deviceName)
-
-		ownerShift := deviceConfig.MountOwnerShiftNone
-		if idmap.CanIdmapMount(devPath, "") {
-			ownerShift = deviceConfig.MountOwnerShiftDynamic
-		}
-
-		options := []string{"bind"}
-		mntOptions := shared.SplitNTrimSpace(conf["raw.mount.options"], ",", -1, true)
-		fsName := "none"
-
-		fileInfo, err := os.Stat(srcPath)
-		if err != nil {
-			return fmt.Errorf("Failed accessing source path %q: %w", srcPath, err)
-		}
-
-		fileMode := fileInfo.Mode()
-		isFile := false
-		if !fileMode.IsDir() {
-			isFile = true
-		}
-
-		f, err := os.OpenFile(srcPath, unix.O_PATH|unix.O_CLOEXEC, 0)
-		if err != nil {
-			return fmt.Errorf("Failed opening source path %q: %w", srcPath, err)
-		}
-
-		srcPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
-		srcFDHandlers = append(srcFDHandlers, f)
-
-		// Clean any existing entry.
-		err = os.Remove(devPath)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-
-		// Create the mount point.
-		if isFile {
-			f, err := os.Create(devPath)
-			if err != nil {
-				return err
-			}
-
-			srcFDHandlers = append(srcFDHandlers, f)
-		} else {
-			err := os.Mkdir(devPath, 0700)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Mount the fs.
-		err = DiskMount(srcPath, devPath, false, "", mntOptions, fsName)
-		if err != nil {
-			return err
-		}
-
-		if isFile {
-			options = append(options, "create=file")
-		} else {
-			options = append(options, "create=dir")
-		}
-
-		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-			DevName:    deviceName,
-			DevSource:  deviceConfig.DevSourcePath{Path: devPath},
-			TargetPath: relativeDestPath,
-			FSType:     "none",
-			Opts:       options,
-			OwnerShift: ownerShift,
-		})
-
-		runConf.PostHooks = append(runConf.PostHooks, func() error {
-			err := unix.Unmount(devPath, unix.MNT_DETACH)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
-	}
-
-	// Serialize the config devices inside the devices directory.
-	f, err := os.Create(d.generateCDIConfigDevicesFilePath())
-	if err != nil {
-		return fmt.Errorf("Could not create the CDI config devices file: %w", err)
-	}
-
-	defer f.Close()
-	err = json.NewEncoder(f).Encode(configDevices)
-	if err != nil {
-		return fmt.Errorf("Could not write to the CDI config devices file: %w", err)
-	}
-
-	return nil
-}
-
-func (d *gpuPhysical) generateCDIHooksFilePath() string {
-	return filepath.Join(d.inst.DevicesPath(), d.name+cdi.CDIHooksFileSuffix)
-}
-
-func (d *gpuPhysical) generateCDIConfigDevicesFilePath() string {
-	return filepath.Join(d.inst.DevicesPath(), d.name+cdi.CDIConfigDevicesFileSuffix)
-}
-
 // startContainer detects the requested GPU devices and sets up unix-char devices.
 // Returns RunConfig populated with mount info required to pass the unix-char devices into the container.
 func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
@@ -369,38 +142,10 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 				return nil, errors.New(`MIG GPU notation detected for a "physical" gputype device. Choose a "mig" gputype device instead.`)
 			}
 
-			c, ok := d.inst.(instance.Container)
-			if !ok {
-				return nil, fmt.Errorf("Failed casting instance %q to container", d.inst.Name())
-			}
-
-			configDevices, hooks, err := cdi.GenerateFromCDI(d.state.OS.InUbuntuCore(), d.inst, *cdiID)
+			err := applyCDIDeviceToContainer(&d.deviceCommon, *cdiID, &runConf)
 			if err != nil {
 				return nil, err
 			}
-
-			// Start the devices needed by the CDI specification.
-			err = d.startCDIDevices(*configDevices, &runConf)
-			if err != nil {
-				return nil, err
-			}
-
-			// Generate hooks file path for use with ApplyHooksToContainer
-			hooksFile := d.generateCDIHooksFilePath()
-			f, err := os.Create(hooksFile)
-			if err != nil {
-				return nil, fmt.Errorf("Could not create the CDI hooks file: %w", err)
-			}
-
-			defer f.Close()
-			err = json.NewEncoder(f).Encode(hooks)
-			if err != nil {
-				return nil, fmt.Errorf("Could not write to the CDI hooks file: %w", err)
-			}
-
-			runConf.PostHooks = append(runConf.PostHooks, func() error {
-				return cdi.ApplyHooksToContainer(hooksFile, c)
-			})
 
 			return &runConf, nil
 		}
@@ -654,41 +399,6 @@ func (d *gpuPhysical) pciDeviceDriverOverrideIOMMU(pciDev pcidev.Device, driverO
 	return nil
 }
 
-// stopCDIDevices reads the configDevices and remove potential unix device and unmounts disk mounts.
-func (d *gpuPhysical) stopCDIDevices(configDevices cdi.ConfigDevices, runConf *deviceConfig.RunConfig) error {
-	// Remove ALL the underlying unix-char dev entries created when the CDI device started.
-	err := unixDeviceRemove(d.inst.DevicesPath(), cdi.CDIUnixPrefix, d.name, "", runConf)
-	if err != nil {
-		return err
-	}
-
-	for _, conf := range configDevices.BindMounts {
-		relativeDestPath := strings.TrimPrefix(conf["path"], "/")
-		devPath := filepath.Join(d.inst.DevicesPath(), filesystem.PathNameEncode(deviceJoinPath(cdi.CDIDiskPrefix, d.name, relativeDestPath)))
-		runConf.PostHooks = append(runConf.PostHooks, func() error {
-			// Clean any existing device mount entry. Should occur first before custom volume unmounts.
-			err := DiskMountClear(devPath)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
-
-		// The disk device doesn't exist do nothing.
-		if !shared.PathExists(devPath) {
-			return nil
-		}
-
-		// Request an unmount of the device inside the instance.
-		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-			TargetPath: relativeDestPath,
-		})
-	}
-
-	return nil
-}
-
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
 // Both CDI and classic GPU devices can be hotplugged for containers.
 func (d *gpuPhysical) CanHotPlug() bool {
@@ -709,12 +419,12 @@ func (d *gpuPhysical) Stop() (*deviceConfig.RunConfig, error) {
 	if cdiID != nil {
 		// This is more efficient than GenerateFromCDI as we don't need to re-generate a CDI
 		// specification to parse it again.
-		configDevices, err := cdi.ReloadConfigDevicesFromDisk(d.generateCDIConfigDevicesFilePath())
+		configDevices, err := cdi.ReloadConfigDevicesFromDisk(cdiConfigDevicesFilePath(d.inst.DevicesPath(), d.name))
 		if err != nil {
 			return nil, err
 		}
 
-		err = d.stopCDIDevices(configDevices, &runConf)
+		err = stopCDIDevices(&d.deviceCommon, configDevices, &runConf)
 		if err != nil {
 			return nil, err
 		}
@@ -747,20 +457,9 @@ func (d *gpuPhysical) postStop() error {
 	if d.inst.Type() == instancetype.Container {
 		cdiID, _ := cdi.ToCDI(d.config["id"])
 		if cdiID != nil {
-			err := unixDeviceDeleteFiles(d.state, d.inst.DevicesPath(), cdi.CDIUnixPrefix, d.name, "")
+			err := postStopCDIDevice(&d.deviceCommon, false)
 			if err != nil {
-				return fmt.Errorf("Failed deleting files for CDI device %q: %w", d.name, err)
-			}
-
-			// Also remove the JSON files that were used to store the CDI related information.
-			err = os.Remove(d.generateCDIHooksFilePath())
-			if err != nil {
-				return fmt.Errorf("Failed deleting CDI hooks file for device %q: %w", d.name, err)
-			}
-
-			err = os.Remove(d.generateCDIConfigDevicesFilePath())
-			if err != nil {
-				return fmt.Errorf("Failed deleting CDI paths to conf file for device %q: %w", d.name, err)
+				return err
 			}
 		} else {
 			err := unixDeviceDeleteFiles(d.state, d.inst.DevicesPath(), "unix", d.name, "")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1990,7 +1990,6 @@ func (d *lxc) startCommon(ctx context.Context, progressReporter ioprogress.Progr
 
 	// Create the devices
 	nicID := -1
-	nvidiaDevices := []string{}
 
 	sortedDevices := d.expandedDevices.Sorted()
 	startDevices := make([]device.Device, 0, len(sortedDevices))
@@ -2133,23 +2132,6 @@ func (d *lxc) startCommon(ctx context.Context, progressReporter ioprogress.Progr
 		// Add any post start hooks.
 		if len(runConf.PostHooks) > 0 {
 			postStartHooks = append(postStartHooks, runConf.PostHooks...)
-		}
-
-		// Build list of NVIDIA GPUs (used for MIG).
-		if len(runConf.GPUDevice) > 0 {
-			for _, entry := range runConf.GPUDevice {
-				if entry.Key == device.GPUNvidiaDeviceKey {
-					nvidiaDevices = append(nvidiaDevices, entry.Value)
-				}
-			}
-		}
-	}
-
-	// Override NVIDIA_VISIBLE_DEVICES if we have devices that need it.
-	if len(nvidiaDevices) > 0 {
-		err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_VISIBLE_DEVICES="+strings.Join(nvidiaDevices, ","))
-		if err != nil {
-			return nil, "", nil, fmt.Errorf("Cannot set NVIDIA_VISIBLE_DEVICES in LXC environment: %w", err)
 		}
 	}
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -339,28 +339,28 @@
 				"keys": [
 					{
 						"id": {
-							"longdesc": "",
-							"shortdesc": "DRM card ID of the GPU device",
+							"longdesc": "The ID can either be the DRM card ID of the parent GPU device, or a fully-qualified Container Device Interface (CDI) name for the MIG device.\nHere are some examples of fully-qualified CDI names:\n\n- `nvidia.com/mig=0:2`: Instructs LXD to pass through the MIG device at index 2 on GPU 0. You can find the index using `nvidia-smi -L` on your host.\n- `nvidia.com/mig=MIG-74c6a31a-fde5-5c61-973b-70e12346c202`: Instructs LXD to pass through a MIG device with a given unique identifier. This identifier should also appear with `nvidia-smi -L`.",
+							"shortdesc": "DRM card ID of the parent GPU, or CDI identifier of the MIG GPU device",
 							"type": "string"
 						}
 					},
 					{
 						"mig.ci": {
-							"longdesc": "",
+							"longdesc": "Use this together with {config:option}`device-gpu-mig-device-conf:mig.gi` to\nidentify a MIG device by its GPU instance ID and compute instance ID.\nLXD resolves the pair to a MIG device UUID using NVML and then uses CDI\nto pass the device through to the container.",
 							"shortdesc": "Existing MIG compute instance ID",
 							"type": "integer"
 						}
 					},
 					{
 						"mig.gi": {
-							"longdesc": "",
+							"longdesc": "Use this together with {config:option}`device-gpu-mig-device-conf:mig.ci` to\nidentify a MIG device by its GPU instance ID and compute instance ID.\nLXD resolves the pair to a MIG device UUID using NVML and then uses CDI\nto pass the device through to the container.",
 							"shortdesc": "Existing MIG GPU instance ID",
 							"type": "integer"
 						}
 					},
 					{
 						"mig.uuid": {
-							"longdesc": "You can omit the `MIG-` prefix when specifying this option.",
+							"longdesc": "You can omit the `MIG-` prefix when specifying this option.\nLXD uses CDI to pass the MIG device through to the container.",
 							"shortdesc": "Existing MIG device UUID",
 							"type": "string"
 						}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -496,6 +496,7 @@ var APIExtensions = []string{
 	"cluster_links_used_by",
 	"network_load_balancer_pool",
 	"clustering_evacuation_force",
+	"gpu_mig_cdi",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR switches `gputype=mig` GPU devices from the legacy `nvidia.runtime` implementation to the Container Device Interface (CDI).

The new CDI approach for MIG GPUs is incompatible with the `nvidia.runtime=true` instance-level setting.

**Changes**:
- Shared CDI functions (start/stop/cleanup) are now detached from `gpuPhysical` struct and become free functions taking a `*deviceCommon` parameter, so they can be used with other GPU types (e.g. `mig`).
- `gputype=mig` now uses CDI for device passthrough. It does so by internally translating `mig.uuid` to the CDI notation `nvidia.com/mig=<uuid>`. Similarly, it translates (`mig.gi`, `mig.ci`) pair to the CDI notation `nvidia.com/mig=<uuid>` with the help of `go-nvml` library.
- The `id` field for `gputype=mig` now also accepts a CDI identifier directly in the form of `nvidia.com/mig=<uuid>` and `nvidia.com/mig=<dev_idx>:<mig_idx>`.

Fixes https://github.com/canonical/lxd/issues/17461.

This PR should be merged together with associated `lxd-ci` test updates https://github.com/canonical/lxd-ci/pull/782.

The follow-up PR will remove the legacy `nvidia.runtime` and other `nvidia.*` instance-level config options from LXD.