### PR TITLE
github: ensure that `snap-tests` can find the Go binaries build by the Code job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -525,7 +525,7 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
       SNAP_RISK: ${{ inputs.snap-risk || 'edge' }}
       SNAP_TRACK: "latest"
-      SUDO_PRESERVE_ENV: "GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
+      SUDO_PRESERVE_ENV: "PATH,GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
     name: Snap
     runs-on: ubuntu-${{ matrix.os }}
     # avoid runaway test burning 6 hours of CI
@@ -757,6 +757,10 @@ jobs:
             fi
           fi
 
+          # Adding the Go bin directory to PATH ensures that the test scripts will find the
+          # LXD binaries built in the code-tests job and downloaded via the system-test-deps artifact.
+          # This avoids rebuilding them and ensures the coverage data is collected from the intended binaries.
+          export PATH="/home/runner/go/bin:${PATH}"
           sudo --preserve-env="${SUDO_PRESERVE_ENV}" ./bin/local-run "tests/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
 
           # Cleanly stopping `snap.lxd.daemon.service` will ensure that any Go


### PR DESCRIPTION
This will ensure that coverage instrumentation is kept.