### PR TITLE
Require `can_view` on source for instance and storage volume copy (stable-5.21)

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/lxd/archive"
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
@@ -37,6 +38,7 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	apiScriptlet "github.com/canonical/lxd/shared/api/scriptlet"
+	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
@@ -1136,6 +1138,29 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 	if req.Config == nil {
 		req.Config = map[string]string{}
+	}
+
+	if req.Source.Type == api.SourceTypeCopy {
+		if req.Source.Source == "" {
+			return response.BadRequest(errors.New("Must specify a source instance"))
+		}
+
+		if req.Source.Project == "" {
+			req.Source.Project = targetProjectName
+		}
+
+		var sourceURL *api.URL
+		instanceName, snapshotName, isSnapshot := api.GetParentAndSnapshotName(req.Source.Source)
+		if isSnapshot {
+			sourceURL = entity.InstanceSnapshotURL(req.Source.Project, instanceName, snapshotName)
+		} else {
+			sourceURL = entity.InstanceURL(req.Source.Project, req.Source.Source)
+		}
+
+		err = s.Authorizer.CheckPermission(r.Context(), sourceURL, auth.EntitlementCanView)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	if req.InstanceType != "" {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1220,14 +1220,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 		switch req.Source.Type {
 		case api.SourceTypeCopy:
-			if req.Source.Source == "" {
-				return api.StatusErrorf(http.StatusBadRequest, "Must specify a source instance")
-			}
-
-			if req.Source.Project == "" {
-				req.Source.Project = targetProjectName
-			}
-
 			sourceInst, err = instance.LoadInstanceDatabaseObject(ctx, tx, req.Source.Project, req.Source.Source)
 			if err != nil {
 				return err

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1067,6 +1067,34 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Currently not allowed to create storage volumes of type %q", req.Type))
 	}
 
+	if req.Source.Type == api.SourceTypeCopy {
+		if req.Source.Name == "" {
+			return response.BadRequest(errors.New("No source volume name supplied"))
+		}
+
+		if req.Source.Project == "" {
+			req.Source.Project = requestProjectName
+		}
+
+		sourceProjectName, err := project.StorageVolumeProject(s.DB.Cluster, req.Source.Project, cluster.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		var sourceURL *api.URL
+		sourceVolumeName, snapshotName, isSnapshot := api.GetParentAndSnapshotName(req.Source.Name)
+		if isSnapshot {
+			sourceURL = entity.StorageVolumeSnapshotURL(sourceProjectName, req.Source.Location, req.Source.Pool, req.Type, sourceVolumeName, snapshotName)
+		} else {
+			sourceURL = entity.StorageVolumeURL(sourceProjectName, req.Source.Location, req.Source.Pool, req.Type, req.Source.Name)
+		}
+
+		err = s.Authorizer.CheckPermission(r.Context(), sourceURL, auth.EntitlementCanView)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	var poolID int64
 	var dbVolume *db.StorageVolume
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -629,6 +629,29 @@ fine_grained_authorization() {
   lxc auth group permission remove test-group project default can_view
   lxc delete copy-target-snap copy-target copy-source
 
+  sub_test "Storage volume copy requires source visibility"
+  pool_name="$(lxc storage list -f csv | cut -d, -f1)"
+  lxc storage volume create "${pool_name}" copy-source-vol
+  lxc storage volume snapshot "${pool_name}" copy-source-vol snap0
+
+  lxc auth group permission add test-group project default can_view
+  lxc auth group permission add test-group project default can_create_storage_volumes
+
+  ! lxc_remote query --wait -X POST "${remote}:/1.0/storage-pools/${pool_name}/volumes/custom?project=default" -d '{"name":"copy-target-vol","type":"custom","source":{"name":"copy-source-vol","type":"copy","pool":"'"${pool_name}"'","project":"default"}}' || false
+  ! lxc_remote query --wait -X POST "${remote}:/1.0/storage-pools/${pool_name}/volumes/custom?project=default" -d '{"name":"copy-target-vol-snap","type":"custom","source":{"name":"copy-source-vol/snap0","type":"copy","pool":"'"${pool_name}"'","project":"default"}}' || false
+
+  lxc auth group permission add test-group storage_volume copy-source-vol can_view project=default pool="${pool_name}" type=custom
+
+  lxc_remote query --wait -X POST "${remote}:/1.0/storage-pools/${pool_name}/volumes/custom?project=default" -d '{"name":"copy-target-vol","type":"custom","source":{"name":"copy-source-vol","type":"copy","pool":"'"${pool_name}"'","project":"default"}}'
+  lxc_remote query --wait -X POST "${remote}:/1.0/storage-pools/${pool_name}/volumes/custom?project=default" -d '{"name":"copy-target-vol-snap","type":"custom","source":{"name":"copy-source-vol/snap0","type":"copy","pool":"'"${pool_name}"'","project":"default"}}'
+
+  lxc auth group permission remove test-group storage_volume copy-source-vol can_view project=default pool="${pool_name}" type=custom
+  lxc auth group permission remove test-group project default can_create_storage_volumes
+  lxc auth group permission remove test-group project default can_view
+  lxc storage volume delete "${pool_name}" copy-target-vol-snap
+  lxc storage volume delete "${pool_name}" copy-target-vol
+  lxc storage volume delete "${pool_name}" copy-source-vol
+
   echo "==> Checking 'can_view_warnings' entitlement..."
   # Delete previous warnings
   lxc query --wait /1.0/warnings\?recursion=1 | jq --exit-status --raw-output '.[].uuid' | xargs -n1 lxc warning delete

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -609,6 +609,26 @@ fine_grained_authorization() {
   lxc delete user-foo --force # Must clean this up now as subsequent tests assume a clean project.
   lxc auth group permission remove test-group project default can_view
 
+  sub_test "Instance copy requires source visibility"
+  lxc init --empty copy-source
+  lxc snapshot copy-source snap0
+
+  lxc auth group permission add test-group project default can_view
+  lxc auth group permission add test-group project default can_create_instances
+
+  ! lxc_remote query --wait -X POST "${remote}:/1.0/instances?project=default" -d '{"name":"copy-target","source":{"type":"copy","source":"copy-source","project":"default"}}' || false
+  ! lxc_remote query --wait -X POST "${remote}:/1.0/instances?project=default" -d '{"name":"copy-target-snap","source":{"type":"copy","source":"copy-source/snap0","project":"default"}}' || false
+
+  lxc auth group permission add test-group instance copy-source can_view project=default
+
+  lxc_remote query --wait -X POST "${remote}:/1.0/instances?project=default" -d '{"name":"copy-target","source":{"type":"copy","source":"copy-source","project":"default"}}'
+  lxc_remote query --wait -X POST "${remote}:/1.0/instances?project=default" -d '{"name":"copy-target-snap","source":{"type":"copy","source":"copy-source/snap0","project":"default"}}'
+
+  lxc auth group permission remove test-group instance copy-source can_view project=default
+  lxc auth group permission remove test-group project default can_create_instances
+  lxc auth group permission remove test-group project default can_view
+  lxc delete copy-target-snap copy-target copy-source
+
   echo "==> Checking 'can_view_warnings' entitlement..."
   # Delete previous warnings
   lxc query --wait /1.0/warnings\?recursion=1 | jq --exit-status --raw-output '.[].uuid' | xargs -n1 lxc warning delete


### PR DESCRIPTION
This PR is a backport of the https://github.com/canonical/lxd/pull/17914 to the `stable-5.21`. It requires the `can_view` restriction on the source when copying instances and storage volumes.

It effectively addresses two vulnerabilities for LXD `5.21`: https://github.com/canonical/lxd/security/advisories/GHSA-qx75-2p3r-pwm5 and https://github.com/canonical/lxd/security/advisories/GHSA-7mr3-28h5-m5vx.