### PR TITLE
github: GHA runners no longer have ephemeral disks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -604,8 +604,7 @@ jobs:
 
       - name: Reclaim disk space
         # This can take multiple minutes if the runner is busy/slow so only run it when/where absolutely needed.
-        # Storage tests need it except when using ceph as it uses the ephemeral disk.
-        if: ${{ matrix.test == 'conversion' || matrix.test == 'vm-nesting' || (startsWith(matrix.test, 'storage-') && !contains(matrix.test, ' ceph')) }}
+        if: ${{ matrix.test == 'conversion' || matrix.test == 'vm-nesting' || startsWith(matrix.test, 'storage-') }}
         uses: ./.github/actions/reclaim-disk-space
 
       - name: Remove docker


### PR DESCRIPTION
The ephemeral disks are long gone but it seems like it worked for a while even with the Ceph overhead. It doesn't anymore so let's free space unconditionally for storage tests.

```
==> Checking VM can be refreshed remotely (different storage pool)
+ lxc snapshot v1
+ lxc copy v1 localhost:v2 --refresh -s vmpool-ceph-154732
Error: Failed instance creation: Error transferring instance data: Failed migration on target: Failed creating instance on target: Failed running: nice -n19 dd if=/var/snap/lxd/common/lxd/storage-pools/vmpool-ceph-154732/virtual-machines/v2/root.img of=/var/snap/lxd/common/lxd/storage-pools/vmpool-ceph-154732/virtual-machines-snapshots/v2/snap1/root.img bs=16M conv=nocreat iflag=direct oflag=direct: exit status 1 (dd: error writing '/var/snap/lxd/common/lxd/storage-pools/vmpool-ceph-154732/virtual-machines-snapshots/v2/snap1/root.img': No space left on device
```

Same as done in [`lxd-ci`](https://github.com/canonical/lxd-ci/commit/d14a971ae9b148cba825dcef8cfa4ba4e1d89343).