### PR TITLE
Add `used_by` field to cluster link API and update handlers

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3121,3 +3121,7 @@ Renames storage pool NVMe/TCP mode from `nvme` to `nvme/tcp`.
 ## `project_replica_mode`
 
 Adds a `replica_mode` field to projects and a new `PUT /1.0/projects/<name>/state` endpoint for promoting and demoting projects between leader and standby modes for replication.
+
+## `cluster_links_used_by`
+
+Adds a `used_by` field to `ClusterLink` resources, returned by `GET /1.0/cluster/links` (with `recursion=1`) and `GET /1.0/cluster/links/{name}`. The field lists URLs of entities that reference the cluster link, filtered by the caller's view permissions.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -426,6 +426,14 @@ definitions:
                 example: bidirectional
                 type: string
                 x-go-name: Type
+            used_by:
+                description: UsedBy is a list of LXD entity URLs that reference the cluster link.
+                example:
+                    - /1.0/replicators/my-replicator?project=default
+                items:
+                    type: string
+                type: array
+                x-go-name: UsedBy
         title: ClusterLink represents high-level information about a cluster link.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
@@ -165,6 +166,7 @@ func clusterLinksGet(d *Daemon, r *http.Request) response.Response {
 	var clusterLinks []dbCluster.ClusterLinkRow
 	var clusterLinkURLs []string
 	var allConfigs map[int64]map[string]string
+	var allUsedBy map[string][]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		clusterLinks, clusterLinkURLs, err = dbCluster.GetClusterLinksAndURLs(ctx, tx.Tx(), func(link dbCluster.ClusterLinkRow) bool {
@@ -178,6 +180,11 @@ func clusterLinksGet(d *Daemon, r *http.Request) response.Response {
 			allConfigs, err = dbCluster.ClusterLinksConfigStore().GetAll(ctx, tx.Tx())
 			if err != nil {
 				return fmt.Errorf("Failed loading cluster link configs: %w", err)
+			}
+
+			allUsedBy, err = dbCluster.GetClusterLinksUsedBy(ctx, tx.Tx(), nil, false)
+			if err != nil {
+				return fmt.Errorf("Failed loading cluster link usage: %w", err)
 			}
 		}
 
@@ -193,7 +200,9 @@ func clusterLinksGet(d *Daemon, r *http.Request) response.Response {
 
 	apiClusterLinks := make([]*api.ClusterLink, 0, len(clusterLinks))
 	for _, link := range clusterLinks {
-		apiClusterLinks = append(apiClusterLinks, link.ToAPI(allConfigs))
+		apiClusterLink := link.ToAPI(allConfigs)
+		apiClusterLink.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, allUsedBy[link.Name])
+		apiClusterLinks = append(apiClusterLinks, apiClusterLink)
 	}
 
 	if len(withEntitlements) > 0 {
@@ -258,6 +267,7 @@ func clusterLinkGet(d *Daemon, r *http.Request) response.Response {
 
 	name := r.PathValue("name")
 	var apiClusterLink *api.ClusterLink
+	var usedByMap map[string][]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbClusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), name)
 		if err != nil {
@@ -270,11 +280,19 @@ func clusterLinkGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		apiClusterLink = dbClusterLink.ToAPI(config)
+
+		usedByMap, err = dbCluster.GetClusterLinksUsedBy(ctx, tx.Tx(), &name, false)
+		if err != nil {
+			return fmt.Errorf("Failed loading cluster link usage: %w", err)
+		}
+
 		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	apiClusterLink.UsedBy = project.FilterUsedBy(r.Context(), s.Authorizer, usedByMap[name])
 
 	if len(withEntitlements) > 0 {
 		err = reportEntitlements(r.Context(), s.Authorizer, entity.TypeClusterLink, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.ClusterLinkURL(name): apiClusterLink})
@@ -510,12 +528,12 @@ func clusterLinkPost(d *Daemon, r *http.Request) response.Response {
 	// Get the existing cluster link.
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Prevent rename if the cluster link is referenced by any entity.
-		usedBy, err := dbCluster.GetClusterLinkUsedBy(ctx, tx.Tx(), name, true)
+		usedBy, err := dbCluster.GetClusterLinksUsedBy(ctx, tx.Tx(), &name, true)
 		if err != nil {
 			return err
 		}
 
-		if len(usedBy) > 0 {
+		if len(usedBy[name]) > 0 {
 			return api.StatusErrorf(http.StatusBadRequest, "Cluster link is currently in use")
 		}
 
@@ -595,12 +613,12 @@ func clusterLinkDelete(d *Daemon, r *http.Request) response.Response {
 	var identity *dbCluster.IdentitiesRow
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Prevent deletion if the cluster link is referenced by any entity.
-		usedBy, err := dbCluster.GetClusterLinkUsedBy(ctx, tx.Tx(), name, true)
+		usedBy, err := dbCluster.GetClusterLinksUsedBy(ctx, tx.Tx(), &name, true)
 		if err != nil {
 			return err
 		}
 
-		if len(usedBy) > 0 {
+		if len(usedBy[name]) > 0 {
 			return api.StatusErrorf(http.StatusBadRequest, "Cluster link is currently in use")
 		}
 

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -151,11 +151,14 @@ var clusterConfigRefs = []clusterConfigRef{
 	},
 }
 
-// GetClusterLinkUsedBy returns a list of URLs of all entities that reference the cluster link with the given name via the 'cluster' config key.
-// If firstOnly is true then the search stops after the first match.
-func GetClusterLinkUsedBy(ctx context.Context, tx *sql.Tx, clusterLinkName string, firstOnly bool) ([]string, error) {
+// GetClusterLinksUsedBy returns a map of cluster link name to list of URLs of all entities that reference the cluster link via the 'cluster' config key.
+// If clusterLinkName is non-nil, only references to that cluster link are returned.
+// If firstOnly is true then the search stops after the first match overall (LIMIT 1 applied globally); only meaningful when clusterLinkName is non-nil.
+func GetClusterLinksUsedBy(ctx context.Context, tx *sql.Tx, clusterLinkName *string, firstOnly bool) (map[string][]string, error) {
 	var b strings.Builder
-	args := make([]any, 0, len(clusterConfigRefs))
+	var args []any
+
+	urls := make(map[string][]string)
 
 	for i, ref := range clusterConfigRefs {
 		if i > 0 {
@@ -166,7 +169,9 @@ func GetClusterLinkUsedBy(ctx context.Context, tx *sql.Tx, clusterLinkName strin
 		b.WriteString(strconv.FormatInt(ref.typeCode, 10))
 		b.WriteString(`, `)
 		b.WriteString(ref.entityTable)
-		b.WriteString(`.name, projects.name FROM `)
+		b.WriteString(`.name, projects.name, `)
+		b.WriteString(ref.configTable)
+		b.WriteString(`.value FROM `)
 		b.WriteString(ref.entityTable)
 		b.WriteString(`
 JOIN `)
@@ -183,29 +188,33 @@ JOIN projects ON `)
 		b.WriteString(`.project_id = projects.id
 WHERE `)
 		b.WriteString(ref.configTable)
-		b.WriteString(`.key = 'cluster' AND `)
-		b.WriteString(ref.configTable)
-		b.WriteString(`.value = ?`)
-		args = append(args, clusterLinkName)
+		b.WriteString(`.key = 'cluster'`)
+
+		if clusterLinkName != nil {
+			b.WriteString(` AND `)
+			b.WriteString(ref.configTable)
+			b.WriteString(`.value = ?`)
+			args = append(args, *clusterLinkName)
+		}
 	}
 
 	if firstOnly {
 		b.WriteString(" LIMIT 1")
 	}
 
-	var urls []string
 	err := query.Scan(ctx, tx, b.String(), func(scan func(dest ...any) error) error {
 		var eType EntityType
 		var eName string
 		var pName string
-		err := scan(&eType, &eName, &pName)
+		var linkName string
+		err := scan(&eType, &eName, &pName, &linkName)
 		if err != nil {
 			return err
 		}
 
 		switch entity.Type(eType) {
 		case entity.TypeReplicator:
-			urls = append(urls, entity.ReplicatorURL(pName, eName).String())
+			urls[linkName] = append(urls[linkName], entity.ReplicatorURL(pName, eName).String())
 		default:
 			return errors.New("Unexpected entity type in cluster link usage query")
 		}

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -418,6 +418,12 @@ type ClusterLink struct {
 	// Cluster link configuration map (refer to doc/clustering.md).
 	// Example: {"user.*": ""}
 	Config map[string]string `json:"config" yaml:"config"`
+
+	// UsedBy is a list of LXD entity URLs that reference the cluster link.
+	// Example: ["/1.0/replicators/my-replicator?project=default"]
+	//
+	// API extension: cluster_links_used_by
+	UsedBy []string `json:"used_by" yaml:"used_by"`
 }
 
 // ClusterLinkPut represents the modifiable fields of a cluster link.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -493,6 +493,7 @@ var APIExtensions = []string{
 	"oidc_device_client_id",
 	"storage_nvme_tcp",
 	"project_replica_mode",
+	"cluster_links_used_by",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5754,6 +5754,19 @@ test_clustering_replicator_basic() {
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator list --project replicator-project | grep -F 'my-replicator'
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator show my-replicator --project replicator-project
 
+  sub_test "Verify cluster link used_by field"
+
+  # Single GET reports the replicator in used_by.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/cluster/links/lxd_two" \
+    | jq --exit-status '.used_by | contains(["/1.0/replicators/my-replicator?project=replicator-project"])'
+
+  # List with recursion=1 also reports used_by.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/cluster/links?recursion=1" \
+    | jq --exit-status 'map(select(.name == "lxd_two")) | .[0].used_by | contains(["/1.0/replicators/my-replicator?project=replicator-project"])'
+
+  # Delete is blocked while a replicator references the link.
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two || false
+
   sub_test "Verify rename"
 
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator rename my-replicator my-replicator-renamed --project replicator-project


### PR DESCRIPTION
Adds a used_by field to `GET /1.0/cluster/links` (`recursion=1`) and `GET /1.0/cluster/links/{name}`, returning URLs of entities that reference the cluster link via the cluster config key (currently: replicators). Results are filtered by the caller's view permissions.

This allows the UI to determine whether a cluster link is in use and conditionally disable the delete button.

New API extension: `cluster_links_used_by`

Fixes #18416