### PR TITLE
lxd/storage/block: Exit gracefully when blkid is denied under snap confinement

### DIFF
--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -383,8 +384,14 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				partition.Size = partitionSize * 512
 
 				// Pull device filesystem UUID information.
+				// Within LXD the block-devices interface is auto-connected, so blkid is
+				// always accessible. Permission errors can only surface when this code is
+				// reused outside LXD under tighter confinement (for example a snap that
+				// does not connect the block-devices interface). That is not an advertised
+				// use case, but we tolerate it by leaving DeviceFSUUID empty rather than
+				// failing the whole resources query.
 				partition.DeviceFSUUID, err = block.DiskFSUUID(filepath.Join("/dev", subEntryName))
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrPermission) {
 					return nil, err
 				}
 
@@ -452,8 +459,14 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			}
 
 			// Pull device filesystem UUID information.
+			// Within LXD the block-devices interface is auto-connected, so blkid is
+			// always accessible. Permission errors can only surface when this code is
+			// reused outside LXD under tighter confinement (for example a snap that
+			// does not connect the block-devices interface). That is not an advertised
+			// use case, but we tolerate it by leaving DeviceFSUUID empty rather than
+			// failing the whole resources query.
 			disk.DeviceFSUUID, err = block.DiskFSUUID(devPath)
-			if err != nil {
+			if err != nil && !errors.Is(err, os.ErrPermission) {
 				return nil, err
 			}
 


### PR DESCRIPTION
## Summary

When `blkid` runs inside a strictly confined snap without the `block-devices`
interface, AppArmor denies execution. The `execve` fails before the process
starts, surfacing as `fork/exec ... permission denied` (`*fs.PathError` wrapping
`EACCES`) rather than a `blkid` exit code. The resources scan
(`GET /1.0/resources`) treated this as fatal and aborted.

`GetStorage` now tolerates `os.ErrPermission` from `DiskFSUUID` at both the disk
and partition call sites: the UUID is left empty and the scan continues.

## Why it matters

MAAS builds `machine-resources` on `lxd/resources` to collect host info. This
lets it consume newer LXD without connecting `block-devices`, which grants broad
raw block access beyond what reporting needs. Within LXD itself the interface is
auto-connected, so behavior is unchanged.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
