### PR TITLE
Run user supplied compression commands under an apparmor profile with `aa-exec` (stable-5.0)

### DIFF
--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -1,13 +1,18 @@
 package apparmor
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	"github.com/google/uuid"
+
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/revert"
 )
 
 var archiveProfileTpl = template.Must(template.New("archiveProfile").Parse(`#include <tunables/global>
@@ -149,4 +154,134 @@ func ArchiveProfileName(outputPath string) string {
 func ArchiveProfileFilename(outputPath string) string {
 	name := strings.Replace(strings.Trim(outputPath, "/"), "/", "-", -1)
 	return profileName("archive", name)
+}
+
+// compressProfileTpl is a template for a highly restricted apparmor profile for use when compressing instances or
+// storage volumes with a user supplied compression algorithm. Commands running under this profile should expect input
+// via stdin. The template only grants write access to an output file if requested (`hasDstPath` template argument),
+// otherwise it is expected that the command should write to stdout. Only the given set of command paths may be executed.
+var compressProfileTpl = template.Must(template.New("compressProfile").Parse(`#include <tunables/global>
+profile "{{.name}}" {
+  #include <abstractions/base>
+{{range $index, $element := .allowedCommandPaths}}
+  {{$element}} mixr,
+{{- end }}
+
+{{- if .hasDstPath }}
+	{{ .dstPath }} rw,
+{{- end }}
+
+  signal (receive) set=("term"),
+
+{{- if .snap }}
+  # Snap-specific libraries
+  /snap/lxd/*/lib/**.so*                  mr,
+{{- end }}
+}
+`))
+
+// CompressWrapper should be used when applying a user specified compression algorithm.
+// The given command is directly modified such that it runs under `aa-exec` with a restricted profile (see [compressProfileTpl]).
+// It returns a cleanup function that deletes the AppArmor profile that the command is running in.
+func CompressWrapper(sysOS *sys.OS, cmd *exec.Cmd, dstPath string, extraAllowedCommands []string) (func(), error) {
+	if !sysOS.AppArmorAvailable {
+		return func() {}, nil
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	if dstPath != "" {
+		fullPath, err := filepath.EvalSymlinks(dstPath)
+		if err == nil {
+			dstPath = fullPath
+		}
+	}
+
+	cmds := append(extraAllowedCommands, cmd.Args[0])
+	allowedCmdPaths := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		cmdPath, err := exec.LookPath(c)
+		if err != nil {
+			return nil, fmt.Errorf("Failed starting compression: Failed finding executable: %w", err)
+		}
+
+		allowedCmdPaths = append(allowedCmdPaths, cmdPath)
+	}
+
+	// Load the profile.
+	profileName, err := compressProfileLoad(sysOS, allowedCmdPaths, dstPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading compression profile: %w", err)
+	}
+
+	cleanup := func() { _ = deleteProfile(sysOS, profileName, profileName) }
+	revert.Add(cleanup)
+
+	// Resolve aa-exec.
+	execPath, err := exec.LookPath("aa-exec")
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the command.
+	newArgs := make([]string, 0, 3+len(cmd.Args))
+	newArgs = append(newArgs, "aa-exec", "-p", profileName)
+	newArgs = append(newArgs, cmd.Args...)
+	cmd.Args = newArgs
+	cmd.Path = execPath
+
+	revert.Success()
+	return cleanup, nil
+}
+
+// compressProfileLoad loads [compressProfileTpl] with the given arguments. A name is generated at random for the profile
+// because it should be loaded and unloaded as necessary using [CompressWrapper].
+func compressProfileLoad(sysOS *sys.OS, allowedCommandPaths []string, dstPath string) (string, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Generate a temporary profile name.
+	name := profileName("compress", uuid.New().String())
+	profilePath := filepath.Join(aaPath, "profiles", name)
+
+	// Generate the profile
+	content, err := compressProfile(name, allowedCommandPaths, dstPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Write it to disk.
+	err = os.WriteFile(profilePath, []byte(content), 0600)
+	if err != nil {
+		return "", err
+	}
+
+	revert.Add(func() { os.Remove(profilePath) })
+
+	// Load it.
+	err = loadProfile(sysOS, name)
+	if err != nil {
+		return "", err
+	}
+
+	revert.Success()
+	return name, nil
+}
+
+// compressProfile generates the AppArmor profile template from the given destination path.
+func compressProfile(name string, allowedCommandPaths []string, dstPath string) (string, error) {
+	sb := &strings.Builder{}
+	err := compressProfileTpl.Execute(sb, map[string]any{
+		"allowedCommandPaths": allowedCommandPaths,
+		"name":                name,
+		"hasDstPath":          dstPath != "",
+		"dstPath":             dstPath,
+		"snap":                shared.InSnap(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
 }

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -156,7 +156,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		defer l.Debug("Finished backup tarball writer")
 		if compress != "none" {
 			backupProgressWriter.WriteCloser = tarFileWriter
-			compressErr = compressFile(compress, tarPipeReader, backupProgressWriter)
+			compressErr = compressFile(s.OS, compress, tarPipeReader, backupProgressWriter)
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {
@@ -445,7 +445,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		l.Debug("Started backup tarball writer")
 		defer l.Debug("Finished backup tarball writer")
 		if compress != "none" {
-			compressErr = compressFile(compress, tarPipeReader, tarFileWriter)
+			compressErr = compressFile(s.OS, compress, tarPipeReader, tarFileWriter)
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/canonical/lxd/lxd/apparmor"
+	"github.com/canonical/lxd/lxd/sys"
 	"github.com/gorilla/mux"
 	"github.com/kballard/go-shellquote"
 	"gopkg.in/yaml.v2"
@@ -122,9 +124,8 @@ var imagePublishLock sync.Mutex
 // stepping on each other's toes.
 var imageTaskMu sync.Mutex
 
-func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
+func compressFile(sysOS *sys.OS, compress string, infile io.Reader, outfile io.Writer) error {
 	reproducible := []string{"gzip"}
-	var cmd *exec.Cmd
 
 	// Parse the command.
 	fields, err := shellquote.Split(compress)
@@ -155,13 +156,20 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		}
 
 		args = append(args, "--no-skip", "--force", "--compressor", "xz", tempfile.Name())
-		cmd = exec.Command(args[0], args[1:]...)
+		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdin = infile
 
+		cleanup, err := apparmor.CompressWrapper(sysOS, cmd, tempfile.Name(), []string{"xz"})
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("tar2sqfs: %v (%v)", err, strings.TrimSpace(string(output)))
 		}
+
 		// Replay the result to outfile
 		_, err = tempfile.Seek(0, io.SeekStart)
 		if err != nil {
@@ -172,23 +180,31 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		args := []string{"-c"}
-		if len(fields) > 1 {
-			args = append(args, fields[1:]...)
-		}
 
-		if shared.StringInSlice(fields[0], reproducible) {
-			args = append(args, "-n")
-		}
+		return nil
+	}
 
-		cmd := exec.Command(fields[0], args...)
-		cmd.Stdin = infile
-		cmd.Stdout = outfile
-		err := cmd.Run()
-		if err != nil {
-			return err
-		}
+	args := []string{"-c"}
+	if len(fields) > 1 {
+		args = append(args, fields[1:]...)
+	}
+
+	if shared.StringInSlice(fields[0], reproducible) {
+		args = append(args, "-n")
+	}
+
+	cmd := exec.Command(fields[0], args...)
+	cmd.Stdin = infile
+	cmd.Stdout = outfile
+	cleanup, err := apparmor.CompressWrapper(sysOS, cmd, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+	err = cmd.Run()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -339,7 +339,7 @@ func imgPostInstanceInfo(s *state.State, r *http.Request, req api.ImagesPost, op
 		compressWriter := io.MultiWriter(imageFile, sha256)
 		go func() {
 			defer wg.Done()
-			compressErr = compressFile(compress, tarReader, compressWriter)
+			compressErr = compressFile(s.OS, compress, tarReader, compressWriter)
 
 			// If a compression error occurred, close the writer to end the instance export.
 			if compressErr != nil {


### PR DESCRIPTION
Addresses https://github.com/canonical/lxd/security/advisories/GHSA-fmc8-p6q7-75cc