### PR TITLE
Run user supplied compression commands under an apparmor profile with `aa-exec` (stable-4.0)

### DIFF
--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -1,0 +1,149 @@
+package apparmor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/google/uuid"
+
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/shared"
+)
+
+// compressProfileTpl is a template for a highly restricted apparmor profile for use when compressing instances or
+// storage volumes with a user supplied compression algorithm. Commands running under this profile should expect input
+// via stdin. The template only grants write access to an output file if requested (`hasDstPath` template argument),
+// otherwise it is expected that the command should write to stdout. Only the given set of command paths may be executed.
+var compressProfileTpl = template.Must(template.New("compressProfile").Parse(`#include <tunables/global>
+profile "{{.name}}" {
+  #include <abstractions/base>
+{{range $index, $element := .allowedCommandPaths}}
+  {{$element}} mixr,
+{{- end }}
+
+{{- if .hasDstPath }}
+	{{ .dstPath }} rw,
+{{- end }}
+
+  signal (receive) set=("term"),
+
+{{- if .snap }}
+  # Snap-specific libraries
+  /snap/lxd/*/lib/**.so*                  mr,
+{{- end }}
+}
+`))
+
+// CompressWrapper should be used when applying a user specified compression algorithm.
+// The given command is directly modified such that it runs under `aa-exec` with a restricted profile (see [compressProfileTpl]).
+// It returns a cleanup function that deletes the AppArmor profile that the command is running in.
+func CompressWrapper(s *state.State, cmd *exec.Cmd, dstPath string, extraAllowedCommands []string) (func(), error) {
+	if !s.OS.AppArmorAvailable {
+		return func() {}, nil
+	}
+
+	if dstPath != "" {
+		fullPath, err := filepath.EvalSymlinks(dstPath)
+		if err == nil {
+			dstPath = fullPath
+		}
+	}
+
+	cmds := append(extraAllowedCommands, cmd.Args[0])
+	allowedCmdPaths := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		cmdPath, err := exec.LookPath(c)
+		if err != nil {
+			return nil, fmt.Errorf("Failed starting compression: Failed finding executable: %w", err)
+		}
+
+		allowedCmdPaths = append(allowedCmdPaths, cmdPath)
+	}
+
+	// Load the profile.
+	profileName, err := compressProfileLoad(s, allowedCmdPaths, dstPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading compression profile: %w", err)
+	}
+
+	cleanup := func() { _ = deleteProfile(s, profileName, profileName) }
+	fail := true
+	defer func() {
+		if fail {
+			cleanup()
+		}
+	}()
+
+	// Resolve aa-exec.
+	execPath, err := exec.LookPath("aa-exec")
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the command.
+	newArgs := make([]string, 0, 3+len(cmd.Args))
+	newArgs = append(newArgs, "aa-exec", "-p", profileName)
+	newArgs = append(newArgs, cmd.Args...)
+	cmd.Args = newArgs
+	cmd.Path = execPath
+
+	fail = false
+	return cleanup, nil
+}
+
+// compressProfileLoad loads [compressProfileTpl] with the given arguments. A name is generated at random for the profile
+// because it should be loaded and unloaded as necessary using [CompressWrapper].
+func compressProfileLoad(s *state.State, allowedCommandPaths []string, dstPath string) (string, error) {
+	// Generate a temporary profile name.
+	name := profileName("compress", uuid.New().String())
+	profilePath := filepath.Join(aaPath, "profiles", name)
+
+	// Generate the profile
+	content, err := compressProfile(name, allowedCommandPaths, dstPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Write it to disk.
+	err = os.WriteFile(profilePath, []byte(content), 0600)
+	if err != nil {
+		return "", err
+	}
+
+	fail := true
+	defer func() {
+		if fail {
+			_ = os.Remove(profilePath)
+		}
+	}()
+
+	// Load it.
+	err = loadProfile(s, name)
+	if err != nil {
+		return "", err
+	}
+
+	fail = false
+	return name, nil
+}
+
+// compressProfile generates the AppArmor profile template from the given destination path.
+func compressProfile(name string, allowedCommandPaths []string, dstPath string) (string, error) {
+	sb := &strings.Builder{}
+	err := compressProfileTpl.Execute(sb, map[string]any{
+		"allowedCommandPaths": allowedCommandPaths,
+		"name":                name,
+		"hasDstPath":          dstPath != "",
+		"dstPath":             dstPath,
+		"snap":                shared.InSnap(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -146,7 +146,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		defer logger.Debug("Finished backup tarball writer")
 		if compress != "none" {
 			backupProgressWriter.WriteCloser = tarFileWriter
-			compressErr = compressFile(compress, tarPipeReader, backupProgressWriter)
+			compressErr = compressFile(s, compress, tarPipeReader, backupProgressWriter)
 
 			// If a compression error occurred, close the tarPipeWriter to end the export.
 			if compressErr != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -327,7 +327,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		compressWriter := io.MultiWriter(imageFile, sha256)
 		go func() {
 			defer wg.Done()
-			compressErr = compressFile(compress, tarReader, compressWriter)
+			compressErr = compressFile(d.State(), compress, tarReader, compressWriter)
 
 			// If a compression error occurred, close the writer to end the instance export.
 			if compressErr != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -28,7 +28,8 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 	"gopkg.in/yaml.v2"
 
-	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/apparmor"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/filter"
@@ -132,9 +133,8 @@ We only want a single publish running at any one time.
 */
 var imagePublishLock sync.Mutex
 
-func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
+func compressFile(s *state.State, compress string, infile io.Reader, outfile io.Writer) error {
 	reproducible := []string{"gzip"}
-	var cmd *exec.Cmd
 
 	// Parse the command.
 	fields, err := shellquote.Split(compress)
@@ -162,36 +162,51 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		if len(fields) > 1 {
 			args = append(args, fields[1:]...)
 		}
+
 		args = append(args, "--no-skip", "--force", "--compressor", "xz", tempfile.Name())
-		cmd = exec.Command(args[0], args[1:]...)
+		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdin = infile
 
+		cleanup, err := apparmor.CompressWrapper(s, cmd, tempfile.Name(), []string{"xz"})
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("tar2sqfs: %v (%v)", err, strings.TrimSpace(string(output)))
 		}
+
 		// Replay the result to outfile
 		tempfile.Seek(0, 0)
 		_, err = io.Copy(outfile, tempfile)
 		if err != nil {
 			return err
 		}
-	} else {
-		args := []string{"-c"}
-		if len(fields) > 1 {
-			args = append(args, fields[1:]...)
-		}
-		if shared.StringInSlice(fields[0], reproducible) {
-			args = append(args, "-n")
-		}
+	}
 
-		cmd := exec.Command(fields[0], args...)
-		cmd.Stdin = infile
-		cmd.Stdout = outfile
-		err := cmd.Run()
-		if err != nil {
-			return err
-		}
+	args := []string{"-c"}
+	if len(fields) > 1 {
+		args = append(args, fields[1:]...)
+	}
+
+	if shared.StringInSlice(fields[0], reproducible) {
+		args = append(args, "-n")
+	}
+
+	cmd := exec.Command(fields[0], args...)
+	cmd.Stdin = infile
+	cmd.Stdout = outfile
+	cleanup, err := apparmor.CompressWrapper(s, cmd, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+	err = cmd.Run()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -56,21 +56,23 @@ const (
 	patchStoragePoolVolumeAPIEndpointCustom     string = "custom"
 )
 
-/* Patches are one-time actions that are sometimes needed to update
-   existing container configuration or move things around on the
-   filesystem.
+/*
+Patches are one-time actions that are sometimes needed to update
 
-   Those patches are applied at startup time after the database schema
-   has been fully updated. Patches can therefore assume a working database.
+	existing container configuration or move things around on the
+	filesystem.
 
-   At the time the patches are applied, the containers aren't started
-   yet and the daemon isn't listening to requests.
+	Those patches are applied at startup time after the database schema
+	has been fully updated. Patches can therefore assume a working database.
 
-   DO NOT use this mechanism for database update. Schema updates must be
-   done through the separate schema update mechanism.
+	At the time the patches are applied, the containers aren't started
+	yet and the daemon isn't listening to requests.
+
+	DO NOT use this mechanism for database update. Schema updates must be
+	done through the separate schema update mechanism.
 
 
-   Only append to the patches list, never remove entries and never re-order them.
+	Only append to the patches list, never remove entries and never re-order them.
 */
 var patches = []patch{
 	{name: "shrink_logs_db_file", stage: patchPostDaemonStorage, run: patchShrinkLogsDBFile},
@@ -3586,7 +3588,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 				}
 				defer compressed.Close()
 
-				err = compressFile("xz", infile, compressed)
+				err = compressFile(d.State(), "xz", infile, compressed)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Addresses https://github.com/canonical/lxd/security/advisories/GHSA-fmc8-p6q7-75cc