### PR TITLE
Fix physical network parent sharing across VLANs in clustered mode

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -41,17 +41,23 @@ func (c *ClusterTx) GetNetworksLocalConfig(ctx context.Context) (map[string]map[
 	return networks, nil
 }
 
+// NetworkNodeParent describes how a network attaches to a parent interface on a
+// given cluster member. Parent is the node-specific parent interface and VLAN is
+// the network's global VLAN setting (empty if unset).
+type NetworkNodeParent struct {
+	Parent string
+	VLAN   string
+}
+
 // GetNetworksNodeParent returns a map associating each node ID in a cluster to networks and their
-// node-specific parent value. If network has no parent, it is omitted.
-func (c *ClusterTx) GetNetworksNodeParent(ctx context.Context) (map[int64]map[string]string, error) {
+// node-specific parent interface together with the network's global VLAN setting.
+// If a network has no parent, it is omitted.
+func (c *ClusterTx) GetNetworksNodeParent(ctx context.Context) (map[int64]map[string]NetworkNodeParent, error) {
 	query := `
-   SELECT networks_config.node_id, networks.name, networks_config.value
+   SELECT COALESCE(networks_config.node_id, 0), networks.name, networks_config.key, networks_config.value
    FROM networks_config
    JOIN networks ON networks.id=networks_config.network_id
-   WHERE (
-      networks_config.key="parent" AND
-      networks_config.node_id IS NOT NULL
-   )`
+   WHERE networks_config.key IN ("parent", "vlan")`
 
 	rows, err := c.tx.QueryContext(ctx, query)
 	if err != nil {
@@ -60,30 +66,43 @@ func (c *ClusterTx) GetNetworksNodeParent(ctx context.Context) (map[int64]map[st
 
 	defer func() { _ = rows.Close() }()
 
-	nodesNetworksParent := make(map[int64]map[string]string)
+	nodesNetworksParent := make(map[int64]map[string]string) // Node ID to network name to node-specific parent.
+	networksVLAN := make(map[string]string)                  // Network name to global VLAN setting.
 
 	for rows.Next() {
 		var (
 			nodeID      int64
 			networkName string
+			key         string
 			value       string
 		)
 
-		err = rows.Scan(&nodeID, &networkName, &value)
+		err = rows.Scan(&nodeID, &networkName, &key, &value)
 		if err != nil {
 			return nil, err
 		}
 
-		if nodeID == 0 || networkName == "" || value == "" {
+		if networkName == "" || value == "" {
 			continue
 		}
 
-		_, nodeInMap := nodesNetworksParent[nodeID]
-		if !nodeInMap {
-			nodesNetworksParent[nodeID] = map[string]string{}
-		}
+		switch key {
+		case "parent":
+			// The parent is node-specific, so it must have a node ID.
+			if nodeID == 0 {
+				continue
+			}
 
-		nodesNetworksParent[nodeID][networkName] = value
+			_, nodeInMap := nodesNetworksParent[nodeID]
+			if !nodeInMap {
+				nodesNetworksParent[nodeID] = map[string]string{}
+			}
+
+			nodesNetworksParent[nodeID][networkName] = value
+		case "vlan":
+			// The VLAN is a global setting shared across all cluster members.
+			networksVLAN[networkName] = value
+		}
 	}
 
 	err = rows.Err()
@@ -91,7 +110,18 @@ func (c *ClusterTx) GetNetworksNodeParent(ctx context.Context) (map[int64]map[st
 		return nil, err
 	}
 
-	return nodesNetworksParent, nil
+	nodesNetworks := make(map[int64]map[string]NetworkNodeParent, len(nodesNetworksParent))
+	for nodeID, networksParent := range nodesNetworksParent {
+		nodesNetworks[nodeID] = make(map[string]NetworkNodeParent, len(networksParent))
+		for networkName, parent := range networksParent {
+			nodesNetworks[nodeID][networkName] = NetworkNodeParent{
+				Parent: parent,
+				VLAN:   networksVLAN[networkName],
+			}
+		}
+	}
+
+	return nodesNetworks, nil
 }
 
 // GetNonPendingNetworkIDs returns a map associating each network name to its ID.

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -218,8 +218,8 @@ func (n *physical) Validate(config map[string]string) error {
 // Returns an error if parent is already in use or the check has failed.
 func (n *physical) checkParentUse(ourConfig map[string]string) error {
 	var err error
-	var projectNetworks map[string]map[int64]api.Network // All managed networks across all projects.
-	var nodesNetworksParent map[int64]map[string]string  // Node IDs mapped to networks and their node-specific parent.
+	var projectNetworks map[string]map[int64]api.Network              // All managed networks across all projects.
+	var nodesNetworksParent map[int64]map[string]db.NetworkNodeParent // Node IDs mapped to networks and their node-specific parent and VLAN.
 
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get all managed networks across all projects.
@@ -266,21 +266,32 @@ func (n *physical) checkParentUse(ourConfig map[string]string) error {
 
 	currNodeID := n.state.DB.Cluster.GetNodeID()
 
-	// Check that parent interfaces on other nodes are not already in use.
+	// Check that parent interfaces on other nodes are not already in use. Two networks can share the same
+	// parent interface only if they are on distinct VLANs, so track the set of VLANs in use per parent.
 	for nodeID, networksParent := range nodesNetworksParent {
 		if nodeID == currNodeID {
 			continue // Skip the current node, it has been checked already.
 		}
 
-		parentsInUse := make(map[string]struct{})
+		parentVLANsInUse := make(map[string]map[string]struct{})
 
 		for _, parent := range networksParent {
-			_, alreadyInUse := parentsInUse[parent]
-			if alreadyInUse {
-				return fmt.Errorf("Parent interface %q in use by another network on cluster member %q", parent, n.nodes[nodeID].Name)
-			}
+			vlansInUse, parentSeen := parentVLANsInUse[parent.Parent]
+			if parentSeen {
+				_, untaggedInUse := vlansInUse[""]
+				_, vlanInUse := vlansInUse[parent.VLAN]
 
-			parentsInUse[parent] = struct{}{}
+				// A network without a VLAN claims the whole parent interface, so it
+				// conflicts with any other network on the same parent. Otherwise only
+				// networks sharing the same VLAN conflict.
+				if parent.VLAN == "" || untaggedInUse || vlanInUse {
+					return fmt.Errorf("Parent interface %q in use by another network on cluster member %q", parent.Parent, n.nodes[nodeID].Name)
+				}
+
+				vlansInUse[parent.VLAN] = struct{}{}
+			} else {
+				parentVLANsInUse[parent.Parent] = map[string]struct{}{parent.VLAN: {}}
+			}
 		}
 	}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1292,6 +1292,53 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
   LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net1}"
 
+  sub_test "Test VLAN-aware sharing of physical network parent interfaces"
+
+  # Create a physical network net1 on VLAN 10 using parent i1 on both members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" --type=physical parent=i1 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" --type=physical parent=i1 --target=node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net1}" --type=physical vlan=10
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net1}" | grep -xF 'status: Created'
+
+  # Check that the same parent on both members can be shared on a different VLAN.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical vlan=20
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Created'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+
+  # Check that the same parent and same VLAN cannot be shared on both members.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node2
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical vlan=10 || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Errored'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+
+  # Check that a network without a VLAN cannot share a parent already in use on a VLAN.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node2
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Errored'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+
+  # Check that a VLAN conflict on another member's parent interface alone is detected.
+  # net2 uses the free parent i2 on node1 but parent i1 on node2, where net1 already uses VLAN 10.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i2 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node2
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical vlan=10 || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Errored'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+
+  # Check that a different VLAN on a parent shared only via another member is allowed.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i2 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical parent=i1 --target=node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net2}" --type=physical vlan=30
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net2}" | grep -xF 'status: Created'
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net2}"
+
+  # Clean up.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net1}"
+
   echo "Test concurrent creation of different bridge networks."
   net1="${net}"
   net2="${net}2"


### PR DESCRIPTION
This PR fixes a bug in clustered-mode validation of `physical` networks where multiple uplink networks sharing the same physical NIC parent on different VLANs were incorrectly rejected.

Fixes https://github.com/canonical/lxd/issues/17940.

Follow-up to the https://github.com/canonical/lxd/pull/15489.