### PR TITLE
Revert "github: ensure that `snap-tests` can find the Go binaries build by the Code job"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -525,7 +525,7 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
       SNAP_RISK: ${{ inputs.snap-risk || 'edge' }}
       SNAP_TRACK: "latest"
-      SUDO_PRESERVE_ENV: "PATH,GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
+      SUDO_PRESERVE_ENV: "GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
     name: Snap
     runs-on: ubuntu-${{ matrix.os }}
     # avoid runaway test burning 6 hours of CI
@@ -757,10 +757,6 @@ jobs:
             fi
           fi
 
-          # Adding the Go bin directory to PATH ensures that the test scripts will find the
-          # LXD binaries built in the code-tests job and downloaded via the system-test-deps artifact.
-          # This avoids rebuilding them and ensures the coverage data is collected from the intended binaries.
-          export PATH="/home/runner/go/bin:${PATH}"
           sudo --preserve-env="${SUDO_PRESERVE_ENV}" ./bin/local-run "tests/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
 
           # Cleanly stopping `snap.lxd.daemon.service` will ensure that any Go


### PR DESCRIPTION
This was causing 3 snap test failures:


See https://github.com/canonical/lxd/actions/runs/28306881445 for an example of which tests are failing.

Suspect the cause is that the Go binaries built with coverage test mode enabled are exhibiting different performance characteristics (slower) and exposing bugs in the product or the test suite.

Reverting for now so that we can spend time digging into it and fixing what needs to be fixing, rather than leaving the these tests failing for an extended period of time.

pylxd:

```
pylxd/client.py:543: ClientConnectionFailed
=============================== warnings summary ===============================
integration/test_containers.py::TestContainers::test_create
  /home/runner/work/lxd/lxd/lxd-ci/pylxd/pylxd/models/operation.py:88: UserWarning: Attempted to set unknown attribute "err_code" on instance of "Operation"
    warnings.warn(

integration/test_containers.py::TestContainers::test_create
  /home/runner/work/lxd/lxd/lxd-ci/pylxd/pylxd/models/operation.py:88: UserWarning: Attempted to set unknown attribute "requestor" on instance of "Operation"
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED integration/test_client.py::TestClient::test_authenticate - pylxd.exce...
FAILED integration/test_client.py::TestClient::test_authenticate_with_project
FAILED integration/test_projects.py::TestProjects::test_all - pylxd.exception...
FAILED integration/test_projects.py::TestProjects::test_create - pylxd.except...
FAILED integration/test_projects.py::TestProjects::test_get - pylxd.exception...
FAILED integration/test_projects.py::TestProject::test_delete - pylxd.excepti...
FAILED integration/test_projects.py::TestProject::test_rename - pylxd.excepti...
FAILED integration/test_projects.py::TestProject::test_save - pylxd.exception...
============= 8 failed, 52 passed, 8 skipped, 2 warnings in 59.65s =============
integration: exit 1 (60.06 seconds) /home/runner/work/lxd/lxd/lxd-ci/pylxd> pytest integration pid=8942
  integration: FAIL code 1 (66.79=setup[6.73]+cmd[60.06] seconds)
  evaluation failed :( (66.81 seconds)
```

snapd:

```

+ snap set lxd 'daemon.preseed={"config": {"core.https_address": "[::]:8443"}}'
Notice: lxc forks/s: 195
+ lxd waitready --timeout=300
++ lxc config get core.https_address
```


storage-vm lvm-thin

```
[94](https://github.com/canonical/lxd/actions/runs/28306881445/job/83865043203#step:22:195)
==> Create storage pool using driver lvm-thin
+ systemctl reload snap.lxd.daemon.service
+ lxd waitready --timeout=300
Error: LXD daemon is shutting down after 300s timeout
```
