### PR TITLE
lxd/instance_console: Remove redundant (and unsafe) write (from Incus)

### DIFF
--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -341,7 +341,6 @@ func (s *consoleWs) doConsole(ctx context.Context) error {
 	s.connsLock.Unlock()
 
 	defer func() {
-		_ = consoleConn.WriteMessage(websocket.BinaryMessage, []byte("\n\r"))
 		_ = consoleConn.Close()
 		_ = ctrlConn.Close()
 	}()


### PR DESCRIPTION
Cherry picked from [2a58e253129851ad1ee8c2ab2822ea7e6714f54a](https://github.com/lxc/incus/commit/2a58e253129851ad1ee8c2ab2822ea7e6714f54a)

Prevents a daemon panic with concurrent console access; reproduced consistently on `2a7db370f66decceb8a4d65dc638708d00604043`:
```
goroutine 7263 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(0x30e52b0d9ce8, 0x1, {0x30e52a9b8ad8?, 0x30e52b0d9cf0?, 0x4a7585?})
	github.com/gorilla/websocket@v1.5.1/conn.go:632 +0x4a6
github.com/gorilla/websocket.(*Conn).WriteMessage(0x30e52a562c60, 0x0?, {0x30e52a9b8ad8, 0x2, 0x2})
	github.com/gorilla/websocket@v1.5.1/conn.go:785 +0x125
main.(*consoleWs).doConsole.func4()
	github.com/canonical/lxd/lxd/instance_console.go:344 +0x49
main.(*consoleWs).doConsole(0x30e52a4c5490, {0x2974b98, 0x30e52b693260})
	github.com/canonical/lxd/lxd/instance_console.go:365 +0x49d
main.(*consoleWs).Do(0x30e52ac52ef8?, {0x2974b98?, 0x30e52b693260?}, 0x24e27e0?)
	github.com/canonical/lxd/lxd/instance_console.go:226 +0x65
github.com/canonical/lxd/lxd/operations.(*Operation).start.func1({0x2974b98?, 0x30e52b693260?}, 0x30e52a2c2900)
	github.com/canonical/lxd/lxd/operations/operations.go:583 +0x8a
created by github.com/canonical/lxd/lxd/operations.(*Operation).start in goroutine 7192
	github.com/canonical/lxd/lxd/operations/operations.go:536 +0x234
```

using

```sh
#!/bin/bash
set -euo pipefail

vm=nv0

old=$(pgrep -n -x lxd || true)
echo "lxd pid: $old"

rm -f /tmp/console-repro.*

loop() {
    n=$1

    for i in {1..80}; do
        timeout .18 \
            script -qfec "/home/wesley/go/bin/lxc console $vm --type console" \
            "/tmp/console-repro.$n.$i.log" \
            >/tmp/console-repro.$n.out \
            2>>/tmp/console-repro.$n.err || true

        p=$(pgrep -n -x lxd || true)
        if [ "$p" != "$old" ]; then
            echo "lxd restarted: worker=$n iter=$i old=$old new=$p"
            return
        fi
    done
}

for n in {1..6}; do
    loop "$n" &
done

wait
```

The script runs to completion with the fix applied.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] ~I have checked and added or updated relevant documentation.~