### PR TITLE
doc: network security backport (stable-5.21)

### DIFF
--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -67,9 +67,14 @@ Control traffic on LXD networks.
 (howto-security-harden-use-ip)=
 ### Limit network exposure
 
-By default, LXD is only accessible locally through a Unix socket. If you need to {ref}`expose LXD to the network <server-expose>`, you must set the LXD server’s {config:option}`server-core:core.https_address`. To reduce the attack surface, do not set this address to a port alone.
+By default, LXD is only accessible locally through a Unix socket.
+If you need to {ref}`expose LXD to the network <server-expose>`, you must set the LXD server’s {config:option}`server-core:core.https_address`.
 
-Instead, use a trusted IP address on the LXD management interface along with a port, such as `192.0.2.10:8443`. If you only need local HTTPS access, use the loopback address and port, such as `127.0.0.1:8443`.
+To reduce the attack surface, provide a full socket address with IP address and port number.
+If you only need local HTTPS access, use a loopback address and port, such as `127.0.0.1:8443`.
+For external HTTPS access, set a trusted IP address on the LXD management interface along with a port, such as `192.0.2.10:8443`.
+
+**Do not** specify a port number alone, such as `:8443`, as this exposes the LXD API to every interface on the host.
 
 (howto-security-harden-instance)=
 ## Instance security

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -76,6 +76,16 @@ For external HTTPS access, set a trusted IP address on the LXD management interf
 
 **Do not** specify a port number alone, such as `:8443`, as this exposes the LXD API to every interface on the host.
 
+(howto-security-harden-restrict-outbound)=
+### Restrict outbound requests
+
+An authenticated user with the `can_create_images` entitlement can probe internal networks by directing the LXD daemon to download images from internal network addresses.
+The requests will fail, but error messages may provide information about internal services.
+
+To prevent users from probing internal networks, restrict IP addresses or domains available to LXD for outbound HTTP and HTTPS requests.
+First, set up a proxy to filter requests.
+Then {ref}`configure the LXD server <server-configure>` to use the proxy by setting **both** {config:option}`server-core:core.proxy_http` and {config:option}`server-core:core.proxy_https` to the proxy address.
+
 (howto-security-harden-instance)=
 ## Instance security
 


### PR DESCRIPTION
Backports #18462 to update the guide to hardening security with information about limiting network exposure and restricting outbound requests.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
