### PR TITLE
Enforce project restrictions during snapshot restore (stable-5.21)

### DIFF
--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -235,6 +235,32 @@ func instanceSnapRestore(s *state.State, projectName string, name string, snap s
 		}
 	}
 
+	// Build the instance config that restoring the snapshot would apply, so it can be
+	// validated against the project's restrictions and limits below.
+	snapProfileNames := make([]string, 0, len(source.Profiles()))
+	for _, profile := range source.Profiles() {
+		snapProfileNames = append(snapProfileNames, profile.Name)
+	}
+
+	snapConfig := api.InstancePut{
+		Config:   source.LocalConfig(),
+		Devices:  source.LocalDevices().CloneNative(),
+		Profiles: snapProfileNames,
+	}
+
+	err = s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check that restoring the snapshot does not violate the project's restrictions
+		// or limits. A snapshot can carry config that was permitted when it was taken but
+		// is forbidden in the instance's current project (for example low-level keys such
+		// as raw.lxc or raw.qemu after the instance was moved into a restricted project).
+		// Restoring re-applies the snapshot's config to the instance, so it must be
+		// validated the same way a direct instance update is.
+		return limits.AllowInstanceUpdate(ctx, s.GlobalConfig, tx, projectName, name, snapConfig, inst.LocalConfig())
+	})
+	if err != nil {
+		return err
+	}
+
 	// Generate a new `volatile.uuid.generation` to differentiate this instance restored from a snapshot from the original instance.
 	source.LocalConfig()["volatile.uuid.generation"] = uuid.New().String()
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -1178,6 +1178,22 @@ run_projects_restrictions() {
 
   lxc delete c1
 
+  # A snapshot must not be usable to smuggle forbidden low-level config past the
+  # restriction. Take a snapshot while low-level keys are allowed, clear the key on
+  # the live instance so the restriction can be re-enabled, then confirm the snapshot
+  # cannot be restored (otherwise the restore would re-apply raw.idmap, bypassing
+  # restricted.containers.lowlevel=block).
+  lxc project set local:p1 restricted.containers.lowlevel=allow restricted.snapshots=allow
+  lxc init --empty c1 -c "raw.idmap=both 0 0" -d "${SMALL_ROOT_DISK}"
+  lxc snapshot c1 snap0
+  lxc config unset c1 raw.idmap
+  lxc project set local:p1 restricted.containers.lowlevel=block
+  ! lxc restore c1 snap0 || false
+  # The live instance must be left untouched by the rejected restore.
+  [ "$(lxc config get c1 raw.idmap || echo fail)" = "" ]
+  lxc delete c1
+  lxc project set local:p1 restricted.containers.lowlevel="" restricted.snapshots=""
+
   # Setting restricted.containers.privilege to 'allow' makes it possible to create
   # privileged containers.
   lxc project set local:p1 restricted.containers.privilege=allow


### PR DESCRIPTION
Fixes [GHSA-47w9-6r3f-938g](https://github.com/canonical/lxd/security/advisories/GHSA-47w9-6r3f-938g).