### PR TITLE
lxd/cluster-link: improve duplicate cluster link error message

### DIFF
--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -895,6 +895,10 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		// Create the identity and its certificate.
 		id, err := dbCluster.CreateTLSIdentity(ctx, tx.Tx(), req.Name, api.IdentityTypeCertificateClusterLink, fingerprint, clusterCert)
 		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusConflict) {
+				return api.NewStatusError(http.StatusConflict, "A cluster link already exists between these clusters")
+			}
+
 			return err
 		}
 
@@ -1068,6 +1072,10 @@ func clusterLinkActivate(s *state.State, r *http.Request, req api.ClusterLinksPo
 		// Activate the pending identity with the certificate.
 		err = dbCluster.ActivateTLSIdentity(ctx, tx.Tx(), identifier, cert)
 		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusConflict) {
+				return api.NewStatusError(http.StatusConflict, "A cluster link already exists between these clusters")
+			}
+
 			return fmt.Errorf("Failed activating identity %q: %w", identifier.String(), err)
 		}
 


### PR DESCRIPTION
## Description

Closes #18523

Improves the error message when creating a duplicate cluster link. Previously the user would see a generic `"Identity already exists"` error, which is confusing when working with cluster links.

Changes:
- **`clusterLinkCreateActive()`**: Returns `"Cluster link %q already exists"` instead of `"Identity already exists"` on conflict.
- **`clusterLinkActivate()`**: Returns `"Cluster link already exists for the remote cluster"` instead of the generic wrapped error.

Both use `api.StatusErrorCheck(err, http.StatusConflict)`, following the same pattern as `certificates_legacy.go`.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation.