### PR TITLE
doc: add arguments to update-certificate example

### DIFF
--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -236,6 +236,6 @@ The certificate is stored at `/var/snap/lxd/common/lxd/cluster.crt` (if you use 
 You can replace the standard certificate with another one, such as a valid certificate obtained through ACME services (see {ref}`authentication-server-certificate` for more information).
 To do so, run the following command on any cluster member:
 
-    lxc cluster update-certificate
+    lxc cluster update-certificate <cert.crt> <cert.key>
 
 This command replaces the certificate on all cluster members. For more information, see: [`lxc cluster update-certificate`](lxc_cluster_update-certificate.md).


### PR DESCRIPTION
`lxc cluster update-certificate` requires <cert.crt> and <cert.key> arguments, but the example in the "How to manage cluster links" guide makes it seem as if they are optional. This PR adds these arguments to the example.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
