### PR TITLE
snap: Add cherry-picks from candidate (stable-4.0)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1079,6 +1079,15 @@ parts:
       git config user.email "noreply@lists.canonical.com"
       git config user.name "LXD snap builder"
 
+      git cherry-pick ca4c25c6e9ebb92f9e241ef9a231d4a715cb812d  # lxc-net: don't start by default inside lxc
+      git cherry-pick f314419d1e054f7833b6976ec5ed32373aace622  # lxc-checkconfig: Fix bashism
+      git cherry-pick 71ba7f65616e72a313e2a41615e449178da9daf2  # doc: Fix reverse allowlist/denylist
+      git cherry-pick f7446b4e10d71f79f9f3952255608268842ee1f3  # cgroups: check that opened file descriptor is a cgroup filesystem
+      git cherry-pick f1c4a17e7df5d819b1b170917865e2e458c8e5db  # cgroups: log fd of newly created cgroup
+      git cherry-pick 8ef019a6ce2555f7b438b3841ab5216e5d6973ba  # doc: Fix reverse allowlist/denylist in Japanese man page
+      git cherry-pick 3b9f84fd2397d06782bbf67dc8421463c43ab139  # ttys: ensure container_ttys= env variable is set correctly
+      git cherry-pick 5ba5725cb4a210c25707beeca64fde5f561d1c71  # cgroups: modify cgroup2 attach logic
+
       set +ex
       snapcraftctl build
       set -ex


### PR DESCRIPTION
This is the resulting diff from `lxd-pkg-snap:4.0-candidate` to `lxd:stable-4.0`:

- version and grade change: intentional (to my knowledge)
- LXD source change: intentional
- LXD cherry-picks: no longer necessary

There are no `source-branch` directives. All `source: git parts have a source tag or commit. 

However I can see edk2 and qemu have `source` or `source-tag`  as `IRRELEVANT` . ~~The override pull section is pulling a branch and not specifying a commit. Shall I look for the commit that would have been pulled in when candidate was last build and pin to that?~~

_Edit: edk2 and qemu both specify tags in the `override_pull` section and clone with `-b <tag>`_

```diff
5,6c5,6
< version: git
< grade: devel
---
> version: "4.0.10"
> grade: stable
1142c1142,1144
<     source: .
---
>     source: https://github.com/canonical/lxd
>     source-type: git
>     source-commit: 2eacddbb65acf10b2fcea4ee92374a90d2376dc4 # LXD 4.0.10
1193a1196,1227
> 
>       git cherry-pick -x aa0adcee9fc3f1fc40adc09cfb98611eb53f733e # lxd/apparmor/instance_lxc: allow devpts for unprivileged containers
>       git cherry-pick -x 73a796169cfe54f1953ac38c06022d5e38acb855 # lxd/apparmor/instance_lxc: allow procfs for unprivileged containers
>       git cherry-pick -x c572eb174ae179507c98a726939a3340f9d28d2d # lxd/apparmor/instance_lxc: allow sysfs for unprivileged containers
>       git cherry-pick -x bc9d5e7662c6311530ec292fa44227f67f7c023b # lxd/storage: Tighten storage pool volume permissions
>       git cherry-pick -x 48aba77c9fa253c15183e413131abcc67631b17d # lxd/storage/drivers/volume: Add comments explaining differences in BaseDirectories permissions
>       git cherry-pick -x 0138ebc8b9036a73670847c1e708343b05efd95c # lxd/patches: Re-apply storage permissions on update
>       git cherry-pick -x c7da9588d65d2a50e76dd0f69d5b744bed9e8af8 # shared/util: Add SingleQuote
>       git cherry-pick -x 222dd18222f49f27166c0883d8439ec945ba9c6a # shared/util: Rework SingleQuote to ShellQuote
>       git cherry-pick -x fdf59ba1b22b5b2cad3742f79cf50bd3536fd675 # lxd/instance/drivers/lxc: Use ShellQuote instead of Quote
>       git cherry-pick -x d671fb5b4c3b27d28c8e66e4510b96e90f702dc5 # lxd/instance/drivers/driver/lxc: Reduce duplicated calls to ShellQuote
>       git cherry-pick -x 3ddbafd5c8a07eca5155b12ede4731b1d5cbea74 # lxd/ubuntupro: adapted from `stable-5.0`
>       git cherry-pick -x 67574845359a6e1bdb15357caeee4fd92d8b7bf4 # shared/version/useragent: support adding more than one feature
>       git cherry-pick -x 201da8fbae4c7ea2b640375dae14dfb39ea7e608 # lxd/api_cluster: ignore failures to update the user agent
>       git cherry-pick -x 076152931f58e19469d0b8d7578f076f44341e4f # lxd/daemon: ignore failures to update the user agent
>       git cherry-pick -x 7d85a498ba66b80d0a835558d0d8784380a56540 # lxd/sys: Add ReleaseInfo
>       git cherry-pick -x b6185d83f88dc916ef74f81625559458d8214d97 # lxd/daemon: add `pro` feature if the host is pro attach
>       git cherry-pick -x 4fbe256d950802f03ee5a1db8abe083f80471955 # shared/validate: Tighten IsCompressionAlgorithm validator to only allow supported values
>       git cherry-pick -x 56db3e39d7ce2a7526e9612efadd8b59d588ad48 # lxd/images: Validate compression algorithm in compressFile
>       git cherry-pick -x 7f9f759062bff6815f9d297824181306f3cf65fe # lxd/images: Fail early if compression algorithm is unsupported
>       git cherry-pick -x 62dfadbd616ebc07d8d6f5b9b6bb0524ab520806 # lxd/instance_backup: Fail fast if compression algorithm is unsupported
>       git cherry-pick -x af114c3bd28fcb58479373725ae8993f85f6d4ae # lxd: Improve validation when editing certificates
>       git cherry-pick -x b290960de053de3f934dff6c3430c03ba7bc9104 # lxd/project/limits: Add raw.apparmor to the list of forbidden low level VM options
>       git cherry-pick -x 56039df87b7da3c98d73a578d71a7bf6e3e54a1a # shared/util: block some pongo2 functions in templates
>       git cherry-pick -x 4dbb63cacb43b1df0c4eff7ee8f6d90a3fef0e2c # shared/util: don't leak output from failed pongo2 template execution
>       git cherry-pick -x 43b48b2cc6aca52dafc3de77c6c801707858a742 # shared/util: explicitly return nil error on success
>       git cherry-pick -x a0e64807f5b1d8aaebf9fcd17d825a0a78398930 # shared/util: introduce recursion limit to RenderTemplate()
>       git cherry-pick -x ca85b301e0cd61d83f29120e9a1f63e38422f35a # shared/util: rework pongo2 template recursion for efficiency
>       git cherry-pick -x 3ee70b8e99194bcd745ea9d53173282a4cb2d3ce # shared/util: Handle panics in the pongo2 package
>       git cherry-pick -x b01add9f28f26cbd52ffe49bca1bab8ca9358cad # lxd/instance: transition to standard RenderTemplate logic
>       git cherry-pick -x c59c985d467b0eb3932b376cde9cdcaf64f7893d # shared/util: capture panics from pongo2
>       git cherry-pick -x 2cc94ece8ec6eaecf0485f17ff17b589a314f4f1 # shared/util_test: add test for RenderTemplateFile
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
