### PR TITLE
client: Skip delta image tests without xdelta3

### DIFF
--- a/client/simplestreams_images_test.go
+++ b/client/simplestreams_images_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,6 +120,19 @@ func computeCombinedFingerprint(meta, rootfs []byte) string {
 	h.Write(meta)
 	h.Write(rootfs)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func requireXdelta3(t *testing.T) {
+	t.Helper()
+
+	_, err := exec.LookPath("xdelta3")
+	if err != nil {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			t.Fatalf("Missing xdelta3")
+		}
+
+		t.Skip("Missing xdelta3")
+	}
 }
 
 func TestGetImageFile_CombinedFingerprintValid(t *testing.T) {
@@ -303,10 +315,7 @@ func newTestSimpleStreamsServerWithDelta(t *testing.T, newMeta []byte, srcRootfs
 }
 
 func TestGetImageFile_DeltaCombinedFingerprintValid(t *testing.T) {
-	_, err := exec.LookPath("xdelta3")
-	if err != nil && runtime.GOOS != "linux" {
-		t.Skip("Missing xdelta3")
-	}
+	requireXdelta3(t)
 
 	srcRootfs := []byte("source-rootfs-content-for-delta-test")
 	newRootfs := []byte("new-rootfs-content-for-delta-test")
@@ -366,10 +375,7 @@ func TestGetImageFile_DeltaCombinedFingerprintValid(t *testing.T) {
 }
 
 func TestGetImageFile_DeltaPerFileHashMismatch(t *testing.T) {
-	_, err := exec.LookPath("xdelta3")
-	if err != nil && runtime.GOOS != "linux" {
-		t.Skip("Missing xdelta3")
-	}
+	requireXdelta3(t)
 
 	srcRootfs := []byte("source-rootfs-content-for-delta-test")
 	newRootfs := []byte("new-rootfs-content-for-delta-test")
@@ -440,10 +446,7 @@ func TestGetImageFile_DeltaPerFileHashMismatch(t *testing.T) {
 // validation still catches a mismatch. This is done by advertising a wrong combined fingerprint
 // in the simplestreams index while keeping all per-file hashes correct.
 func TestGetImageFile_DeltaCombinedFingerprintMismatch(t *testing.T) {
-	_, err := exec.LookPath("xdelta3")
-	if err != nil && runtime.GOOS != "linux" {
-		t.Skip("Missing xdelta3")
-	}
+	requireXdelta3(t)
 
 	srcRootfs := []byte("source-rootfs-for-valid-hash-test")
 	newRootfs := []byte("new-rootfs-for-valid-hash-test")


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

`client` delta-image tests fail locally when `xdelta3` is missing. kinda annoying, easy to hit outside CI.

This change makes those tests skip when `xdelta3` is not in `PATH`. CI coverage stays the same, runtime code stays the same too.

Repro:
`which xdelta3`
`go test ./client -run 'TestGetImageFile_Delta'`

Before:
tests fail with `exec: "xdelta3": executable file not found in $PATH`

After:
the delta tests skip cleanly, and `go test ./client/...` passes.
