### PR TITLE
lxd/endpoints: Fix infinite loop in network error log writer (from Incus)

### DIFF
--- a/lxd/endpoints/network_util.go
+++ b/lxd/endpoints/network_util.go
@@ -27,10 +27,9 @@ func (d networkServerErrorLogWriter) Write(p []byte) (int, error) {
 
 func (d networkServerErrorLogWriter) stripLog(p []byte) string {
 	// Strip the beginning of the log until we reach "http:".
-	for len(p) > 5 && string(p[0:5]) != "http:" {
-		p = bytes.TrimLeftFunc(p, func(r rune) bool {
-			return r != 'h'
-		})
+	idx := bytes.Index(p, []byte("http:"))
+	if idx > 0 {
+		p = p[idx:]
 	}
 
 	// Strip the newline from the end.


### PR DESCRIPTION
> A log line starting with 'h' but not 'http:', for example 'http2:' would cause an infinite loop.
> 
> (cherry picked from commit 05113883e2b814c9065fc983ee5038ac0359faa9)
> 
> License: Apache-2.0

I spotted this in my emails and realised that I am the culprit :facepalm:. Best avoid an infinite loop here.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
