### PR TITLE
github: Remove use of LXD_PRIVATE_DEPLOY_KEY SSH key in LP push workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1373,14 +1373,6 @@ jobs:
           repo: "git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd"
           ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}" # zizmor: ignore[secrets-outside-env]
 
-      - name: Setup lxd-private SSH access
-        env:
-          INPUTS_SSH_KEY: ${{ secrets.LXD_PRIVATE_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
-        run: |
-          set -eu # let's not use -x here to avoid leaking the SSH key in the logs
-          ssh-add - <<< "${INPUTS_SSH_KEY}"
-          unset INPUTS_SSH_KEY
-
       - name: Trigger Launchpad snap build
         run: |
           set -eux


### PR DESCRIPTION
No longer required as same key (LAUNCHPAD_LXD_BOT_KEY) is used for both readonly access to lxd-private (for rebasing) and pushing to LP.
