### PR TITLE
fix(tests): correct inverted assertions for read-only snapshot property editing

### DIFF
--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -85,7 +85,12 @@ snapshots() {
         ;;
     esac
 
-    ! lxc config edit foo/snap0 < "$tmp_yaml" 2>&1 | grep -xF "$ERROR_MSG" || false
+    local output
+    if output="$(CLIENT_DEBUG="" SHELL_TRACING="" lxc config edit foo/snap0 < "$tmp_yaml" 2>&1)"; then
+      false
+    else
+      echo "$output" | grep -xF "$ERROR_MSG"
+    fi
   done
   rm "${tmp_yaml}"
 

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -114,7 +114,12 @@ EOF
         ;;
     esac
 
-    ! lxc storage volume edit "${storage_pool}" "${storage_volume}/snap0" < "$tmp_yaml" 2>&1 | grep -xF "$ERROR_MSG" || false
+    local output
+    if output="$(CLIENT_DEBUG="" SHELL_TRACING="" lxc storage volume edit "${storage_pool}" "${storage_volume}/snap0" < "$tmp_yaml" 2>&1)"; then
+      false
+    else
+      echo "$output" | grep -xF "$ERROR_MSG"
+    fi
   done
   rm "${tmp_yaml}"
 


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.

## Summary

- `test/suites/snapshots.sh` and `test/suites/storage_snapshots.sh` both contain inverted test assertions that cause the tests to pass when editing read-only snapshot properties silently succeeds (the broken behavior) and fail when the API correctly rejects such edits.
- The pipeline `! cmd 2>&1 | grep -xF "$MSG" || false` negates grep's exit code, so the test passes when the error message is absent — exactly the opposite of the intended assertion.
- Replaces the inverted pipeline with the pattern identified by @simondeziel in issue #18398: capture output into a variable, assert the command exits non-zero, then assert the expected error string is present.

## Why this matters

The inverted assertions mean the regression introduced in #17070 (addressing #14423) was never caught by the test suite. A member maintainer (@simondeziel) diagnosed the flaw and provided the corrected pattern in the issue thread. This PR applies that pattern to both affected test files.

## Testing

These are shell test files with no production code changes. Bash syntax has been verified (`bash -n`). The corrected assertions will:

- Fail when `lxc config edit foo/snap0` with a modified read-only field silently returns exit 0 (regression guard active)
- Pass when the API correctly returns a non-zero exit code with the expected "Only 'expires_at' field(s) can be modified" error message
- Behave identically in the `storage_snapshots.sh` parallel case for storage volume snapshots
- Leave the positive `expires_at`-editable test immediately following the loop unaffected

Fixes #18398
