### PR TITLE
Refactor operation construction and GET API handlers

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -242,7 +242,7 @@ func projectUsedByMap(ctx context.Context, tx *sql.Tx, projectName string) (map[
 		entity.TypeReplicator,
 	}
 
-	entityURLs, err := dbCluster.GetEntityURLs(ctx, tx, projectName, reportedEntityTypes...)
+	entityURLs, err := dbCluster.GetEntityURLsByProjectAndType(ctx, tx, projectName, reportedEntityTypes...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting project used-by URLs: %w", err)
 	}

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -235,12 +235,12 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 		return nil, fmt.Errorf("Could not get entity URL: Unknown entity type %q", entityType)
 	}
 
-	stmt := info.urlByIDQuery()
+	stmt := info.urlsByIDsQuery(int64(entityID))
 	if stmt == "" {
 		return nil, fmt.Errorf("Could not get entity URL: No statement found for entity type %q", entityType)
 	}
 
-	row := tx.QueryRowContext(ctx, stmt, entityID)
+	row := tx.QueryRowContext(ctx, stmt)
 	entityRef := &EntityRef{}
 	err := entityRef.scan(row.Scan)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -252,11 +252,11 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 	return entityRef.URL(), nil
 }
 
-// GetEntityURLs accepts a project name and a variadic of entity types and returns a map of entity.Type to map of entity ID, to *api.URL.
+// GetEntityURLsByProjectAndType accepts a project name and a variadic of entity types and returns a map of entity.Type to map of entity ID, to *api.URL.
 // This method combines the above queries into a single query using the UNION operator. If no entity types are given, this function will
 // return URLs for all entity types. If no project name is given, this function will return URLs for all projects. This may result in
 // stupendously large queries, so use with caution!
