### PR TITLE
Storage: Fix CephFS volume multi-use (stable-5.21)

### DIFF
--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/db"
@@ -244,6 +245,14 @@ func daemonStorageValidate(s *state.State, target string) (validatedTarget strin
 		// Don't fail on systems with snapdir=visible.
 		if entryName == ".zfs" {
 			continue
+		}
+
+		if slices.Contains([]string{"instances", "custom"}, entryName) {
+			// Don't fail on multi-node volumes (e.g. CephFS) which might already contain the
+			// directory skeleton for storing instance and custom volume backups.
+			if pool.Driver().Info().VolumeMultiNode {
+				continue
+			}
 		}
 
 		return "", fmt.Errorf("Storage volume %q isn't empty", target)


### PR DESCRIPTION
In https://github.com/canonical/microcloud/issues/1417 it was reported that setting either `storage.backups_volume` with the same CephFS vol across multiple cluster members currently returns this error for every n+1 cluster member:

`Error: Failed validation of "storage.backups_volume": Storage volume "remote-fs/backups" isn't empty`

It's already fixed in 6 as it's using a different layout without the initial skeleton inside the backups vol.

The PR adds an exception.