### PR TITLE
shared/util: include `stdout` along with `stderr` on exec failures

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -994,11 +994,22 @@ type RunError struct {
 }
 
 func (e RunError) Error() string {
-	if e.stderr.Len() == 0 {
-		return fmt.Sprintf("Failed running: %s %s: %v", e.cmd, strings.Join(e.args, " "), e.err)
+	hasStdout := e.stdout != nil && e.stdout.Len() > 0
+	hasStderr := e.stderr.Len() > 0
+
+	if hasStdout && hasStderr {
+		return fmt.Sprintf("Failed running: %s %s: %v (%s) (%s)", e.cmd, strings.Join(e.args, " "), e.err, strings.TrimSpace(e.stdout.String()), strings.TrimSpace(e.stderr.String()))
 	}
 
-	return fmt.Sprintf("Failed running: %s %s: %v (%s)", e.cmd, strings.Join(e.args, " "), e.err, strings.TrimSpace(e.stderr.String()))
+	if hasStdout {
+		return fmt.Sprintf("Failed running: %s %s: %v (%s)", e.cmd, strings.Join(e.args, " "), e.err, strings.TrimSpace(e.stdout.String()))
+	}
+
+	if hasStderr {
+		return fmt.Sprintf("Failed running: %s %s: %v (%s)", e.cmd, strings.Join(e.args, " "), e.err, strings.TrimSpace(e.stderr.String()))
+	}
+
+	return fmt.Sprintf("Failed running: %s %s: %v", e.cmd, strings.Join(e.args, " "), e.err)
 }
 
 func (e RunError) Unwrap() error {


### PR DESCRIPTION
In practice this looks like this:

```
+ lxc restore v1 snap0
Error: Failed restoring snapshot rootfs: Error resizing LV snapshot named "/dev/vmpool-lvm-72055/virtual-machines_v1-snap0": Failed running: lvresize -l +100%ORIGIN -f /dev/vmpool-lvm-72055/virtual-machines_v1-snap0: exit status 5 (Reached maximum COW size 104.00 MiB (26 extents).) (Command failed with status code 5.)
```