### PR TITLE
Prune all operations in a recurring task

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2031,6 +2031,9 @@ func (d *Daemon) init() error {
 
 		// Run scheduled replicators (minutely check of configurable cron expression)
 		d.tasks.Add(runScheduledReplicatorsTask(d.State))
+
+		// Synchronize operations with the database (minutely)
+		d.tasks.Add(synchronizeOperationsTask(d.State))
 	}
 
 	// Load Ubuntu Pro configuration before starting any instances.
@@ -2142,9 +2145,6 @@ func (d *Daemon) startClusterTasks() {
 
 	// Remove orphaned operations
 	d.clusterTasks.Add(autoRemoveOrphanedOperationsTask(d.State))
-
-	// Prune expired operations from the database (hourly)
-	d.clusterTasks.Add(pruneExpiredOperationsTask(d.State))
 
 	// Perform automatic evacuation for offline cluster members
 	d.clusterTasks.Add(autoHealClusterTask(d.State, d.gateway))

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -104,6 +104,21 @@ func (o Operation) Requestor() *request.RequestorAuditor {
 	}
 }
 
+// IsFinished returns true if the operation status is final.
+func (o Operation) IsFinished() bool {
+	return api.StatusCode(o.Row.StatusCode).IsFinal()
+}
+
+// UpdatedAt returns the last update timestamp for the operation.
+func (o Operation) UpdatedAt() time.Time {
+	return o.Row.UpdatedAt
+}
+
+// IsChild returns true if the operation references a parent.
+func (o Operation) IsChild() bool {
+	return o.Row.Parent != nil
+}
+
 // RequestorProtocol is the database representation of the Requestor Protocol.
 //
 // RequestorProtocol is defined on string so that constants can be converted by casting. The [sql.Scanner] and

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -357,11 +357,6 @@ func GetOperationsByProjectAndType(ctx context.Context, tx *sql.Tx, projectName 
 	return query.Select[Operation](ctx, tx, "WHERE coalesce(projects.name, '') = ? AND operations.type = ?", projectName, opType)
 }
 
