### PR TITLE
doc: Adds 5.21.5 and 5.0.7 release notes 

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -188,6 +188,7 @@ MNIST
 MTU
 Mullvad
 multicast
+multipath
 namespaced
 NATed
 natively
@@ -342,6 +343,7 @@ subvolume
 subvolumes
 superset
 SVG
+swtpm
 symlink
 symlinks
 syscall
@@ -397,6 +399,7 @@ VFS
 VFs
 VirtIO
 virtiofs
+virtiofsd
 virtualize
 virtualized
 VLAN

--- a/doc/reference/release-notes/5.0-lts/index.md
+++ b/doc/reference/release-notes/5.0-lts/index.md
@@ -15,6 +15,8 @@ This page lists release notes for LXD 5.0.
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
+
+LXD 5.0.7 </reference/release-notes/5.0-lts/release-notes-5.0.7>
 ```
 
 For older release notes, see [our Discourse forum](https://discourse.ubuntu.com/tags/c/lxd/126/release).

--- a/doc/reference/release-notes/5.0-lts/release-notes-5.0.7.md
+++ b/doc/reference/release-notes/5.0-lts/release-notes-5.0.7.md
@@ -1,0 +1,107 @@
+---
+myst:
+  html_meta:
+    description: Release notes for LXD 5.0.7, including highlights about new features, bugfixes, and other updates from the LXD project.
+---
+
+(ref-release-notes-5.0.7)=
+# LXD 5.0.7 release notes
+
+This is a {ref}`LTS release <ref-releases-lts>` and is recommended for production use.
+
+```{admonition} Release notes content
+:class: note
+These release notes cover updates in the [core LXD repository](https://github.com/canonical/lxd) and the [LXD snap package](https://snapcraft.io/lxd).
+```
+
+This is a maintenance release for the 5.0 LTS series. It focuses on security hardening, stricter input validation, and bug fixes backported from the main development branch.
+
+(ref-release-notes-5.0.7-highlights)=
+## Highlights
+
+This section highlights notable improvements in this release.
+
+### Security hardening
+
+A number of inputs are now validated more strictly and some low-level options have been further restricted as part of security hardening backports:
+
+- Stricter image fingerprint validation, including computing and verifying the combined hash during image downloads.
+- Stricter validation of low-level VM options: `raw.apparmor` and `raw.qemu.conf` were added to the list of forbidden low-level options.
+- Improved validation when editing certificates.
+- Validation of struct slices and configuration during backup import.
+- Tightened the compression algorithm validation to only allow supported values.
+
+### Template rendering hardening
+
+The instance template rendering logic was reworked to align with the standard `RenderTemplate` implementation. This introduces a recursion limit, blocks some `pongo2` template functions, handles panics from the `pongo2` package, and avoids leaking output from failed template execution.
+
+(ref-release-notes-5.0.7-bugfixes)=
+## Bug fixes
+
+The following bug fixes are included in this release.
+
+- [{spellexception}`Compute and verify combined hash during image downloads`](https://github.com/canonical/lxd/pull/17994)
+- [{spellexception}`Validate all backup config slices for nil values`](https://github.com/canonical/lxd/pull/18227)
+- [{spellexception}`Validate backup .Config`](https://github.com/canonical/lxd/pull/18227)
+- [{spellexception}`Do not persist changes in UpdateInstanceConfig during import`](https://github.com/canonical/lxd/pull/17968)
+- [{spellexception}`Do not use backup config from disk in internalImportFromBackup`](https://github.com/canonical/lxd/pull/17968)
+- [{spellexception}`Always exclude backup config from the generic VFS tarball`](https://github.com/canonical/lxd/pull/17968)
+- [{spellexception}`Validate whether instance snapshot can be created in createFromBackup`](https://github.com/canonical/lxd/pull/18304)
+- [{spellexception}`Quote architecture name supplied in shared/osarch`](https://github.com/canonical/lxd/pull/18304)
+- [{spellexception}`Do not bypass the instance limit check`](https://github.com/canonical/lxd/pull/17991)
+- [{spellexception}`Fail fast if the compression algorithm is unsupported for images, instance backups, and storage volume backups`](https://github.com/canonical/lxd/pull/17820)
+- [{spellexception}`Capture panics from pongo2 during template rendering`](https://github.com/canonical/lxd/pull/17980)
+- [{spellexception}`Introduce a recursion limit to RenderTemplate()`](https://github.com/canonical/lxd/pull/17980)
+- [{spellexception}`Block some pongo2 functions in templates`](https://github.com/canonical/lxd/pull/17980)
+
+(ref-release-notes-5.0.7-incompatible)=
+## Backwards-incompatible changes
+
+These changes are not compatible with older versions of LXD or its clients.
+
+### Minimum system requirement changes
+
+The minimum supported version of some components has changed:
+
+- The minimum required version of Go to build LXD is now 1.25.8 (see [Updated minimum Go version](#ref-release-notes-5.0.7-go)).
+
+### Stricter validation and tightened permissions
+
+Several inputs are now validated more strictly, and some low-level options have been further restricted as part of security hardening backports. Requests that previously succeeded with malformed or unexpected values may now be rejected:
+
+- Stricter image fingerprint validation.
+- Stricter checks for low-level (`raw.*`) VM configuration options, including `raw.apparmor` and `raw.qemu.conf`.
+- Improved certificate edit validation.
+- Validation of struct slices and configuration during import.
+- The compression algorithm validator now only allows supported values.
+
+(ref-release-notes-5.0.7-go)=
+## Updated minimum Go version
+
+If you are building LXD from source instead of using a package manager, the minimum version of Go required to build LXD is now 1.25.8 (previously 1.24.6).
+
+(ref-release-notes-5.0.7-snap)=
+## Snap packaging changes
+
+- Transitioned the snap base from `core20` to `core22`.
+- QEMU is now built from the Ubuntu source package (`8.2.2+ds-0ubuntu1.17`) instead of upstream Git.
+- Added an edk2/OVMF patch to disable the UEFI shell when Secure Boot is enabled.
+- Added the `apparmor.unprivileged-restrictions-disable` snap configuration option (default `true`).
+- The `lxd-ui` build now uses Node.js 20 (previously 18).
+- Refreshed the bundled Ceph stage libraries for `core22`.
+
+(ref-release-notes-5.0.7-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/lxd/compare/lxd-5.0.6...lxd-5.0.7).
+
+(ref-release-notes-5.0.7-downloads)=
+## Downloads
+
+The source tarballs and binary clients can be found on our [download page](https://github.com/canonical/lxd/releases/tag/lxd-5.0.7).
+
+Binary packages are also available for:
+
+- **Linux:** `snap install lxd --channel=5.0/stable`
+- **MacOS client:** `brew install lxc`
+- **Windows client:** `choco install lxc`

--- a/doc/reference/release-notes/5.21-lts/index.md
+++ b/doc/reference/release-notes/5.21-lts/index.md
@@ -16,6 +16,7 @@ This page lists release notes for LXD 5.21 LTS.
 :titlesonly:
 :maxdepth: 1
 
+LXD 5.21.5 </reference/release-notes/5.21-lts/release-notes-5.21.5>
 ```
 
 For older release notes, see [our Discourse forum](https://discourse.ubuntu.com/tags/c/lxd/126/release).

--- a/doc/reference/release-notes/5.21-lts/release-notes-5.21.5.md
+++ b/doc/reference/release-notes/5.21-lts/release-notes-5.21.5.md
@@ -1,0 +1,183 @@
+---
+myst:
+  html_meta:
+    description: Release notes for LXD 5.21.5, including highlights about new features, bugfixes, and other updates from the LXD project.
+---
+
+(ref-release-notes-5.21.5)=
+# LXD 5.21.5 release notes
+
+This is a {ref}`LTS release <ref-releases-lts>` and is recommended for production use.
+
+```{admonition} Release notes content
+:class: note
+These release notes cover updates in the [core LXD repository](https://github.com/canonical/lxd) and the [LXD snap package](https://snapcraft.io/lxd).
+```
+
+This is a maintenance release for the 5.21 LTS series. It backports a number of new features, storage and networking improvements, security hardening, and bug fixes from the main development branch.
+
+(ref-release-notes-5.21.5-highlights)=
+## Highlights
+
+This section highlights new and improved features in this release.
+
+### HPE Alletra storage driver
+
+A new `alletra` storage driver has been added for the consumption of storage volumes from an HPE Alletra storage array. The driver supports both iSCSI and NVMe/TCP connections, including volume resize and multipath handling.
+
+- Documentation: {ref}`storage-alletra`
+- API extension: {ref}`extension-storage-driver-alletra`
+
+### OVN internal load balancers and network forwards
+
+Support for internal OVN load balancers and network forwards has been introduced. This allows `ovn` networks to define ports on internal IP addresses that can be forwarded to other internal IPs within their networks, removing the previous limitation that load balancers and network forwards could only forward from external IP addresses.
+
+- Documentation: {ref}`network-load-balancers` and {ref}`network-forwards`
+- API extension: {ref}`extension-ovn-internal-load-balancer`
+
+### OVN DHCP ranges
+
+Support for the {config:option}`network-ovn-network-conf:ipv4.dhcp.ranges` configuration key has been added for `ovn` networks, allowing a list of IPv4 ranges to be reserved for dynamic allocation using DHCP.
+
+- Documentation: {ref}`network-ovn-setup`
+- API extension: {ref}`extension-ovn-dhcp-ranges`
+
+### OVN NIC acceleration parent
+
+Support has been added for specifying the OVN NIC acceleration physical function interfaces from which to allocate virtual functions. This avoids the need to add physical function interfaces to the OVN integration bridge.
+
+- Documentation: {ref}`nic-ovn`
+- API extension: {ref}`extension-ovn-nic-acceleration-parent`
+
+### Forced project deletion
+
+Support has been added for force deleting projects together with their entities (instances, profiles, images, networks, network ACLs, network zones, storage volumes, and storage buckets) by setting the `force` query parameter on `DELETE /1.0/projects/{name}` requests.
+
+- API extension: {ref}`extension-projects-force-delete`
+
+### Importing custom volumes from tarballs
+
+A new `tar` option has been added for the `--type` parameter in the `POST /1.0/storage-pools/{poolName}/volumes/{type}` API call.
+
+- Documentation: {ref}`howto-storage-volumes`
+- API extension: {ref}`extension-import-custom-volume-tar`
+
+### Persistent VM PCIe bus allocations
+
+Support has been added for persistently recording VM PCIe bus allocations in `volatile.<name>.bus` configuration keys, improving the stability of device addressing across VM restarts.
+
+- API extension: {ref}`extension-vm-persistent-bus`
+
+### Operation requestor information
+
+A new `requestor` field has been added to operations, which contains information about the caller that initiated the operation.
+
+- API extension: {ref}`extension-operation-requestor`
+
+### Disk usage in resources
+
+A `used_by` field has been added to disks returned by the resources endpoint to indicate their use by any virtual parent device, for example `bcache`.
+
+- API extension: {ref}`extension-resources-disk-used-by`
+
+(ref-release-notes-5.21.5-bugfixes)=
+## Bug fixes
+
+The following bug fixes are included in this release.
+
+- [{spellexception}`Fix CephFS volume multi-use`](https://github.com/canonical/lxd/pull/18509)
+- [{spellexception}`Fix local config being wiped out by reverter`](https://github.com/canonical/lxd/pull/18186)
+- [{spellexception}`Fix in-memory config corruption on update failure`](https://github.com/canonical/lxd/pull/17198)
+- [{spellexception}`Fix potential crash if non string config sent as notification in api10Put`](https://github.com/canonical/lxd/pull/18186)
+- [{spellexception}`Fix deadlock by only taking storage pool and network creation lock for external API requests`](https://github.com/canonical/lxd/pull/18122)
+- [{spellexception}`Fix nil pointer dereference in instance backup restore`](https://github.com/canonical/lxd/pull/18255)
+- [{spellexception}`Validate snapshot.ExpiresAt is non-nil`](https://github.com/canonical/lxd/pull/18390)
+- [{spellexception}`Fix instance migration with pool/project/target changes`](https://github.com/canonical/lxd/pull/18093)
+- [{spellexception}`Fix remote cluster migration`](https://github.com/canonical/lxd/pull/17086)
+- [{spellexception}`Fix cluster healing functionality`](https://github.com/canonical/lxd/pull/18152)
+- [{spellexception}`Validate a cluster group edit does not ignore a member removal`](https://github.com/canonical/lxd/pull/17023)
+- [{spellexception}`Fix effective project handling for used-by lists`](https://github.com/canonical/lxd/pull/17023)
+- [{spellexception}`Fix project for warning lifecycle events`](https://github.com/canonical/lxd/pull/17074)
+- [{spellexception}`Fix missing requestor on the project API`](https://github.com/canonical/lxd/pull/17074)
+- [{spellexception}`Fix pruneExpiredImages() to correctly track images`](https://github.com/canonical/lxd/pull/17086)
+- [{spellexception}`Fix fingerprint arg usage in the images API`](https://github.com/canonical/lxd/pull/17074)
+- [{spellexception}`Fix bad snapshot index calculation in the storage backend`](https://github.com/canonical/lxd/pull/18255)
+- [{spellexception}`Fix storage patch update with instance volume with size config`](https://github.com/canonical/lxd/pull/16403)
+- [{spellexception}`Unmap block device for ISO volumes`](https://github.com/canonical/lxd/pull/16378)
+- [{spellexception}`Round Pure Storage volume size to make it divisible by 512B`](https://github.com/canonical/lxd/pull/16356)
+- [{spellexception}`Ensure Pure Storage image size is applied if not specified otherwise`](https://github.com/canonical/lxd/pull/16339)
+- [{spellexception}`Fix Alletra and Pure block device unmap and volume resize in iSCSI/multipath mode`](https://github.com/canonical/lxd/pull/17074)
+- [{spellexception}`Fix NVMe Discovery() to filter out invalid NQNs`](https://github.com/canonical/lxd/pull/16378)
+- [{spellexception}`Fix lxc auth regression where groups were not removed from identities`](https://github.com/canonical/lxd/pull/17080)
+- [{spellexception}`Fix crash on nil qmp handler in RunJSON`](https://github.com/canonical/lxd/pull/18252)
+- [{spellexception}`Fix race condition in simpleListenerConnection.WriteJSON()`](https://github.com/canonical/lxd/pull/17086)
+- [{spellexception}`Explicitly close both ends of mirrored websockets to avoid hanging instance console websockets`](https://github.com/canonical/lxd/pull/17074)
+- [{spellexception}`Fix stale CDI-related files cleanup logic for physical GPU devices`](https://github.com/canonical/lxd/pull/16611)
+- [{spellexception}`Fix getDHCPv4Reservations() and randomAddressInSubnet() in the network drivers`](https://github.com/canonical/lxd/pull/17080)
+- [{spellexception}`Fix IsNetworkPortRange() to respect ports being 16 bits`](https://github.com/canonical/lxd/pull/17023)
+- [{spellexception}`Make /proc/cpuinfo parser less strict`](https://github.com/canonical/lxd/pull/16662)
+- [{spellexception}`Fix file push owner/group change not working on VMs`](https://github.com/canonical/lxd/pull/16331)
+- [{spellexception}`Use uint64 for interface statistics counters`](https://github.com/canonical/lxd/pull/17086)
+- [{spellexception}`Fix incorrect address comparison when changing the pprof address`](https://github.com/canonical/lxd/pull/18186)
+- [{spellexception}`Fix goroutine hangs in events handling`](https://github.com/canonical/lxd/pull/18402)
+
+(ref-release-notes-5.21.5-incompatible)=
+## Backwards-incompatible changes
+
+These changes are not compatible with older versions of LXD or its clients.
+
+### Minimum system requirement changes
+
+The minimum supported version of some components has changed:
+
+- The minimum required version of Go to build LXD is now 1.25.11 (see [Updated minimum Go version](#ref-release-notes-5.21.5-go)).
+
+### Stricter validation and tightened permissions
+
+Several inputs are now validated more strictly, and some permissions have been tightened as part of security hardening backports. Requests that previously succeeded with malformed or unexpected values may now be rejected:
+
+- Stricter certificate fingerprint validation.
+- Stricter checks for low-level (`raw.*`) configuration options.
+- Improved certificate edit validation.
+- Tightened storage pool permissions.
+- Validation of struct slices and config during import.
+
+(ref-release-notes-5.21.5-go)=
+## Updated minimum Go version
+
+If you are building LXD from source instead of using a package manager, the minimum version of Go required to build LXD is now 1.25.11 (previously 1.24.5).
+
+(ref-release-notes-5.21.5-snap)=
+## Snap packaging changes
+
+- Transitioned the snap base from `core22` to `core24`.
+- Several bundled components are now staged from the Ubuntu archive or built from Ubuntu source packages instead of being built from upstream Git, reducing build complexity. This includes Open vSwitch, OVN, swtpm, virtiofsd, and squashfs-tools-ng.
+- QEMU is now built from the Ubuntu source package (`8.2.2+ds-0ubuntu1.17`) instead of upstream Git.
+- EDK2/OVMF is now built from the Ubuntu source package (`2024.02-2ubuntu0.8`) instead of upstream Git.
+- SPICE is now built from the Ubuntu source package (`0.15.1-1build2`) instead of upstream Git.
+- Enabled LXCFS per-container process tracking (`snap set lxd lxcfs.pidfd=true`) by default.
+- dqlite bumped to v1.17.3.
+- LXC bumped to v6.0.6.
+- LXCFS bumped to v6.0.6.
+- LXCFS: Reverted partial backport of PSI functionality that prevented host machine suspend (#17983).
+- libnvidia-container bumped to v1.19.0.
+- NVIDIA container toolkit bumped to v1.19.0.
+- ZFS 2.2 bumped to 2.2.9.
+- ZFS 2.3 bumped to 2.3.6.
+- ZFS 2.4 bumped to 2.4.1.
+
+(ref-release-notes-5.21.5-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/lxd/compare/lxd-5.21.4...lxd-5.21.5).
+
+(ref-release-notes-5.21.5-downloads)=
+## Downloads
+
+The source tarballs and binary clients can be found on our [download page](https://github.com/canonical/lxd/releases/tag/lxd-5.21.5).
+
+Binary packages are also available for:
+
+- **Linux:** `snap install lxd --channel=5.21/stable`
+- **MacOS client:** `brew install lxc`
+- **Windows client:** `choco install lxc`


### PR DESCRIPTION
Depends on https://github.com/canonical/lxd/pull/18568

I made some changes to the 5.21.5 release notes since https://github.com/canonical/lxd/pull/18566 so I will sync them later once the release note structure is resolved see https://github.com/canonical/lxd/pull/18569#pullrequestreview-4570590855