### PR TITLE
lxd/api_replicators: Prevent duplicate replicators targeting same cluster link

### DIFF
--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -83,6 +83,8 @@ If a target cluster is unreachable, promotion still proceeds to allow disaster r
 
 After configuring the projects on both clusters, create a replicator on the leader cluster. The `cluster` configuration key is required and must be set to the name of an existing cluster link.
 
+Each cluster link can be targeted by at most one replicator per project. Creating or updating a replicator to target a cluster link already used by another replicator in the same project fails with a conflict error.
+
 ```bash
 lxc replicator create <replicator_name> cluster=<standby_cluster_link_name> --project <project_name>
 ```

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -406,6 +406,38 @@ func replicatorValidateConfig(ctx context.Context, s *state.State, config map[st
 	return nil
 }
 
+// replicatorCheckClusterLinkUnique returns an error if another replicator in the given project
+// already targets the given cluster link. excludeID should be the ID of the replicator being
+// updated, or 0 when creating a new replicator.
+func replicatorCheckClusterLinkUnique(ctx context.Context, tx *db.ClusterTx, projectName string, clusterLinkName string, excludeID int64) error {
+	replicators, _, err := dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, nil)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]int64, 0, len(replicators))
+	for _, replicator := range replicators {
+		ids = append(ids, replicator.Row.ID)
+	}
+
+	allConfigs, err := dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), ids...)
+	if err != nil {
+		return fmt.Errorf("Failed loading replicator configs: %w", err)
+	}
+
+	for _, replicator := range replicators {
+		if replicator.Row.ID == excludeID {
+			continue
+		}
+
+		if allConfigs[replicator.Row.ID]["cluster"] == clusterLinkName {
+			return api.StatusErrorf(http.StatusConflict, "A replicator targeting cluster link %q already exists in project %q", clusterLinkName, projectName)
+		}
+	}
+
+	return nil
+}
+
 // swagger:operation POST /1.0/replicators replicators replicators_post
 //
 //	Add a replicator
@@ -466,6 +498,11 @@ func replicatorsPost(d *Daemon, r *http.Request) response.Response {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
 			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		err = replicatorCheckClusterLinkUnique(ctx, tx, projectName, req.Config["cluster"], 0)
+		if err != nil {
+			return err
 		}
 
 		id, err := dbCluster.CreateReplicator(ctx, tx.Tx(), dbCluster.ReplicatorRow{
@@ -729,6 +766,11 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 	}
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = replicatorCheckClusterLinkUnique(ctx, tx, projectName, req.Config["cluster"], dbReplicator.Row.ID)
+		if err != nil {
+			return err
+		}
+
 		if !isPatch || req.Description != "" {
 			dbReplicator.Row.Description = req.Description
 		}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5786,6 +5786,14 @@ test_clustering_replicator_basic() {
   printf 'description: "Updated description"\nconfig:\n  cluster: lxd_two\n' | LXD_DIR="${LXD_ONE_DIR}" lxc replicator edit my-replicator --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator show my-replicator --project replicator-project | grep -F 'Updated description'
 
+  sub_test "Verify duplicate cluster link target is rejected"
+
+  # Creating a second replicator in the same project that targets the same cluster link must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator-2 cluster=lxd_two --project replicator-project 2>&1)" = 'Error: A replicator targeting cluster link "lxd_two" already exists in project "replicator-project"' ]
+
+  # Re-saving the existing replicator with its own unchanged cluster link must still succeed (no false positive).
+  printf 'description: "Updated description"\nconfig:\n  cluster: lxd_two\n' | LXD_DIR="${LXD_ONE_DIR}" lxc replicator edit my-replicator --project replicator-project
+
   sub_test "Verify direct instance creation is blocked in standby project"
 
   if CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c1-standby-bypass --project replicator-project 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Reject creating or updating a replicator if another replicator in the same project already targets the same cluster link (returns a 409 Conflict)
- Add integration test coverage for the new validation in `test_clustering_replicator_basic`
- Document the one-replicator-per-cluster-link-per-project constraint in the replicator setup guide

## Test plan
- [x] `lxc replicator create` rejects a second replicator in the same project targeting an already-used cluster link
- [x] Re-saving an existing replicator with its own unchanged cluster link still succeeds (no false positive)