### PR TITLE
snap/lxd: on `core22`, `iw` is at `/sbin/iw` (stable-5.0)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1520,6 +1520,7 @@ parts:
       usr/share/misc/: share/misc/
       var/lib/usbutils/usb.ids: share/misc/
       usr/sbin/: bin/
+      sbin/iw: bin/
       sbin/sgdisk: bin/
     prime:
       - bin/dnsmasq


### PR DESCRIPTION
On newer bases, it moved to `/usr/sbin/iw`.