### PR TITLE
snap: Build lxd-user statically so it doesn't depend on glibc (stable-5.0)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -934,14 +934,24 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		return nil, err
 	}
 
+	// Instruct liblxc to use the lxd-stophook wrapper in the bin directory of the snap instead of lxd in sbin.
+	// This is the historical path where the lxd binary used to be, but it was replaced with a small wrapper
+	// script which redirects the stop hook requests to lxd-user (which is statically compiled) so that stop
+	// hook notifications to LXD work when the snap base version is changed.
+	lxdStopHookPath := d.state.OS.ExecPath
+	if shared.InSnap() && strings.HasSuffix(lxdStopHookPath, "sbin/lxd") {
+		// Convert /snap/lxd/current/sbin/lxd into /snap/lxd/current/bin/lxd.
+		lxdStopHookPath = strings.TrimSuffix(lxdStopHookPath, "sbin/lxd") + "bin/lxd"
+	}
+
 	// Call the onstopns hook on stop but before namespaces are unmounted.
-	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", d.state.OS.ExecPath, shared.VarPath(""), projectShellQuoted, instanceShellQuoted))
+	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", lxdStopHookPath, shared.VarPath(""), projectShellQuoted, instanceShellQuoted))
 	if err != nil {
 		return nil, err
 	}
 
 	// Call the onstop hook on stop.
-	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", d.state.OS.ExecPath, shared.VarPath(""), projectShellQuoted, instanceShellQuoted))
+	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", lxdStopHookPath, shared.VarPath(""), projectShellQuoted, instanceShellQuoted))
 	if err != nil {
 		return nil, err
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1509,7 +1509,7 @@ parts:
       # Build static binaries
       CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-agent" -tags=agent,netgo github.com/canonical/lxd/lxd-agent
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-benchmark" github.com/canonical/lxd/lxd-benchmark
-      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" github.com/canonical/lxd/lxd-user
+      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/lxd-user" -tags netgo github.com/canonical/lxd/lxd-user
 
       # Setup bash completion
       mkdir -p "${CRAFT_PART_INSTALL}/etc/bash_completion.d/"


### PR DESCRIPTION

This allows containers to be restarted after core upgrade.