### PR TITLE
doc: update RTD project and restore "edit this page" button (stable-5.21)

### DIFF
--- a/doc/_static/js/overwrite_links.js
+++ b/doc/_static/js/overwrite_links.js
@@ -1,5 +1,5 @@
- // Replace oldDomain with newDomain
- const oldDomain = 'canonical-lxd-documentation.readthedocs-hosted.com';
+ // Replaces oldDomain with newDomain in relevant anchor tags
+ const oldDomain = 'canonical-lxd.readthedocs-hosted.com';
  const newDomain = 'canonical.com/lxd/docs';
 
  function escapeRegExp(value) {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,9 +112,9 @@ html_context = {
 html_extra_path = ['_extra']
 
 # Enables the pencil icon to edit pages on GitHub, shown at the top of each page
-# html_theme_options = {
-#     'source_edit_link': html_context['github_url']
-# }
+html_theme_options = {
+    'source_edit_link': html_context['github_url']
+}
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/


### PR DESCRIPTION
This PR advances the documentation migration to `canonical.com/lxd/docs` by updating the RTD project URL and restoring the "edit this page" button.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