-func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, filteringEntityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) {
+func GetEntityURLsByProjectAndType(ctx context.Context, tx *sql.Tx, projectName string, filteringEntityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) {
 	var stmts []string
 	var args []any
 	result := make(map[entity.Type]map[int]*api.URL)

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -53,8 +53,8 @@ type entityTypeDBInfo interface {
 	allURLsQuery() string
 
 	// urlByIDQuery must return a SQL query that when executed, returns values identically to allURLsQuery. The query
-	// must accept a single integer bind argument for the ID of the resource.
-	urlByIDQuery() string
+	// must contain an "IN" clause containing the given ids. It does not accept any bind parameters.
+	urlsByIDsQuery(ids ...int64) string
 
 	// urlsByProjectQuery must return a SQL query that when executed, returns values identically to allURLsQuery. The
 	// query must accept a single string bind argument for the project name.

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -361,6 +361,55 @@ func GetEntityURLsByProjectAndType(ctx context.Context, tx *sql.Tx, projectName 
 	return result, nil
 }
 
+// GetEntityURLsByEntityTypeAndID performs a single query to return entity URLs for many different entity types and IDs.
+// It effectively converts the input map of entity type to list of IDs to a map of entity type to map of ID to URL.
+func GetEntityURLsByEntityTypeAndID(ctx context.Context, tx *sql.Tx, entities map[entity.Type][]int64) (map[entity.Type]map[int64]*api.URL, error) {
+	result := make(map[entity.Type]map[int64]*api.URL)
+	stmts := make([]string, 0, len(entities))
+	for entityType, ids := range entities {
+		if entityType == entity.TypeServer {
+			result[entity.TypeServer] = map[int64]*api.URL{0: entity.ServerURL()}
+			continue
+		}
+
+		info, ok := entityTypes[entityType]
+		if !ok {
+			return nil, fmt.Errorf("Could not get entity URL: Unknown entity type %q", entityType)
+		}
+
+		stmt := info.urlsByIDsQuery(ids...)
+		if stmt == "" {
+			return nil, fmt.Errorf("Could not get entity URL: No statement found for entity type %q", entityType)
+		}
+
+		stmts = append(stmts, stmt)
+		result[entityType] = make(map[int64]*api.URL)
+	}
+
+	// If there were only server entities, then there's nothing left to do.
+	if len(stmts) == 0 {
+		return result, nil
+	}
+
+	// Join into a single statement with UNION and query.
+	stmt := strings.Join(stmts, " UNION ")
+	err := query.Scan(ctx, tx, stmt, func(scan func(dest ...any) error) error {
+		entityRef := &EntityRef{}
+		err := entityRef.scan(scan)
+		if err != nil {
+			return fmt.Errorf("Failed scanning entity URL: %w", err)
+		}
+
+		result[entity.Type(entityRef.EntityType)][int64(entityRef.EntityID)] = entityRef.URL()
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed performing entity URL query: %w", err)
+	}
+
+	return result, nil
+}
+
 // PopulateEntityReferencesFromURLs populates the values in the given map with entity references corresponding to the api.URL keys.
 // It will return an error if any of the given URLs do not correspond to a LXD entity.
 func PopulateEntityReferencesFromURLs(ctx context.Context, tx *sql.Tx, entityURLMap map[*api.URL]*EntityRef) error {

--- a/lxd/db/cluster/entities_test.go
+++ b/lxd/db/cluster/entities_test.go
@@ -26,7 +26,7 @@ func TestEntityStatementValidity(t *testing.T) {
 	}
 
 	for entityType, info := range entityTypes {
-		urlByIDQuery := info.urlByIDQuery()
+		urlByIDQuery := info.urlsByIDsQuery(1)
 		if urlByIDQuery == "" {
 			continue
 		}
@@ -52,7 +52,7 @@ func TestEntityStatementValidity(t *testing.T) {
 		}
 
 		for middleEntityType, middleEntityInfo := range entityTypes {
-			middleQuery := middleEntityInfo.urlByIDQuery()
+			middleQuery := middleEntityInfo.urlsByIDsQuery(1)
 			if middleQuery == "" {
 				continue
 			}

--- a/lxd/db/cluster/entity_type_auth_group.go
+++ b/lxd/db/cluster/entity_type_auth_group.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeAuthGroup implements entityTypeDBInfo for an AuthGroup.
@@ -17,8 +19,8 @@ func (e entityTypeAuthGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, auth_groups.id, '', '', json_array(auth_groups.name) FROM auth_groups`, e.code())
 }
 
-func (e entityTypeAuthGroup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE auth_groups.id = ?"
+func (e entityTypeAuthGroup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE auth_groups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeAuthGroup) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_certificate.go
+++ b/lxd/db/cluster/entity_type_certificate.go
@@ -35,8 +35,8 @@ func (e entityTypeCertificate) allURLsQuery() string {
 		query.IntParams(certIdentityTypes()...))
 }
 
-func (e entityTypeCertificate) urlByIDQuery() string {
-	return e.allURLsQuery() + " AND identities.id = ?"
+func (e entityTypeCertificate) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " AND identities.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeCertificate) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeClusterGroup implements entityTypeDBInfo for a ClusterGroup.
@@ -17,8 +19,8 @@ func (e entityTypeClusterGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, cluster_groups.id, '', '', json_array(cluster_groups.name) FROM cluster_groups`, e.code())
 }
 
-func (e entityTypeClusterGroup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE cluster_groups.id = ?"
+func (e entityTypeClusterGroup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE cluster_groups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeClusterGroup) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_cluster_link.go
+++ b/lxd/db/cluster/entity_type_cluster_link.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeClusterLink implements entityTypeDBInfo for a [ClusterLinkRow].
@@ -21,8 +23,8 @@ func (e entityTypeClusterLink) urlsByProjectQuery() string {
 	return ""
 }
 
-func (e entityTypeClusterLink) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE cluster_links.id = ?"
+func (e entityTypeClusterLink) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE cluster_links.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeClusterLink) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_cluster_member.go
+++ b/lxd/db/cluster/entity_type_cluster_member.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeClusterMember implements entityTypeDBInfo for a ClusterMember.
@@ -17,8 +19,8 @@ func (e entityTypeClusterMember) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, nodes.id, '', '', json_array(nodes.name) FROM nodes`, e.code())
 }
 
-func (e entityTypeClusterMember) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE nodes.id = ?"
+func (e entityTypeClusterMember) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE nodes.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeClusterMember) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_common.go
+++ b/lxd/db/cluster/entity_type_common.go
@@ -18,7 +18,7 @@ func (e entityTypeCommon) urlsByProjectQuery() string {
 }
 
 // urlByIDQuery returns empty because not all entityTypeDBInfo implementations have one (see entityTypeServer).
-func (e entityTypeCommon) urlByIDQuery() string {
+func (e entityTypeCommon) urlsByIDsQuery(...int64) string {
 	return ""
 }
 

--- a/lxd/db/cluster/entity_type_container.go
+++ b/lxd/db/cluster/entity_type_container.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 )
 
@@ -28,8 +29,8 @@ func (e entityTypeContainer) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " AND projects.name = ?"
 }
 
-func (e entityTypeContainer) urlByIDQuery() string {
-	return e.allURLsQuery() + " AND instances.id = ?"
+func (e entityTypeContainer) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " AND instances.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeContainer) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -48,8 +48,8 @@ WHERE type IN %s`,
 		query.IntParams(e.identityTypes()...))
 }
 
-func (e entityTypeIdentity) urlByIDQuery() string {
-	return e.allURLsQuery() + " AND identities.id = ?"
+func (e entityTypeIdentity) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " AND identities.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeIdentity) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_identity_provider_group.go
+++ b/lxd/db/cluster/entity_type_identity_provider_group.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeIdentityProviderGroup implements entityTypeDBInfo for an IdentityProviderGroup.
@@ -17,8 +19,8 @@ func (e entityTypeIdentityProviderGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, identity_provider_groups.id, '', '', json_array(identity_provider_groups.name) FROM identity_provider_groups`, e.code())
 }
 
-func (e entityTypeIdentityProviderGroup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE identity_provider_groups.id = ?"
+func (e entityTypeIdentityProviderGroup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE identity_provider_groups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeIdentityProviderGroup) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_image.go
+++ b/lxd/db/cluster/entity_type_image.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeImage implements entityTypeDBInfo for an Image.
@@ -24,8 +26,8 @@ func (e entityTypeImage) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeImage) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE images.id = ?"
+func (e entityTypeImage) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE images.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeImage) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_image_alias.go
+++ b/lxd/db/cluster/entity_type_image_alias.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeImageAlias implements entityTypeDBInfo for an ImageAlias.
@@ -24,8 +26,8 @@ func (e entityTypeImageAlias) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeImageAlias) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE images_aliases.id = ?"
+func (e entityTypeImageAlias) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE images_aliases.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeImageAlias) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeInstance implements entityTypeDBInfo for an Instance.
@@ -24,8 +26,8 @@ func (e entityTypeInstance) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeInstance) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE instances.id = ?"
+func (e entityTypeInstance) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE instances.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeInstance) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeInstanceBackup implements entityTypeDBInfo for an InstanceBackup.
@@ -30,8 +32,8 @@ func (e entityTypeInstanceBackup) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeInstanceBackup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE instances_backups.id = ?"
+func (e entityTypeInstanceBackup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE instances_backups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeInstanceBackup) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_instance_snapshot.go
+++ b/lxd/db/cluster/entity_type_instance_snapshot.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeInstanceSnapshot implements entityTypeDBInfo for an InstanceSnapshot.
@@ -25,8 +27,8 @@ func (e entityTypeInstanceSnapshot) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeInstanceSnapshot) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE projects.name = ?"
+func (e entityTypeInstanceSnapshot) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE instances_snapshots.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeInstanceSnapshot) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_network.go
+++ b/lxd/db/cluster/entity_type_network.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeNetwork implements entityTypeDBInfo for a Network.
@@ -24,8 +26,8 @@ func (e entityTypeNetwork) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeNetwork) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE networks.id = ?"
+func (e entityTypeNetwork) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE networks.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeNetwork) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_network_acl.go
+++ b/lxd/db/cluster/entity_type_network_acl.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeNetworkACL implements entityTypeDBInfo for a NetworkACL.
@@ -24,8 +26,8 @@ func (e entityTypeNetworkACL) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeNetworkACL) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE networks_acls.id = ?"
+func (e entityTypeNetworkACL) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE networks_acls.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeNetworkACL) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_network_zone.go
+++ b/lxd/db/cluster/entity_type_network_zone.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeNetworkZone implements entityTypeDBInfo for a NetworkZone.
@@ -24,8 +26,8 @@ func (e entityTypeNetworkZone) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeNetworkZone) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE networks_zones.id = ?"
+func (e entityTypeNetworkZone) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE networks_zones.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeNetworkZone) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_placement_group.go
+++ b/lxd/db/cluster/entity_type_placement_group.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"strconv"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypePlacementGroup implements [entityTypeDBInfo] for an [api.PlacementGroup].
@@ -26,8 +28,8 @@ JOIN projects ON projects.id = placement_groups.project_id
 `
 }
 
-func (e entityTypePlacementGroup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE placement_groups.id = ?"
+func (e entityTypePlacementGroup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE placement_groups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypePlacementGroup) urlsByProjectQuery() string {

--- a/lxd/db/cluster/entity_type_profile.go
+++ b/lxd/db/cluster/entity_type_profile.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeProfile implements entityTypeDBInfo for a Profile.
@@ -24,8 +26,8 @@ func (e entityTypeProfile) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeProfile) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE profiles.id = ?"
+func (e entityTypeProfile) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE profiles.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeProfile) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_project.go
+++ b/lxd/db/cluster/entity_type_project.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeProject implements entityTypeDBInfo for a Project.
@@ -21,8 +23,8 @@ func (e entityTypeProject) urlsByProjectQuery() string {
 	return ""
 }
 
-func (e entityTypeProject) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE id = ?"
+func (e entityTypeProject) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE projects.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeProject) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_replicator.go
+++ b/lxd/db/cluster/entity_type_replicator.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeReplicator implements entityTypeDBInfo for a Replicator.
@@ -24,8 +26,8 @@ func (e entityTypeReplicator) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeReplicator) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE replicators.id = ?"
+func (e entityTypeReplicator) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE replicators.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeReplicator) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_storage_bucket.go
+++ b/lxd/db/cluster/entity_type_storage_bucket.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeStorageBucket implements entityTypeDBInfo for a StorageBucket.
@@ -28,8 +30,8 @@ func (e entityTypeStorageBucket) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeStorageBucket) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE storage_buckets.id = ?"
+func (e entityTypeStorageBucket) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE storage_buckets.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeStorageBucket) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_storage_pool.go
+++ b/lxd/db/cluster/entity_type_storage_pool.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeStoragePool implements entityTypeDBInfo for a StoragePool.
@@ -17,8 +19,8 @@ func (e entityTypeStoragePool) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, storage_pools.id, '', '', json_array(storage_pools.name) FROM storage_pools`, e.code())
 }
 
-func (e entityTypeStoragePool) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE storage_pools.id = ?"
+func (e entityTypeStoragePool) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE storage_pools.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeStoragePool) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_storage_volume.go
+++ b/lxd/db/cluster/entity_type_storage_volume.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeStorageVolume implements entityTypeDBInfo for a StorageVolume.
@@ -47,8 +49,8 @@ func (e entityTypeStorageVolume) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeStorageVolume) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE storage_volumes.id = ?"
+func (e entityTypeStorageVolume) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE storage_volumes.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeStorageVolume) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_storage_volume_backup.go
+++ b/lxd/db/cluster/entity_type_storage_volume_backup.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeStorageVolumeBackup implements entityTypeDBInfo for a StorageVolumeBackup.
@@ -49,8 +51,8 @@ func (e entityTypeStorageVolumeBackup) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeStorageVolumeBackup) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE storage_volumes_backups.id = ?"
+func (e entityTypeStorageVolumeBackup) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE storage_volumes_backups.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeStorageVolumeBackup) idFromURLQuery() string {

--- a/lxd/db/cluster/entity_type_storage_volume_snapshot.go
+++ b/lxd/db/cluster/entity_type_storage_volume_snapshot.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/db/query"
 )
 
 // entityTypeStorageVolumeSnapshot implements entityTypeDBInfo for a StorageVolumeSnapshot.
@@ -49,8 +51,8 @@ func (e entityTypeStorageVolumeSnapshot) urlsByProjectQuery() string {
 	return e.allURLsQuery() + " WHERE projects.name = ?"
 }
 
-func (e entityTypeStorageVolumeSnapshot) urlByIDQuery() string {
-	return e.allURLsQuery() + " WHERE storage_volumes_snapshots.id = ?"
+func (e entityTypeStorageVolumeSnapshot) urlsByIDsQuery(ids ...int64) string {
+	return e.allURLsQuery() + " WHERE storage_volumes_snapshots.id IN " + query.IntParams(ids...)
 }
 
 func (e entityTypeStorageVolumeSnapshot) idFromURLQuery() string {

--- a/lxd/db/cluster/generated.go
+++ b/lxd/db/cluster/generated.go
@@ -715,6 +715,63 @@ func (o *Operation) ScanArgs() []any {
 	return []any{&o.Row.ID, &o.Row.UUID, &o.Row.NodeID, &o.Row.Type, &o.Row.ProjectID, &o.Row.RequestorProtocol, &o.Row.RequestorIdentityID, &o.Row.EntityID, &o.Row.Metadata, &o.Row.Class, &o.Row.CreatedAt, &o.Row.UpdatedAt, &o.Row.Inputs, &o.Row.StatusCode, &o.Row.Error, &o.Row.ConflictReference, &o.Row.Parent, &o.Row.Stage, &o.Row.ErrorCode, &o.ProjectName, &o.NodeAddress, &o.NodeName, &o.IdentityIdentifier}
 }
 
+// TableName returns the table name for [OperationsResourcesRow] entities.
+func (o OperationsResourcesRow) TableName() string {
+	return "operations_resources"
+}
+
+// SelectColumns returns a slice of column names for [OperationsResourcesRow] entities.
+func (o OperationsResourcesRow) SelectColumns() []string {
+	return []string{
+		"operations_resources.operation_id",
+		"operations_resources.entity_id",
+		"operations_resources.entity_type",
+	}
+}
+
+// Joins returns a slice of join expressions for [OperationsResourcesRow].
+func (o OperationsResourcesRow) Joins() []string {
+	return []string{}
+}
+
+// ScanArgs implements [query.ScanArger] for [OperationsResourcesRow].
+// This returns references to struct fields in definition order.
+func (o *OperationsResourcesRow) ScanArgs() []any {
+	return []any{&o.OperationID, &o.EntityID, &o.EntityType}
+}
+
+// CreateValues returns a list of values from [OperationsResourcesRow] entities matching the bind arguments in [CreateStmt].
+func (o OperationsResourcesRow) CreateValues() []any {
+	return []any{o.OperationID, o.EntityID, o.EntityType}
+}
+
+// UpdateValues returns a list of values from [OperationsResourcesRow] entities matching the columns in [UpdateStmt].
+func (o OperationsResourcesRow) UpdateValues() []any {
+	return []any{o.OperationID, o.EntityID, o.EntityType}
+}
+
+// PKColumns returns the column names for the primary key of a [OperationsResourcesRow] entity used during an update.
+// The returned slice must have the same number of elements as PKValues.
+func (o OperationsResourcesRow) PKColumns() []string {
+	return []string{"operation_id", "entity_id", "entity_type"}
+}
+
+// PKValues returns the values for the primary key of a [OperationsResourcesRow] entity used during an update.
+// The returned slice must have the same number of elements as PKColumns.
+func (o OperationsResourcesRow) PKValues() []any {
+	return []any{o.OperationID, o.EntityID, o.EntityType}
+}
+
+// CreateStmt returns a query that creates a [OperationsResourcesRow] entity.
+func (o OperationsResourcesRow) CreateStmt() string {
+	return "INSERT INTO operations_resources (operation_id, entity_id, entity_type) VALUES (?, ?, ?)"
+}
+
+// UpdateStmt returns a query that updates a [OperationsResourcesRow] by primary key.
+func (o OperationsResourcesRow) UpdateStmt() string {
+	return "UPDATE operations_resources SET operation_id = ?, entity_id = ?, entity_type = ? "
+}
+
 // TableName returns the table name for [OperationsRow] entities.
 func (o OperationsRow) TableName() string {
 	return "operations"

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -295,8 +295,7 @@ func CreateOperationResources(ctx context.Context, tx *sql.Tx, opID int64, resou
 		return nil
 	}
 
-	sb := strings.Builder{}
-	sb.WriteString(`INSERT INTO operations_resources (operation_id, entity_id, entity_type) VALUES `)
+	var opResources []OperationsResourcesRow
 	for _, entityURLs := range resources {
 		for _, entityURL := range entityURLs {
 			entityReference, err := GetEntityReferenceFromURL(ctx, tx, &entityURL)
@@ -304,25 +303,15 @@ func CreateOperationResources(ctx context.Context, tx *sql.Tx, opID int64, resou
 				return fmt.Errorf("Failed getting entity ID from resource URL %q: %w", entityURL.String(), err)
 			}
 
-			entityTypeCode, err := entityReference.EntityType.Value()
-			if err != nil {
-				return fmt.Errorf("Failed getting entity type code for entity type %q: %w", entityReference.EntityType, err)
-			}
-
-			fmt.Fprintf(&sb, "(%d, %d, %d),", opID, entityReference.EntityID, entityTypeCode)
+			opResources = append(opResources, OperationsResourcesRow{
+				OperationID: opID,
+				EntityID:    int64(entityReference.EntityID),
+				EntityType:  entityReference.EntityType,
+			})
 		}
 	}
 
-	// Get the final stmt and replace the trailing comma with a semicolon.
-	insertStmt := sb.String()
-	insertStmt = insertStmt[:len(insertStmt)-1] + ";"
-
-	_, err := tx.ExecContext(ctx, insertStmt)
-	if err != nil {
-		return fmt.Errorf("Failed inserting operation resources: %w", err)
-	}
-
-	return nil
+	return query.CreateMany(ctx, tx, opResources)
 }
 
 // deleteEphemeralOperationsFromNodes deletes ephemeral operations from nodes with the given list of IDs.

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -17,7 +17,6 @@ import (
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
-	"github.com/canonical/lxd/shared/logger"
 )
 
 // OperationsRow is a row of the operations table.
@@ -222,70 +221,6 @@ func UpdateOperation(ctx context.Context, tx *sql.Tx, opUUID string, nodeID int6
 	}
 
 	return nil
-}
-
-// GetOperationResources loads operation resources from the cluster db.
-// The entity type is used as the key of the map, as the actual key is not stored in the DB.
-func GetOperationResources(ctx context.Context, tx *sql.Tx, opID int64) (map[entity.Type][]api.URL, error) {
-	stmt := `SELECT entity_id, entity_type FROM operations_resources WHERE operation_id = ?`
-
-	// We cannot call GetEntityURL from within the scan function because it would start a new transaction.
-	// So first we read all the entity IDs and types into a slice, then we loop over that slice to get the URLs.
-	resources := []*struct {
-		EntityID   int
-		EntityType EntityType
-	}{}
-	err := query.Scan(ctx, tx, stmt, func(scan func(dest ...any) error) error {
-		r := struct {
-			EntityID   int
-			EntityType EntityType
-		}{}
-
-		err := scan(&r.EntityID, &r.EntityType)
-		if err != nil {
-			return err
-		}
-
-		resources = append(resources, &r)
-
-		return nil
-	}, opID)
-	if err != nil {
-		return nil, fmt.Errorf("Failed reading operation resources: %w", err)
-	}
-
-	var result map[entity.Type][]api.URL
-	for _, r := range resources {
-		entityURL, err := GetEntityURL(ctx, tx, entity.Type(r.EntityType), r.EntityID)
-		if err != nil {
-			// If a delete operation has already deleted its resources, it's possible that some of the resources will not be found.
-			// In that case, we just skip those resources and return the ones that are still there.
-			if api.StatusErrorCheck(err, http.StatusNotFound) {
-				logger.Debug("Failed loading resource URL for operation resource, skipping resource", logger.Ctx{"entity_type": r.EntityType, "entity_id": r.EntityID, "err": err})
-				continue
-			}
-
-			return nil, fmt.Errorf("Failed loading resource URL for operation resource: %w", err)
-		}
-
-		if result == nil {
-			result = map[entity.Type][]api.URL{}
-		}
-
-		_, ok := result[entity.Type(r.EntityType)]
-		if !ok {
-			result[entity.Type(r.EntityType)] = []api.URL{}
-		}
-
-		result[entity.Type(r.EntityType)] = append(result[entity.Type(r.EntityType)], *entityURL)
-	}
-
-	return result, nil
-}
-
-// GetParentOperations returns all parent operation, that is all operations that don't have a parent.
-func GetParentOperations(ctx context.Context, tx *sql.Tx) ([]Operation, error) {
-	return query.Select[Operation](ctx, tx, "WHERE operations.parent IS NULL")
 }
 
 // CreateOperationResources registers operation resources in the cluster db.

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -184,6 +184,29 @@ func (OperationsResourcesRow) APIName() string {
 	return "Operation resource"
 }
 
+// GetOperations returns slice of [Operation] based on given filters. If includeChildren is false, only operations that
+// do not reference parent operations are returned. If the project is non-nil, only operations in the given project are
+// returned.
+func GetOperations(ctx context.Context, tx *sql.Tx, includeChildren bool, project *string) ([]Operation, error) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, 1)
+	if !includeChildren {
+		clauses = append(clauses, "operations.parent IS NULL")
+	}
+
+	if project != nil {
+		clauses = append(clauses, "projects.name = ?")
+		args = append(args, *project)
+	}
+
+	clause := ""
+	if len(clauses) > 0 {
+		clause = "WHERE " + strings.Join(clauses, " AND ")
+	}
+
+	return query.Select[Operation](ctx, tx, clause, args...)
+}
+
 // UpdateOperation updates operation status, metadata and error (if set) in the cluster db.
 // This is used to keep DB in sync with the current status of the operation when the operation changes
 // its status, or when calls to commit metadata explicitly. The caller is expected to pass in the current node ID.

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -89,14 +89,6 @@ type Operation struct {
 	IdentityIdentifier string `db:"coalesce(identities.identifier, '')"`
 }
 
-// OperationFilter specifies potential query parameter fields.
-type OperationFilter struct {
-	ID     *int64
-	NodeID *int64
-	UUID   *string
-	Parent *int64
-}
-
 // RequestorProtocol is the database representation of the Requestor Protocol.
 //
 // RequestorProtocol is defined on string so that constants can be converted by casting. The [sql.Scanner] and

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -169,6 +169,22 @@ func (r *RequestorProtocol) Value() (driver.Value, error) {
 	return nil, fmt.Errorf("Invalid requestor protocol %q", *r)
 }
 
+// OperationsResourcesRow represents a row of the operations_resources table.
+// db:model operations_resources
+type OperationsResourcesRow struct {
+	// db:primary
+	OperationID int64 `db:"operation_id"`
+	// db:primary
+	EntityID int64 `db:"entity_id"`
+	// db:primary
+	EntityType EntityType `db:"entity_type"`
+}
+
+// APIName implements [query.APINamer] for [OperationsResourcesRow] for API friendly error messages.
+func (OperationsResourcesRow) APIName() string {
+	return "Operation resource"
+}
+
 // UpdateOperation updates operation status, metadata and error (if set) in the cluster db.
 // This is used to keep DB in sync with the current status of the operation when the operation changes
 // its status, or when calls to commit metadata explicitly. The caller is expected to pass in the current node ID.

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -88,6 +88,22 @@ type Operation struct {
 	IdentityIdentifier string `db:"coalesce(identities.identifier, '')"`
 }
 
+// Requestor returns the [request.RequestorAuditor] for the [Operation], if set.
+func (o Operation) Requestor() *request.RequestorAuditor {
+	// If no protocol is set, it was a server operation with no requestor.
+	if o.Row.RequestorProtocol == nil || *o.Row.RequestorProtocol == "" {
+		return nil
+	}
+
+	// Otherwise return a requestor auditor with the details.
+	// Note that the origin address is not saved.
+	return &request.RequestorAuditor{
+		IdentityID: o.Row.RequestorIdentityID,
+		Username:   o.IdentityIdentifier,
+		Protocol:   string(*o.Row.RequestorProtocol),
+	}
+}
+
 // RequestorProtocol is the database representation of the Requestor Protocol.
 //
 // RequestorProtocol is defined on string so that constants can be converted by casting. The [sql.Scanner] and

--- a/lxd/db/cluster/permissions.go
+++ b/lxd/db/cluster/permissions.go
@@ -68,7 +68,7 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 
 	// If there are any entity types with multiple permissions, get all URLs for those entities.
 	if len(entityTypes) > 0 {
-		entityURLsAll, err := GetEntityURLs(ctx, tx, "", entityTypes...)
+		entityURLsAll, err := GetEntityURLsByProjectAndType(ctx, tx, "", entityTypes...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/lxd/db/openfga/openfga.go
+++ b/lxd/db/openfga/openfga.go
@@ -584,7 +584,7 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 		// Get the entity URLs with the given type and project (if set).
 		var entityURLs map[entity.Type]map[int]*api.URL
 		err = o.clusterDB.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			entityURLs, err = cluster.GetEntityURLs(ctx, tx.Tx(), projectName, entityType)
+			entityURLs, err = cluster.GetEntityURLsByProjectAndType(ctx, tx.Tx(), projectName, entityType)
 			if err != nil {
 				return err
 			}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -17,7 +17,6 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
-	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/request"
@@ -180,11 +179,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			return api.StatusErrorf(http.StatusBadRequest, "Child operations cannot be retrieved individually")
 		}
 
-		op, err = operations.ConstructOperationFromDB(ctx, tx.Tx(), s, dbOp)
-		if err != nil {
-			return err
-		}
-
+		dbOps := []dbCluster.Operation{*dbOp}
 		if recursion > 0 {
 			// Load all child operations for embedding in the response.
 			childDbOps, err := dbCluster.GetOperationsWithParent(ctx, tx.Tx(), dbOp.Row.ID)
@@ -192,18 +187,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			children := make([]*operations.Operation, 0, len(childDbOps))
-			for _, childDbOp := range childDbOps {
-				childOp, err := operations.ConstructOperationFromDB(ctx, tx.Tx(), s, &childDbOp)
-				if err != nil {
-					return err
-				}
-
-				children = append(children, childOp)
-			}
-
-			op.AddChildren(children...)
-			childCount = int64(len(children))
+			dbOps = append(dbOps, childDbOps...)
 		} else {
 			// Count children from DB without loading full child operations.
 			childCount, err = dbCluster.CountOperationChildren(ctx, tx.Tx(), dbOp.Row.ID)
@@ -211,6 +195,17 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 		}
+
+		constructedOps, err := operations.ConstructOperationsFromDB(ctx, tx.Tx(), s, dbOps)
+		if err != nil {
+			return err
+		}
+
+		if len(constructedOps) != 1 {
+			return fmt.Errorf("Expected to construct one operation but got %d", len(constructedOps))
+		}
+
+		op = constructedOps[0]
 
 		return nil
 	})
@@ -223,10 +218,15 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	_, body := op.RenderFullWithoutProgress()
-	body.ChildCount = childCount
+	_, apiOperation := op.RenderFullWithoutProgress()
 
-	return response.SyncResponse(true, body)
+	// If recursion > 0 the child count will be set when rendering the operation.
+	// Otherwise we need to set it because we didn't load the children.
+	if recursion == 0 {
+		apiOperation.ChildCount = childCount
+	}
+
+	return response.SyncResponse(true, apiOperation)
 }
 
 // swagger:operation DELETE /1.0/operations/{id} operations operation_delete
@@ -481,6 +481,11 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	var projectFilter *string
+	if !allProjects {
+		projectFilter = &projectName
+	}
+
 	canViewProjectOperations, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanViewOperations, entity.TypeProject)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed getting operation permission checker: %w", err))
@@ -498,38 +503,17 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 	recursion, _ := util.IsRecursionRequest(r)
 
 	// Map of parent operations keyed by the operation ID.
-	parentOps := make(map[int64]*operations.Operation)
+	var ops []*operations.Operation
 
 	// Child counts by parent UUID, populated via aggregate DB query for recursion < 2.
 	childCounts := make(map[string]int64)
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projects, err := dbCluster.GetProjectIDsToNames(ctx, tx.Tx())
-		if err != nil {
-			return fmt.Errorf("Failed loading project IDs to names: %w", err)
-		}
-
-		// Make sure the requested project exists if not all-projects.
-		if !allProjects {
-			found := false
-			for _, name := range projects {
-				if name == projectName {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("Project %q does not exist", projectName)
-			}
-		}
-
-		// For non-recursive responses, retrieve child counts via an aggregate query rather than
-		// loading and constructing every child operation just to compute counts.
-		if recursion < 2 {
-			childCounts, err = dbCluster.CountOperationChildrenByParent(ctx, tx.Tx())
+		// Check the project exists
+		if projectFilter != nil {
+			_, err := dbCluster.GetProject(ctx, tx.Tx(), *projectFilter)
 			if err != nil {
-				return fmt.Errorf("Failed getting child operation counts: %w", err)
+				return err
 			}
 		}
 
@@ -537,74 +521,42 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		// For recursive responses, load all operations so children can be embedded.
 		var dbOps []dbCluster.Operation
 		if recursion < 2 {
-			dbOps, err = dbCluster.GetParentOperations(ctx, tx.Tx())
+			dbOps, err = dbCluster.GetOperations(ctx, tx.Tx(), false, projectFilter)
 			if err != nil {
 				return fmt.Errorf("Failed getting operations: %w", err)
 			}
+
+			// For non-recursive responses, retrieve child counts via an aggregate query rather than
+			// loading and constructing every child operation just to compute counts.
+			childCounts, err = dbCluster.CountOperationChildrenByParent(ctx, tx.Tx())
+			if err != nil {
+				return fmt.Errorf("Failed getting child operation counts: %w", err)
+			}
 		} else {
-			dbOps, err = query.Select[dbCluster.Operation](ctx, tx.Tx(), "")
+			dbOps, err = dbCluster.GetOperations(ctx, tx.Tx(), true, projectFilter)
 			if err != nil {
 				return fmt.Errorf("Failed getting operations: %w", err)
 			}
 		}
 
-		// Map of child operations keyed by their parent operation ID (only used for recursion >= 2).
-		childOps := make(map[int64][]*operations.Operation)
+		filteredOps := make([]dbCluster.Operation, 0, len(dbOps))
 		for _, dbOp := range dbOps {
-			// Get operation project name if it has one.
-			operationProject := ""
-			if dbOp.Row.ProjectID != nil {
-				var ok bool
-				operationProject, ok = projects[*dbOp.Row.ProjectID]
-				if !ok {
-					return fmt.Errorf("Failed finding project name for operation with non-existent project ID %d", *dbOp.Row.ProjectID)
-				}
-			}
-
-			if !allProjects && operationProject != "" && operationProject != projectName {
-				continue
-			}
-
 			// Omit operations that don't have a project if the caller does not have access to server operations.
-			if operationProject == "" && !canViewServerOperations {
+			if dbOp.Row.ProjectID == nil && !canViewServerOperations {
 				continue
-			}
-
-			// Construct the operation object, which will also reconstruct its requestor.
-			op, err := operations.ConstructOperationFromDB(ctx, tx.Tx(), s, &dbOp)
-			if err != nil {
-				return fmt.Errorf("Failed loading operation ID %q: %w", dbOp.Row.UUID, err)
 			}
 
 			// Omit operations if the caller does not have `can_view_operations` on the operations' project and the caller is not the operation owner.
-			if !canViewProjectOperations(entity.ProjectURL(operationProject)) && !requestor.CallerIsEqual(op.Requestor()) {
+			if !canViewProjectOperations(entity.ProjectURL(dbOp.ProjectName)) && !requestor.CallerIsEqual(dbOp.Requestor()) {
 				continue
 			}
 
-			// If this is a child operation, add it to the list keyed by parent DB ID.
-			// We'll match these to actual parents later. This only occurs for recursion >= 2
-			// since child operations are excluded from the DB query for recursion < 2.
-			if dbOp.Row.Parent != nil {
-				_, ok := childOps[*dbOp.Row.Parent]
-				if !ok {
-					childOps[*dbOp.Row.Parent] = make([]*operations.Operation, 0)
-				}
-
-				childOps[*dbOp.Row.Parent] = append(childOps[*dbOp.Row.Parent], op)
-			} else {
-				parentOps[dbOp.Row.ID] = op
-			}
+			filteredOps = append(filteredOps, dbOp)
 		}
 
-		// Now add the child operations to their parents (only for recursion >= 2).
-		for parentID, children := range childOps {
-			parentOp, ok := parentOps[parentID]
-			if !ok {
-				logger.Warn("Failed finding parent operation for child operations, skipping children", logger.Ctx{"parentID": parentID})
-				continue
-			}
-
-			parentOp.AddChildren(children...)
+		ops, err = operations.ConstructOperationsFromDB(ctx, tx.Tx(), s, filteredOps)
+		if err != nil {
+			return fmt.Errorf("Failed constructing operation list: %w", err)
 		}
 
 		return nil
@@ -614,12 +566,13 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Render the operations.
-	apiOps := make([]*api.OperationFull, 0, len(parentOps))
-	for _, op := range parentOps {
+	apiOps := make([]*api.OperationFull, 0, len(ops))
+	for _, op := range ops {
 		var apiOp *api.OperationFull
 		if recursion >= 2 {
 			_, apiOp = op.RenderFullWithoutProgress()
 		} else {
+			// If not recursive, set the child count.
 			_, retOp := op.RenderWithoutProgress()
 			retOp.ChildCount = childCounts[op.ID()]
 			apiOp = &api.OperationFull{Operation: *retOp}

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -13,10 +13,10 @@ import (
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/db/query"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
+	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -156,10 +156,86 @@ func removeDBOperation(op *Operation) error {
 	return err
 }
 
-// ConstructOperationFromDB is a constructor of a single Operation object based on its database representation.
-// ConstructOperationFromDB doesn't populate the parent field, as that would require loading all other operations from the DB. Instead,
-// the caller is expected to set the parent field on the returned Operation object based on other loaded operations, if needed.
-func ConstructOperationFromDB(ctx context.Context, tx *sql.Tx, s *state.State, dbOp *cluster.Operation) (*Operation, error) {
+// ConstructOperationsFromDB is a constructs a list of Operation objects based on their database representation.
+func ConstructOperationsFromDB(ctx context.Context, tx *sql.Tx, s *state.State, dbOps []cluster.Operation) ([]*Operation, error) {
+	if len(dbOps) == 0 {
+		return []*Operation{}, nil
+	}
+
+	// Get a list of all entity types and IDs to resolve.
+	allEntities := make(map[entity.Type][]int64)
+
+	// Construct a list of parents.
+	parents := make([]cluster.Operation, 0, len(dbOps))
+
+	// Construct a map of parent operation IDs to their children.
+	children := make(map[int64][]cluster.Operation, len(dbOps))
+
+	// Get a list of all operations to get resources for.
+	opIDs := make([]int64, 0, len(dbOps))
+
+	for _, dbOp := range dbOps {
+		opIDs = append(opIDs, dbOp.Row.ID)
+		opEntityType := dbOp.Row.Type.EntityType()
+		allEntities[opEntityType] = append(allEntities[opEntityType], dbOp.Row.EntityID)
+		if dbOp.Row.Parent == nil {
+			parents = append(parents, dbOp)
+			continue
+		}
+
+		children[*dbOp.Row.Parent] = append(children[*dbOp.Row.Parent], dbOp)
+	}
+
+	// Preload operation resource IDs.
+	resources := make(map[int64][]cluster.OperationsResourcesRow)
+	err := query.SelectFunc[cluster.OperationsResourcesRow](ctx, tx, "WHERE operations_resources.operation_id IN "+query.IntParams(opIDs...), func(resource cluster.OperationsResourcesRow) error {
+		resourceEntityType := entity.Type(resource.EntityType)
+		allEntities[resourceEntityType] = append(allEntities[resourceEntityType], resource.EntityID)
+		resources[resource.OperationID] = append(resources[resource.OperationID], resource)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Get URLs for all operations and their resources.
+	entityURLs, err := cluster.GetEntityURLsByEntityTypeAndID(ctx, tx, allEntities)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting operation entity URLs: %w", err)
+	}
+
+	ops := make([]*Operation, 0, len(dbOps))
+	for _, parent := range parents {
+		op, err := constructSingleOperation(s, parent, resources, entityURLs)
+		if err != nil {
+			return nil, fmt.Errorf("Failed constructing operation: %w", err)
+		}
+
+		for _, child := range children[parent.Row.ID] {
+			childOp, err := constructSingleOperation(s, child, resources, entityURLs)
+			if err != nil {
+				return nil, fmt.Errorf("Failed constructing child operation: %w", err)
+			}
+
+			op.addChild(childOp)
+		}
+
+		ops = append(ops, op)
+	}
+
+	return ops, nil
+}
+
+func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources map[int64][]cluster.OperationsResourcesRow, entityURLs map[entity.Type]map[int64]*api.URL) (*Operation, error) {
+	getURL := func(p entity.Type, id int64) *api.URL {
+		urlsOfType, ok := entityURLs[p]
+		if !ok {
+			return nil
+		}
+
+		return urlsOfType[id]
+	}
+
 	op := Operation{
 		projectName:       dbOp.ProjectName,
 		id:                dbOp.Row.UUID,
@@ -177,6 +253,7 @@ func ConstructOperationFromDB(ctx context.Context, tx *sql.Tx, s *state.State, d
 		err:               dbOp.Row.Error,
 		errCode:           dbOp.Row.ErrorCode,
 		conflictReference: dbOp.Row.ConflictReference,
+		requestor:         dbOp.Requestor(),
 	}
 
 	// If server is not clustered, the DB contains 'none' as the node name. In that case we use the server name as the location.
@@ -196,54 +273,37 @@ func ConstructOperationFromDB(ctx context.Context, tx *sql.Tx, s *state.State, d
 
 	op.events = s.Events
 
-	// Load operation entity URL.
-	// Note that we rely on the entity_type of the operation and the entityURL being the same. This is enforced by a check in the initOperation().
-	entityURL, err := cluster.GetEntityURL(ctx, tx, dbOp.Row.Type.EntityType(), int(dbOp.Row.EntityID))
-	if err == nil {
-		op.entityURL = entityURL
-	} else {
-		// Fail for all errors other than the not found (see below)
-		if !api.StatusErrorCheck(err, http.StatusNotFound) {
-			return nil, fmt.Errorf("Failed loading entity URL for operation: %w", err)
-		}
-
-		// For various delete operations, these operations actually delete the entity somewhere in the operation code, which means that we might not be able to load the entity URL after the entity was deleted.
-		// If this is the case, the entity URL will simply be empty.
-		logger.Debug("Failed loading entity URL for operation, leaving it empty on the operation struct", logger.Ctx{"operationID": dbOp.Row.UUID, "entityType": dbOp.Row.Type.EntityType(), "entityID": dbOp.Row.EntityID})
+	op.entityURL = getURL(dbOp.Row.Type.EntityType(), dbOp.Row.EntityID)
+	if op.entityURL == nil {
+		// Various operations (e.g. deletion operations) actually delete the entity within the operation run hook.
+		// The entity URL is saved to the operation metadata at create time for this reason.
+		// Log a debug message for inspection in case this is not the intended behaviour.
+		op.logger.Debug("Failed loading entity URL for operation, leaving it empty on the operation struct", logger.Ctx{"entityType": dbOp.Row.Type.EntityType(), "entityID": dbOp.Row.EntityID})
 	}
 
 	// Load operation resources.
-	op.resources, err = cluster.GetOperationResources(ctx, tx, dbOp.Row.ID)
-	if err != nil {
-		return nil, fmt.Errorf("Failed loading operation resources for operation %d: %w", dbOp.Row.ID, err)
+	if len(resources[dbOp.Row.ID]) > 0 {
+		op.resources = make(map[entity.Type][]api.URL)
+		for _, resource := range resources[dbOp.Row.ID] {
+			resourceEntityType := entity.Type(resource.EntityType)
+			resourceURL := getURL(resourceEntityType, resource.EntityID)
+			if resourceURL == nil {
+				op.logger.Debug("Failed loading resource URL for operation", logger.Ctx{"entityType": resourceEntityType, "entityID": resource.EntityID})
+				continue
+			}
+
+			op.resources[resourceEntityType] = append(op.resources[resourceEntityType], *resourceURL)
+		}
 	}
 
 	// Load operation metadata.
 	var metadata map[string]any
-	err = json.Unmarshal([]byte(dbOp.Row.Metadata), &metadata)
+	err := json.Unmarshal([]byte(dbOp.Row.Metadata), &metadata)
 	if err != nil {
 		return nil, fmt.Errorf("Failed unmarshalling operation metadata for operation %d: %w", dbOp.Row.ID, err)
 	}
 
 	op.metadata = metadata
-
-	// Load the requestor identity if a protocol was set.
-	// Note that the origin address is not saved, so cannot be set on the reconstructed operation.
-	if dbOp.Row.RequestorProtocol != nil && *dbOp.Row.RequestorProtocol != "" {
-		op.requestor = &request.RequestorAuditor{
-			Protocol: string(*dbOp.Row.RequestorProtocol),
-		}
-
-		if dbOp.Row.RequestorIdentityID != nil {
-			identity, err := cluster.GetIdentityByID(ctx, tx, *dbOp.Row.RequestorIdentityID)
-			if err != nil {
-				return nil, fmt.Errorf("Failed loading identity for operation %d: %w", dbOp.Row.ID, err)
-			}
-
-			op.requestor.IdentityID = &identity.ID
-			op.requestor.Username = identity.Identifier
-		}
-	}
 
 	return &op, nil
 }

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -256,7 +256,7 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 			return nil, fmt.Errorf("Failed creating child operation: %w", err)
 		}
 
-		op.AddChildren(childOp)
+		op.addChild(childOp)
 	}
 
 	shutdownCtx := context.TODO()
@@ -283,20 +283,14 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 	return op, nil
 }
 
-// AddChildren adds a child operation to the parent operation. It also sets the parent of the child operation to the parent operation.
-func (op *Operation) AddChildren(children ...*Operation) {
-	if op.children == nil {
-		op.children = make([]*Operation, 0, len(children))
-	}
-
+// addChild adds a child operation to the parent operation. It also sets the parent of the child operation to the parent operation.
+func (op *Operation) addChild(child *Operation) {
 	op.lock.Lock()
-	op.children = append(op.children, children...)
+	op.children = append(op.children, child)
 	op.lock.Unlock()
-	for _, child := range children {
-		child.lock.Lock()
-		child.parent = op
-		child.lock.Unlock()
-	}
+	child.lock.Lock()
+	child.parent = op
+	child.lock.Unlock()
 }
 
 // CheckRequestor checks that the requestor of a given HTTP request is equal to the requestor of the operation.

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -731,23 +731,16 @@ func (op *Operation) RenderFullWithoutProgress() (string, *api.OperationFull) {
 		Operation: *baseOp,
 	}
 
-	if len(op.children) > 0 {
-		childAPIOps := make([]*api.Operation, 0, len(op.children))
-		for _, childOp := range op.children {
-			_, child := childOp.RenderWithoutProgress()
-			childAPIOps = append(childAPIOps, child)
-		}
-
-		// Sort operations by UUID. Since we use UUIDv7, this will also sort operations by creation time.
-		slices.SortFunc(childAPIOps, func(a, b *api.Operation) int {
-			return strings.Compare(a.ID, b.ID)
-		})
-
-		retOp.Children = make([]api.Operation, 0, len(op.children))
-		for _, childOp := range childAPIOps {
-			retOp.Children = append(retOp.Children, *childOp)
-		}
+	retOp.Children = make([]api.Operation, 0, len(op.children))
+	for _, childOp := range op.children {
+		_, child := childOp.RenderWithoutProgress()
+		retOp.Children = append(retOp.Children, *child)
 	}
+
+	// Sort operations by UUID. Since we use UUIDv7, this will also sort operations by creation time.
+	slices.SortFunc(retOp.Children, func(a, b api.Operation) int {
+		return strings.Compare(a.ID, b.ID)
+	})
 
 	return url, retOp
 }

--- a/lxd/permissions.go
+++ b/lxd/permissions.go
@@ -162,7 +162,7 @@ func getPermissions(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		entityURLs, err = cluster.GetEntityURLs(ctx, tx.Tx(), projectNameFilter, entityTypes...)
+		entityURLs, err = cluster.GetEntityURLsByProjectAndType(ctx, tx.Tx(), projectNameFilter, entityTypes...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR addresses a number of querying inefficiencies in GET /1.0/operations APIs with the following changes:

1. Removes any unnecessary queries (e.g. those that are not needed since #18356 where we now have extra fields populated by left join).
2. Constructs operations together rather than individually. This allows the `operations` package to fully handle parent/child relations, as well as pre-load entity URLs all at once.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
