### PR TITLE
Storage: PowerFlex 5 follow ups and PowerStore version fix

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6340,15 +6340,6 @@ Must have at least SystemAdmin role to give LXD full control over managed storag
 
 ```
 
-```{config:option} powerflex.version storage-powerflex-pool-conf
-:defaultdesc: "Discovered version"
-:scope: "global"
-:shortdesc: "Software version of the PowerFlex array."
-:type: "string"
-This field is automatically populated after querying the PowerFlex version.
-It cannot be set by the user.
-```
-
 ```{config:option} rsync.bwlimit storage-powerflex-pool-conf
 :defaultdesc: "`0` (no limit)"
 :scope: "global"
@@ -6364,6 +6355,15 @@ to be placed on the socket I/O.
 :shortdesc: "Whether to use compression while migrating storage pools"
 :type: "bool"
 
+```
+
+```{config:option} volatile.powerflex.version storage-powerflex-pool-conf
+:defaultdesc: "Discovered version"
+:scope: "global"
+:shortdesc: "Software version of the PowerFlex array."
+:type: "string"
+This field is automatically populated after querying the PowerFlex version.
+It cannot be set by the user.
 ```
 
 ```{config:option} volume.size storage-powerflex-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7021,15 +7021,6 @@
 						}
 					},
 					{
-						"powerflex.version": {
-							"defaultdesc": "Discovered version",
-							"longdesc": "This field is automatically populated after querying the PowerFlex version.\nIt cannot be set by the user.",
-							"scope": "global",
-							"shortdesc": "Software version of the PowerFlex array.",
-							"type": "string"
-						}
-					},
-					{
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
@@ -7045,6 +7036,15 @@
 							"scope": "global",
 							"shortdesc": "Whether to use compression while migrating storage pools",
 							"type": "bool"
+						}
+					},
+					{
+						"volatile.powerflex.version": {
+							"defaultdesc": "Discovered version",
+							"longdesc": "This field is automatically populated after querying the PowerFlex version.\nIt cannot be set by the user.",
+							"scope": "global",
+							"shortdesc": "Software version of the PowerFlex array.",
+							"type": "string"
 						}
 					},
 					{

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -233,11 +233,15 @@ func storagePoolDriversCacheUpdate(ctx context.Context, s *state.State) {
 	supportedDrivers := make([]api.ServerStorageDriverInfo, 0, len(info))
 
 	for _, entry := range info {
-		supportedDrivers = append(supportedDrivers, api.ServerStorageDriverInfo{
-			Name:    entry.Name,
-			Version: entry.Version,
-			Remote:  entry.Remote,
-		})
+		// If an empty version is reported by the driver that is an indicator that
+		// the driver (or its dependencies) are not available on this system.
+		if entry.Version != "" {
+			supportedDrivers = append(supportedDrivers, api.ServerStorageDriverInfo{
+				Name:    entry.Name,
+				Version: entry.Version,
+				Remote:  entry.Remote,
+			})
+		}
 
 		if slices.Contains(drivers, entry.Name) {
 			usedDrivers[entry.Name] = entry.Version

--- a/lxd/storage/connectors/connector_sdc.go
+++ b/lxd/storage/connectors/connector_sdc.go
@@ -33,9 +33,14 @@ func (c *connectorSDC) Transport() TransportType {
 	return TransportTCP
 }
 
-// Version returns an empty string and no error.
+// Version returns a non-empty string if the SDC kernel module is loaded.
 func (c *connectorSDC) Version() (string, error) {
-	return "", nil
+	ok := c.drvCfgIsSDCInstalled()
+	if !ok {
+		return "", errors.New("SDC kernel module is not loaded")
+	}
+
+	return "detected (" + TypeSDC + ")", nil
 }
 
 // drvCfgIsSDCInstalled checks if the SDC kernel module is loaded.

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -69,10 +69,9 @@ func (d *powerflex) load() error {
 	powerFlexVersion = strings.Join(versions, " / ")
 	powerFlexLoaded = true
 
-	// Load the kernel modules of the respective connector.
-	// Ignore if the modules cannot be loaded.
-	// Support for a specific connector is checked during pool creation.
-	// When a LXD host gets rebooted this ensures that the kernel modules are still loaded.
+	// Load the kernel modules of the respective connector, ignoring those that cannot be loaded.
+	// Support for a specific connector is checked during pool creation. However, this
+	// ensures that the kernel modules are loaded, even if the host has been rebooted.
 	connector, err := d.connector()
 	if err == nil {
 		_ = connector.LoadModules()

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -104,7 +104,7 @@ func (d *powerflex) isRemote() bool {
 // hasThinCloneSupport returns true if the PowerFlex system version supports thin clones.
 // This is true for all PowerFlex version starting with 5.0.
 func (d *powerflex) hasThinCloneSupport() bool {
-	powerFlexVersion, err := version.NewDottedVersion(d.config["powerflex.version"])
+	powerFlexVersion, err := version.NewDottedVersion(d.config["volatile.powerflex.version"])
 	if err != nil {
 		return false
 	}
@@ -173,8 +173,8 @@ func (d *powerflex) FillConfig() error {
 	}
 
 	// Exit if there already is a PowerFlex version set as this field gets auto-populated.
-	if d.config["powerflex.version"] != "" {
-		return errors.New(`Cannot set "powerflex.version" manually`)
+	if d.config["volatile.powerflex.version"] != "" {
+		return errors.New(`Cannot set "volatile.powerflex.version" manually`)
 	}
 
 	// Retrieve and store the PowerFlex system version.
@@ -183,7 +183,7 @@ func (d *powerflex) FillConfig() error {
 		return err
 	}
 
-	d.config["powerflex.version"] = version
+	d.config["volatile.powerflex.version"] = version
 	return nil
 }
 
@@ -328,7 +328,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  shortdesc: Size/quota of the storage volume
 		//  scope: global
 		"volume.size": validate.Optional(validate.IsMultipleOfUnit("1GiB")),
-		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.version)
+		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=volatile.powerflex.version)
 		// This field is automatically populated after querying the PowerFlex version.
 		// It cannot be set by the user.
 		// ---
@@ -336,7 +336,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  defaultdesc: Discovered version
 		//  shortdesc: Software version of the PowerFlex array.
 		//  scope: global
-		"powerflex.version": validate.Optional(validate.IsDottedVersion),
+		"volatile.powerflex.version": validate.Optional(validate.IsDottedVersion),
 	}
 
 	err := d.validatePool(config, rules, d.commonVolumeRules())
@@ -346,8 +346,8 @@ func (d *powerflex) Validate(config map[string]string) error {
 
 	// Ensure powerflex.mode cannot be changed to avoid leaving volume mappings
 	// and to prevent disturbing running instances.
-	// Ensure powerflex.version cannot be changed.
-	immutableKeys := []string{"powerflex.mode", "powerflex.version"}
+	// Ensure volatile.powerflex.version cannot be changed.
+	immutableKeys := []string{"powerflex.mode", "volatile.powerflex.version"}
 	for _, key := range immutableKeys {
 		newVal := config[key]
 		oldVal := d.config[key]

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -171,15 +171,20 @@ func (d *powerflex) FillConfig() error {
 		}
 	}
 
-	// Exit if there already is a PowerFlex version set as this field gets auto-populated.
-	if d.config["volatile.powerflex.version"] != "" {
-		return errors.New(`Cannot set "volatile.powerflex.version" manually`)
-	}
-
 	// Retrieve and store the PowerFlex system version.
 	version, err := d.client().getVersion()
 	if err != nil {
 		return err
+	}
+
+	userProvidedVersion := d.config["volatile.powerflex.version"]
+
+	// Exit if there already is a different PowerFlex version set by the user as this field gets auto-populated.
+	// This ensures we don't overwrite a user-provided value.
+	// We have to allow setting it to support creating pools in a cluster which will trigger the creation of each member
+	// using the config which is provided in the final pool create call.
+	if userProvidedVersion != "" && userProvidedVersion != version {
+		return errors.New(`Cannot set "volatile.powerflex.version" manually`)
 	}
 
 	d.config["volatile.powerflex.version"] = version

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -28,6 +28,14 @@ import (
 // factorGiB divides a byte size value into Gibibytes.
 const factorGiB = 1024 * 1024 * 1024
 
+// emptyParentUUID is used whenever we have to differentiate between a snapshot and a thin clone in PowerFlex 5.
+// A snapshot with a parent UUID will be treated as one.
+// However when unsetting its parent UUID, we treat it as a thin clone.
+// This helps when mounting snapshots as we have to create a thin clone of the respective snapshot.
+// Unlike other drivers we cannot use the "s" prefix for this use case.
+// PowerFlex 4 tracks snapshots as regular volumes (not underneath their parent vol) which required using the prefix there.
+const emptyParentUUID = ""
+
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
 func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
 	revert := revert.New()
@@ -1066,7 +1074,7 @@ func (d *powerflex) GetVolumeDiskPath(vol Volume) (string, error) {
 		// maps a temporary thin clone.
 		// Therefore ensure the snapshot's parent volume UUID is unset to indicate we are referring to the thin clone
 		// when deriving the volume name.
-		vol.SetParentUUID("")
+		vol.SetParentUUID(emptyParentUUID)
 	}
 
 	if vol.IsVMBlock() || (vol.volType == VolumeTypeCustom && IsContentBlock(vol.contentType)) {
@@ -1384,7 +1392,7 @@ func (d *powerflex) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogr
 
 	// Unset parent vol UUID to indicate thin clone.
 	// Get the new thin clone volume name.
-	snapVol.SetParentUUID("")
+	snapVol.SetParentUUID(emptyParentUUID)
 	thinCloneVolName, err := d.getVolumeName(snapVol)
 	if err != nil {
 		return err
@@ -1414,7 +1422,7 @@ func (d *powerflex) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogr
 		}
 
 		// Unset parent vol UUID to indicate thin clone.
-		snapFsVol.SetParentUUID("")
+		snapFsVol.SetParentUUID(emptyParentUUID)
 		thinCloneFsVolName, err := d.getVolumeName(snapFsVol)
 		if err != nil {
 			return err
@@ -1446,7 +1454,7 @@ func (d *powerflex) UnmountVolumeSnapshot(snapVol Volume, progressReporter iopro
 	}
 
 	// Unset parent vol UUID to indicate thin clone.
-	snapVol.SetParentUUID("")
+	snapVol.SetParentUUID(emptyParentUUID)
 
 	ourUnmount, err := d.UnmountVolume(snapVol, false, progressReporter)
 	if err != nil {
@@ -1479,7 +1487,7 @@ func (d *powerflex) UnmountVolumeSnapshot(snapVol Volume, progressReporter iopro
 		snapFsVol := snapVol.NewVMBlockFilesystemVolume()
 
 		// Unset parent vol UUID to indicate thin clone.
-		snapFsVol.SetParentUUID("")
+		snapFsVol.SetParentUUID(emptyParentUUID)
 
 		snapFsVolName, err := d.getVolumeName(snapFsVol)
 		if err != nil {

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -58,7 +58,10 @@ func (d *powerstore) load() error {
 		return nil
 	}
 
+	versions := connectors.GetSupportedVersions(powerStoreSupportedConnectors)
+	powerStoreVersion = strings.Join(versions, " / ")
 	powerStoreLoaded = true
+
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -62,6 +62,14 @@ func (d *powerstore) load() error {
 	powerStoreVersion = strings.Join(versions, " / ")
 	powerStoreLoaded = true
 
+	// Load the kernel modules of the respective connector, ignoring those that cannot be loaded.
+	// Support for a specific connector is checked during pool creation. However, this
+	// ensures that the kernel modules are loaded, even if the host has been rebooted.
+	connector, err := d.connector()
+	if err == nil {
+		_ = connector.LoadModules()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For PowerFlex the PR addresses some open comments in https://github.com/canonical/lxd/pull/18391 and some learnings from https://github.com/canonical/lxd/pull/18333.
Also it ensures PowerFlex pools can be created in clusters (there was an issue around the new `volatile.powerflex.version` key).

In addition this includes support in PowerStore to actually populate the version of the connectors. 
Furthermore if a driver doesn't support any version, we should not display it in the list of supported drivers if none of its connectors returns a valid version:

```
lxc info
...
storage_supported_drivers:
    - name: powerstore
      version: ""
      remote: true
...
```

That PR concludes PF5 tests (also in clusters).
