### PR TITLE
github: ensure that `snap-tests` can find the Go binaries built by the Code job (take 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -525,7 +525,7 @@ jobs:
       BRANCH_NAME: ${{ github.ref_name }}
       SNAP_RISK: ${{ inputs.snap-risk || 'edge' }}
       SNAP_TRACK: "latest"
-      SUDO_PRESERVE_ENV: "GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
+      SUDO_PRESERVE_ENV: "PATH,GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
     name: Snap
     runs-on: ubuntu-${{ matrix.os }}
     # avoid runaway test burning 6 hours of CI
@@ -758,6 +758,10 @@ jobs:
             fi
           fi
 
+          # Adding the Go bin directory to PATH ensures that the test scripts will find the
+          # LXD binaries built in the code-tests job and downloaded via the system-test-deps artifact.
+          # This avoids rebuilding them and ensures the coverage data is collected from the intended binaries.
+          export PATH="/home/runner/go/bin:${PATH}"
           sudo --preserve-env="${SUDO_PRESERVE_ENV}" ./bin/local-run "tests/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
 
           # Cleanly stopping `snap.lxd.daemon.service` will ensure that any Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -758,10 +758,12 @@ jobs:
             fi
           fi
 
-          # Adding the Go bin directory to PATH ensures that the test scripts will find the
-          # LXD binaries built in the code-tests job and downloaded via the system-test-deps artifact.
-          # This avoids rebuilding them and ensures the coverage data is collected from the intended binaries.
-          export PATH="/home/runner/go/bin:${PATH}"
+          # Append the Go bin directory to PATH so the test scripts can find the host-only
+          # binaries built in the code-tests job and downloaded via the system-test-deps artifact
+          # (notably the coverage-instrumented lxd-convert, which the snap does not ship).
+          # It is appended (not prepended) so the snap's lxc/lxd wrappers keep precedence; the snap
+          # lxc/lxd/lxd-agent coverage is collected separately via the sideloaded *.debug binaries.
+          export PATH="${PATH}:/home/runner/go/bin"
           sudo --preserve-env="${SUDO_PRESERVE_ENV}" ./bin/local-run "tests/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
 
           # Cleanly stopping `snap.lxd.daemon.service` will ensure that any Go


### PR DESCRIPTION
Follow-up on https://github.com/canonical/lxd/pull/18612 (temporary revert) for the issue introduced by https://github.com/canonical/lxd/pull/18530 