### PR TITLE
Run user supplied compression commands under an apparmor profile with `aa-exec` (stable-5.21)

### DIFF
--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -3,13 +3,17 @@ package apparmor
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	"github.com/google/uuid"
+
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/revert"
 )
 
 var archiveProfileTpl = template.Must(template.New("archiveProfile").Parse(`#include <tunables/global>
@@ -158,4 +162,139 @@ func ArchiveProfileName(outputPath string) string {
 func ArchiveProfileFilename(outputPath string) string {
 	name := strings.ReplaceAll(strings.Trim(outputPath, "/"), "/", "-")
 	return profileName("archive", name)
+}
+
+// compressProfileTpl is a template for a highly restricted apparmor profile for use when compressing instances or
+// storage volumes with a user supplied compression algorithm. Commands running under this profile should expect input
+// via stdin. The template only grants write access to an output file if requested (`hasDstPath` template argument),
+// otherwise it is expected that the command should write to stdout. Only the given set of command paths may be executed.
+var compressProfileTpl = template.Must(template.New("compressProfile").Parse(`#include <tunables/global>
+profile "{{.name}}" {
+  #include <abstractions/base>
+{{range $index, $element := .allowedCommandPaths}}
+  {{$element}} mixr,
+{{- end }}
+
+{{- if .hasDstPath }}
+	{{ .dstPath }} rw,
+{{- end }}
+
+  signal (receive) set=("term"),
+
+{{- if .snap }}
+  # Snap-specific libraries
+  /snap/lxd/*/lib/**.so*                  mr,
+{{- end }}
+}
+`))
+
+// CompressWrapper should be used when applying a user specified compression algorithm.
+// The given command is directly modified such that it runs under `aa-exec` with a restricted profile (see [compressProfileTpl]).
+// It returns a cleanup function that deletes the AppArmor profile that the command is running in.
+func CompressWrapper(sysOS *sys.OS, cmd *exec.Cmd, dstPath string, extraAllowedCommands []string) (func(), error) {
+	if !sysOS.AppArmorAvailable || !sysOS.AppArmorAdmin {
+		return func() {}, nil
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	if dstPath != "" {
+		fullPath, err := filepath.EvalSymlinks(dstPath)
+		if err == nil {
+			dstPath = fullPath
+		}
+	}
+
+	cmds := append(extraAllowedCommands, cmd.Args[0])
+	allowedCmdPaths := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		cmdPath, err := exec.LookPath(c)
+		if err != nil {
+			return nil, fmt.Errorf("Failed starting compression: Failed finding executable: %w", err)
+		}
+
+		cmdPathFull, err := filepath.EvalSymlinks(cmdPath)
+		if err == nil {
+			cmdPath = cmdPathFull
+		}
+
+		allowedCmdPaths = append(allowedCmdPaths, cmdPath)
+	}
+
+	// Load the profile.
+	profileName, err := compressProfileLoad(sysOS, allowedCmdPaths, dstPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading compression profile: %w", err)
+	}
+
+	cleanup := func() { _ = deleteProfile(sysOS, profileName, profileName) }
+	revert.Add(cleanup)
+
+	// Resolve aa-exec.
+	execPath, err := exec.LookPath("aa-exec")
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the command.
+	newArgs := make([]string, 0, 3+len(cmd.Args))
+	newArgs = append(newArgs, "aa-exec", "-p", profileName)
+	newArgs = append(newArgs, cmd.Args...)
+	cmd.Args = newArgs
+	cmd.Path = execPath
+
+	revert.Success()
+	return cleanup, nil
+}
+
+// compressProfileLoad loads [compressProfileTpl] with the given arguments. A name is generated at random for the profile
+// because it should be loaded and unloaded as necessary using [CompressWrapper].
+func compressProfileLoad(sysOS *sys.OS, allowedCommandPaths []string, dstPath string) (string, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Generate a temporary profile name.
+	name := profileName("compress", uuid.New().String())
+	profilePath := filepath.Join(aaPath, "profiles", name)
+
+	// Generate the profile
+	content, err := compressProfile(name, allowedCommandPaths, dstPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Write it to disk.
+	err = os.WriteFile(profilePath, []byte(content), 0600)
+	if err != nil {
+		return "", err
+	}
+
+	revert.Add(func() { os.Remove(profilePath) })
+
+	// Load it.
+	err = loadProfile(sysOS, name)
+	if err != nil {
+		return "", err
+	}
+
+	revert.Success()
+	return name, nil
+}
+
+// compressProfile generates the AppArmor profile template from the given destination path.
+func compressProfile(name string, allowedCommandPaths []string, dstPath string) (string, error) {
+	sb := &strings.Builder{}
+	err := compressProfileTpl.Execute(sb, map[string]any{
+		"allowedCommandPaths": allowedCommandPaths,
+		"name":                name,
+		"hasDstPath":          dstPath != "",
+		"dstPath":             dstPath,
+		"snap":                shared.InSnap(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
 }

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -164,7 +164,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		defer l.Debug("Finished backup tarball writer")
 		if compress != "none" {
 			backupProgressWriter.WriteCloser = tarFileWriter
-			compressErr = compressFile(compress, tarPipeReader, backupProgressWriter)
+			compressErr = compressFile(s.OS, compress, tarPipeReader, backupProgressWriter)
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {
@@ -482,7 +482,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		l.Debug("Started backup tarball writer")
 		defer l.Debug("Finished backup tarball writer")
 		if compress != "none" {
-			compressErr = compressFile(compress, tarPipeReader, tarFileWriter)
+			compressErr = compressFile(s.OS, compress, tarPipeReader, tarFileWriter)
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -511,7 +511,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 		compressWriter := io.MultiWriter(imageFile, sha256)
 		go func() {
 			defer wg.Done()
-			compressErr = compressFile(compress, tarReader, compressWriter)
+			compressErr = compressFile(s.OS, compress, tarReader, compressWriter)
 
 			// If a compression error occurred, close the writer to end the instance export.
 			if compressErr != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -32,6 +32,7 @@ import (
 	"go.yaml.in/yaml/v2"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/apparmor"
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
@@ -48,6 +49,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	storagePools "github.com/canonical/lxd/lxd/storage"
+	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/lxd/task"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
@@ -295,9 +297,7 @@ var imagePublishLock sync.Mutex
 // stepping on each other's toes.
 var imageTaskMu sync.Mutex
 
-func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
-	var cmd *exec.Cmd
-
+func compressFile(sysOS *sys.OS, compress string, infile io.Reader, outfile io.Writer) error {
 	// Parse the command.
 	fields, err := shellquote.Split(compress)
 	if err != nil {
@@ -327,13 +327,20 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		}
 
 		args = append(args, "--quiet", "--no-skip", "--force", "--compressor", "xz", tempfile.Name())
-		cmd = exec.Command("tar2sqfs", args...)
+		cmd := exec.Command("tar2sqfs", args...)
 		cmd.Stdin = infile
 
+		cleanup, err := apparmor.CompressWrapper(sysOS, cmd, tempfile.Name(), []string{"xz"})
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("tar2sqfs: %w (%v)", err, strings.TrimSpace(string(output)))
 		}
+
 		// Replay the result to outfile
 		_, err = tempfile.Seek(0, io.SeekStart)
 		if err != nil {
@@ -344,23 +351,31 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		args := []string{"-c"}
-		if len(fields) > 1 {
-			args = append(args, fields[1:]...)
-		}
 
-		if fields[0] == "gzip" {
-			args = append(args, "-n")
-		}
+		return nil
+	}
 
-		cmd := exec.Command(fields[0], args...)
-		cmd.Stdin = infile
-		cmd.Stdout = outfile
-		err := cmd.Run()
-		if err != nil {
-			return err
-		}
+	args := []string{"-c"}
+	if len(fields) > 1 {
+		args = append(args, fields[1:]...)
+	}
+
+	if fields[0] == "gzip" {
+		args = append(args, "-n")
+	}
+
+	cmd := exec.Command(fields[0], args...)
+	cmd.Stdin = infile
+	cmd.Stdout = outfile
+	cleanup, err := apparmor.CompressWrapper(sysOS, cmd, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+	err = cmd.Run()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -222,6 +222,15 @@ test_basic_usage() {
   # Ensure invalid compression algorithm is rejected.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc publish bar --compression=ls 2>&1)" = 'Error: Invalid compression algorithm "ls"' ]
 
+  # Ensure compression algorithm cannot be supplied with dangerous arguments.
+  lxc init testimage c1
+  ! lxc publish c1 --compression="zstd -d -f --pass-through -o ${TEST_DIR}/busybox -- ${LXD_DIR}/containers/c1/rootfs/bin/busybox" || false
+  if [ -e "${TEST_DIR}/busybox" ]; then
+    echo "Custom compression attack successful!" >&2
+    exit 1
+  fi
+  lxc delete c1
+
   # Test image compression on publish
   lxc publish bar --alias=foo-image-compressed --compression=bzip2 prop=val1
   [ "$(lxc image get-property foo-image-compressed prop)" = "val1" ]


### PR DESCRIPTION
Addresses https://github.com/canonical/lxd/security/advisories/GHSA-fmc8-p6q7-75cc