### PR TITLE
lxd/storage/drivers/ceph_volumes: mounting snapshot read-only

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -2051,6 +2051,11 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, progressReporter ioprogress.P
 		mountFlags, mountOptions := filesystem.ResolveMountOptions(strings.Split(snapVol.ConfigBlockMountOptions(), ","))
 		mountOptions = addNoRecoveryMountOption(mountOptions, RBDFilesystem)
 
+		// Snapshots should be mounted read-only. This is also required for the norecovery option added
+		// above to be accepted (the kernel rejects rw mounts combined with norecovery/noload), which can
+		// otherwise fail when snapshotting a running instance with a dirty filesystem journal.
+		mountFlags |= unix.MS_RDONLY
+
 		if renegerateFilesystemUUIDNeeded(RBDFilesystem) {
 			// When mounting XFS filesystems temporarily we can use the nouuid option rather than fully
 			// regenerating the filesystem UUID.


### PR DESCRIPTION
Other block-based drivers already ensure snapshots are mounted read-only, which is required now by modern `ext4` FS when using `noload`/`norecovery` mount option. The problematic read-write mount with `noload` isn't a new issue but it's been more visible with more `ext4` features being enabled by default in 26.04.