### PR TITLE
Network: Add load balancer pool health checks

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -216,6 +216,7 @@ type InstanceServer interface {
 	GetNetworkLoadBalancer(networkName string, listenAddress string) (forward *api.NetworkLoadBalancer, ETag string, err error)
 	GetNetworkLoadBalancerPools(networkName string) (pools []api.NetworkLoadBalancerPool, err error)
 	GetNetworkLoadBalancerPool(networkName string, poolName string) (pool *api.NetworkLoadBalancerPool, ETag string, err error)
+	GetNetworkLoadBalancerPoolState(networkName string, poolName string) (state *api.NetworkLoadBalancerPoolState, err error)
 	CreateNetworkLoadBalancer(networkName string, forward api.NetworkLoadBalancersPost) (op Operation, err error)
 	CreateNetworkLoadBalancerPool(networkName string, pool api.NetworkLoadBalancerPoolsPost) (op Operation, err error)
 	UpdateNetworkLoadBalancer(networkName string, listenAddress string, forward api.NetworkLoadBalancerPut, ETag string) (op Operation, err error)

--- a/client/lxd_network_load_balancers.go
+++ b/client/lxd_network_load_balancers.go
@@ -219,6 +219,25 @@ func (r *ProtocolLXD) GetNetworkLoadBalancerPool(networkName string, poolName st
 	return &loadBalancerPool, etag, nil
 }
 
+// GetNetworkLoadBalancerPoolState returns the state of a network load balancer pool by name in the provided network.
+func (r *ProtocolLXD) GetNetworkLoadBalancerPoolState(networkName string, poolName string) (*api.NetworkLoadBalancerPoolState, error) {
+	err := r.CheckExtension("network_load_balancer_pool")
+	if err != nil {
+		return nil, err
+	}
+
+	var loadBalancerPoolState api.NetworkLoadBalancerPoolState
+
+	// Send the request.
+	u := api.NewURL().Path("networks", networkName, "load-balancer-pools", poolName, "state")
+	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &loadBalancerPoolState)
+	if err != nil {
+		return nil, err
+	}
+
+	return &loadBalancerPoolState, nil
+}
+
 // DeleteNetworkLoadBalancerPool deletes an existing network load balancer pool.
 func (r *ProtocolLXD) DeleteNetworkLoadBalancerPool(networkName string, poolName string) (Operation, error) {
 	err := r.CheckExtension("network_load_balancer_pool")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3625,3 +3625,17 @@ Because the legacy `nvidia.runtime` instance-level option is incompatible with C
 ## `cluster_links_unidirectional`
 
 This extends the {ref}`cluster links <exp-cluster-links>` API with support for unidirectional cluster links. The local cluster consumes a trust token issued by the remote cluster to establish the link and pin the remote's certificate. The remote cluster creates a dedicated identity for the local cluster and can authenticate its incoming requests, but does not store addresses for the local cluster and cannot initiate outbound requests to it.
+
+(extension-network-load-balancer-pool-health-checks)=
+## `network_load_balancer_pool_health_checks`
+
+This introduces health checks for OVN load balancer pools.
+New configuration options on the load balancer pool are added to further customize (or disable) the health check:
+
+* {config:option}`network-load-balancer-pool-properties:healthcheck`
+* {config:option}`network-load-balancer-pool-properties:healthcheck.interval`
+* {config:option}`network-load-balancer-pool-properties:healthcheck.timeout`
+* {config:option}`network-load-balancer-pool-properties:healthcheck.success_count`
+* {config:option}`network-load-balancer-pool-properties:healthcheck.failure_count`
+
+In addition a new endpoint [`GET /1.0/networks/{networkName}/load-balancer-pools/{poolName}/state`](swagger:/network-load-balancer-pools/network_load_balancer_pool_state_get) is added which returns the health check status for all instances in the pool.

--- a/doc/howto/network_load_balancers.md
+++ b/doc/howto/network_load_balancers.md
@@ -21,6 +21,7 @@ A load balancer is made up of:
 - One or more listen ports that are configured to forward to one or more pools of instances.
 
 A pool of instances allows a more simplified definition of backends as it doesn't require additional configuration of the internal IP.
+Furthermore a pool uses health checks to identify offline backends to which the load balancer should not forward any traffic.
 
 ## Create a network load balancer
 
@@ -150,6 +151,14 @@ Use the following command to add instances to the pool:
 lxc network load-balancer pool instance add <network> <pool_name> <instance_name> [<target_port>]
 ```
 
+```{important}
+When adding an instance to a pool that is already referenced by a load balancer port, be aware that OVN will start
+to send traffic to this instance immediately as its status isn't yet known to the load balancer.
+
+Only after the health check returned for the first time, the instance will be removed from the list of eligible targets
+if there isn't any service listening on the target port.
+```
+
 Example:
 
 ```bash
@@ -257,6 +266,7 @@ description: ""
 config:
   protocol: tcp
   target_port: "443"
+  healthcheck.interval: 10
 instances:
 - name: i1
 - name: i2
@@ -265,6 +275,18 @@ instances:
 used_by:
 - /1.0/networks/default/load-balancers/192.0.2.178
 ```
+
+## Get the state of a network load balancer pool
+
+When a pool is referenced by a network load balancer port and contains instances, the current state of the health check can be observed for all instances in the pool.
+
+Use the following command to get the state of a network load balancer pool:
+
+```bash
+lxc network load-balancer pool info <network_name> <pool_name>
+```
+
+The status for each of the pool's instances is reported for each load balancer port that references the pool.
 
 ## Delete a network load balancer
 

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -3562,6 +3562,46 @@ See {ref}`network-load-balancers-port-specifications`.
 
 <!-- config group network-load-balancer-load-balancer-properties end -->
 <!-- config group network-load-balancer-pool-properties start -->
+```{config:option} healthcheck network-load-balancer-pool-properties
+:defaultdesc: "`true`"
+:required: "no"
+:shortdesc: "Whether to enable or disable health checks"
+:type: "bool"
+
+```
+
+```{config:option} healthcheck.failure_count network-load-balancer-pool-properties
+:defaultdesc: "`1`"
+:required: "no"
+:shortdesc: "Number of failed probe attempts after which an instance is considered unhealthy."
+:type: "integer"
+
+```
+
+```{config:option} healthcheck.interval network-load-balancer-pool-properties
+:defaultdesc: "`5`"
+:required: "no"
+:shortdesc: "Interval in seconds between probes of the pool's instances."
+:type: "integer"
+
+```
+
+```{config:option} healthcheck.success_count network-load-balancer-pool-properties
+:defaultdesc: "`1`"
+:required: "no"
+:shortdesc: "Number of successful probe attempts after which an instance is considered healthy."
+:type: "integer"
+
+```
+
+```{config:option} healthcheck.timeout network-load-balancer-pool-properties
+:defaultdesc: "`3`"
+:required: "no"
+:shortdesc: "Timeout in seconds after a probe appears to be faulty."
+:type: "integer"
+
+```
+
 ```{config:option} protocol network-load-balancer-pool-properties
 :defaultdesc: "`tcp`"
 :required: "no"

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3929,6 +3929,68 @@ definitions:
         title: NetworkLoadBalancerPoolPut represents the modifiable fields of a LXD network load balancer pool.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    NetworkLoadBalancerPoolState:
+        properties:
+            targets:
+                description: Actual targets in the pool with their status.
+                items:
+                    $ref: '#/definitions/NetworkLoadBalancerPoolTarget'
+                type: array
+                x-go-name: Targets
+        title: NetworkLoadBalancerPoolState represents the state of a network load balancer pool.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    NetworkLoadBalancerPoolTarget:
+        description: |-
+            If an instance has both IPv4 and IPv6 addresses on the same network interface,
+            those are represented as two targets inside the pool.
+            Each target has its own health check with its own status.
+        properties:
+            address:
+                description: Address represents the address of the target.
+                example: 198.51.100.2
+                type: string
+                x-go-name: Address
+            device:
+                description: Device represents the target instance's network device.
+                example: eth0
+                type: string
+                x-go-name: Device
+            listen_address:
+                description: ListenAddress represents the address of the target's parent load balancer.
+                example: 1.2.3.4
+                type: string
+                x-go-name: ListenAddress
+            listen_port:
+                description: ListenPort represents the port of the target's parent load balancer.
+                example: '"443"'
+                type: string
+                x-go-name: ListenPort
+            name:
+                description: Name represents the target instance's name.
+                example: c1
+                type: string
+                x-go-name: Name
+            port:
+                description: Port represents the port probed on the target's address.
+                example: '"8443"'
+                type: string
+                x-go-name: Port
+            status:
+                description: |-
+                    Status represents the status of the target address.
+                    It can be one of:
+                    error   indicates an error occurred while probing the target address.
+                    offline indicates the target address is not responding to probes.
+                    online  indicates the target address is responding to probes.
+                    pending indicates the target address is pending to being probed.
+                    unknown indicates that the targeted instance is not running and there is no service monitor configured, or that health checks are disabled on the pool.
+                example: online
+                type: string
+                x-go-name: Status
+        title: NetworkLoadBalancerPoolTarget represents the actual targets on a pool's instance.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     NetworkLoadBalancerPoolsPost:
         properties:
             config:
@@ -15082,7 +15144,28 @@ paths:
                 - application/json
             responses:
                 "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                    description: API endpoints
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                description: List of network load balancer pools
+                                items:
+                                    $ref: '#/definitions/NetworkLoadBalancerPool'
+                                type: array
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15112,8 +15195,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15138,8 +15221,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15164,7 +15247,25 @@ paths:
                 - application/json
             responses:
                 "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                    description: API endpoints
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/NetworkLoadBalancerPool'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15194,8 +15295,8 @@ paths:
             produces:
                 - application/json
             responses:
-                "200":
-                    $ref: '#/responses/EmptySyncResponse'
+                "202":
+                    $ref: '#/responses/Operation'
                 "400":
                     $ref: '#/responses/BadRequest'
                 "403":
@@ -15203,6 +15304,50 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Update a network load balancer pool
+            tags:
+                - network-load-balancer-pools
+    /1.0/networks/{networkName}/load-balancer-pools/{poolName}/state:
+        get:
+            consumes:
+                - application/json
+            description: Retrieves the state of a specific network load balancer pool.
+            operationId: network_load_balancer_pool_state_get
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: API endpoints
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/NetworkLoadBalancerPoolState'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the state of a network load balancer pool
             tags:
                 - network-load-balancer-pools
     /1.0/networks/{networkName}/load-balancers:

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -1343,6 +1343,9 @@ func (c *cmdNetworkLoadBalancerPool) command() *cobra.Command {
 	// Pool Get.
 	cmd.AddCommand(c.commandGet())
 
+	// Pool Info.
+	cmd.AddCommand(c.commandInfo())
+
 	// Pool Instance.
 	networkLoadBalancerPoolInstanceCmd := cmdNetworkLoadBalancerPoolInstance{global: c.global, networkLoadBalancerPool: c}
 	cmd.AddCommand(networkLoadBalancerPoolInstanceCmd.command())
@@ -1456,12 +1459,14 @@ func (c *cmdNetworkLoadBalancerPool) helpTemplate() string {
 	return `### This is a YAML representation of the network load balancer pool.
 ### Any line starting with a '#' will be ignored.
 ###
-### A network load balancer pool consists of a set of instances (each with an optional port).
+### A network load balancer pool consists of a set of instances (each with an optional port) and healthcheck configuration.
 ###
 ### An example would look like:
 ### name: pool1
 ### description: ""
 ### config:
+###  healthcheck.interval: "10"
+###  healthcheck.timeout: "10"
 ###  protocol: tcp
 ###  target_port: "443"
 ### instances:
@@ -2097,6 +2102,108 @@ func (c *cmdNetworkLoadBalancerPool) runGet(cmd *cobra.Command, args []string) e
 		}
 	}
 
+	return nil
+}
+
+func (c *cmdNetworkLoadBalancerPool) commandInfo() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("info", "[<remote>:]<network> <pool_name>")
+	cmd.Short = "Show load balancer pool state information"
+	cmd.Long = cli.FormatSection("Description", cmd.Short)
+	cmd.RunE = c.runInfo
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpTopLevelResource("network", toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpNetworkLoadBalancerPools(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+func (c *cmdNetworkLoadBalancerPool) runInfo(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	if resource.name == "" {
+		return errors.New("Missing network name")
+	}
+
+	if args[1] == "" {
+		return errors.New("Missing pool name")
+	}
+
+	// Get the current config.
+	loadBalancerPool, _, err := client.GetNetworkLoadBalancerPool(resource.name, args[1])
+	if err != nil {
+		return err
+	}
+
+	// Get the current state.
+	loadBalancerState, err := client.GetNetworkLoadBalancerPoolState(resource.name, args[1])
+	if err != nil {
+		return err
+	}
+
+	loadBalancerStateTargets := map[string][]map[string]string{}
+
+	// Build up the map of load balancer targets.
+	for _, target := range loadBalancerState.Targets {
+		vip := net.JoinHostPort(target.ListenAddress, target.ListenPort)
+
+		if loadBalancerStateTargets[vip] == nil {
+			// Initialize the slice with size 1 as we don't know if there are additional targets.
+			loadBalancerStateTargets[vip] = []map[string]string{}
+		}
+
+		targetConfig := map[string]string{
+			"instance": target.Name,
+			"device":   target.Device,
+			"status":   target.Status,
+		}
+
+		if target.Address != "" && target.Port != "" {
+			targetConfig["address"] = net.JoinHostPort(target.Address, target.Port)
+		}
+
+		loadBalancerStateTargets[vip] = append(loadBalancerStateTargets[vip], targetConfig)
+	}
+
+	// Declare the poolinfo map of maps in order to build up the yaml.
+	poolInfo := make(map[string]any)
+	poolInfo["info"] = map[string]string{
+		"description": loadBalancerPool.Description,
+		"name":        loadBalancerPool.Name,
+		"protocol":    loadBalancerPool.Config["protocol"],
+	}
+
+	poolInfo["load-balancers"] = loadBalancerStateTargets
+
+	// Convert pool info to YAML and print.
+	data, err := yaml.Marshal(poolInfo)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(string(data))
 	return nil
 }
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -106,6 +106,7 @@ var api10 = []APIEndpoint{
 	networkLoadBalancerCmd,
 	networkLoadBalancersCmd,
 	networkLoadBalancerPoolCmd,
+	networkLoadBalancerPoolStateCmd,
 	networkLoadBalancerPoolsCmd,
 	networkPeerCmd,
 	networkPeersCmd,

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -3981,6 +3981,51 @@
 			"properties": {
 				"keys": [
 					{
+						"healthcheck": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Whether to enable or disable health checks",
+							"type": "bool"
+						}
+					},
+					{
+						"healthcheck.failure_count": {
+							"defaultdesc": "`1`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Number of failed probe attempts after which an instance is considered unhealthy.",
+							"type": "integer"
+						}
+					},
+					{
+						"healthcheck.interval": {
+							"defaultdesc": "`5`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Interval in seconds between probes of the pool's instances.",
+							"type": "integer"
+						}
+					},
+					{
+						"healthcheck.success_count": {
+							"defaultdesc": "`1`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Number of successful probe attempts after which an instance is considered healthy.",
+							"type": "integer"
+						}
+					},
+					{
+						"healthcheck.timeout": {
+							"defaultdesc": "`3`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Timeout in seconds after a probe appears to be faulty.",
+							"type": "integer"
+						}
+					},
+					{
 						"protocol": {
 							"defaultdesc": "`tcp`",
 							"longdesc": "Can be either `tcp` or `udp`.",

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/canonical/lxd/client"
@@ -64,10 +65,25 @@ type forwardPortMap struct {
 	target      forwardTarget
 }
 
+// loadBalancerHealthCheck represents the health check configuration for a load balancer pool.
+type loadBalancerHealthCheck struct {
+	// The interval between health checks.
+	interval time.Duration
+	// The timeout after which a health check is considered failed.
+	timeout time.Duration
+	// The number of consecutive successful health checks required before considering a target healthy.
+	successCount uint64
+	// The number of consecutive failed health checks required before considering a target unhealthy.
+	failureCount uint64
+}
+
+// loadBalancerPortMap represents a mapping of listen port(s) to target port(s).
+// An optional health check configuration can be set for the target(s).
 type loadBalancerPortMap struct {
 	listenPorts []uint64
 	protocol    string
 	targets     []forwardTarget
+	healthCheck *loadBalancerHealthCheck
 }
 
 // subnetUsageType indicates the type of use for a subnet.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -1797,3 +1797,8 @@ func (n *common) LoadBalancerPoolUpdate(poolName string, loadBalancerPool api.Ne
 func (n *common) LoadBalancerPoolDelete(poolName string) error {
 	return ErrNotImplemented
 }
+
+// LoadBalancerPoolState returns ErrNotImplemented for drivers that do not support load balancer pool state.
+func (n *common) LoadBalancerPoolState(poolName string) (*api.NetworkLoadBalancerPoolState, error) {
+	return nil, ErrNotImplemented
+}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -6638,6 +6638,46 @@ func (n *ovn) loadBalancerPoolValidate(ctx context.Context, tx *db.ClusterTx, po
 		//  required: yes
 		//  shortdesc: Port used on instances for ingress pool traffic
 		"target_port": validate.Required(validate.IsNetworkPort),
+		// lxdmeta:generate(entities=network-load-balancer-pool; group=properties; key=healthcheck)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  required: no
+		//  shortdesc: Whether to enable or disable health checks
+		"healthcheck": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=network-load-balancer-pool; group=properties; key=healthcheck.interval)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: `5`
+		//  required: no
+		//  shortdesc: Interval in seconds between probes of the pool's instances.
+		"healthcheck.interval": validate.Optional(validate.IsUint64),
+		// lxdmeta:generate(entities=network-load-balancer-pool; group=properties; key=healthcheck.timeout)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: `3`
+		//  required: no
+		//  shortdesc: Timeout in seconds after a probe appears to be faulty.
+		"healthcheck.timeout": validate.Optional(validate.IsUint64),
+		// lxdmeta:generate(entities=network-load-balancer-pool; group=properties; key=healthcheck.success_count)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: `1`
+		//  required: no
+		//  shortdesc: Number of successful probe attempts after which an instance is considered healthy.
+		"healthcheck.success_count": validate.Optional(validate.IsUint64),
+		// lxdmeta:generate(entities=network-load-balancer-pool; group=properties; key=healthcheck.failure_count)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: `1`
+		//  required: no
+		//  shortdesc: Number of failed probe attempts after which an instance is considered unhealthy.
+		"healthcheck.failure_count": validate.Optional(validate.IsUint64),
 	}
 
 	// Run the validator against each field.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -41,6 +41,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
+	"github.com/canonical/lxd/shared/version"
 )
 
 const ovnChassisPriorityMax = 32767
@@ -5332,6 +5333,29 @@ func (n *ovn) loadBalancerFlattenVIPs(listenAddress net.IP, portMaps []*loadBala
 				vip.Targets = append(vip.Targets, loadBalancerTarget)
 			}
 
+			if portMap.healthCheck != nil {
+				healthCheck := openvswitch.OVNLoadBalancerHealthCheck{
+					Interval:     portMap.healthCheck.interval,
+					Timeout:      portMap.healthCheck.timeout,
+					SuccessCount: portMap.healthCheck.successCount,
+					FailureCount: portMap.healthCheck.failureCount,
+				}
+
+				var err error
+
+				if listenAddress.To4() != nil {
+					healthCheck.SourceAddress, _, err = n.parseRouterIntPortIPv4Net()
+				} else {
+					healthCheck.SourceAddress, _, err = n.parseRouterIntPortIPv6Net()
+				}
+
+				if err != nil {
+					return nil, err
+				}
+
+				vip.HealthCheck = &healthCheck
+			}
+
 			vips = append(vips, vip)
 		}
 	}
@@ -5339,10 +5363,83 @@ func (n *ovn) loadBalancerFlattenVIPs(listenAddress net.IP, portMaps []*loadBala
 	return vips, nil
 }
 
+// checkPoolHealthCheck checks the pool's health check settings and returns a health check struct if valid.
+func (n *ovn) checkPoolHealthCheck(pool *api.NetworkLoadBalancerPool) (*loadBalancerHealthCheck, error) {
+	// If health checks are disabled, return early.
+	if shared.IsFalse(pool.Config["healthcheck"]) {
+		return nil, nil
+	}
+
+	var err error
+
+	// Use defaults if none are provided in the pool's config.
+	// These are the values defined by OVN in https://github.com/ovn-org/ovn/blob/main/controller/pinctrl.c.
+	healthCheckConfig := map[string]uint64{
+		"healthcheck.interval":      5,
+		"healthcheck.timeout":       3,
+		"healthcheck.success_count": 1,
+		"healthcheck.failure_count": 1,
+	}
+
+	for k := range healthCheckConfig {
+		strVal, ok := pool.Config[k]
+		if !ok {
+			continue
+		}
+
+		bitSize := 64
+		if k == "healthcheck.interval" || k == "healthcheck.timeout" {
+			bitSize = 63
+		}
+
+		// We accept uint64 values for health check settings as OVN allows setting such high values.
+		// However it's unlikely those are ever used in practice, so we accept converting using a slightly smaller bitSize
+		// so some of the settings fit into an int64 when converted to time.Duration.
+		healthCheckConfig[k], err = strconv.ParseUint(strVal, 10, bitSize)
+		if err != nil {
+			return nil, fmt.Errorf("Failed converting %q: %w", k, err)
+		}
+	}
+
+	return &loadBalancerHealthCheck{
+		interval:     time.Second * time.Duration(healthCheckConfig["healthcheck.interval"]),
+		timeout:      time.Second * time.Duration(healthCheckConfig["healthcheck.timeout"]),
+		successCount: healthCheckConfig["healthcheck.success_count"],
+		failureCount: healthCheckConfig["healthcheck.failure_count"],
+	}, nil
+}
+
+// poolHealthCheckSupported checks if the current OVN version supports our demands for configuring health checks.
+func (n *ovn) poolHealthCheckSupported() error {
+	client, err := openvswitch.NewOVN(n.state.GlobalConfig.NetworkOVNNorthboundConnection(), n.state.GlobalConfig.NetworkOVNSSL)
+	if err != nil {
+		return fmt.Errorf("Failed getting OVN client: %w", err)
+	}
+
+	nbVersion, err := client.GetNorthdVersion()
+	if err != nil {
+		return fmt.Errorf("Failed getting OVN northd version: %w", err)
+	}
+
+	// 25.09.90 is the first version that was shipped with support for using the network's router IP as source for health checks.
+	// See patch https://mail.openvswitch.org/pipermail/ovs-dev/2026-February/429961.html.
+	minVersion, err := version.NewDottedVersion("25.09.90")
+	if err != nil {
+		return fmt.Errorf("Failed parsing minimum OVN version: %w", err)
+	}
+
+	if nbVersion.Compare(minVersion) < 0 {
+		return fmt.Errorf("Cannot use OVN version %q (< 25.09.90) to configure health checks", nbVersion)
+	}
+
+	return nil
+}
+
 // checkLoadBalancerPoolInstances check if any of the load balancer ports reference a pool of instances.
 // It checks the instances in the pool and returns port maps for the respective parent load balancer.
 // Instances which are stopped are filtered out and not included in the port maps.
 func (n *ovn) checkLoadBalancerPoolInstances(listenAddress net.IP, forward api.NetworkLoadBalancerPut) ([]*loadBalancerPortMap, error) {
+	healthCheckSupportedErr := n.poolHealthCheckSupported()
 	var portMaps []*loadBalancerPortMap
 
 	activeNICs, err := n.getLoadBalancerInstanceNICs()
@@ -5488,6 +5585,16 @@ func (n *ovn) checkLoadBalancerPoolInstances(listenAddress net.IP, forward api.N
 			// If the pool doesn't have any instances, don't bother creating a port map.
 			if len(portMap.targets) == 0 {
 				continue
+			}
+
+			// Check and configure the health check.
+			portMap.healthCheck, err = n.checkPoolHealthCheck(pool)
+			if err != nil {
+				return nil, fmt.Errorf("Failed configuring load balancer health check for pool %q: %w", pool.Name, err)
+			}
+
+			if portMap.healthCheck != nil && healthCheckSupportedErr != nil {
+				return nil, healthCheckSupportedErr
 			}
 
 			portMaps = append(portMaps, &portMap)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -7163,6 +7163,132 @@ func (n *ovn) getLoadBalancerPool(ctx context.Context, tx *sql.Tx, poolName stri
 	return poolDB.ToAPI(allConfigs, allInstances)
 }
 
+// LoadBalancerPoolState returns the state of a network load balancer pool.
+func (n *ovn) LoadBalancerPoolState(poolName string) (*api.NetworkLoadBalancerPoolState, error) {
+	var pool *api.NetworkLoadBalancerPool
+	var loadBalancers map[int64]*api.NetworkLoadBalancer
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		pool, err = n.getLoadBalancerPool(ctx, tx.Tx(), poolName)
+		if err != nil {
+			return err
+		}
+
+		loadBalancers, err = tx.GetNetworkLoadBalancers(ctx, n.ID(), false)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a map of load balancer listen addresses using the pool together with their listen ports.
+	poolListenAddresses := make(map[string][]string)
+	for _, lb := range loadBalancers {
+		for _, port := range lb.Ports {
+			if port.TargetPool == poolName {
+				if poolListenAddresses[lb.ListenAddress] == nil {
+					poolListenAddresses[lb.ListenAddress] = []string{}
+				}
+
+				poolListenAddresses[lb.ListenAddress] = append(poolListenAddresses[lb.ListenAddress], port.ListenPort)
+			}
+		}
+	}
+
+	client, err := openvswitch.NewOVN(n.state.GlobalConfig.NetworkOVNNorthboundConnection(), n.state.GlobalConfig.NetworkOVNSSL)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting OVN client: %w", err)
+	}
+
+	poolState := &api.NetworkLoadBalancerPoolState{
+		// For the initialize size assume each instance has at least one device in the network.
+		Targets: make([]api.NetworkLoadBalancerPoolTarget, 0, len(pool.Instances)),
+	}
+
+	// Populate the pool's instances service monitor target state.
+	for _, poolInstance := range pool.Instances {
+		// Load the instance from the DB by name.
+		dbInst, err := instance.LoadByProjectAndName(n.state, n.project, poolInstance.Name)
+		if err != nil {
+			return nil, fmt.Errorf("Failed loading instance %q: %w", poolInstance.Name, err)
+		}
+
+		instanceUUID := dbInst.LocalConfig()["volatile.uuid"]
+
+		// Find NICs connected to this network.
+		for devName, devConfig := range dbInst.ExpandedDevices() {
+			if devConfig["type"] != "nic" || !NICUsesNetwork(devConfig, &api.Network{Name: n.name}) {
+				continue
+			}
+
+			targetPort := pool.Config["target_port"]
+			if poolInstance.TargetPort != "" {
+				targetPort = poolInstance.TargetPort
+			}
+
+			// Load the service monitor's status for the given instance device.
+			monitors, err := client.ServiceMonitorStatusGet(n.getInstanceDevicePortName(instanceUUID, devName), targetPort)
+			if err != nil {
+				return nil, err
+			}
+
+			// Add state of started instances for which a service monitor exists.
+			for _, monitor := range monitors {
+				for listenAddr, listenPorts := range poolListenAddresses {
+					listenIP := net.ParseIP(listenAddr)
+					if listenIP == nil {
+						continue
+					}
+
+					// Match IPv4 target to IPv4 load balancer, IPv6 to IPv6.
+					if (monitor.Address.To4() != nil) != (listenIP.To4() != nil) {
+						continue
+					}
+
+					// Until OVN performed the first health check, the status is empty.
+					// Return it as pending.
+					if monitor.Status == "" {
+						monitor.Status = "pending"
+					}
+
+					for _, port := range listenPorts {
+						poolState.Targets = append(poolState.Targets, api.NetworkLoadBalancerPoolTarget{
+							ListenAddress: listenAddr,
+							ListenPort:    port,
+							Name:          poolInstance.Name,
+							Address:       monitor.Address.String(),
+							Port:          targetPort,
+							Device:        devName,
+							Status:        monitor.Status,
+						})
+					}
+				}
+			}
+
+			// Add state for stopped instance which don't have a service monitor configured.
+			if len(monitors) == 0 {
+				for listenAddr, listenPorts := range poolListenAddresses {
+					for _, port := range listenPorts {
+						poolState.Targets = append(poolState.Targets, api.NetworkLoadBalancerPoolTarget{
+							ListenAddress: listenAddr,
+							ListenPort:    port,
+							Name:          poolInstance.Name,
+							Device:        devName,
+							// A status of "unknown" is used to indicate that the instance is not running and there is no service monitor configured.
+							// In addition if health checks are disabled on the pool, the status of all targets is returned as "unknown" as well.
+							Status: "unknown",
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return poolState, nil
+}
+
 // getLoadBalancerInstanceNICs returns a list of active instance NICs which are referenced by load balancers on this network.
 // The operation is performed with the records from the database.
 // Another approach would be to query all the active service monitors using ovn-sbctl.

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -72,6 +72,7 @@ type Network interface {
 	LoadBalancerPoolCreate(loadBalancerPool api.NetworkLoadBalancerPoolsPost) error
 	LoadBalancerPoolUpdate(poolName string, loadBalancerPool api.NetworkLoadBalancerPoolPut) error
 	LoadBalancerPoolDelete(poolName string) error
+	LoadBalancerPoolState(poolName string) (*api.NetworkLoadBalancerPoolState, error)
 
 	// Peerings.
 	PeerCreate(forward api.NetworkPeersPost) error

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -147,12 +147,28 @@ type OVNLoadBalancerTarget struct {
 	Port       uint64
 }
 
+// OVNLoadBalancerHealthCheck represents a OVN load balancer health check.
+type OVNLoadBalancerHealthCheck struct {
+	Interval      time.Duration
+	Timeout       time.Duration
+	SuccessCount  uint64
+	FailureCount  uint64
+	SourceAddress net.IP
+}
+
 // OVNLoadBalancerVIP represents a OVN load balancer Virtual IP entry.
 type OVNLoadBalancerVIP struct {
 	Protocol      string // Either "tcp" or "udp". But only applies to port based VIPs.
 	ListenAddress net.IP
 	ListenPort    uint64
 	Targets       []OVNLoadBalancerTarget
+	HealthCheck   *OVNLoadBalancerHealthCheck
+}
+
+// OVNServiceMonitorStatus represents the status of an OVN load balancer target as reported by OVN's service monitor.
+type OVNServiceMonitorStatus struct {
+	Address net.IP
+	Status  string
 }
 
 // OVNRouterRoute represents a static route added to a logical router.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -2,6 +2,7 @@ package openvswitch
 
 import (
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"net"
@@ -1940,32 +1941,53 @@ func (o *OVN) loadBalancerUUIDs(loadBalancerName OVNLoadBalancer) (map[string][]
 	return lbUUIDs, nil
 }
 
-// loadBalancerVIPs returns a slice of VIPs currently configured on the given load balancer.
-func (o *OVN) loadBalancerVIPs(loadBalancerName OVNLoadBalancer, protocol string) ([]string, error) {
+// loadBalancerConfig returns slices of the load balancer's current VIPs and ip_port_mappings.
+func (o *OVN) loadBalancerConfig(loadBalancerName OVNLoadBalancer, protocol string) (vips []string, mappings []string, err error) {
 	lbName := string(loadBalancerName) + "-" + protocol
-	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=vips", "list", "load_balancer", lbName)
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=vips,ip_port_mappings", "list", "load_balancer", lbName)
 	if err != nil {
-		return nil, fmt.Errorf("Failed listing the VIPs of load balancer %q: %w", lbName, err)
+		return nil, nil, fmt.Errorf("Failed listing the config of load balancer %q: %w", lbName, err)
 	}
 
-	output, err = unquote(strings.TrimSpace(output))
+	// Use a CSV reader to properly handle any potential quoting.
+	// Simply splitting the output by comma does not work as the "vips" value itself also uses a comma as a separator.
+	r := csv.NewReader(strings.NewReader(output))
+	record, err := r.Read()
 	if err != nil {
-		return nil, fmt.Errorf("Failed unquoting VIPs output %q of load balancer %q: %w", output, lbName, err)
+		return nil, nil, fmt.Errorf("Failed parsing config of load balancer %q: %w", lbName, err)
 	}
 
-	vipTargets := strings.Fields(output)
-	vips := make([]string, 0, len(vipTargets))
+	if len(record) != 2 {
+		return nil, nil, fmt.Errorf("Unexpected column count %d in output of load balancer %q", len(record), lbName)
+	}
 
+	vipTargets := strings.Fields(record[0])
+	vips = make([]string, 0, len(vipTargets))
+
+	// Record all VIPs.
 	for _, vipTarget := range vipTargets {
 		before, _, found := strings.Cut(vipTarget, "=")
 		if !found {
-			return nil, fmt.Errorf("Invalid line %q in VIPs output of load balancer %q", vipTarget, lbName)
+			return nil, nil, fmt.Errorf("Invalid line %q in VIPs output of load balancer %q", vipTarget, lbName)
 		}
 
 		vips = append(vips, before)
 	}
 
-	return vips, nil
+	ipPortMappings := strings.Fields(record[1])
+	mappings = make([]string, 0, len(ipPortMappings))
+
+	// Record all targets.
+	for _, ipPortMapping := range ipPortMappings {
+		mapping, _, found := strings.Cut(ipPortMapping, "=")
+		if !found {
+			return nil, nil, fmt.Errorf("Invalid line %q in ip_port_mappings output of load balancer %q", ipPortMapping, lbName)
+		}
+
+		mappings = append(mappings, mapping)
+	}
+
+	return vips, mappings, nil
 }
 
 // ipToString wraps IPv6 addresses in square brackets.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/linux"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/dnsutil"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
@@ -1999,6 +2001,189 @@ func (o *OVN) ipToString(ip net.IP) string {
 	return ip.String()
 }
 
+// LoadBalancerHealthCheckGet returns the UUID of the health check for the given VIP.
+func (o *OVN) LoadBalancerHealthCheckGet(vip string) (string, error) {
+	// Check if a health check already exists for this VIP.
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=_uuid",
+		"find", "load_balancer_health_check", `vip="`+vip+`"`)
+	if err != nil {
+		return "", err
+	}
+
+	hcUUID := strings.TrimSpace(output)
+	if hcUUID != "" {
+		// Health check for this VIP already exists.
+		return hcUUID, nil
+	}
+
+	return "", api.StatusErrorf(http.StatusNotFound, "Failed finding health check for vip %q", vip)
+}
+
+// LoadBalancerHealthCheckAdd adds a health check for the given VIP and the necessary port mappings for all targets.
+// If it already exists it ensures the health check options are up to date.
+func (o *OVN) LoadBalancerHealthCheckAdd(loadBalancerName OVNLoadBalancer, loadBalancerVIP OVNLoadBalancerVIP) error {
+	if loadBalancerVIP.HealthCheck == nil {
+		return errors.New("Health check configuration is missing")
+	}
+
+	for _, target := range loadBalancerVIP.Targets {
+		err := o.LoadBalancerHealthCheckMappingAdd(loadBalancerName, loadBalancerVIP.Protocol, loadBalancerVIP.HealthCheck.SourceAddress, target)
+		if err != nil {
+			return fmt.Errorf("Failed adding health check mapping between vip %q and target %q: %w", loadBalancerVIP.HealthCheck.SourceAddress.String(), target.Address.String(), err)
+		}
+	}
+
+	vipStr := o.ipToString(loadBalancerVIP.ListenAddress) + ":" + strconv.FormatUint(loadBalancerVIP.ListenPort, 10)
+	hcUUID, err := o.LoadBalancerHealthCheckGet(vipStr)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return fmt.Errorf("Failed checking if health check exists for vip %q: %w", vipStr, err)
+	}
+
+	args := []string{}
+
+	// When formatting ignore the floating point returned from Seconds() as this cannot be represented in OVN anyway.
+	interval := strconv.FormatUint(uint64(loadBalancerVIP.HealthCheck.Interval.Seconds()), 10)
+	timeout := strconv.FormatUint(uint64(loadBalancerVIP.HealthCheck.Timeout.Seconds()), 10)
+	successCount := strconv.FormatUint(uint64(loadBalancerVIP.HealthCheck.SuccessCount), 10)
+	failureCount := strconv.FormatUint(uint64(loadBalancerVIP.HealthCheck.FailureCount), 10)
+
+	if hcUUID == "" {
+		// Create a new health check.
+		args = append(args,
+			"--id=@id",
+			"create",
+			"load_balancer_health_check",
+			`vip="`+vipStr+`"`,
+			"options:interval="+interval,
+			"options:timeout="+timeout,
+			"options:success_count="+successCount,
+			"options:failure_count="+failureCount,
+		)
+
+		loadBalancerProtocolName := string(loadBalancerName) + "-" + loadBalancerVIP.Protocol
+		args = append(args,
+			"--",
+			"add",
+			"load_balancer",
+			loadBalancerProtocolName,
+			"health_check",
+			"@id",
+		)
+	} else {
+		// Update existing health check.
+		args = append(args,
+			"set",
+			"load_balancer_health_check",
+			hcUUID,
+			"options:interval="+interval,
+			"options:timeout="+timeout,
+			"options:success_count="+successCount,
+			"options:failure_count="+failureCount,
+		)
+	}
+
+	// Add the load balancer health check.
+	_, err = o.nbctl(args...)
+	if err != nil {
+		return fmt.Errorf("Failed adding health check for vip %q: %w", vipStr, err)
+	}
+
+	return nil
+}
+
+// LoadBalancerHealthCheckDelete removes the health check for the given VIP from the load balancer.
+// If it doesn't exist its a noop.
+func (o *OVN) LoadBalancerHealthCheckDelete(loadBalancerProtocolName string, vip string) error {
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--columns=_uuid",
+		"find", "load_balancer_health_check", `vip="`+vip+`"`)
+	if err != nil {
+		return fmt.Errorf("Failed finding health check for vip %q: %w", vip, err)
+	}
+
+	hcUUID := strings.TrimSpace(output)
+	if hcUUID != "" {
+		// Remove the health check from the load balancer. This also
+		// destroys the now-unreferenced health check row.
+		_, err = o.nbctl("remove", "load_balancer", loadBalancerProtocolName, "health_check", hcUUID)
+		if err != nil {
+			return fmt.Errorf("Failed deleting health check for vip %q on load balancer %q: %w", vip, loadBalancerProtocolName, err)
+		}
+	}
+
+	return nil
+}
+
+// LoadBalancerHealthCheckMappingAdd adds a port mapping for the given target.
+// If it already exists, it is a no-op.
+func (o *OVN) LoadBalancerHealthCheckMappingAdd(loadBalancerName OVNLoadBalancer, loadBalancerProtocol string, sourceAddress net.IP, target OVNLoadBalancerTarget) error {
+	args := make([]string, 0, 5)
+
+	loadBalancerProtocolName := string(loadBalancerName) + "-" + loadBalancerProtocol
+
+	args = append(args,
+		"add",
+		"load_balancer",
+		loadBalancerProtocolName,
+		"ip_port_mappings",
+		`"`+o.ipToString(target.Address)+`"="`+string(target.SwitchPort)+":"+o.ipToString(sourceAddress)+`"`,
+	)
+
+	// Add the load balancer health check mappings.
+	_, err := o.nbctl(args...)
+	return err
+}
+
+// LoadBalancerHealthCheckMappingDelete removes the port mapping for the given target.
+// If it doesn't exist its a noop.
+func (o *OVN) LoadBalancerHealthCheckMappingDelete(loadBalancerProtocolName string, targetAddress string) error {
+	args := make([]string, 0, 5)
+
+	args = append(args,
+		"remove",
+		"load_balancer",
+		loadBalancerProtocolName,
+		"ip_port_mappings",
+		`"`+targetAddress+`"`,
+	)
+	_, err := o.nbctl(args...)
+	return err
+}
+
+// ServiceMonitorStatusGet returns the service monitor's status for the given switch port.
+// The targetPort is used to filter the results in case the switchPort is used by multiple VIPs with different target ports.
+// A status is returned for each address configured on the port.
+func (o *OVN) ServiceMonitorStatusGet(switchPort OVNSwitchPort, targetPort string) ([]OVNServiceMonitorStatus, error) {
+	output, err := o.sbctl("--format=csv", "--no-headings", "--data=bare", "--columns=ip,status", "find", "Service_Monitor",
+		"logical_port="+string(switchPort), "port="+targetPort,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting service monitor status for switch port %q: %w", switchPort, err)
+	}
+
+	lines := shared.SplitNTrimSpace(output, "\n", -1, true)
+	addressToStatus := make([]OVNServiceMonitorStatus, 0, len(lines))
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		// 10.135.198.3,online
+		// fd42:b0f:7376:f557:216:3eff:fe32:2d63,offline
+		ip, status, found := strings.Cut(line, ",")
+		if !found {
+			return nil, fmt.Errorf("Invalid service monitor status response line: %q", line)
+		}
+
+		addressToStatus = append(addressToStatus, OVNServiceMonitorStatus{
+			Address: net.ParseIP(ip),
+			Status:  status,
+		})
+	}
+
+	return addressToStatus, nil
+}
+
 // LoadBalancerApply creates a new load balancer (if doesn't exist) on the specified routers and switches.
 // Providing an empty set of vips will delete the load balancer.
 func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNRouter, switches []OVNSwitch, vips ...OVNLoadBalancerVIP) error {
@@ -2012,6 +2197,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 	}
 
 	allVIPsForProtocol := map[string][]string{}
+	allMappingsForLB := map[string][]string{}
 
 	// Get a view of all load balancers matching the given name.
 	lbUUIDs, err := o.loadBalancerUUIDs(loadBalancerName)
@@ -2080,6 +2266,15 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 			} else {
 				targetArgs = append(targetArgs, ipStr)
 			}
+
+			// Record the mapping only if health check is configured.
+			if vip.HealthCheck != nil {
+				if allMappingsForLB[lbName] == nil {
+					allMappingsForLB[lbName] = []string{}
+				}
+
+				allMappingsForLB[lbName] = append(allMappingsForLB[lbName], ipStr)
+			}
 		}
 
 		if len(args) > 0 {
@@ -2118,7 +2313,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 
 		lbName := string(loadBalancerName) + "-" + protocol
 
-		currentVIPs, err := o.loadBalancerVIPs(loadBalancerName, protocol)
+		currentVIPs, currentMappings, err := o.loadBalancerConfig(loadBalancerName, protocol)
 		if err == nil {
 			for _, currentVIP := range currentVIPs {
 				if !slices.Contains(allVIPsForProtocol[protocol], currentVIP) {
@@ -2127,6 +2322,22 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 					}
 
 					args = append(args, "--if-exists", "lb-del", lbName, currentVIP)
+
+					// Remove the obsolete health check if exists.
+					err = o.LoadBalancerHealthCheckDelete(lbName, currentVIP)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			for _, currentMapping := range currentMappings {
+				if !slices.Contains(allMappingsForLB[lbName], currentMapping) {
+					// Remove the obsolete mapping if exists.
+					err = o.LoadBalancerHealthCheckMappingDelete(lbName, currentMapping)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -2153,6 +2364,24 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 		_, err := o.nbctl(args...)
 		if err != nil {
 			return err
+		}
+	}
+
+	// Apply the load balancer health check changes.
+	// Unset health checks for VIPs that don't require it anymore.
+	for _, vip := range vips {
+		vipStr := o.ipToString(vip.ListenAddress) + ":" + strconv.FormatUint(vip.ListenPort, 10)
+
+		if vip.HealthCheck != nil {
+			err = o.LoadBalancerHealthCheckAdd(loadBalancerName, vip)
+			if err != nil {
+				return fmt.Errorf("Failed setting up health check for vip %q on port %d using protocol %q: %w", vipStr, vip.ListenPort, vip.Protocol, err)
+			}
+		} else {
+			err = o.LoadBalancerHealthCheckDelete(string(loadBalancerName)+"-"+vip.Protocol, vipStr)
+			if err != nil {
+				return fmt.Errorf("Failed removing health check for vip %q on port %d using protocol %q: %w", vipStr, vip.ListenPort, vip.Protocol, err)
+			}
 		}
 	}
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -18,6 +18,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/dnsutil"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/version"
 )
 
 // OVNRouter OVN router name.
@@ -2581,4 +2582,26 @@ func (o *OVN) GetLogicalRouterPortActiveChassisHostname(ovnRouterPort OVNRouterP
 	}
 
 	return strings.TrimSpace(hostname), err
+}
+
+// GetNorthdVersion gets the northd internal version from the NB_Global table.
+func (o *OVN) GetNorthdVersion() (*version.DottedVersion, error) {
+	output, err := o.nbctl("get", "NB_Global", ".", "options:northd_internal_version")
+	if err != nil {
+		return nil, err
+	}
+
+	output, err = unquote(strings.TrimSpace(output))
+	if err != nil {
+		return nil, fmt.Errorf("Failed unquoting northd_internal_version %q: %w", output, err)
+	}
+
+	// MicroOVN uses the format "25.09.90-21.7.0-82.12".
+	// Upstream OVN just uses the format "25.09.90".
+	ovnVersion, _, found := strings.Cut(output, "-")
+	if !found {
+		return nil, fmt.Errorf("Failed splitting northd_internal_version %q", output)
+	}
+
+	return version.NewDottedVersion(ovnVersion)
 }

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -58,6 +58,13 @@ var networkLoadBalancerPoolCmd = APIEndpoint{
 	Put:    APIEndpointAction{Handler: networkLoadBalancerPoolPut, AccessHandler: networkAccessHandler(auth.EntitlementCanEdit)},
 }
 
+var networkLoadBalancerPoolStateCmd = APIEndpoint{
+	Path:        "networks/{networkName}/load-balancer-pools/{poolName}/state",
+	MetricsType: entity.TypeNetwork,
+
+	Get: APIEndpointAction{Handler: networkLoadBalancerPoolStateGet, AccessHandler: networkAccessHandler(auth.EntitlementCanView)},
+}
+
 // API endpoints
 
 // swagger:operation GET /1.0/networks/{networkName}/load-balancers network-load-balancers network_load_balancers_get
@@ -1023,6 +1030,83 @@ func networkLoadBalancerPoolGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponseETag(true, loadBalancerPool, loadBalancerPool.Etag())
+}
+
+// swagger:operation GET /1.0/networks/{networkName}/load-balancer-pools/{poolName}/state network-load-balancer-pools network_load_balancer_pool_state_get
+//
+//	Get the state of a network load balancer pool
+//
+//	Retrieves the state of a specific network load balancer pool.
+//
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkLoadBalancerPoolState"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func networkLoadBalancerPoolStateGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	details, err := request.GetContextValue[networkDetails](r.Context(), ctxNetworkDetails)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
+	}
+
+	resp := networkLoadBalancerPoolCheckAccess(n, details)
+	if resp != nil {
+		return resp
+	}
+
+	poolName := r.PathValue("poolName")
+
+	poolState, err := n.LoadBalancerPoolState(poolName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, poolState)
 }
 
 // swagger:operation DELETE /1.0/networks/{networkName}/load-balancer-pools/{poolName} network-load-balancer-pools network_load_balancer_pool_delete

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -775,8 +775,8 @@ func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 //	    schema:
 //	      $ref: "#/definitions/NetworkLoadBalancerPoolsPost"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -869,7 +869,28 @@ func networkLoadBalancerPoolUsedBy(projectName string, networkName string, loadB
 //	    example: default
 //	responses:
 //	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network load balancer pools
+//	          items:
+//	            $ref: "#/definitions/NetworkLoadBalancerPool"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -962,7 +983,25 @@ func networkLoadBalancerPoolsGet(d *Daemon, r *http.Request) response.Response {
 //	    example: default
 //	responses:
 //	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkLoadBalancerPool"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -1127,8 +1166,8 @@ func networkLoadBalancerPoolStateGet(d *Daemon, r *http.Request) response.Respon
 //	    type: string
 //	    example: default
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":
@@ -1209,8 +1248,8 @@ func networkLoadBalancerPoolDelete(d *Daemon, r *http.Request) response.Response
 //	    schema:
 //	      $ref: "#/definitions/NetworkLoadBalancerPoolPut"
 //	responses:
-//	  "200":
-//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
 //	  "400":
 //	    $ref: "#/responses/BadRequest"
 //	  "403":

--- a/shared/api/network_load_balancer.go
+++ b/shared/api/network_load_balancer.go
@@ -299,6 +299,60 @@ func (lb *NetworkLoadBalancer) SetWritable(put NetworkLoadBalancerPut) {
 	lb.Ports = put.Ports
 }
 
+// NetworkLoadBalancerPoolTarget represents the actual targets on a pool's instance.
+// If an instance has both IPv4 and IPv6 addresses on the same network interface,
+// those are represented as two targets inside the pool.
+// Each target has its own health check with its own status.
+//
+// swagger:model
+//
+// API extension: network_load_balancer_pool_health_checks.
+type NetworkLoadBalancerPoolTarget struct {
+	// ListenAddress represents the address of the target's parent load balancer.
+	// Example: 1.2.3.4
+	ListenAddress string `json:"listen_address" yaml:"listen_address"`
+
+	// ListenPort represents the port of the target's parent load balancer.
+	// Example: "443"
+	ListenPort string `json:"listen_port" yaml:"listen_port"`
+
+	// Name represents the target instance's name.
+	// Example: c1
+	Name string `json:"name" yaml:"name"`
+
+	// Address represents the address of the target.
+	// Example: 198.51.100.2
+	Address string `json:"address" yaml:"address"`
+
+	// Port represents the port probed on the target's address.
+	// Example: "8443"
+	Port string `json:"port" yaml:"port"`
+
+	// Device represents the target instance's network device.
+	// Example: eth0
+	Device string `json:"device" yaml:"device"`
+
+	// Status represents the status of the target address.
+	// It can be one of:
+	// error   indicates an error occurred while probing the target address.
+	// offline indicates the target address is not responding to probes.
+	// online  indicates the target address is responding to probes.
+	// pending indicates the target address is pending to being probed.
+	// unknown indicates that the targeted instance is not running and there is no service monitor configured, or that health checks are disabled on the pool.
+	// Example: online
+	Status string `json:"status" yaml:"status"`
+}
+
+// NetworkLoadBalancerPoolState represents the state of a network load balancer pool.
+//
+// swagger:model
+//
+// API extension: network_load_balancer_pool_health_checks.
+type NetworkLoadBalancerPoolState struct {
+	// Actual targets in the pool with their status.
+	Targets []NetworkLoadBalancerPoolTarget `json:"targets,omitempty" yaml:"targets,omitempty"`
+}
+
 // NetworkLoadBalancerPoolInstance represents an instance in a load balancer pool.
 // An instance can have multiple targets depending on how many addresses it has in the pool's network.
 //

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -89,6 +89,16 @@ func IsUint32(value string) error {
 	return nil
 }
 
+// IsUint64 validates whether the string can be converted to an uint64.
+func IsUint64(value string) error {
+	_, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid value for uint64 %q: %w", value, err)
+	}
+
+	return nil
+}
+
 // ParseUint32Range parses a uint32 range in the form "number" or "start-end".
 // Returns the start number and the size of the range.
 func ParseUint32Range(value string) (start uint32, rangeSize uint32, err error) {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -498,6 +498,7 @@ var APIExtensions = []string{
 	"clustering_evacuation_force",
 	"gpu_mig_cdi",
 	"cluster_links_unidirectional",
+	"network_load_balancer_pool_health_checks",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -1337,7 +1337,12 @@ probe_pool_targets() {
 
   # Try 100 times to be sure we got a response from all instances, as the load balancer may choose the same instance for multiple consecutive requests.
   for i in $(seq 1 100); do
-    response="$(curl --silent --connect-timeout 5 -H "Connection: close" "http://${load_balancer_ip}:80")"
+    # We have to use a fairly long connect timeout to ensure the first request goes through when using OVN load balancer health checks.
+    # When using the gateway/router as source IP for the health checks, there seems to be an initial MAC binding missing which drops
+    # the backend's reply for the SYN sent by curl.
+    # Therefore wait for retransmit.
+    # All of the following requests will go through immediately.
+    response="$(curl --silent --connect-timeout 120 -H "Connection: close" "http://${load_balancer_ip}:80")"
     match=false
     for valid in "${valid_responses[@]}"; do
       if [ "${response}" = "${valid}" ]; then

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -1211,7 +1211,7 @@ test_network_ovn() {
   lxc launch testimage c1 -n "${ovn_network}" -d "eth0,ipv4.address=10.24.140.50"
   setup_instance_ip4_interface c1
   # shellcheck disable=SC2016
-  lxc exec c1 -- sh -c 'echo "$(hostname)" > /tmp/index.html && httpd -p 80 -h /tmp'
+  lxc exec c1 -- sh -c 'hostname > /tmp/index.html && httpd -p 80 -h /tmp'
   lxc network load-balancer pool instance add "${ovn_network}" http c1
 
   echo "==> Create a dual-stack load balancer using the same pool."

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -1107,6 +1107,28 @@ test_network_ovn() {
   unset_ovn_configuration
 }
 
+wait_for_pool_status() {
+  network="${1}"
+  load_balancer_ip="${2}"
+  pool="${3}"
+  status="${4}"
+  targets="${5}"
+
+  for i in $(seq 1 5); do
+    if lxc network load-balancer pool info "${network}" "${pool}" | yq --exit-status '."load-balancers"."'"${load_balancer_ip}"':80" | map(select(.status == "'"${status}"'")) | length == '"${targets}"''; then
+      break
+    fi
+
+    # As the pool has a check interval of 1 second, the targets should be present after 5 iterations/seconds.
+    if [ "$i" -eq 5 ]; then
+      echo "${targets} targets failed to become ${status} within the expected time"
+      exit 1
+    fi
+
+    sleep 1
+  done
+}
+
 probe_pool_targets() {
   load_balancer_ip="${1}"
   shift

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -925,14 +925,20 @@ test_network_ovn() {
 
   load_balancer_ips=("10.24.140.100" "fd42:bd85:5f89:5293::100" "192.0.2.100" "2001:db8:1:2::100")
 
-  echo "==> Create a load balancer pool using 80 TCP."
-  lxc network load-balancer pool create "${ovn_network}" http target_port=80
+  echo "==> Create a load balancer pool using 80, TCP and a short interval to speed up tests"
+  lxc network load-balancer pool create "${ovn_network}" http target_port=80 healthcheck.interval=1 healthcheck.timeout=1
 
   echo "==> Check the list of load balancer pools shows the created pool."
   [ "$(lxc network load-balancer pool list "${ovn_network}" -f json | jq length)" = "1" ]
 
   echo "==> Check that the load balancer pool shows the right target port."
   [ "$(lxc network load-balancer pool get "${ovn_network}" http target_port)" = "80" ]
+
+  echo "==> Check that the load balancer pool shows the right interval."
+  [ "$(lxc network load-balancer pool get "${ovn_network}" http healthcheck.interval)" = "1" ]
+
+  echo "==> Check that the load balancer pool shows the right timeout."
+  [ "$(lxc network load-balancer pool get "${ovn_network}" http healthcheck.timeout)" = "1" ]
 
   echo "==> Check that the load balancer pool shows port tcp if none was provided during creation."
   [ "$(lxc network load-balancer pool get "${ovn_network}" http protocol)" = "tcp" ]
@@ -1008,22 +1014,181 @@ test_network_ovn() {
     echo "==> Check the profile device cannot be removed while the interface is used by a load balancer port."
     [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc profile device remove foo eth0 2>&1)" = "Error: At least one instance relies on this profile's nic device for network load balancer pool membership" ]
 
+    echo "==> Check the instance status is unknown as it was added to the pool in a stopped state."
+    # "unknown" means it's not added to the load balancer and there is no service monitor which reports a status for it.
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80".[] | select(.instance == "c4").status == "unknown"'
+
     echo "==> Check the instance can be removed which also removes its participation in the load balancer pool."
     lxc rm -f c4
+
+    echo "==> Check the instance is removed from the pool."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.instance == "c4")) | length == 0'
 
     lxc profile delete foo
 
     echo "==> Check the load balancer pool shows as being used."
     lxc network load-balancer pool show "${ovn_network}" http | yq --exit-status '.used_by | length == 1'
 
-    echo "==> Spawn a web server in all instances to serve traffic on port 80."
-    for i in 1 2 3; do
+    echo "==> Check the load balancer pool's state shows a single load balancer."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers" | length == 1'
+
+    echo "==> Check the load balancer pool's state shows three targets for port 80."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | length == 3'
+
+    echo "==> Check the target isn't online as there isn't any service running inside the instance."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status != "online")) | length == 3'
+
+    echo "==> Spawn a web server in the first two instances to serve traffic on port 80."
+    for i in 1 2; do
       # shellcheck disable=SC2016
       lxc exec "c${i}" -- sh -c 'hostname > /tmp/index.html && httpd -p 80 -h /tmp'
     done
 
-    echo "==> Check that the load balancers accordingly distribute traffic to all instances."
-    probe_pool_targets "${bracketed_ip}" c1 c2 c3
+    echo "==> Wait for the targets to become healthy."
+    wait_for_pool_status "${ovn_network}" "${bracketed_ip}" http online 2
+
+    echo "==> Check that the first instance target is online."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "online" and .instance == "c1")) | length == 1'
+
+    echo "==> Check that the second instance target is online."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "online" and .instance == "c2")) | length == 1'
+
+    echo "==> Check that the third instance target is still marked as offline."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status != "online" and .instance == "c3")) | length == 1'
+
+    echo "==> Check that the load balancers accordingly distribute traffic to the first two instances."
+    probe_pool_targets "${bracketed_ip}" c1 c2
+
+    echo "==> Tear down the second server."
+    lxc exec "c2" -- killall httpd
+
+    echo "==> Wait for the second instance target to become unhealthy."
+    for i in $(seq 1 3); do
+      if lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "online" and .instance == "c2")) | length == 0'; then
+        break
+      fi
+
+      # As the pool has a check interval of 1 second, the target should be marked unhealthy after 3 iterations.
+      if [ "$i" -eq 3 ]; then
+        echo "Target failed to become unhealthy within the expected time"
+        exit 1
+      fi
+
+      sleep 1
+    done
+
+    echo "==> Check that the first instance target is online."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "online" and .instance == "c1")) | length == 1'
+
+    echo "==> Check that the second instance target is offline."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "offline" and .instance == "c2")) | length == 1'
+
+    echo "==> Check that the third instance target is still marked as offline."
+    lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "offline" and .instance == "c3")) | length == 1'
+
+    echo "==> Check that the load balancers accordingly distribute traffic only to the first instance"
+    probe_pool_targets "${bracketed_ip}" c1
+
+    echo "==> Start the web server in the third instance."
+    # shellcheck disable=SC2016
+    lxc exec c3 -- sh -c 'hostname > /tmp/index.html && httpd -p 80 -h /tmp'
+
+    echo "==> Wait for the new target to become healthy."
+    wait_for_pool_status "${ovn_network}" "${bracketed_ip}" http online 2
+
+    echo "==> Check that the load balancers accordingly distribute traffic to the first and third instances."
+    probe_pool_targets "${bracketed_ip}" c1 c3
+
+    echo "==> Stop the first instance."
+    lxc stop -f c1
+
+    echo "==> Check the health check status of the first instances becomes unhealthy."
+    for i in $(seq 1 3); do
+      if lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."'"${bracketed_ip}"':80" | map(select(.status == "offline" and .instance == "c1")) | length == 1'; then
+        break
+      fi
+
+      # As the pool has a check interval of 1 second, the target should be marked unhealthy after 3 iterations.
+      if [ "$i" -eq 3 ]; then
+        echo "Target failed to become unhealthy within the expected time"
+        exit 1
+      fi
+
+      sleep 1
+    done
+
+    echo "==> Monitor the status does not yield online until it is reachable again."
+    (
+      timeout=10
+      elapsed=0
+      while true; do
+        status="$(lxc network load-balancer pool info "${ovn_network}" http | yq -r '."load-balancers"."'"${bracketed_ip}"':80".[] | select(.instance == "c1").status')"
+        if [ "${status}" = "online" ]; then
+          exit 0
+        fi
+
+        elapsed=$((elapsed + 1))
+        if [ "${elapsed}" -ge "${timeout}" ]; then
+          echo "ERROR: Timed out waiting for c1 target to become online" >&2
+          exit 1
+        fi
+
+        sleep 1
+      done
+    ) &
+
+    monitor_pid="$!"
+
+    echo "==> Start c1 and its web server."
+    lxc start c1
+    setup_instance_ip4_interface c1
+    # shellcheck disable=SC2016
+    lxc exec c1 -- sh -c 'hostname > /tmp/index.html && httpd -p 80 -h /tmp'
+
+    echo "==> Wait for background monitor to confirm clean offline-to-online transition."
+    wait "${monitor_pid}"
+
+    echo "==> Remove the first instance from the pool."
+    lxc network load-balancer pool instance remove "${ovn_network}" http c1
+
+    echo "==> Add the first instance back to the pool."
+    lxc network load-balancer pool instance add "${ovn_network}" http c1
+
+    echo "==> Monitor the status of the first instance yields online after it is added back to the pool and the target is healthy."
+    (
+      timeout=10
+      elapsed=0
+      while true; do
+        status="$(lxc network load-balancer pool info "${ovn_network}" http | yq -r '."load-balancers"."'"${bracketed_ip}"':80".[] | select(.instance == "c1").status')"
+        if [ "${status}" = "online" ]; then
+          exit 0
+        fi
+
+        # "offline" means that the instance target isn't reachable.
+        #   We don't expect this as the target of the first instance is online.
+        # "unknown" means there is no health check for the instance.
+        #   It's not yet added to the LB, but already in the DB so the state endpoint appends it to the list of targets for which a service monitor exists.
+        # "pending" means OVN hasn't yet probed the instance target.
+        # "" means the yq command didn't find the instance and cannot report a status.
+        if [ "${status}" != "unknown" ] && [ "${status}" != "pending" ] && [ "${status}" != "" ]; then
+          echo "ERROR: Unexpected status '${status}' for c1 target" >&2
+          exit 1
+        fi
+
+        elapsed=$((elapsed + 1))
+        if [ "${elapsed}" -ge "${timeout}" ]; then
+          echo "ERROR: Timed out waiting for c1 target to become online" >&2
+          exit 1
+        fi
+
+        sleep 1
+      done
+    ) &
+
+    monitor_pid="$!"
+
+    echo "==> Wait for background monitor to confirm clean transition to online status."
+    wait "${monitor_pid}"
 
     echo "==> Tear down all servers."
     for i in 1 2 3; do
@@ -1053,17 +1218,43 @@ test_network_ovn() {
   lxc network load-balancer port add "${ovn_network}" 192.0.2.100 tcp 80 target_pool=http
   lxc network load-balancer port add "${ovn_network}" 2001:db8:1:2::100 tcp 80 target_pool=http
 
+  echo "==> Wait for the new target to become healthy for the dual-stack load balancer."
+  wait_for_pool_status "${ovn_network}" 192.0.2.100 http online 1
+  wait_for_pool_status "${ovn_network}" "$(wrap_ipv6 2001:db8:1:2::100)" http online 1
+
   echo "==> Check the load balancer pool shows as being used twice."
   lxc network load-balancer pool show "${ovn_network}" http | yq --exit-status '.used_by | length == 2'
+
+  echo "==> Check the load balancer pool's state shows two load balancers."
+  lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers" | length == 2'
 
   echo "==> Check that the load balancers accordingly distribute traffic to the single instance."
   probe_pool_targets 192.0.2.100 c1
   probe_pool_targets "$(wrap_ipv6 2001:db8:1:2::100)" c1
 
+  echo "==> Check that disabling the pool health check moves the target status to unknown."
+  lxc network load-balancer pool set "${ovn_network}" http healthcheck=false
+  lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."192.0.2.100:80" | map(select(.status == "unknown")) | length == 1'
+  lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."[2001:db8:1:2::100]:80" | map(select(.status == "unknown")) | length == 1'
+
+  echo "==> Check that unsetting the healthcheck configuration re-enables it by default."
+  lxc network load-balancer pool unset "${ovn_network}" http healthcheck
+  lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."192.0.2.100:80" | map(select(.status != "unknown")) | length == 1'
+  lxc network load-balancer pool info "${ovn_network}" http | yq --exit-status '."load-balancers"."[2001:db8:1:2::100]:80" | map(select(.status != "unknown")) | length == 1'
+
+  echo "==> Wait for the target to become healthy again for the dual-stack load balancer."
+  wait_for_pool_status "${ovn_network}" 192.0.2.100 http online 1
+  wait_for_pool_status "${ovn_network}" "$(wrap_ipv6 2001:db8:1:2::100)" http online 1
+
   echo "==> Change the instance IPv4 address and check the load balancer updates the target address accordingly."
   lxc config device set c1 eth0 ipv4.address=10.24.140.51
   # Mimic what the DHCP client would do.
   setup_instance_ip4_interface c1
+
+  echo "==> Wait for the target to become healthy again for the dual-stack load balancer."
+  wait_for_pool_status "${ovn_network}" 192.0.2.100 http online 1
+  # Only IPv4 address was changed so IPv6 target should remain online.
+  wait_for_pool_status "${ovn_network}" "$(wrap_ipv6 2001:db8:1:2::100)" http online 1
 
   echo "==> Check that the load balancers accordingly distribute traffic to the single instance."
   probe_pool_targets 192.0.2.100 c1
@@ -1072,6 +1263,10 @@ test_network_ovn() {
   echo "==> Change the pool's target port to something invalid and use the instance override to restore."
   lxc network load-balancer pool set "${ovn_network}" http target_port=81
   lxc network load-balancer pool show "${ovn_network}" http | yq '.instances[].target_port = "80"' | lxc network load-balancer pool edit "${ovn_network}" http
+
+  echo "==> Wait for the target to become healthy again for the dual-stack load balancer."
+  wait_for_pool_status "${ovn_network}" 192.0.2.100 http online 1
+  wait_for_pool_status "${ovn_network}" "$(wrap_ipv6 2001:db8:1:2::100)" http online 1
 
   echo "==> Check that the load balancers accordingly distribute traffic to the single instance."
   probe_pool_targets 192.0.2.100 c1


### PR DESCRIPTION
This PR adds health checks to OVN load balancer pools.
A new API extension `network_load_balancer_pool_health_checks` is added too.

The config items that can be configured on a load balancer pool are identical to the ones allowed when configuring the health check in the [`load_balancer_health_check`](https://manpages.ubuntu.com/manpages/resolute/man5/ovn-nb.5.html#load-balancer-health-check-table) table.
