### PR TITLE
Add clear-replica support and update documentation

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3523,7 +3523,7 @@ This includes the following new endpoints (see {ref}`rest-api` for details):
 * [`DELETE /1.0/cluster/links/<name>`](swagger:/cluster-links/cluster_link_delete)
 
 (extension-replicators)=
-## replicators
+## `replicators`
 
 This introduces the replicators API. Replicators are used to replicate project instances across clusters.
 

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -16,8 +16,9 @@ Replication is configured at the project level. Both clusters have a project wit
 
 - `leader`: The project is writable. Instances in this project are the source of replication. The replicator runs from this cluster.
 - `standby`: Instances in this project are replicas, kept in sync by the replicator. New instances cannot be created directly in this project, and existing instances cannot be started. The project must be promoted to `leader` during a failover before instances can be started.
+- (empty): The project is not part of any replication setup. This is the default for new projects.
 
-Replica mode is managed via `lxc project promote-replica` and `lxc project demote-replica`. It is not a configuration key and cannot be set with `lxc project set`.
+Replica mode is managed via `lxc project promote-replica`, `lxc project demote-replica`, and `lxc project clear-replica` (which resets the replica mode back to empty). It is not a configuration key and cannot be set with `lxc project set`.
 
 Only the standby project needs the {config:option}`project-replica:replica.cluster` configuration key, which identifies the cluster link that is allowed to push replication data into it. The leader project does not need this key because the replicator defines the target cluster.
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5179,7 +5179,7 @@ definitions:
         description: ProjectStatePut represents the fields for updating project replica state
         properties:
             replica_mode:
-                description: 'Replica mode to set: "leader" or "standby"'
+                description: 'Replica mode to set: "leader", "standby", or "" to clear the replica mode'
                 example: leader
                 type: string
                 x-go-name: ReplicaMode

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -87,6 +87,10 @@ func (c *cmdProject) command() *cobra.Command {
 	projectDemoteCmd := cmdProjectDemote{global: c.global, project: c}
 	cmd.AddCommand(projectDemoteCmd.command())
 
+	// Clear replica mode
+	projectClearReplicaCmd := cmdProjectClearReplica{global: c.global, project: c}
+	cmd.AddCommand(projectClearReplicaCmd.command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
@@ -1251,6 +1255,69 @@ func (c *cmdProjectDemote) run(cmd *cobra.Command, args []string) error {
 
 	if !c.global.flagQuiet {
 		fmt.Printf("Project %s demoted to standby mode\n", resource.name)
+	}
+
+	return nil
+}
+
+// Clear replica mode.
+type cmdProjectClearReplica struct {
+	global  *cmdGlobal
+	project *cmdProject
+}
+
+func (c *cmdProjectClearReplica) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("clear-replica", "[<remote>:]<project>")
+	cmd.Short = "Clear the replica mode of a project"
+	cmd.Long = cli.FormatSection("Description",
+		`Clears the replica mode of a project, removing it from any replication setup.`)
+
+	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpTopLevelResource("project", toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+func (c *cmdProjectClearReplica) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return errors.New("Missing project name")
+	}
+
+	// Clear the project's replica mode
+	op, err := resource.server.UpdateProjectState(resource.name, api.ProjectStatePut{ReplicaMode: api.ReplicatorProjectModeNone}, false)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		fmt.Printf("Project %s replica mode cleared\n", resource.name)
 	}
 
 	return nil

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1529,6 +1529,11 @@ func projectStatePut(d *Daemon, r *http.Request) response.Response {
 			return projectDemote(ctx, s, name, force)
 		}
 
+	case api.ReplicatorProjectModeNone:
+		run = func(ctx context.Context, op *operations.Operation) error {
+			return projectClearReplicaMode(ctx, s, name)
+		}
+
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown replica mode %q", req.ReplicaMode))
 	}
