### PR TITLE
github: Added code coverage reporting on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ on:
 env:
   LXD_SKIP_TESTS: "concurrent"  # concurrent is too unreliable/racy
   LXD_REQUIRED_TESTS: "network_ovn"
-  GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
+  GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' ) || ( github.event_name == 'pull_request' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed
   IMAGE_CACHE_DIR: "/home/runner/image-cache"
   SNAP_CACHE_DIR: "/home/runner/snap-cache"
@@ -1045,6 +1045,72 @@ jobs:
         with:
           name: lxd-clients-${{ runner.os }}
           path: bin/
+
+  upload-coverage:
+    name: Upload coverage
+    needs: [code-tests, system-tests, snap-tests, client, ui-e2e-tests]
+    # Using `!cancelled()` means that failures on any of the `needs` won't prevent this from running
+    # which is why the `.result == 'success'` of each needs to be checked.
+    if: |
+      !cancelled() &&
+      needs.code-tests.result == 'success' &&
+      needs.system-tests.result == 'success' &&
+      needs.snap-tests.result == 'success' &&
+      needs.client.result == 'success' &&
+      (needs.ui-e2e-tests.result == 'success' || needs.ui-e2e-tests.result == 'skipped') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'canonical/lxd')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Make GOCOVERDIR
+        run: |
+          set -eux
+          mkdir -p coverage
+          cd coverage
+          echo "GOCOVERDIR=$(pwd)" >> "${GITHUB_ENV}"
+
+      - name: Install coverage tools
+        run: |
+          set -eux
+          go install github.com/afunix/gocov/gocov@latest
+          go install github.com/b-dean/gocov-xml@v1.2.1-bdd.0 # XXX: Using this repo is a temporary workaround until https://github.com/AlekSi/gocov-xml/pull/20 is merged. See https://github.com/AlekSi/gocov-xml/pull/20#issuecomment-3275134132 for more details.
+
+      - name: Download coverage data
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-*
+          path: ${{env.GOCOVERDIR}}
+          merge-multiple: true
+
+      - name: Convert coverage files
+        run: |
+          set -eux
+          go tool covdata percent -i="${GOCOVERDIR}"
+          go tool covdata textfmt -i="${GOCOVERDIR}" -o="${GOCOVERDIR}"/coverage.out
+          head "${GOCOVERDIR}"/coverage.out
+          # Convert to Cobertura XML format.
+          gocov convert "${GOCOVERDIR}"/coverage.out > "${GOCOVERDIR}"/coverage.json
+          gocov-xml < "${GOCOVERDIR}"/coverage.json > "${GOCOVERDIR}"/coverage-go.xml
+
+      - name: Upload code coverage
+        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
+        with:
+          file: ${{env.GOCOVERDIR}}/coverage-go.xml
+          language: Go
+          label: code-coverage
 
   ui-e2e-tests:
     name: UI e2e tests


### PR DESCRIPTION
Closes issue #18344 

## Description

Enable unit test coverage reporting on pull requests using GitHub's new
code coverage feature (public preview).

Three changes to `.github/workflows/tests.yml`:
- Enable `GOCOVERAGE` on `pull_request` events so unit tests run with coverage instrumentation
- Add `code-quality: write` workflow permission for the upload action
- Add new `upload-coverage` job that converts binary coverage data to Cobertura XML and uploads it via `actions/upload-code-coverage@v1`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
