### PR TITLE
storage: Make `powerstore.mode` required 

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6552,6 +6552,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} powerstore.mode storage-powerstore-pool-conf
 :defaultdesc: "the discovered mode"
+:required: "true"
 :scope: "global"
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7249,6 +7249,7 @@
 						"powerstore.mode": {
 							"defaultdesc": "the discovered mode",
 							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported values are `iscsi` and `scsi/fc`.",
+							"required": "true",
 							"scope": "global",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -179,7 +179,8 @@ func (d *powerstore) Validate(config map[string]string) error {
 		//  defaultdesc: the discovered mode
 		//  shortdesc: How volumes are mapped to the local server
 		//  scope: global
-		"powerstore.mode": validate.Optional(validate.IsOneOf(powerStoreSupportedConnectors...)),
+		//  required: true
+		"powerstore.mode": validate.IsOneOf(powerStoreSupportedConnectors...),
 		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.target)
 		// A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
 		// ---


### PR DESCRIPTION
Most drivers use `nvme/tcp` as default value for mode. PowerStore currently has no default value. I suggest making `powerstore.mode` required for now and later when `nvme/tcp` becomes available, drop the restriction and use the same default value as other drivers.