### PR TITLE
Network: Load balancer pool followup

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -7073,14 +7073,13 @@ func (n *ovn) getLoadBalancerInstanceNICs() ([]OVNLoadBalancerInstanceNIC, error
 // InstanceDevicePortValidateUseByLoadBalancer checks whether the given instance is referenced by any load balancer pool on this network.
 // Returns an error if it is, indicating the instance must be removed from the pool first.
 func (n *ovn) InstanceDevicePortValidateUseByLoadBalancer(deviceInstance instance.Instance) error {
-	var loadBalancers map[int64]*api.NetworkLoadBalancer
-	var err error
-
 	return n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		loadBalancers, err = tx.GetNetworkLoadBalancers(ctx, n.ID(), false)
+		loadBalancers, err := tx.GetNetworkLoadBalancers(ctx, n.ID(), false)
 		if err != nil {
 			return err
 		}
+
+		loadBalancerPools := make(map[string]*api.NetworkLoadBalancerPool)
 
 		for _, lb := range loadBalancers {
 			for _, port := range lb.Ports {
@@ -7089,12 +7088,14 @@ func (n *ovn) InstanceDevicePortValidateUseByLoadBalancer(deviceInstance instanc
 				}
 
 				// Load the pool and check its instances.
-				pool, err := n.getLoadBalancerPool(ctx, tx.Tx(), port.TargetPool)
-				if err != nil {
-					return fmt.Errorf("Failed getting load balancer pool %q: %w", port.TargetPool, err)
+				if loadBalancerPools[port.TargetPool] == nil {
+					loadBalancerPools[port.TargetPool], err = n.getLoadBalancerPool(ctx, tx.Tx(), port.TargetPool)
+					if err != nil {
+						return fmt.Errorf("Failed getting load balancer pool %q: %w", port.TargetPool, err)
+					}
 				}
 
-				for _, poolInst := range pool.Instances {
+				for _, poolInst := range loadBalancerPools[port.TargetPool].Instances {
 					if poolInst.Name == deviceInstance.Name() {
 						return api.StatusErrorf(http.StatusBadRequest, "Instance %q is referenced by load balancer pool %q and listen address %q", deviceInstance.Name(), port.TargetPool, lb.ListenAddress)
 					}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3152,27 +3152,6 @@ func (n *ovn) Delete(clientType request.ClientType) error {
 		if err != nil {
 			return fmt.Errorf("Failed deleting network forwards and load balancers: %w", err)
 		}
-
-		// Delete any load balancer pools.
-		// The load balancers and their ports are already cleaned up at this stage.
-		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			pools, err := dbCluster.GetNetworksLoadBalancerPools(ctx, tx.Tx(), n.ID(), nil)
-			if err != nil {
-				return err
-			}
-
-			for _, pool := range pools {
-				err = dbCluster.DeleteNetworksLoadBalancerPool(ctx, tx.Tx(), n.ID(), pool.Row.Name)
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			return err
-		}
 	}
 
 	return n.delete()

--- a/lxd/network_load_balancers_test.go
+++ b/lxd/network_load_balancers_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/canonical/lxd/lxd/network"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// mockNetwork satisfies network.Network for unit tests.
+type mockNetwork struct {
+	network.Network
+	managed     bool
+	info        network.Info
+	networkType string
+}
+
+func (s *mockNetwork) IsManaged() bool {
+	return s.managed
+}
+
+func (s *mockNetwork) Info() network.Info {
+	return s.info
+}
+
+func (s *mockNetwork) Type() string {
+	return s.networkType
+}
+
+// supportedNetwork is the ideal supported network.
+var supportedNetwork = &mockNetwork{
+	managed: true,
+	info: network.Info{
+		LoadBalancers: true,
+	},
+	networkType: "ovn",
+}
+
+// supportedProject is the ideal supported project.
+var supportedProject = networkDetails{
+	requestProject: api.Project{
+		Config: map[string]string{
+			"features.networks": "true",
+		},
+	},
+	networkName: "default",
+}
+
+func Test_networkLoadBalancerPoolCheckAccess(t *testing.T) {
+	tests := []struct {
+		TestName string
+		network  network.Network
+		details  networkDetails
+		response response.Response
+	}{
+		{
+			TestName: "Check pool creation is allowed if project has network features enabled and supports load balancers",
+			network:  supportedNetwork,
+			details:  supportedProject,
+			response: nil,
+		},
+		{
+			TestName: "Check pool creation is forbidden if project has network features enabled but does not support load balancers",
+			network: &mockNetwork{
+				managed: true,
+				info: network.Info{
+					LoadBalancers: false,
+				},
+				networkType: "foo",
+			},
+			details:  supportedProject,
+			response: response.BadRequest(errors.New(`Network driver "foo" does not support load balancers`)),
+		},
+		{
+			TestName: "Check pool creation is forbidden if project does not have network features enabled but does support load balancers",
+			network:  supportedNetwork,
+			details: networkDetails{
+				requestProject: api.Project{
+					Name: "default",
+					Config: map[string]string{
+						"features.networks": "false",
+					},
+				},
+				networkName: "default",
+			},
+			response: response.BadRequest(errors.New(`Project "default" requires features.networks=true`)),
+		},
+		{
+			TestName: "Check pool creation is forbidden if project does not have network features specifically set but does support load balancers",
+			network:  supportedNetwork,
+			details: networkDetails{
+				requestProject: api.Project{
+					Name:   "default",
+					Config: map[string]string{},
+				},
+				networkName: "default",
+			},
+			response: response.BadRequest(errors.New(`Project "default" requires features.networks=true`)),
+		},
+		{
+			TestName: "Check pool creation is forbidden if network is not in the list of allowed networks",
+			network:  supportedNetwork,
+			details: networkDetails{
+				requestProject: api.Project{
+					Config: map[string]string{
+						"restricted":                 "true",
+						"restricted.networks.access": "foo",
+					},
+				},
+				networkName: "bar",
+			},
+			response: response.NotFound(api.NewStatusError(http.StatusNotFound, "Network not found")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			resp := networkLoadBalancerPoolCheckAccess(test.network, test.details)
+			assert.Equal(t, test.response, resp)
+		})
+	}
+}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -18,6 +18,77 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// checkProfileNICDeviceUsage checks if there are any instances of this profile attached to network load balancer pools.
+// The profile update cannot remove the mandatory nic device referenced by the load balancer pool.
+func checkProfileNICDeviceUsage(ctx context.Context, tx *db.ClusterTx, insts map[int]db.InstanceArgs, profileName string, req api.ProfilePut) error {
+	// Check if there are any instances of this profile attached to network load balancer pools.
+	// The profile update cannot remove the mandatory nic device.
+	for _, inst := range insts {
+		var networkNames []string
+
+		// Check if this instance is a member of any load balancer pool.
+		poolInstRows, err := cluster.GetNetworksLoadBalancerPoolInstanceRowsByID(ctx, tx.Tx(), int64(inst.ID))
+		if err != nil {
+			return err
+		}
+
+		// Exit early if instance is not a member of any pool.
+		if len(poolInstRows) == 0 {
+			continue
+		}
+
+		for _, poolInstRow := range poolInstRows {
+			// Get the pool to find its network.
+			pool, err := cluster.GetNetworksLoadBalancerPoolRowByID(ctx, tx.Tx(), poolInstRow.PoolID)
+			if err != nil {
+				return err
+			}
+
+			// Get the network name from the pool's network ID.
+			networkName, _, err := tx.GetNetworkNameAndProjectWithID(ctx, int(pool.NetworkID))
+			if err != nil {
+				return err
+			}
+
+			networkNames = append(networkNames, networkName)
+		}
+
+		// Build the new expanded devices with the updated profile.
+		newProfiles := make([]api.Profile, len(inst.Profiles))
+		copy(newProfiles, inst.Profiles)
+		for i, prof := range newProfiles {
+			// Find the profile being updated and update its devices.
+			if prof.Name == profileName {
+				newProfiles[i].Devices = req.Devices
+				break
+			}
+		}
+
+		newExpandedDevices := instancetype.ExpandInstanceDevices(inst.Devices.Clone(), newProfiles)
+
+		for _, networkName := range networkNames {
+			// Check if the new expanded devices still have a NIC connected to this network.
+			hasNIC := false
+			for _, devConfig := range newExpandedDevices {
+				if devConfig["type"] != "nic" {
+					continue
+				}
+
+				if network.NICUsesNetwork(devConfig, &api.Network{Name: networkName}) {
+					hasNIC = true
+					break
+				}
+			}
+
+			if !hasNIC {
+				return errors.New("At least one instance relies on this profile's nic device for network load balancer pool membership")
+			}
+		}
+	}
+
+	return nil
+}
+
 func doProfileUpdate(ctx context.Context, s *state.State, p api.Project, profileName string, profile *api.Profile, req api.ProfilePut) error {
 	// Check project limits.
 	err := s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
@@ -89,69 +160,10 @@ func doProfileUpdate(ctx context.Context, s *state.State, p api.Project, profile
 	}
 
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		// Check if there are any instances of this profile attached to network load balancer pools.
-		// The profile update cannot remove the mandatory nic device.
-		for _, inst := range insts {
-			var networkNames []string
-
-			// Check if this instance is a member of any load balancer pool.
-			poolInstRows, err := cluster.GetNetworksLoadBalancerPoolInstanceRowsByID(ctx, tx.Tx(), int64(inst.ID))
-			if err != nil {
-				return err
-			}
-
-			// Exit early if instance is not a member of any pool.
-			if len(poolInstRows) == 0 {
-				continue
-			}
-
-			for _, poolInstRow := range poolInstRows {
-				// Get the pool to find its network.
-				pool, err := cluster.GetNetworksLoadBalancerPoolRowByID(ctx, tx.Tx(), poolInstRow.PoolID)
-				if err != nil {
-					return err
-				}
-
-				// Get the network name from the pool's network ID.
-				networkName, _, err := tx.GetNetworkNameAndProjectWithID(ctx, int(pool.NetworkID))
-				if err != nil {
-					return err
-				}
-
-				networkNames = append(networkNames, networkName)
-			}
-
-			// Build the new expanded devices with the updated profile.
-			newProfiles := make([]api.Profile, len(inst.Profiles))
-			copy(newProfiles, inst.Profiles)
-			for i, prof := range newProfiles {
-				// Find the profile being updated and update its devices.
-				if prof.Name == profileName {
-					newProfiles[i].Devices = req.Devices
-					break
-				}
-			}
-
-			newExpandedDevices := instancetype.ExpandInstanceDevices(inst.Devices.Clone(), newProfiles)
-
-			for _, networkName := range networkNames {
-				// Check if the new expanded devices still have a NIC connected to this network.
-				hasNIC := false
-				for _, devConfig := range newExpandedDevices {
-					if devConfig["type"] != "nic" {
-						continue
-					}
-
-					if network.NICUsesNetwork(devConfig, &api.Network{Name: networkName}) {
-						hasNIC = true
-						break
-					}
-				}
-
-				if !hasNIC {
-					return errors.New("At least one instance relies on this profile's nic device for network load balancer pool membership")
-				}
-			}
+		// Check for instances which are referenced by load balancer pools through a nic device in this profile.
+		err := checkProfileNICDeviceUsage(ctx, tx, insts, profileName, req)
+		if err != nil {
+			return err
 		}
 
 		// Update the database.


### PR DESCRIPTION
This PR addresses some last comments from https://github.com/canonical/lxd/pull/18179:

* Drop unnecessary pool delete on parent network delete
* Cache pools when looping
* Reduce cyclomatic complexity
* Add unit tests for pool access checks

This can be safely merged after 6.9.