-// DeleteOperation deletes an operation by UUID.
-func DeleteOperation(ctx context.Context, tx *sql.Tx, operationUUID string) error {
-	return query.DeleteOne[OperationsRow](ctx, tx, "WHERE operations.uuid = ?", operationUUID)
-}
-
 // GetOperation gets an [Operation] by UUID.
 func GetOperation(ctx context.Context, tx *sql.Tx, operationUUID string) (*Operation, error) {
 	return query.SelectOne[Operation](ctx, tx, "WHERE operations.uuid = ?", operationUUID)

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -256,12 +256,6 @@ func OpenCluster(closingCtx context.Context, name string, store driver.NodeStore
 		// Set the local member ID
 		clusterDB.NodeID(memberID)
 
-		// Clear any operation tied to this member
-		err = cluster.ClearStaleOperationsFromNodes(ctx, tx.tx, memberID)
-		if err != nil {
-			return err
-		}
-
 		return nil
 	})
 	if err != nil {

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"slices"
 	"strconv"
@@ -1120,34 +1121,55 @@ func (c *ClusterTx) GetCandidateMembers(ctx context.Context, allMembers []NodeIn
 // GetNodeWithLeastInstances returns the name of the member with the least number of instances that are either
 // already created or being created with an operation.
 func (c *ClusterTx) GetNodeWithLeastInstances(ctx context.Context, members []NodeInfo) (*NodeInfo, error) {
-	var member *NodeInfo
-	var lowestInstanceCount = -1
-
-	for i := range members {
-		// Fetch the number of instances already created on this member.
-		created, err := query.Count(ctx, c.tx, "instances", "node_id=?", members[i].ID)
-		if err != nil {
-			return nil, fmt.Errorf("Failed getting instances count: %w", err)
-		}
-
-		// Fetch the number of instances currently being created on this member.
-		pending, err := query.Count(ctx, c.tx, "operations", "node_id=? AND type=?", members[i].ID, operationtype.InstanceCreate)
-		if err != nil {
-			return nil, fmt.Errorf("Failed getting pending instances count: %w", err)
-		}
-
-		memberInstanceCount := created + pending
-		if lowestInstanceCount == -1 || memberInstanceCount < lowestInstanceCount {
-			lowestInstanceCount = memberInstanceCount
-			member = &members[i]
-		}
-	}
-
-	if member == nil {
+	if len(members) == 0 {
 		return nil, api.StatusErrorf(http.StatusNotFound, "No suitable cluster member could be found")
 	}
 
-	return member, nil
+	// Initialize member instance counts and get a slice of member IDs for use in query.
+	memberIDs := make([]int64, 0, len(members))
+	counts := make(map[int64]int64)
+	for _, nodeInfo := range members {
+		memberIDs = append(memberIDs, nodeInfo.ID)
+		counts[nodeInfo.ID] = 0
+	}
+
+	// Create a union query for instances and running instance create operations.
+	var b strings.Builder
+	b.WriteString("SELECT instances.node_id, COUNT(*) FROM instances WHERE instances.node_id IN ")
+	b.WriteString(query.IntParams(memberIDs...))
+	b.WriteString(" GROUP BY instances.node_id ")
+	b.WriteString("UNION ALL ")
+	b.WriteString("SELECT operations.node_id, COUNT(*) FROM operations WHERE operations.node_id IN ")
+	b.WriteString(query.IntParams(memberIDs...))
+	b.WriteString(" AND operations.type = ? AND operations.status_code = ? GROUP BY operations.node_id")
+
+	// Query and populate instance counts.
+	err := query.Scan(ctx, c.tx, b.String(), func(scan func(dest ...any) error) error {
+		var nodeID, count int64
+		err := scan(&nodeID, &count)
+		if err != nil {
+			return err
+		}
+
+		counts[nodeID] += count
+		return nil
+	}, operationtype.InstanceCreate, api.Running)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting instance count: %w", err)
+	}
+
+	// Iterate over the given members to find the one with the lowest instance (or pending instance) count.
+	lowest := int64(math.MaxInt64)
+	var nodeWithFewestInstances *NodeInfo
+	for _, member := range members {
+		count := counts[member.ID]
+		if count < lowest {
+			lowest = count
+			nodeWithFewestInstances = &member
+		}
+	}
+
+	return nodeWithFewestInstances, nil
 }
 
 // SetNodeVersion updates the schema and API version of the node with the

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -374,8 +374,8 @@ func TestGetNodeWithLeastInstances_Pending(t *testing.T) {
 
 	// Add a pending instance to the default node (ID 1)
 	_, err = tx.Tx().Exec(`
-INSERT INTO operations (id, uuid, node_id, type, project_id, class, metadata, inputs, error, conflict_reference) VALUES (1, 'abc', 1, ?, 1, 1, '', '', '', '')
-`, operationtype.InstanceCreate)
+INSERT INTO operations (id, uuid, node_id, type, project_id, class, metadata, inputs, error, conflict_reference, status_code) VALUES (1, 'abc', 1, ?, 1, 1, '', '', '', '', ?)
+`, operationtype.InstanceCreate, api.Running)
 	require.NoError(t, err)
 
 	allMembers, err := tx.GetNodes(context.Background())

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -53,7 +53,7 @@ func TestOperation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].Row.UUID)
 
-	err = cluster.DeleteOperation(context.TODO(), tx.Tx(), "abcd")
+	err = query.DeleteOne[cluster.OperationsRow](context.TODO(), tx.Tx(), "WHERE uuid = ?", "abcd")
 	require.NoError(t, err)
 
 	operation, err = cluster.GetOperation(context.TODO(), tx.Tx(), uuid)
@@ -95,7 +95,7 @@ func TestOperationNoProject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].Row.UUID)
 
-	err = cluster.DeleteOperation(context.TODO(), tx.Tx(), "abcd")
+	err = query.DeleteOne[cluster.OperationsRow](context.TODO(), tx.Tx(), "WHERE uuid = ?", "abcd")
 	require.NoError(t, err)
 
 	operation, err = cluster.GetOperation(context.TODO(), tx.Tx(), uuid)
@@ -141,6 +141,6 @@ func TestOperationUpdate(t *testing.T) {
 	assert.ErrorAs(t, err, &statusErr)
 	assert.Equal(t, http.StatusConflict, statusErr.Status())
 
-	err = cluster.DeleteOperation(context.TODO(), tx.Tx(), "abcd")
+	err = query.DeleteOne[cluster.OperationsRow](context.TODO(), tx.Tx(), "WHERE uuid = ?", "abcd")
 	require.NoError(t, err)
 }

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -105,7 +105,7 @@ const (
 	ProjectDelete
 	Wait
 	SnapshotsCreateScheduled
-	PruneExpiredOperations
+	SynchronizeOperations
 	StoragePoolCreate
 	StoragePoolUpdate
 	StoragePoolDelete
@@ -316,8 +316,8 @@ func (t Type) Description() string {
 		return "Just chilling"
 	case SnapshotsCreateScheduled:
 		return "Creating scheduled instance snapshots"
-	case PruneExpiredOperations:
-		return "Pruning expired operations"
+	case SynchronizeOperations:
+		return "Synchronizing operations"
 	case StoragePoolCreate:
 		return "Creating storage pool"
 	case StoragePoolUpdate:
@@ -413,7 +413,7 @@ func (t Type) EntityType() entity.Type {
 		WarningsPruneResolved, ClusterMemberEvacuate, ClusterMemberRestore, LogsExpire, InstanceTypesUpdate,
 		BackupsExpire, SnapshotsExpire, ClusterJoinToken, CertificateAddToken, RenewServerCertificate,
 		ClusterHeal, ImagesUpdate, VolumeSnapshotsCreateScheduled, SnapshotsCreateScheduled,
-		PruneExpiredOperations, RefreshClusterLinkVolatileAddresses,
+		SynchronizeOperations, RefreshClusterLinkVolatileAddresses,
 		StoragePoolCreate, Wait:
 		return entity.TypeServer
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -646,9 +646,15 @@ func operationsGetByType(ctx context.Context, s *state.State, projectName string
 		}
 	}
 
+	now := time.Now()
 	apiOps := make([]*api.Operation, 0, len(ops))
 	for _, op := range ops {
 		if s.ServerClustered && excludeOffline && !online[op.NodeAddress] {
+			continue
+		}
+
+		// Skip operations that are finished and are pending deletion.
+		if api.StatusCode(op.Row.StatusCode).IsFinal() && now.Sub(op.Row.UpdatedAt) > operations.OperationRetentionDuration {
 			continue
 		}
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1094,46 +1094,34 @@ func autoRemoveOrphanedOperations(ctx context.Context, s *state.State) error {
 	return nil
 }
 
-// PruneExpiredOperationsTask returns a task function and schedule that is used to prune expired operations from the database.
-func pruneExpiredOperationsTask(stateFunc func() *state.State) (task.Func, task.Schedule) {
+// synchronizeOperationsTask returns a task function and schedule that is used to synchronize and prune expired operations from the database.
+func synchronizeOperationsTask(stateFunc func() *state.State) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
 		s := stateFunc()
-
-		leaderInfo, err := s.LeaderInfo()
-		if err != nil {
-			logger.Error("Failed getting leader cluster member address", logger.Ctx{"err": err})
-			return
-		}
-
-		if !leaderInfo.Leader {
-			logger.Debug("Skipping pruning expired operations since we're not leader")
-			return
-		}
-
 		opRun := func(ctx context.Context, op *operations.Operation) error {
-			return operations.PruneExpiredOperations(ctx, s)
+			return operations.Synchronize(ctx, s)
 		}
 
 		args := operations.OperationArgs{
-			Type:    operationtype.PruneExpiredOperations,
+			Type:    operationtype.SynchronizeOperations,
 			Class:   operationtype.OperationClassTask,
 			RunHook: opRun,
 		}
 
 		op, err := operations.ScheduleServerOperation(s, args)
 		if err != nil {
-			logger.Error("Failed creating prune expired operations operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating operation synchronization operation", logger.Ctx{"err": err})
 			return
 		}
 
 		err = op.Wait(ctx)
 		if err != nil {
-			logger.Error("Failed pruning expired operations", logger.Ctx{"err": err})
+			logger.Error("Failed synchronizing operations", logger.Ctx{"err": err})
 			return
 		}
 	}
 
-	return f, task.Hourly()
+	return f, task.Every(time.Minute)
 }
 
 // operationWaitPost represents the fields of a request to register a dummy operation.

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -144,18 +144,6 @@ func updateDBOperation(ctx context.Context, op *Operation) error {
 	return nil
 }
 
-func removeDBOperation(op *Operation) error {
-	if op.state == nil {
-		return errors.New("Failed deleting operation: No state available")
-	}
-
-	err := op.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return cluster.DeleteOperation(ctx, tx.Tx(), op.id)
-	})
-
-	return err
-}
-
 // ConstructOperationsFromDB is a constructs a list of Operation objects based on their database representation.
 func ConstructOperationsFromDB(ctx context.Context, tx *sql.Tx, s *state.State, dbOps []cluster.Operation) ([]*Operation, error) {
 	if len(dbOps) == 0 {

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/canonical/lxd/lxd/db"
@@ -19,6 +22,20 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
+)
+
+const (
+	// OperationRetentionDuration is the duration after an operation is finalized for which it cannot be deleted (for non-bulk operations).
+	OperationRetentionDuration = 5 * time.Second
+
+	// OperationRetentionDurationBulk is the duration after a bulk operation is finalized for which it cannot be deleted.
+	OperationRetentionDurationBulk = 24 * time.Hour
+)
+
+const (
+	danglingOperationFinalizationErrorText  = "Operation exited uncleanly or was unable to report its status"
+	danglingOperationFinalizationErrorCode  = int64(http.StatusInternalServerError)
+	danglingOperationFinalizationStatusCode = int64(api.Failure)
 )
 
 func registerDBOperation(ctx context.Context, op *Operation) error {
@@ -313,47 +330,333 @@ func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources 
 	return &op, nil
 }
 
-// PruneExpiredOperations deletes database entries of all operations which finished more than 24 hours ago.
-// Normally, operations are cleared 5 seconds after they finish. However, more complex operations, such as bulk operations,
-// are only cleared by this task, to allow more time to inspect their results.
-func PruneExpiredOperations(ctx context.Context, s *state.State) error {
+// Synchronize is run on database start up and shutdown, and as a recurring task every minute.
+// It first checks the local map for any operations that need to be retained. These are:
+// - Bulk operations that completed less than 24 hours ago.
+// - Other operations that completed less than 5 seconds ago.
+// It then checks all operations registered to this cluster member in the database:
+// - Any bulk operations that completed less than 24 hours ago are retained.
+// - Any other operations that completed less than 5 seconds ago are retained.
+// Retained operations that are present in the database and not present in the local map are reconstructed and added to
+// the local map. All other operations in the local map and registered to this member in the database are deleted.
+// Finally, all retained operations are checked for consistency between the local map and the database:
+//   - If an operation was reconstructed but its status is not final, then it was not properly cleaned up. The status is
+//     set to an internal error.
+//   - If an operations "updated_at" timestamp in the database does not match the local operation. This indicates that the
+//     operation failed to store its state. It is updated to match what is present in the local map.
+func Synchronize(ctx context.Context, s *state.State) error {
+	// Get a set of operation database IDs to retain and a list of operation UUIDs to delete.
+	syncStartedAt, maxID, localOps, operationIDRetentionSet, operationUUIDsToInternallyDelete := sortLocalOperationsForSynchronization()
+
+	// Delete from the internal map. These operations should no longer be present. If the upcoming transaction fails,
+	// all operations that are not present in the map will still be deleted on the next task run.
+	deleteInternal(operationUUIDsToInternallyDelete...)
+
+	var reconstructedOps []*Operation
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		dbOps, err := query.Select[cluster.OperationsRow](ctx, tx.Tx(), "")
+		// Query for all operations on this member and find operations that should be in the local map but are not
+		// (e.g. bulk operations that are less than 24 hours old that need to be persisted on daemon restart).
+		allLocallyRegisteredDBOps, operationsToReconstruct, err := loadOperationsToSynchronize(ctx, tx, maxID, syncStartedAt, localOps, operationIDRetentionSet)
 		if err != nil {
-			return fmt.Errorf("Failed loading operations: %w", err)
+			return fmt.Errorf("Failed querying for locally registered operations: %w", err)
 		}
 
-		for _, dbOp := range dbOps {
-			// Don't prune operations which are still running.
-			if !api.StatusCode(dbOp.StatusCode).IsFinal() {
-				continue
-			}
+		// Delete any operations registered to this member that are not in the retention set.
+		nDeleted, err := deleteLocallyRegisteredOperationsNotInSet(ctx, tx, operationIDRetentionSet, maxID)
+		if err != nil {
+			return fmt.Errorf("Failed pruning expired operations: %w", err)
+		}
 
-			// Don't delete child operations. These will be deleted by the foreign key constraint when the parent operation is deleted.
-			if dbOp.Parent != nil {
-				continue
-			}
+		logger.Debug("Pruned expired operations", logger.Ctx{"count": nDeleted})
 
-			// Prune operations which were last updated more than 24 hours ago.
-			if dbOp.UpdatedAt.Add(24 * time.Hour).After(time.Now()) {
-				continue
-			}
+		// If the daemon is killed while an operation is running, it should not be reconstructed in a running state.
+		// Ensure that any such operations are updated with an appropriate error status.
+		err = finalizeUnfinishedDBOperations(ctx, tx, syncStartedAt, operationsToReconstruct, operationIDRetentionSet)
+		if err != nil {
+			return fmt.Errorf("Failed finalizing dangling operations: %w", err)
+		}
 
-			err = cluster.DeleteOperation(ctx, tx.Tx(), dbOp.UUID)
-			if err != nil {
-				return fmt.Errorf("Failed deleting expired operation: %w", err)
-			}
+		// Reconstruct the operations.
+		reconstructedOps, err = ConstructOperationsFromDB(ctx, tx.Tx(), s, slices.Collect(maps.Values(operationsToReconstruct)))
+		if err != nil {
+			return fmt.Errorf("Failed reconstructing operations during synchronization: %w", err)
+		}
 
-			logger.Info("Pruned expired operation", logger.Ctx{"operation": dbOp.UUID})
+		// Check operation and database update timestamps to verify that all local operations are accurately represented.
+		err = ensureLocalOperationsAreSynchronized(ctx, tx, allLocallyRegisteredDBOps, operationIDRetentionSet, localOps)
+		if err != nil {
+			return fmt.Errorf("Failed synchronizing local operations: %w", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed synchronizing operations: %w", err)
 	}
 
-	logger.Debug("Done pruning expired operations")
+	// Add the reconstructed operations back to the local map.
+	// Only lock if necessary.
+	if len(reconstructedOps) > 0 {
+		operationsLock.Lock()
+		for _, reconstructedOp := range reconstructedOps {
+			operations[reconstructedOp.id] = reconstructedOp
+			for _, child := range reconstructedOp.children {
+				operations[child.id] = child
+			}
+		}
+
+		operationsLock.Unlock()
+	}
 
 	return nil
+}
+
+// ensureLocalOperationsAreSynchronized looks at the local operations map and compares the Operation.lastPersistenceAttempt timestamp against the
+// updated_at column of its database counterpart. If there was an attempt to persist the operation that did not succeed, these values will be mismatched.
+// The operation is then persisted in its current state.
+func ensureLocalOperationsAreSynchronized(ctx context.Context, tx *db.ClusterTx, locallyRegisteredDBOps []cluster.Operation, operationIDRetentionSet map[int64]struct{}, localOps map[string]*Operation) error {
+	errs := make([]error, 0, len(locallyRegisteredDBOps))
+
+	// At this point, all operations in the retained operations map are either present locally, or are bulk operations that are not present locally
+	// but are in the database and finished less than 24 hours ago. We now range over all database operations and check that they are in sync.
+	for _, dbOp := range locallyRegisteredDBOps {
+		// Skip the ones we've just deleted.
+		_, ok := operationIDRetentionSet[dbOp.Row.ID]
+		if !ok {
+			continue
+		}
+
+		op, ok := localOps[dbOp.Row.UUID]
+		if !ok {
+			// If the row is retained but is not present in the local map, it is one of the reconstructed operations.
+			continue
+		}
+
+		// If Operation.lastPersistenceAttempt is equal to operations.updated_at, then the operation is in sync with the database.
+		lastPersistenceAttemptUnixMillis := op.lastPersistenceAttempt.UnixMilli()
+		dbUpdatedAtUnixMillis := dbOp.Row.UpdatedAt.UnixMilli()
+		if lastPersistenceAttemptUnixMillis <= dbUpdatedAtUnixMillis {
+			// The lastPersistenceAttempt should never be behind operations.updated_at.
+			// If it is, update it to the current database value and log a warning.
+			if lastPersistenceAttemptUnixMillis < dbUpdatedAtUnixMillis {
+				op.lastPersistenceAttempt = dbOp.Row.UpdatedAt
+				op.updatedAt = dbOp.Row.UpdatedAt
+				logger.Warn("Operation persistence tracking mismatch", logger.Ctx{"uuid": op.id})
+			}
+
+			continue
+		}
+
+		// If the operation is not in sync, it could be due to a misbehaving database when the operation attempted to persist its data.
+		// Synchronize the operation now.
+		op.logger.Info("Resynchronizing operation")
+		op.lastPersistenceAttempt = op.updatedAt
+		err := cluster.UpdateOperation(ctx, tx.Tx(), op.id, tx.GetNodeID(), op.updatedAt, op.status, op.metadata, op.err, op.errCode)
+		if err != nil {
+			errs = append(errs, err)
+			op.logger.Warn("Failed synchronizing operation with database", logger.Ctx{"err": err})
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// finalizeUnfinishedDBOperations accepts a list of operations that are not in the local map but should be.
+// If any operation statuses are not final, something went wrong before the operations were able to persist their final status.
+// This function writes an error status for those operations.
+func finalizeUnfinishedDBOperations(ctx context.Context, tx *db.ClusterTx, syncStartedAt time.Time, operationsToReconstruct map[string]cluster.Operation, operationIDRetentionSet map[int64]struct{}) error {
+	unfinishedReconstructedOperationIDs := filterReconstructCandidatesForFinalization(syncStartedAt, operationsToReconstruct, operationIDRetentionSet)
+	if len(unfinishedReconstructedOperationIDs) == 0 {
+		return nil
+	}
+
+	stmt := "UPDATE operations SET status_code = ?, error = ?, error_code = ?, updated_at = ? WHERE id IN " + query.IntParams(unfinishedReconstructedOperationIDs...)
+	res, err := tx.Tx().ExecContext(ctx, stmt, danglingOperationFinalizationStatusCode, danglingOperationFinalizationErrorText, danglingOperationFinalizationErrorCode, syncStartedAt)
+	if err != nil {
+		return fmt.Errorf("Failed writing error status for unfinished orphaned operations: %w", err)
+	}
+
+	nAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed validating write for unfinished orphaned operations: %w", err)
+	}
+
+	if int(nAffected) != len(unfinishedReconstructedOperationIDs) {
+		return fmt.Errorf("Failed validating write for unfinished orphaned operations: Expected %d writes, got %d", len(unfinishedReconstructedOperationIDs), nAffected)
+	}
+
+	return nil
+}
+
+// filterReconstructCandidatesForFinalization inspects the operations that are to be reconstructed.
+// If their status is not final, something went wrong. Their status needs to be changed now as their run hook will not be re-run.
+// The input map is modified to reflect this (so that any operations that are reconstructed are up-to-date) and IDs the operations to finalize are returned for update in a single query.
+func filterReconstructCandidatesForFinalization(syncStartedAt time.Time, operationsToReconstruct map[string]cluster.Operation, operationIDRetentionSet map[int64]struct{}) []int64 {
+	unfinishedReconstructedOperationIDs := make([]int64, 0, len(operationsToReconstruct))
+	for opUUID, operation := range operationsToReconstruct {
+		if api.StatusCode(operation.Row.StatusCode).IsFinal() {
+			continue
+		}
+
+		// If we are a child operation that is being reconstructed, then we are not in the local map and we are present
+		// in the database, and our status is not final. If the parent of this operation is not retained, something went
+		// wrong, but this child has already been deleted from the database, so there is no update to do (so skip it).
+		if operation.Row.Parent != nil {
+			_, ok := operationIDRetentionSet[*operation.Row.Parent]
+			if !ok {
+				continue
+			}
+
+			// Also we don't want to reconstruct it because the parent has gone, so we need to delete it from the reconstruction set.
+			delete(operationsToReconstruct, operation.Row.UUID)
+		}
+
+		// Overwrite the value in the reconstructed operations map so that the operation is reconstructed with a finalized status.
+		operation.Row.StatusCode = danglingOperationFinalizationStatusCode
+		operation.Row.Error = danglingOperationFinalizationErrorText
+		operation.Row.ErrorCode = danglingOperationFinalizationErrorCode
+		operation.Row.UpdatedAt = syncStartedAt
+		operationsToReconstruct[opUUID] = operation
+
+		// Append the operation ID so that we can update all rows in one query.
+		unfinishedReconstructedOperationIDs = append(unfinishedReconstructedOperationIDs, operation.Row.ID)
+	}
+
+	return unfinishedReconstructedOperationIDs
+}
+
+// deleteLocallyRegisteredOperationsNotInSet deletes any operations that are registered to this cluster member, are less
+// than or equal to the given max ID, and are not in the given set.
+func deleteLocallyRegisteredOperationsNotInSet(ctx context.Context, tx *db.ClusterTx, opsToRetain map[int64]struct{}, maxID int64) (int64, error) {
+	var b strings.Builder
+	b.WriteString("WHERE node_id = ? AND id <= ?")
+	if len(opsToRetain) > 0 {
+		b.WriteString(" AND id NOT IN ")
+		b.WriteString(query.IntParams(slices.Collect(maps.Keys(opsToRetain))...))
+	}
+
+	nDeleted, err := query.DeleteMany[cluster.OperationsRow](ctx, tx.Tx(), b.String(), tx.GetNodeID(), maxID)
+	if err != nil {
+		return 0, fmt.Errorf("Failed deleting locally registered operations not in given set: %w", err)
+	}
+
+	return nDeleted, nil
+}
+
+// loadOperationsToSynchronize returns a list of all locally registered operations, and a list of operations that are candidates for reconstruction.
+// The local map is passed in so that we don't overwrite operations already present.
+// Any operations that are to be reconstructed also need to be retained, so the operationIDRetentionSet is passed in and modified.
+func loadOperationsToSynchronize(ctx context.Context, tx *db.ClusterTx, maxID int64, syncStartedAt time.Time, localOps map[string]*Operation, operationIDRetentionSet map[int64]struct{}) (allMemberOperations []cluster.Operation, operationsToReconstruct map[string]cluster.Operation, err error) {
+	operationsToReconstruct = make(map[string]cluster.Operation)
+	// Anonymous function to append to our list of operations to reconstruct.
+	// We don't want to reconstruct operations that are already present (the local map is the source of truth, so
+	// overwriting it with an operation reconstructed from the database is incorrect).
+	// We also don't want to reconstruct operations whose database ID is greater than the maximum ID at the time of snapshotting the
+	// local operations map. These should now be present in the local map but not in our copy.
+	addReconstructCandidate := func(dbOp cluster.Operation) {
+		_, ok := localOps[dbOp.Row.UUID]
+		if ok {
+			return
+		}
+
+		if dbOp.Row.ID > maxID {
+			return
+		}
+
+		operationsToReconstruct[dbOp.Row.UUID] = dbOp
+	}
+
+	// Order by parent in ascending order with nulls last so that child operations are scanned first.
+	selectClause := "WHERE operations.node_id = ? ORDER BY operations.parent ASC NULLS LAST"
+	parentIDs := make(map[int64]struct{})
+	err = query.SelectFunc[cluster.Operation](ctx, tx.Tx(), selectClause, func(operation cluster.Operation) error {
+		allMemberOperations = append(allMemberOperations, operation)
+
+		// Figure out if the operation is parent operation. Child operations are scanned first, so this populates the
+		// parentIDs map before parents are scanned.
+		var isParent bool
+		if operation.Row.Parent != nil {
+			parentIDs[*operation.Row.Parent] = struct{}{}
+		} else {
+			_, isParent = parentIDs[operation.Row.ID]
+		}
+
+		// If the operation is retained, then it is added to the retention set and added as a reconstruct candidate.
+		if isRetentionCandidate(syncStartedAt, operation, isParent) {
+			operationIDRetentionSet[operation.Row.ID] = struct{}{}
+			addReconstructCandidate(operation)
+		}
+
+		return nil
+	}, tx.GetNodeID())
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed getting operations to synchronize: %w", err)
+	}
+
+	return allMemberOperations, operationsToReconstruct, nil
+}
+
+// sortLocalOperationsForSynchronization inspects the local operations map and returns:
+//   - The time at which the map snapshot is taken.
+//   - The maximum database ID present in the map.
+//   - A copy of the local map.
+//   - A set of operation database IDs to retain.
+//   - A list of operation UUIDs to locally delete.
+func sortLocalOperationsForSynchronization() (syncStartedAt time.Time, maxID int64, localOps map[string]*Operation, operationIDRetentionSet map[int64]struct{}, opsToDeleteInternal []string) {
+	localOps = make(map[string]*Operation)
+	operationIDRetentionSet = make(map[int64]struct{})
+
+	operationsLock.Lock()
+	defer operationsLock.Unlock()
+
+	syncStartedAt = time.Now()
+	for _, op := range operations {
+		// Add operation to map copy.
+		localOps[op.id] = op
+
+		// Update the max ID.
+		if op.dbID > maxID {
+			maxID = op.dbID
+		}
+
+		if isRetentionCandidate(syncStartedAt, op, len(op.children) > 0) {
+			operationIDRetentionSet[op.dbID] = struct{}{}
+			continue
+		}
+
+		// Delete all other operations from the local map.
+		opsToDeleteInternal = append(opsToDeleteInternal, op.id)
+	}
+
+	return syncStartedAt, maxID, localOps, operationIDRetentionSet, opsToDeleteInternal
+}
+
+// isRetentionCandidate returns true if the given [*Operation] or [cluster.Operation] should be retained (i.e. it should
+// remain present both in the local map and in the database).
+func isRetentionCandidate[O interface {
+	IsFinished() bool
+	IsChild() bool
+	UpdatedAt() time.Time
+	*Operation | cluster.Operation
+}](now time.Time, op O, isParent bool) bool {
+	// Retain all children, because we will delete them by foreign key in the database, and they will be equivalently
+	// deleted from the internal map via deleteInternal.
+	if op.IsChild() {
+		return true
+	}
+
+	// Retain operations that have not completed. We can't delete operations that haven't finished yet.
+	if !op.IsFinished() {
+		return true
+	}
+
+	// Retain any operations that completed less than 5 seconds ago. We retain these for API inspection.
+	updatedAt := op.UpdatedAt()
+	if now.Before(updatedAt.Add(OperationRetentionDuration)) {
+		return true
+	}
+
+	// Retain bulk operations that completed less than 24 hours ago. We retain these for the API inspection.
+	// Otherwise, the operation can be discarded.
+	return isParent && now.Before(updatedAt.Add(OperationRetentionDurationBulk))
 }

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -263,12 +263,6 @@ func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources 
 		op.location = dbOp.NodeName
 	}
 
-	// If operation is already in final state, cancel both contexts, there's no point in running any hook.
-	if op.status.IsFinal() {
-		op.running.Cancel()
-		op.finished.Cancel()
-	}
-
 	op.logger = logger.AddContext(logger.Ctx{"operation": op.id, "project": op.projectName, "class": op.class.String(), "description": op.description})
 
 	op.events = s.Events
@@ -304,6 +298,14 @@ func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources 
 	}
 
 	op.metadata = metadata
+
+	// Set the finalization function.
+	setDoneFunc(&op)
+
+	// Immediately cancel the run context and call done.
+	// We have just reconstructed the operation from the database, so it is for inspection only.
+	op.running.Cancel()
+	op.done()
 
 	return &op, nil
 }

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -136,7 +136,9 @@ func registerDBOperation(ctx context.Context, op *Operation) error {
 	return nil
 }
 
-func updateDBOperation(ctx context.Context, op *Operation) error {
+// persistOperation saves the operation to the database in its current state. The [cluster.OperationsRow.UpdatedAt]
+// column is only set to the value of Operation.updatedAt, not necessarily the current time.
+func persistOperation(ctx context.Context, op *Operation) error {
 	if op.state == nil {
 		return errors.New("Failed updating operation: No state available")
 	}

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -108,16 +108,20 @@ func registerDBOperation(ctx context.Context, op *Operation) error {
 			return err
 		}
 
+		op.dbID = parentOpID
+
 		// Create child operation records, if any.
 		for _, childOp := range op.children {
 			if childOp.projectName != op.projectName {
 				return errors.New("Child operations cannot have a different project to the parent operation")
 			}
 
-			_, err := registerSingleOperation(ctx, tx, childOp, &parentOpID, projectIDPtr)
+			childOpID, err := registerSingleOperation(ctx, tx, childOp, &parentOpID, projectIDPtr)
 			if err != nil {
 				return err
 			}
+
+			childOp.dbID = childOpID
 		}
 
 		return nil
@@ -225,6 +229,7 @@ func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources 
 	}
 
 	op := Operation{
+		dbID:              dbOp.Row.ID,
 		projectName:       dbOp.ProjectName,
 		id:                dbOp.Row.UUID,
 		class:             operationtype.Class(dbOp.Row.Class),

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -83,6 +83,9 @@ func registerDBOperation(ctx context.Context, op *Operation) error {
 			return 0, err
 		}
 
+		// Save the time at which the operation was persisted
+		op.lastPersistenceAttempt = op.updatedAt
+
 		err = cluster.CreateOperationResources(ctx, tx.Tx(), dbOpID, op.resources)
 		if err != nil {
 			return 0, err
@@ -137,6 +140,10 @@ func updateDBOperation(ctx context.Context, op *Operation) error {
 	if op.state == nil {
 		return errors.New("Failed updating operation: No state available")
 	}
+
+	// Save the lastPersistenceAttempt field as the current updatedAt value.
+	// If persistence fails, the updated_at row in the database will be behind this value.
+	op.lastPersistenceAttempt = op.updatedAt
 
 	err := op.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return cluster.UpdateOperation(ctx, tx.Tx(), op.id, tx.GetNodeID(), op.updatedAt, op.status, op.metadata, op.err, op.errCode)
@@ -229,24 +236,25 @@ func constructSingleOperation(s *state.State, dbOp cluster.Operation, resources 
 	}
 
 	op := Operation{
-		dbID:              dbOp.Row.ID,
-		projectName:       dbOp.ProjectName,
-		id:                dbOp.Row.UUID,
-		class:             operationtype.Class(dbOp.Row.Class),
-		createdAt:         dbOp.Row.CreatedAt,
-		updatedAt:         dbOp.Row.UpdatedAt,
-		status:            api.StatusCode(dbOp.Row.StatusCode),
-		url:               api.NewURL().Path(version.APIVersion, "operations", dbOp.Row.UUID).String(),
-		description:       dbOp.Row.Type.Description(),
-		dbOpType:          dbOp.Row.Type,
-		finished:          cancel.New(),
-		running:           cancel.New(),
-		state:             s,
-		location:          dbOp.NodeName,
-		err:               dbOp.Row.Error,
-		errCode:           dbOp.Row.ErrorCode,
-		conflictReference: dbOp.Row.ConflictReference,
-		requestor:         dbOp.Requestor(),
+		dbID:                   dbOp.Row.ID,
+		projectName:            dbOp.ProjectName,
+		id:                     dbOp.Row.UUID,
+		class:                  operationtype.Class(dbOp.Row.Class),
+		createdAt:              dbOp.Row.CreatedAt,
+		updatedAt:              dbOp.Row.UpdatedAt,
+		lastPersistenceAttempt: dbOp.Row.UpdatedAt,
+		status:                 api.StatusCode(dbOp.Row.StatusCode),
+		url:                    api.NewURL().Path(version.APIVersion, "operations", dbOp.Row.UUID).String(),
+		description:            dbOp.Row.Type.Description(),
+		dbOpType:               dbOp.Row.Type,
+		finished:               cancel.New(),
+		running:                cancel.New(),
+		state:                  s,
+		location:               dbOp.NodeName,
+		err:                    dbOp.Row.Error,
+		errCode:                dbOp.Row.ErrorCode,
+		conflictReference:      dbOp.Row.ConflictReference,
+		requestor:              dbOp.Requestor(),
 	}
 
 	// If server is not clustered, the DB contains 'none' as the node name. In that case we use the server name as the location.

--- a/lxd/operations/db_test.go
+++ b/lxd/operations/db_test.go
@@ -1,0 +1,277 @@
+package operations
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/shared/api"
+)
+
+type dbSuite struct {
+	suite.Suite
+}
+
+func TestDB(t *testing.T) {
+	suite.Run(t, new(dbSuite))
+}
+
+func (s *dbSuite) Test_isRetentionCandidateLocal() {
+	now := time.Now()
+	type testCase struct {
+		name     string
+		opFunc   func() *Operation
+		expected bool
+	}
+
+	tests := []testCase{
+		{
+			name: "running operation updated 4 seconds ago",
+			opFunc: func() *Operation {
+				op := newTestOp(s.Require())
+				op.updatedAt = now.Add(-4 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "running operation updated 6 seconds ago",
+			opFunc: func() *Operation {
+				op := newTestOp(s.Require())
+				op.updatedAt = now.Add(-6 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "finished operation updated 4 seconds ago",
+			opFunc: func() *Operation {
+				op := newTestOp(s.Require())
+				op.finished.Cancel()
+				op.updatedAt = now.Add(-4 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "finished operation updated 6 seconds ago",
+			opFunc: func() *Operation {
+				op := newTestOp(s.Require())
+				op.finished.Cancel()
+				op.updatedAt = now.Add(-6 * time.Second)
+				return op
+			},
+			expected: false,
+		},
+		{
+			name: "running bulk operation parent updated 24 hours and 1 second ago",
+			opFunc: func() *Operation {
+				parent := newTestOp(s.Require())
+				child := newTestOp(s.Require())
+				parent.children = []*Operation{child}
+				parent.updatedAt = time.Now().Add(-(24*time.Hour + time.Second))
+				return parent
+			},
+			expected: true,
+		},
+		{
+			name: "running bulk operation child updated 24 hours and 1 second ago",
+			opFunc: func() *Operation {
+				parent := newTestOp(s.Require())
+				child := newTestOp(s.Require())
+				parent.children = []*Operation{child}
+				child.parent = parent
+				child.updatedAt = time.Now().Add(-(24*time.Hour + time.Second))
+				return child
+			},
+			expected: true,
+		},
+		{
+			name: "finished bulk operation parent updated 23 hours 59 minutes and 59 seconds ago",
+			opFunc: func() *Operation {
+				parent := newTestOp(s.Require())
+				child := newTestOp(s.Require())
+				parent.children = []*Operation{child}
+				child.parent = parent
+				parent.finished.Cancel()
+				parent.updatedAt = now.Add(-(24*time.Hour - time.Second))
+				return parent
+			},
+			expected: true,
+		},
+		{
+			name: "finished bulk operation child updated 23 hours 59 minutes and 59 seconds ago",
+			opFunc: func() *Operation {
+				parent := newTestOp(s.Require())
+				child := newTestOp(s.Require())
+				parent.children = []*Operation{child}
+				child.parent = parent
+				child.finished.Cancel()
+				child.updatedAt = now.Add(-(24*time.Hour - time.Second))
+				return child
+			},
+			expected: true,
+		},
+		{
+			name: "finished bulk operation parent updated 24 hours and 1 second ago",
+			opFunc: func() *Operation {
+				parent := newTestOp(s.Require())
+				child := newTestOp(s.Require())
+				parent.children = []*Operation{child}
+				child.parent = parent
+				parent.finished.Cancel()
+				parent.updatedAt = now.Add(-(24*time.Hour + time.Second))
+				return parent
+			},
+			expected: false,
+		},
+	}
+
+	for i, tt := range tests {
+		s.T().Logf("case %d: %q", i, tt.name)
+		op := tt.opFunc()
+		actual := isRetentionCandidate(now, op, len(op.children) > 0)
+		s.Equal(tt.expected, actual)
+	}
+}
+
+func (s *dbSuite) Test_isRetentionCandidateDB() {
+	now := time.Now()
+	type testCase struct {
+		name     string
+		opFunc   func() cluster.Operation
+		isParent bool
+		expected bool
+	}
+
+	tests := []testCase{
+		{
+			name: "running operation updated 4 seconds ago",
+			opFunc: func() cluster.Operation {
+				op := newTestDBOp(s.Require())
+				op.Row.UpdatedAt = now.Add(-4 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "running operation updated 6 seconds ago",
+			opFunc: func() cluster.Operation {
+				op := newTestDBOp(s.Require())
+				op.Row.UpdatedAt = now.Add(-6 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "finished operation updated 4 seconds ago",
+			opFunc: func() cluster.Operation {
+				op := newTestDBOp(s.Require())
+				op.Row.StatusCode = int64(api.Success)
+				op.Row.UpdatedAt = now.Add(-4 * time.Second)
+				return op
+			},
+			expected: true,
+		},
+		{
+			name: "finished operation updated 6 seconds ago",
+			opFunc: func() cluster.Operation {
+				op := newTestDBOp(s.Require())
+				op.Row.StatusCode = int64(api.Success)
+				op.Row.UpdatedAt = now.Add(-6 * time.Second)
+				return op
+			},
+			expected: false,
+		},
+		{
+			name: "running bulk operation parent updated 24 hours and 1 second ago",
+			opFunc: func() cluster.Operation {
+				parent := newTestDBOp(s.Require())
+				parent.Row.UpdatedAt = time.Now().Add(-(24*time.Hour + time.Second))
+				return parent
+			},
+			isParent: true,
+			expected: true,
+		},
+		{
+			name: "running bulk operation child updated 24 hours and 1 second ago",
+			opFunc: func() cluster.Operation {
+				parent := newTestDBOp(s.Require())
+				child := newTestDBOp(s.Require())
+				child.Row.UpdatedAt = time.Now().Add(-(24*time.Hour + time.Second))
+				child.Row.Parent = &parent.Row.ID
+				return child
+			},
+			expected: true,
+		},
+		{
+			name: "finished bulk operation parent updated 23 hours 59 minutes and 59 seconds ago",
+			opFunc: func() cluster.Operation {
+				parent := newTestDBOp(s.Require())
+				parent.Row.StatusCode = int64(api.Success)
+				parent.Row.UpdatedAt = now.Add(-(24*time.Hour - time.Second))
+				return parent
+			},
+			isParent: true,
+			expected: true,
+		},
+		{
+			name: "finished bulk operation child updated 23 hours 59 minutes and 59 seconds ago",
+			opFunc: func() cluster.Operation {
+				parent := newTestDBOp(s.Require())
+				child := newTestDBOp(s.Require())
+				child.Row.StatusCode = int64(api.Success)
+				child.Row.UpdatedAt = now.Add(-(24*time.Hour - time.Second))
+				child.Row.Parent = &parent.Row.ID
+				return child
+			},
+			expected: true,
+		},
+		{
+			name: "finished bulk operation parent updated 24 hours and 1 second ago",
+			opFunc: func() cluster.Operation {
+				parent := newTestDBOp(s.Require())
+				parent.Row.StatusCode = int64(api.Success)
+				parent.Row.UpdatedAt = now.Add(-(24*time.Hour + time.Second))
+				return parent
+			},
+			isParent: true,
+			expected: false,
+		},
+	}
+
+	for i, tt := range tests {
+		s.T().Logf("case %d: %q", i, tt.name)
+		op := tt.opFunc()
+		actual := isRetentionCandidate(now, op, tt.isParent)
+		s.Equal(tt.expected, actual)
+	}
+}
+
+var dbID int64
+
+func newTestDBOp(require *require.Assertions) cluster.Operation {
+	v7UUID, err := uuid.NewV7()
+	require.NoError(err)
+	opUUID := v7UUID.String()
+	sec, nsec := v7UUID.Time().UnixTime()
+	now := time.Unix(sec, nsec)
+
+	dbID++
+	return cluster.Operation{
+		Row: cluster.OperationsRow{
+			ID:         dbID,
+			UUID:       opUUID,
+			NodeID:     1,
+			Metadata:   "{}",
+			Class:      1,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+			StatusCode: int64(api.Running),
+		},
+	}
+}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -56,6 +56,50 @@ func OperationGetInternal(id string) (*Operation, error) {
 	return op, nil
 }
 
+// deleteInternal deletes the operations with the given IDs from the operations map.
+// If a given operation UUID is a parent operation, the children are also deleted. This is to match database behaviour,
+// where child operations are deleted via foreign key on the parent.
+func deleteInternal(operationUUIDs ...string) {
+	if len(operationUUIDs) == 0 {
+		return
+	}
+
+	// Get a list of operations to call "done" on. This is so that we hold operationsLock for as little time as possible.
+	// Can't pre-allocate here, as we don't know how many child operations there are.
+	var doneOps []*Operation
+
+	// Iterate over given IDs and check the local map.
+	operationsLock.Lock()
+	for _, id := range operationUUIDs {
+		op, ok := operations[id]
+		if !ok {
+			continue
+		}
+
+		// Skip child operations. These are only deleted when the parent is deleted.
+		if op.parent != nil {
+			continue
+		}
+
+		// Append the parent operation to our list and delete from the map.
+		doneOps = append(doneOps, op)
+		delete(operations, id)
+
+		// Do the same for all the children.
+		for _, child := range op.children {
+			doneOps = append(doneOps, child)
+			delete(operations, child.id)
+		}
+	}
+
+	operationsLock.Unlock()
+
+	// Call done on all operations we collected.
+	for _, op := range doneOps {
+		op.done()
+	}
+}
+
 // Operation represents an operation.
 type Operation struct {
 	projectName     string

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -145,6 +145,11 @@ type Operation struct {
 	// Locking for concurrent access to the Operation
 	lock sync.Mutex
 
+	// lastPersistenceAttempt contains the value of updatedAt on the last attempted write of the operation to the database.
+	// If the write fails, the value of lastPersistenceAttempt will be greater than the value of the `operations.updated_at`
+	// column for the row representing this operation. This is used for operation synchronization.
+	lastPersistenceAttempt time.Time
+
 	state  *state.State
 	events *events.Server
 

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -542,6 +542,11 @@ func (op *Operation) IsRunning() bool {
 	return op.running.Err() == nil
 }
 
+// IsFinished returns true if the operation is finalized.
+func (op *Operation) IsFinished() bool {
+	return op.finished.Err() != nil
+}
+
 // Cancel cancels a running operation. If the operation cannot be cancelled, it
 // returns an error.
 func (op *Operation) Cancel() {
@@ -921,6 +926,11 @@ func (op *Operation) Status() api.StatusCode {
 	return op.status
 }
 
+// UpdatedAt returns the last update time of the operation.
+func (op *Operation) UpdatedAt() time.Time {
+	return op.updatedAt
+}
+
 // Class returns the operation class.
 func (op *Operation) Class() operationtype.Class {
 	return op.class
@@ -939,6 +949,11 @@ func (op *Operation) Parent() *Operation {
 // Children returns the child operations if this operation is a parent operation, or an empty slice if this operation is not a parent operation.
 func (op *Operation) Children() []*Operation {
 	return op.children
+}
+
+// IsChild returns true if the Operation is a child operation.
+func (op *Operation) IsChild() bool {
+	return op.parent != nil
 }
 
 // validateMetadata returns an error if the metadata contains a known key with an invalid value (such as

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -780,6 +780,10 @@ func (op *Operation) CommitMetadata() error {
 	op.lock.Lock()
 	defer op.lock.Unlock()
 
+	if op.readonly {
+		return errors.New("Read-only operations cannot be updated")
+	}
+
 	op.updatedAt = time.Now()
 	// Use the operation context for the database update, so that if the operation is cancelled, the database update will be cancelled as well.
 	return updateDBOperation(context.Context(op.running), op)

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -102,6 +102,7 @@ func deleteInternal(operationUUIDs ...string) {
 
 // Operation represents an operation.
 type Operation struct {
+	dbID            int64
 	projectName     string
 	id              string
 	class           operationtype.Class

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -411,20 +411,6 @@ func statusToMetricsResult(status api.StatusCode) metrics.RequestResult {
 	}
 }
 
-func updateStatus(op *Operation, newStatus api.StatusCode) {
-	oldStatus := op.status
-	// We cannot really use operation context as it was already cancelled.
-	err := op.updateStatus(context.TODO(), newStatus)
-	if err != nil {
-		op.logger.Warn("Failed updating operation status", logger.Ctx{
-			"operation": op.id,
-			"err":       err,
-			"oldStatus": oldStatus,
-			"newStatus": newStatus,
-		})
-	}
-}
-
 // start a pending operation.
 func (op *Operation) start() {
 	op.lock.Lock()
@@ -505,9 +491,9 @@ func (op *Operation) start() {
 
 				// If the run context was cancelled, the previous state should be "cancelling", and the final state should be "cancelled".
 				if errors.Is(err, context.Canceled) {
-					updateStatus(op, api.Cancelled)
+					op.persistWithNewStatus(api.Cancelled)
 				} else {
-					updateStatus(op, api.Failure)
+					op.persistWithNewStatus(api.Failure)
 				}
 
 				// Always call cancel. This is a no-op if already cancelled.
@@ -527,7 +513,7 @@ func (op *Operation) start() {
 			}
 
 			op.lock.Lock()
-			updateStatus(op, api.Success)
+			op.persistWithNewStatus(api.Success)
 			op.running.Cancel()
 			op.lock.Unlock()
 			op.done()
@@ -575,7 +561,7 @@ func (op *Operation) Cancel() {
 		// The allows an operation to emit a cancelling status if it is in the middle of something that could take a while to clean up.
 		// If we're a parent operation with children, the start routine is waiting for the children to finish,
 		// and will set the final status, error and error code to cancelled.
-		updateStatus(op, api.Cancelling)
+		op.persistWithNewStatus(api.Cancelling)
 
 		// Signal the child operations to stop as well.
 		for _, childOp := range op.children {
@@ -586,7 +572,7 @@ func (op *Operation) Cancel() {
 		// We cannot use the operation context here because it has already been cancelled above.
 		op.err = context.Canceled.Error()
 		op.errCode = http.StatusInternalServerError
-		updateStatus(op, api.Cancelled)
+		op.persistWithNewStatus(api.Cancelled)
 	}
 
 	op.lock.Unlock()
@@ -771,10 +757,22 @@ func (op *Operation) EntityURL() *api.URL {
 	return op.entityURL
 }
 
-func (op *Operation) updateStatus(ctx context.Context, newStatus api.StatusCode) error {
+// persistWithNewStatus updates the Operation.status in-memory and sets the Operation.updatedAt to the current time,
+// then it persists the operation to the database. If persistence fails, a warning is logged but execution is allowed to
+// continue. Desynchronized operations will be fixed up via the Synchronize function and background task.
+func (op *Operation) persistWithNewStatus(newStatus api.StatusCode) {
+	oldStatus := op.status
 	op.status = newStatus
 	op.updatedAt = time.Now()
-	return updateDBOperation(ctx, op)
+	err := persistOperation(op.finished, op)
+	if err != nil {
+		op.logger.Warn("Failed updating operation status", logger.Ctx{
+			"operation": op.id,
+			"err":       err,
+			"oldStatus": oldStatus,
+			"newStatus": newStatus,
+		})
+	}
 }
 
 // UpdateMetadata updates the metadata of the operation. It returns an error if the operation has completed.
@@ -825,8 +823,8 @@ func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
 	return nil
 }
 
-// CommitMetadata commits the metadata and status of the operation to the database, and updates the updatedAt time.
-func (op *Operation) CommitMetadata() error {
+// Persist saves the current operation state to the database. The operation is locked while it is being saved.
+func (op *Operation) Persist() error {
 	op.lock.Lock()
 	defer op.lock.Unlock()
 
@@ -834,9 +832,8 @@ func (op *Operation) CommitMetadata() error {
 		return errors.New("Read-only operations cannot be updated")
 	}
 
-	op.updatedAt = time.Now()
-	// Use the operation context for the database update, so that if the operation is cancelled, the database update will be cancelled as well.
-	return updateDBOperation(context.Context(op.running), op)
+	// Use the operations running context for the database update, so that if the operation is cancelled, the database update will be cancelled as well.
+	return persistOperation(context.Context(op.running), op)
 }
 
 // ExtendMetadata updates the metadata of the operation with the additional data provided.

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -102,6 +102,9 @@ type Operation struct {
 
 	state  *state.State
 	events *events.Server
+
+	// done is a sync.OnceFunc that is instantiated when the operation is scheduled.
+	done func()
 }
 
 // OperationScheduler is a signature used in function arguments where the function is used to deduplicate operation
@@ -236,6 +239,9 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		op.onRun = args.RunHook
 		op.onConnect = args.ConnectHook
 
+		// Set the finalization function.
+		setDoneFunc(&op)
+
 		return &op, nil
 	}
 
@@ -281,6 +287,25 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 
 	op.start()
 	return op, nil
+}
+
+// setDoneFunc is used to set a [sync.OnceFunc] finalizer on the operation. This is used both when the operation is
+// initially scheduled and when an operation is reconstructed from the database.
+func setDoneFunc(op *Operation) {
+	op.done = sync.OnceFunc(func() {
+		op.lock.Lock()
+
+		finalStatus := op.status
+		op.readonly = true
+		op.onRun = nil
+		op.onConnect = nil
+		op.finished.Cancel()
+		op.lock.Unlock()
+
+		if op.metricsCallback != nil {
+			op.metricsCallback(statusToMetricsResult(finalStatus))
+		}
+	})
 }
 
 // addChild adds a child operation to the parent operation. It also sets the parent of the child operation to the parent operation.
@@ -334,87 +359,6 @@ func statusToMetricsResult(status api.StatusCode) metrics.RequestResult {
 	default:
 		return metrics.ErrorServer
 	}
-}
-
-func (op *Operation) done() {
-	if op.metricsCallback != nil {
-		op.metricsCallback(statusToMetricsResult(op.status))
-	}
-
-	if op.readonly {
-		return
-	}
-
-	op.lock.Lock()
-	op.readonly = true
-	op.onRun = nil
-	op.onConnect = nil
-	op.finished.Cancel()
-	op.lock.Unlock()
-
-	// If we are a child operation, we're done. The parent operation will clean all the child entries when it finishes.
-	if op.parent != nil {
-		return
-	}
-
-	// If this is a parent operation of a bulk operation, we clear the entries from the internal map, but leave the database records in place.
-	// The database records will be cleared later by the pruneExpiredOperationsTask().
-	if len(op.children) > 0 {
-		operationsLock.Lock()
-		_, ok := operations[op.id]
-		if !ok {
-			operationsLock.Unlock()
-			return
-		}
-
-		delete(operations, op.id)
-
-		// Clear child operations
-		for _, childOp := range op.children {
-			_, ok := operations[childOp.id]
-			if ok {
-				delete(operations, childOp.id)
-			}
-		}
-
-		operationsLock.Unlock()
-		return
-	}
-
-	go func() {
-		shutdownCtx := context.Background()
-		if op.state != nil {
-			shutdownCtx = op.state.ShutdownCtx
-		}
-
-		select {
-		case <-shutdownCtx.Done():
-			return // Expect all operation records to be removed by daemon.Stop in one query.
-		case <-time.After(time.Second * 5): // Wait 5s before removing from internal map and database.
-		}
-
-		operationsLock.Lock()
-		_, ok := operations[op.id]
-		if !ok {
-			operationsLock.Unlock()
-			return
-		}
-
-		delete(operations, op.id)
-		operationsLock.Unlock()
-
-		if op.state == nil {
-			return
-		}
-
-		err := removeDBOperation(op)
-		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
-			// Operations can be deleted from the database before the operation clean up go routine has
-			// run in cases where the project that the operation(s) are associated to is deleted first.
-			// So don't log warning if operation not found.
-			op.logger.Warn("Failed deleting operation", logger.Ctx{"status": op.status, "err": err})
-		}
-	}()
 }
 
 func updateStatus(op *Operation, newStatus api.StatusCode) {

--- a/lxd/operations/operations_test.go
+++ b/lxd/operations/operations_test.go
@@ -1,0 +1,149 @@
+package operations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/cancel"
+	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/logger"
+)
+
+type operationsSuite struct {
+	suite.Suite
+}
+
+func newTestOp(require *require.Assertions) *Operation {
+	v7UUID, err := uuid.NewV7()
+	require.NoError(err)
+	opUUID := v7UUID.String()
+	sec, nsec := v7UUID.Time().UnixTime()
+	now := time.Unix(sec, nsec)
+
+	op := &Operation{
+		id:                     opUUID,
+		class:                  1,
+		createdAt:              now,
+		updatedAt:              now,
+		status:                 api.Running,
+		url:                    "/1.0",
+		entityURL:              entity.ServerURL(),
+		dbOpType:               1000,
+		logger:                 logger.AddContext(logger.Ctx{"uuid": opUUID}),
+		finished:               cancel.New(),
+		running:                cancel.New(),
+		lastPersistenceAttempt: now,
+		readonly:               false,
+	}
+
+	setDoneFunc(op)
+
+	return op
+}
+
+func TestOperationsSuite(t *testing.T) {
+	suite.Run(t, new(operationsSuite))
+}
+
+// withLock wraps operation map locking for testing so that it fails immediately if locked
+// (rather than waiting for the test deadline).
+func (s *operationsSuite) withLock(f func()) {
+	wasUnlocked := operationsLock.TryLock()
+	if !wasUnlocked {
+		s.Require().FailNow("Operations map is locked")
+	}
+
+	f()
+
+	operationsLock.Unlock()
+}
+
+func (s *operationsSuite) SetupTest() {
+	// Ensures a blank operations map for each test.
+	s.withLock(func() {
+		operations = make(map[string]*Operation)
+	})
+}
+
+func (s *operationsSuite) TearDownTest() {
+	// Ensures operationsLock is not locked when the test is torn down.
+	s.withLock(func() {})
+}
+
+func (s *operationsSuite) Test_deleteInternalNoChildren() {
+	op1 := newTestOp(s.Require())
+	op2 := newTestOp(s.Require())
+	op3 := newTestOp(s.Require())
+
+	s.withLock(func() {
+		operations[op1.id] = op1
+		operations[op2.id] = op2
+		operations[op3.id] = op3
+	})
+
+	notFoundUUIDv7, err := uuid.NewV7()
+	s.Require().NoError(err)
+	deleteInternal(op1.id, op3.id, notFoundUUIDv7.String())
+
+	s.withLock(func() {
+		s.Len(operations, 1)
+		_, ok := operations[op2.id]
+		s.True(ok)
+	})
+
+	s.True(op1.readonly)
+	s.ErrorIs(op1.finished.Err(), context.Canceled)
+	s.True(op3.readonly)
+	s.ErrorIs(op3.finished.Err(), context.Canceled)
+	s.False(op2.readonly)
+	s.NoError(op2.finished.Err())
+}
+
+func (s *operationsSuite) Test_deleteInternalParentWithChildren() {
+	op1 := newTestOp(s.Require())
+	op2 := newTestOp(s.Require())
+	op1Child := newTestOp(s.Require())
+	op1Child.parent = op1
+	op1.children = []*Operation{op1Child}
+
+	s.withLock(func() {
+		operations[op1.id] = op1
+		operations[op2.id] = op2
+		operations[op1Child.id] = op1Child
+	})
+
+	// Deleting the child operation is a no-op.
+	deleteInternal(op1Child.id)
+
+	s.withLock(func() {
+		s.Len(operations, 3)
+	})
+
+	s.False(op1.readonly)
+	s.NoError(op1.finished.Err())
+	s.False(op1Child.readonly)
+	s.NoError(op1Child.finished.Err())
+	s.False(op2.readonly)
+	s.NoError(op2.finished.Err())
+
+	deleteInternal(op1.id)
+
+	s.withLock(func() {
+		s.Len(operations, 1)
+		_, ok := operations[op2.id]
+		s.True(ok)
+	})
+
+	s.True(op1.readonly)
+	s.ErrorIs(op1.finished.Err(), context.Canceled)
+	s.True(op1Child.readonly)
+	s.ErrorIs(op1Child.finished.Err(), context.Canceled)
+	s.False(op2.readonly)
+	s.NoError(op2.finished.Err())
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -963,7 +963,6 @@ test_clustering_storage() {
 
     # Copy the container without specifying a target, it will be placed on node2
     # since it's the one with the least number of containers (0 vs 1)
-    sleep 6 # Wait for pending operations to be removed from the database
     LXD_DIR="${LXD_ONE_DIR}" lxc copy foo bar
     [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L bar)" = "node2" ]
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3475,15 +3475,19 @@ test_clustering_evacuation() {
     delay=0.2
     max_attempts=60
 
+    # Check if the operation is still running in a loop. The jq command is a little complex because the response from
+    # /1.0/operations?recursion=1 is an object where each key is the lowercased operation status, and each value is an
+    # array of operations whose status matches the key. The command flattens this into a single array, then unwraps the
+    # array to get a list of objects, then selects only the evacuation operation by its description, and checks the status code.
     for i in $(seq "${max_attempts}"); do
-      if ! LXD_DIR="${lxd_dir}" lxc operation list --format csv | grep -F "Evacuating cluster member" >/dev/null; then
+      if LXD_DIR="${lxd_dir}" lxc query /1.0/operations?recursion=1 | jq --exit-status '[.[]] | flatten | .[] | select(.description == "Evacuating cluster member") | .status_code >= 200'; then
         return 0
       fi
 
       sleep "${delay}"
     done
 
-    echo "Evacuation operation still present after ${i} attempts (~${delay}s interval)"
+    echo "Evacuation operation still running after ${i} attempts (~${delay}s interval)"
     return 1
   }
   echo "Create cluster with 3 nodes"

--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -30,7 +30,7 @@ test_get_operations() {
     test "${proj1_count}" -eq 1
     proj2_count=$(jq --exit-status '[.success[] | select(.description == "Executing command")] | length' <<< "${proj2_full_ops_json}")
     test "${proj2_count}" -eq 1
-    all_count=$(jq --exit-status '[.success[] | select(.description == "Executing command")] | length' <<< "${all_full_ops_json}")
+    all_count=$(jq --exit-status '[.success[] | select(.description == "Executing command" and (.metadata.entity_url | test("project=op-proj\\d$")?))] | length' <<< "${all_full_ops_json}")
     test "${all_count}" -eq 2
 
     proj1_op_id=$(jq --exit-status -r '.success[] | select(.description == "Executing command") | .id' <<< "${proj1_full_ops_json}")


### PR DESCRIPTION
Updates the operation prune task to run every minute. Operations with children are kept for 24 hours, but all other operations are deleted if they are complete and last updated more than 5 seconds ago.

This means that all operations will hang around for a bit longer, but none should be left lingering forever.

Closes #18475 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
