### PR TITLE
lxd/instance_console: Remove redundant (and unsafe) write (from Incus) (stable-5.21)

### DIFF
--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -336,7 +336,6 @@ func (s *consoleWs) doConsole() error {
 	s.connsLock.Unlock()
 
 	defer func() {
-		_ = consoleConn.WriteMessage(websocket.BinaryMessage, []byte("\n\r"))
 		_ = consoleConn.Close()
 		_ = ctrlConn.Close()
 	}()


### PR DESCRIPTION
Backport of https://github.com/canonical/lxd/pull/18477

(cherry picked from commit 952fa82ed3bfb707b7ebf9a702b62cb9beac9774)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] ~I have checked and added or updated relevant documentation.~
