### PR TITLE
Fix zfs storage leak after shutdown due to lingering forkfile daemon …

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1895,7 +1895,7 @@ func (d *lxc) startCommon(ctx context.Context, progressReporter ioprogress.Progr
 	// Wait for any file operations to complete.
 	// This is to avoid having an active mount by forkfile and so all file operations
 	// from this point will use the container's namespace rather than a chroot.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	// Mount instance root volume.
 	mountInfo, err := d.mount()
@@ -2615,7 +2615,7 @@ func (d *lxc) Stop(ctx context.Context, stateful bool) error {
 	}
 
 	// Forcefully stop any forkfile process if running.
-	d.stopForkfile(true)
+	d.StopForkFile(true)
 
 	// Release liblxc container once done.
 	defer func() {
@@ -2897,7 +2897,7 @@ func (d *lxc) onStop(ctx context.Context, args map[string]string) error {
 
 		// Wait for any file operations to complete.
 		// This is to required so we can actually unmount the container.
-		d.stopForkfile(false)
+		d.StopForkFile(false)
 
 		// Clean up devices.
 		d.cleanupDevices(false, "")
@@ -3352,7 +3352,7 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface, opts ...instance.State
 // snapshot creates a snapshot of the instance.
 func (d *lxc) snapshot(ctx context.Context, name string, expiry *time.Time, diskVolumesMode string, progressReporter ioprogress.ProgressReporter) error {
 	// Wait for any file operations to complete to have a more consistent snapshot.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	return d.snapshotCommon(ctx, d, name, expiry, false, diskVolumesMode, progressReporter)
 }
@@ -3390,7 +3390,7 @@ func (d *lxc) Restore(ctx context.Context, sourceContainer instance.Instance, st
 
 	// Wait for any file operations to complete.
 	// This is required so we can actually unmount the container and restore its rootfs.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	wasRunning, op, err := d.restoreCommon(ctx, d, sourceContainer, diskVolumesMode, progressReporter)
 	if err != nil {
@@ -3457,7 +3457,7 @@ func (d *lxc) delete(ctx context.Context, force bool) error {
 	// Wait for any file operations to complete.
 	// This is required so we can actually unmount the container and delete it.
 	if !d.IsSnapshot() {
-		d.stopForkfile(false)
+		d.StopForkFile(false)
 	}
 
 	// Delete any persistent warnings for instance.
@@ -3576,7 +3576,7 @@ func (d *lxc) Rename(ctx context.Context, newName string, applyTemplateTrigger b
 	// race with the unmount and fail. Snapshots cannot have file operations
 	// in flight, so this is not required for them.
 	if !d.IsSnapshot() {
-		d.stopForkfile(false)
+		d.StopForkFile(false)
 	}
 
 	// Clean things up.
@@ -5982,8 +5982,8 @@ func (d *lxc) FileSFTPNoLock() (*sftp.Client, error) {
 	return d.fileSFTPConnToClient(conn)
 }
 
-// stopForkFile attempts to send SIGTERM (if force is true) or SIGINT to forkfile then waits for it to exit.
-func (d *lxc) stopForkfile(force bool) {
+// StopForkFile attempts to send SIGTERM (if force is true) or SIGINT to forkfile then waits for it to exit.
+func (d *lxc) StopForkFile(force bool) {
 	// Make sure that when the function exits, no forkfile is running by acquiring the lock (which indicates
 	// that forkfile isn't running and holding the lock) and then releasing it.
 	defer func() {
@@ -6999,7 +6999,7 @@ func (d *lxc) LockExclusive() (*operationlock.InstanceOperation, error) {
 	}
 
 	// Stop forkfile as otherwise it will hold the root volume open preventing unmount.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	return op, err
 }

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -200,6 +200,7 @@ type Container interface {
 	DevptsFd() (*os.File, error)
 	FileSFTPNoLock() (*sftp.Client, error)
 	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
+	StopForkFile(force bool)
 }
 
 // VM interface is for VM specific functions.

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -539,6 +539,13 @@ func instancesShutdown(ctx context.Context, instances []instance.Instance) {
 	for i, inst := range instances {
 		// Skip stopped instances.
 		if !inst.IsRunning() {
+			// Stopped containers could still have a forkfile daemon running which could make
+			// the storage busy, causing unmount to fail, so make sure it is stopped.
+			c, isContainer := inst.(instance.Container)
+			if isContainer {
+				c.StopForkFile(true)
+			}
+
 			continue
 		}
 

--- a/test/includes/check.sh
+++ b/test/includes/check.sh
@@ -73,6 +73,32 @@ check_log_presence() {
   fi
 }
 
+# check_log_absence checks that specific messages do not appear in a log file.
+# The order in which the reference messages are given does not matter.
+check_log_absence() {
+  local logfile="$1"
+  shift
+  local unexpected_messages=("$@")
+
+  local none_found=true
+  for message in "${unexpected_messages[@]}"; do
+    if grep -qF "$message" "$logfile"; then
+      echo "ERROR: Found unexpected message: '$message'"
+      none_found=false
+    else
+      echo "Confirmed absent message: '$message'"
+    fi
+  done
+
+  if [ "$none_found" = "true" ]; then
+    echo "Log file check completed. No unexpected messages found."
+    return 0
+  else
+    echo "Log file check completed with errors. Unexpected messages found."
+    return 1
+  fi
+}
+
 # check_log_order checks for specific messages in a log file and validates their order.
 # * The matching priorities are in the following order:
 #   1. Unix nano timestamps (timestamp=<unix_nano>)

--- a/test/suites/shutdown.sh
+++ b/test/suites/shutdown.sh
@@ -677,4 +677,54 @@ test_shutdown() {
     lxc storage volume delete mypool backups
     lxc storage volume delete mypool images
     lxc storage delete mypool
+
+    scenario_name="scenario10"
+    echo "$scenario_name"
+    echo "- LXD shutdown sequence with a stopped instance that has a lingering forkfile daemon."
+    echo "- The forkfile daemon was started by a file operation on the stopped instance and"
+    echo "  keeps the instance's storage volume mounted/busy for a short while afterwards."
+    echo "Expected behavior: LXD should stop the lingering forkfile daemon before unmounting"
+    echo "storage pools so that they can be unmounted cleanly and are not left mounted/orphaned."
+    echo "----------------------------------------------------------"
+
+    if [ "$lxd_backend" != "zfs" ]; then
+        echo "Skipping $scenario_name: zpool export only applies to the zfs storage driver."
+    else
+        lxc init testimage i1
+
+        # Performing a file operation on a stopped instance makes LXD mount the instance's
+        # storage volume and spawn a forkfile daemon that keeps it mounted for a while afterwards.
+        echo "test" | lxc file push -q - i1/root/forkfile-test
+
+        lxd_shutdown_restart "${scenario_name}"
+
+        expected_msgs=(
+            'Starting shutdown sequence'
+            'Stopping daemon storage volumes'
+            'Daemon storage volumes unmounted'
+            'Operations deleted from the database'
+            'Closing the database'
+        )
+        if ! check_log_presence "$scenario_name.log" "${expected_msgs[@]}"; then
+            echo "Failed to find expected messages in the log file."
+            exit 1
+        fi
+
+        # The lingering forkfile daemon must be stopped before storage pools are unmounted,
+        # otherwise unmounting/exporting the pool fails because the instance's volume is still
+        # busy, which can leave the pool mounted/orphaned after shutdown.
+        unexpected_msgs=(
+            'Cannot unmount storage pool'
+            'Failed running: zpool export'
+            'pool or dataset is busy'
+        )
+        if ! check_log_absence "$scenario_name.log" "${unexpected_msgs[@]}"; then
+            echo "Storage pool failed to unmount because of a lingering forkfile daemon."
+            exit 1
+        fi
+
+        # Cleanup
+        lxc delete -f i1
+        rm "$scenario_name.log"
+    fi
 }


### PR DESCRIPTION
…(canonical#18362)

## Testing done

1. Using the repro stated in https://github.com/canonical/lxd/issues/18362
2. Using the new test added in this commit, w/o the fix, the new test fails, with the fix, the new test passes. (`LXD_BACKEND=zfs; ./main.sh shutdown`)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
