### PR TITLE
Require `view` permission on source project for instance and storage volume copy (stable-5.0)

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -981,14 +981,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 		switch req.Source.Type {
 		case "copy":
-			if req.Source.Source == "" {
-				return api.StatusErrorf(http.StatusBadRequest, "Must specify a source instance")
-			}
-
-			if req.Source.Project == "" {
-				req.Source.Project = targetProjectName
-			}
-
 			sourceInst, err = instance.LoadInstanceDatabaseObject(ctx, tx, req.Source.Project, req.Source.Source)
 			if err != nil {
 				return err

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -923,6 +923,20 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
+	if req.Source.Type == "copy" {
+		if req.Source.Source == "" {
+			return response.BadRequest(fmt.Errorf("Must specify a source instance"))
+		}
+
+		if req.Source.Project == "" {
+			req.Source.Project = targetProjectName
+		}
+
+		if !s.Authorizer.UserHasPermission(r, req.Source.Project, "view") {
+			return response.Forbidden(nil)
+		}
+	}
+
 	var targetProject *api.Project
 	var profiles []api.Profile
 	var sourceInst *dbCluster.Instance

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -657,6 +657,21 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Currently not allowed to create storage volumes of type %q", req.Type))
 	}
 
+	if req.Source.Type == "copy" {
+		// Determine the effective source project for the permission check without mutating
+		// req.Source.Project. The cluster-internal copy path forwards req.Source.Project to the
+		// source member, where an empty value means "same as the request project". Setting it to an
+		// explicit value here would make that path treat the copy as a cross-project move and fail.
+		sourceProject := req.Source.Project
+		if sourceProject == "" {
+			sourceProject = requestProjectName
+		}
+
+		if !s.Authorizer.UserHasPermission(r, sourceProject, "view") {
+			return response.Forbidden(nil)
+		}
+	}
+
 	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
 	if err != nil {
 		return response.SmartError(err)

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -92,6 +92,32 @@ test_tls_restrictions() {
   lxc_remote storage volume list "localhost:${pool_name}" --project blah | grep blah-volume
   lxc_remote storage volume delete "localhost:${pool_name}" blah-volume --project blah
 
+  # Confirm copying an instance or a custom storage volume requires "view" permission of the source project.
+
+  # Create source entities in the default project using the unrestricted (admin) client.
+  # The restricted client is scoped to project blah and cannot view the default project.
+  # Enable features.storage.volumes=true for blah so its volumes are not shared with the default project.
+  lxc init --empty instance-in-default
+  lxc project set blah features.storage.volumes=true
+  lxc storage volume create "${pool_name}" volume-in-default
+
+  # Restricted client must not be able to copy the default project's entities into blah.
+  ! lxc_remote query --wait -X POST "localhost:/1.0/instances?project=blah" -d '{\"name\":\"copied-instance\",\"source\":{\"type\":\"copy\",\"source\":\"instance-in-default\",\"project\":\"default\"}}' || false
+  ! lxc_remote query --wait -X POST "localhost:/1.0/storage-pools/${pool_name}/volumes/custom?project=blah" -d '{\"name\":\"copied-volume\",\"source\":{\"type\":\"copy\",\"name\":\"volume-in-default\",\"pool\":\"'"${pool_name}"'\",\"project\":\"default\"}}' || false
+
+  # Once the certificate can view the default project, the copies should succeed.
+  lxc query -X PATCH "/1.0/certificates/${FINGERPRINT}" -d '{\"projects\":[\"blah\",\"default\"]}'
+  lxc_remote query --wait -X POST "localhost:/1.0/instances?project=blah" -d '{\"name\":\"copied-instance\",\"source\":{\"type\":\"copy\",\"source\":\"instance-in-default\",\"project\":\"default\"}}'
+  lxc_remote query --wait -X POST "localhost:/1.0/storage-pools/${pool_name}/volumes/custom?project=blah" -d '{\"name\":\"copied-volume\",\"source\":{\"type\":\"copy\",\"name\":\"volume-in-default\",\"pool\":\"'"${pool_name}"'\",\"project\":\"default\"}}'
+
+  # Restore the restriction to project blah only and clean up.
+  lxc query -X PATCH "/1.0/certificates/${FINGERPRINT}" -d '{\"projects\":[\"blah\"]}'
+  lxc delete copied-instance --project blah
+  lxc storage volume delete "${pool_name}" copied-volume --project blah
+  lxc delete instance-in-default
+  lxc storage volume delete "${pool_name}" volume-in-default
+  lxc project unset blah features.storage.volumes
+
   # Cleanup
   lxc config trust show "${FINGERPRINT}" | sed -e "s/restricted: true/restricted: false/" | lxc config trust edit "${FINGERPRINT}"
   lxc project delete blah


### PR DESCRIPTION
This PR enforces `view` permission requirement on the source project for copying instances and storage volumes.

Inspired by the https://github.com/canonical/lxd/pull/17914.

It effectively addresses two vulnerabilities for LXD `5.0`: https://github.com/canonical/lxd/security/advisories/GHSA-qx75-2p3r-pwm5 and https://github.com/canonical/lxd/security/advisories/GHSA-7mr3-28h5-m5vx.