### PR TITLE
lxd/apparmor/qemu: allow reading OpenSSL config

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -51,6 +51,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .rootPath }}/etc/nsswitch.conf         r,
   {{ .rootPath }}/etc/passwd                r,
   {{ .rootPath }}/etc/group                 r,
+  {{ .rootPath }}/etc/ssl/openssl.cnf       r,
   @{PROC}/version                           r,
 
   # Extra config paths


### PR DESCRIPTION
Related to Ceph:

```
[  324.355435] audit: type=1400 audit(1781545575.027:426): apparmor="DENIED" operation="open" class="file" profile="lxd-v1_</var/snap/lxd/common/lxd>" name="/var/lib/snapd/hostfs/etc/ssl/openssl.cnf" pid=16258 comm="msgr-worker-2" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
```