### PR TITLE
doc: update RTD project URL (stable-5.0)

### DIFF
--- a/doc/.sphinx/_static/js/overwrite_links.js
+++ b/doc/.sphinx/_static/js/overwrite_links.js
@@ -1,5 +1,5 @@
- // Replace oldDomain with newDomain
- const oldDomain = 'canonical-lxd-documentation.readthedocs-hosted.com';
+ // Replaces oldDomain with newDomain in relevant anchor tags
+ const oldDomain = 'canonical-lxd.readthedocs-hosted.com';
  const newDomain = 'canonical.com/lxd/docs';
 
  function escapeRegExp(value) {


### PR DESCRIPTION
This PR advances the documentation migration to `canonical.com/lxd/docs` by updating the RTD project URL.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
