### PR TITLE
snap: build documentation on riscv64

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -36,4 +36,4 @@ linkify-it-py==2.0.3
 pyyaml==6.0.3
 sphinx-copybutton==0.5.2
 sphinx-remove-toctrees==1.0.0.post1
-watchfiles==1.1.1
+watchfiles==1.2.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1558,9 +1558,9 @@ parts:
         exit 1
       fi
 
-      # Some python dependencies are not available for armhf/riscv64 or just require a build from source.
+      # Some python dependencies are not available for armhf or just require a build from source.
       # Not worth the effort for now.
-      if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "riscv64" ]; then
+      if [ "$(uname -m)" != "armv7l" ]; then
         # Build the static website
         # XXX: needed for snapcraft 8.x only
         PATH="/usr/bin:${PATH}" make doc # ensure python3 is found in PATH


### PR DESCRIPTION
LXD-UI provides links to the documentation. Hence we should build it.

Watchfiles 1.1.1 fails to build Rust code on riscv64. Bump the dependency to 1.2.0.

## Checklist

- [ X ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ X ] I have checked and added or updated relevant documentation.  _No documentation change needed_
