### PR TITLE
doc: direct users to information related to cryptography

### DIFF
--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -185,6 +185,11 @@ In a production environment, you can forward security events to a centralized lo
 
 For detailed information on monitoring and configuring security events, see {ref}`howto-security-events`.
 
+(security-cryptography)=
+## Cryptography
+
+LXD uses cryptographic technologies to authenticate, encrypt, and decrypt communication between servers, and to verify images copied from remote servers. For details, see {ref}`authentication` and {ref}`about-images`, as well as the guides to common operations related to {ref}`lxd-server` and {ref}`images`.
+
 ## Related topics
 
 {{security_how}}
@@ -192,3 +197,4 @@ For detailed information on monitoring and configuring security events, see {ref
 Explanation:
 
 - {ref}`authentication`
+- {ref}`about-images`

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -58,16 +58,13 @@ The root user and all members of the `lxd` group can interact with the local dae
 (security_remote_access)=
 ### Access to the remote API
 
-By default, access to the daemon is only possible locally.
-By setting the {config:option}`server-core:core.https_address` configuration option, you can expose the same API over the network on a {abbr}`TLS (Transport Layer Security)` socket.
-See {ref}`server-expose` for instructions.
+By default, access to the daemon is only possible locally, but you can also {ref}`expose LXD to the network <server-expose>` on a {abbr}`TLS` (Transport Layer Security) socket. 
 Remote clients can then connect to LXD and access any image that is marked for public use.
 
 There are several ways to authenticate remote clients as trusted clients to allow them to access the API.
 See {ref}`authentication` for details.
+To increase your security posture in a production setup, you can also {ref}`harden remote API access <howto-security-harden-remote>` and {ref}`configure your firewall <network-bridge-firewall>`.
 
-In a production setup, you should set {config:option}`server-core:core.https_address` to the single address where the server should be available (rather than any address on the host).
-In addition, you should set firewall rules to allow access to the LXD port only from authorized hosts/subnets.
 
 (container-security)=
 ## Container security


### PR DESCRIPTION
This PR aims to fulfill SSDLC requirements by helping users to find documentation related to cryptography.

Relevant information was already available in the documentation, particularly in the explanation pages on "Remote API authentication" and "Local and remote images," as well as the "LXD server and client" guides, the "Images" guides, and the "How to harden security for LXD" guide.

This PR aims to assist users searching for information on cryptographic technologies by adding a "Cryptography" section to the "Security" explanation with a concise description of relevant topics combined with useful cross references.

Similar information was also already available in the "Security" explanation in the section on "Access to the remote API." In order to focus this explanation page on high-level information, rather than "how-to" instructions, this PR also removes some of instructions from that section (e.g. use `core.https_address`, use a single address, etc.), and instead directs users to instructions in relevant how-to guides.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
