### PR TITLE
github: Add code coverage reporting on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,13 +49,14 @@ on:
 env:
   LXD_SKIP_TESTS: "concurrent"  # concurrent is too unreliable/racy
   LXD_REQUIRED_TESTS: "network_ovn"
-  GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
+  GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || github.event_name == 'pull_request' || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed
   IMAGE_CACHE_DIR: "/home/runner/image-cache"
   SNAP_CACHE_DIR: "/home/runner/snap-cache"
 
 permissions:
   contents: read
+  code-quality: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -1045,6 +1046,50 @@ jobs:
         with:
           name: lxd-clients-${{ runner.os }}
           path: bin/
+
+  upload-coverage:
+    needs: code-tests
+    if: ${{ !cancelled() && needs.code-tests.result == 'success' && github.event_name == 'pull_request' && github.repository == 'canonical/lxd' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install coverage tools
+        run: |
+          set -eux
+          go install github.com/afunix/gocov/gocov@latest
+          go install github.com/b-dean/gocov-xml@v1.2.1-bdd.0
+
+      - name: Download coverage data
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-unit
+          path: coverage
+
+      - name: Convert coverage to Cobertura XML
+        run: |
+          set -eux
+          go tool covdata textfmt -i=coverage -o=coverage/coverage.out
+          gocov convert coverage/coverage.out > coverage/coverage.json
+          gocov-xml < coverage/coverage.json > coverage/coverage-go.xml
+
+      - name: Upload code coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/coverage-go.xml
+          language: Go
+          label: code-coverage/unit
 
   ui-e2e-tests:
     name: UI e2e tests


### PR DESCRIPTION
Closes issue #18344 

## Description

Enable unit test coverage reporting on pull requests using GitHub's new
code coverage feature (public preview).

Three changes to `.github/workflows/tests.yml`:
- Enable `GOCOVERAGE` on `pull_request` events so unit tests run with coverage instrumentation
- Add `code-quality: write` workflow permission for the upload action
- Add new `upload-coverage` job that converts binary coverage data to Cobertura XML and uploads it via `actions/upload-code-coverage@v1`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [] I have checked and added or updated relevant documentation.
