### PR TITLE
doc/_templates/footer.html: add closing </div> tag

### DIFF
--- a/doc/_templates/footer.html
+++ b/doc/_templates/footer.html
@@ -84,4 +84,5 @@
   <div class="right-details">
     {# mod: Added link to manage cookie tracker settings #}
       <a href="" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a>
+  </div>
 </div>


### PR DESCRIPTION
A small update to add a closing </div> tag.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