@@ -1725,6 +1730,40 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 	// Update the replica mode to standby.
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return dbCluster.UpdateProjectReplicaMode(ctx, tx.Tx(), projectName, api.ReplicatorProjectModeStandby)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed updating project replica mode: %w", err)
+	}
+
+	s.Events.SendLifecycle(projectName, lifecycle.ProjectUpdated.Event(projectName, request.CreateRequestor(ctx), nil))
+
+	return nil
+}
+
+// projectClearReplicaMode clears the project's replica mode, removing it from any replication setup.
+func projectClearReplicaMode(ctx context.Context, s *state.State, projectName string) error {
+	var replicaMode dbCluster.ProjectReplicaMode
+
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		replicaMode = dbProject.ReplicaMode
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if replicaMode == dbCluster.ProjectReplicaMode(api.ReplicatorProjectModeNone) {
+		return fmt.Errorf("Project %q is not in a replica mode", projectName)
+	}
+
+	// Clear the replica mode.
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.UpdateProjectReplicaMode(ctx, tx.Tx(), projectName, api.ReplicatorProjectModeNone)
 	})
 	if err != nil {
 		return fmt.Errorf("Failed updating project replica mode: %w", err)

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1808,19 +1808,19 @@ func triggerScheduledReplicator(ctx context.Context, s *state.State, replicator 
 func validateReplicatorModes(sourceMode string, targetMode string, restore bool) error {
 	if restore {
 		if sourceMode != api.ReplicatorProjectModeStandby {
-			return errors.New("Source project must be in standby mode to run replicator in restore mode")
+			return errors.New("Local project must be in standby mode to run replicator in restore mode")
 		}
 
 		if targetMode != api.ReplicatorProjectModeLeader {
-			return errors.New("Target project must be in leader mode to run replicator in restore mode")
+			return errors.New("Project on the remote cluster must be in leader mode to run replicator in restore mode")
 		}
 	} else {
 		if sourceMode != api.ReplicatorProjectModeLeader {
-			return errors.New("Source project must be in leader mode to run replicator")
+			return errors.New("Local project must be in leader mode to run replicator")
 		}
 
 		if targetMode != api.ReplicatorProjectModeStandby {
-			return errors.New("Target project must be in standby mode to run replicator")
+			return errors.New("Project on the remote cluster must be in standby mode to run replicator")
 		}
 	}
 

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -139,7 +139,7 @@ type ProjectStateResource struct {
 //
 // API extension: project_replica_mode.
 type ProjectStatePut struct {
-	// Replica mode to set: "leader" or "standby"
+	// Replica mode to set: "leader", "standby", or "" to clear the replica mode
 	// Example: leader
 	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
 }

--- a/shared/api/replicator.go
+++ b/shared/api/replicator.go
@@ -5,6 +5,9 @@ import (
 )
 
 const (
+	// ReplicatorProjectModeNone indicates the project is not part of any replication setup.
+	ReplicatorProjectModeNone = ""
+
 	// ReplicatorProjectModeLeader indicates the project is the active source for replication.
 	ReplicatorProjectModeLeader = "leader"
 

--- a/test/lint/api-extensions-doc-links.sh
+++ b/test/lint/api-extensions-doc-links.sh
@@ -20,3 +20,12 @@ if [ "${#missing[@]}" -gt 0 ]; then
   printf '  - %s\n' "${missing[@]}"
   exit 1
 fi
+
+echo "Checking that API extension headings in ${DOC_FILE} are formatted as code..."
+
+bad_headings="$(grep -nE '^## [^`]' "${DOC_FILE}" || true)"
+if [ -n "${bad_headings}" ]; then
+  echo "ERROR: the following headings in ${DOC_FILE} are not formatted as code (expected ## \`name\`):"
+  echo "${bad_headings}"
+  exit 1
+fi

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6613,6 +6613,30 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project create replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project create replicator-project
 
+  sub_test "Verify clear-replica resets a project's replica mode back to empty"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create replica-state-project
+
+  # New projects have no replica mode set.
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq -r '.replica_mode' || echo fail)" = "" ]
+
+  # clear-replica is rejected when the project has no replica mode set.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is not in a replica mode' ]
+
+  # clear-replica resets the replica mode back to empty from leader mode.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq -r '.replica_mode')" = "leader" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq -r '.replica_mode' || echo fail)" = "" ]
+
+  # clear-replica resets the replica mode back to empty from standby mode.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replica-state-project --force
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq -r '.replica_mode')" = "standby" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq -r '.replica_mode' || echo fail)" = "" ]
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc project delete replica-state-project
+
   # Setup auth groups and cluster links so that promote validation can reach
   # the target project through the cluster-link identity.
   LXD_DIR="${LXD_ONE_DIR}" lxc auth group create replicator-group

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6087,7 +6087,7 @@ test_clustering_replicator_dr() {
 
   grep -F 'ACTIVE' <<< "${link_info}"
 
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Target project must be in standby mode to run replicator' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Project on the remote cluster must be in standby mode to run replicator' ]
 
   sub_test "Verify --restore is rejected when local instances are running"
 
@@ -6714,7 +6714,7 @@ test_clustering_replicator_unclustered() {
 
   # LXD_ONE still has leader mode set; forward run must be rejected because LXD_TWO
   # (the target) is now also leader.
-  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Target project must be in standby mode to run replicator' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project 2>&1)" = 'Error: Project on the remote cluster must be in standby mode to run replicator' ]
 
   sub_test "Verify --restore is rejected when local instances are running"
 


### PR DESCRIPTION
This pull request introduces support for clearing a project's replica mode, allowing projects to be removed from any replication setup and return to their default state. It adds a new `clear-replica` command to the CLI, updates the API and documentation to reflect this new capability, and includes tests for the new behavior.