### PR TITLE
Remove snapshot config from replicators

### DIFF
--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -29,7 +29,7 @@ The leader project pushes its instances to the standby project over the cluster 
 
 When a replicator runs, LXD performs an incremental refresh of every instance in the leader project to the standby project. Instances that do not yet exist on the standby are created; existing instances are updated to match the leader's current state.
 
-If {config:option}`replicator-conf:snapshot` is set to `true` on the replicator, LXD creates a point-in-time snapshot of each instance on the leader before the refresh. This provides a consistent rollback point on the source cluster in case anything goes wrong during replication.
+Before each refresh, LXD creates a point-in-time snapshot of each instance on the leader. This provides a consistent rollback point on the source cluster in case anything goes wrong during replication. The exception is instances that already have a {config:option}`instance-snapshots:snapshots.schedule` configured: their scheduled snapshots already provide point-in-time history, so LXD skips the extra snapshot to avoid redundancy.
 
 Replication can be triggered manually with `lxc replicator run`, or scheduled automatically using a cron expression in the {config:option}`replicator-conf:schedule` configuration key.
 
@@ -54,7 +54,7 @@ LXD supports two distinct approaches to cross-site disaster recovery:
 | **Scheduling** | Controlled by LXD ({config:option}`replicator-conf:schedule` config key) | Controlled by the storage vendor |
 | **Requires cluster link** | Yes | No |
 | **Recovery method** | Promote standby project with `lxc project promote-replica` | Promote storage array, then run `lxd recover` |
-| **Snapshot support** | Optional pre-replication snapshots | Depends on storage vendor |
+| **Snapshot support** | Automatic pre-replication snapshots | Depends on storage vendor |
 
 Use replicators when you want LXD to manage replication end-to-end across two clusters without dependency on a specific storage backend. Use {ref}`storage replication <disaster-recovery-replication>` when you need replication at the storage array level, or when you are not using cluster links.
 

--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -136,10 +136,10 @@ Each cluster link can be targeted by at most one replicator per project. Creatin
    lxc replicator create my-replicator cluster=lxd-standby --project myproject
    ```
 
-   You can also create a replicator with a schedule and snapshot options:
+   You can also create a replicator with a schedule:
 
    ```bash
-   lxc replicator create my-replicator cluster=lxd-standby schedule="@daily" snapshot=true --project myproject
+   lxc replicator create my-replicator cluster=lxd-standby schedule="@daily" --project myproject
    ```
 
 ````
@@ -151,7 +151,7 @@ Each cluster link can be targeted by at most one replicator per project. Creatin
    Select the cluster link established between the leader and the standby.
    Enter a name and optionally a description for the new replicator.
    Select the {ref}`project that you configured <howto-replicators-project-setup>`.
-   You can also select a snapshot option and enter a schedule.
+   You can also enter a schedule.
 
    Click {guilabel}`Create`.
 
@@ -212,10 +212,10 @@ Each replicator run performs an incremental instance sync to the standby cluster
 the equivalent of `lxc copy --refresh`. This transfers only the data that has changed since the last sync,
 using any existing snapshots as a reference point to minimize the amount of data transferred.
 
-When you set `snapshot=true` on a replicator, LXD creates a point-in-time snapshot of each
-source instance before performing the incremental copy. This gives the copy operation a
-consistent reference point, which reduces the amount of data transferred on each sync and
-provides a rollback point on the source in case anything goes wrong during replication.
+Before the incremental copy, LXD creates a point-in-time snapshot of each source instance.
+This gives the copy operation a consistent reference point, which reduces the amount of data
+transferred on each sync and provides a rollback point on the source in case anything goes
+wrong during replication.
 
 Snapshot naming and expiry are controlled entirely by the instance's own configuration (for
 example {config:option}`instance-snapshots:snapshots.pattern` and
@@ -225,10 +225,6 @@ instance. The replicator does not impose its own naming scheme.
 If an instance already has a {config:option}`instance-snapshots:snapshots.schedule` set at
 the instance or profile level, the replicator skips creating a new snapshot and reuses the
 most recent existing snapshot as the reference point for the incremental copy instead.
-
-When `snapshot` is not set (or set to `false`), no new snapshot is created before the
-incremental copy runs. If existing snapshots are present on the instance, the copy operation
-uses them to transfer only the delta; if no snapshots exist, the full instance is transferred.
 
 ```{note}
 Snapshots created by replication accumulate over time. Use `snapshots.expiry` on the instance or

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4604,13 +4604,6 @@ Required when creating a replicator.
 Specify a cron expression for the replication schedule. For example, `@daily` or `0 6 * * *`.
 ```
 
-```{config:option} snapshot replicator-conf
-:scope: "global"
-:shortdesc: "Whether to snapshot instances before replication."
-:type: "bool"
-
-```
-
 <!-- config group replicator-conf end -->
 <!-- config group replicator-miscellaneous start -->
 ```{config:option} user.* replicator-miscellaneous

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -359,14 +359,6 @@ func replicatorValidateConfig(ctx context.Context, s *state.State, config map[st
 			return s.Authorizer.CheckPermission(ctx, entity.ClusterLinkURL(value), auth.EntitlementCanView)
 		}),
 
-		// lxdmeta:generate(entities=replicator; group=conf; key=snapshot)
-		//
-		// ---
-		//  type: bool
-		//  shortdesc: Whether to snapshot instances before replication.
-		//  scope: global
-		"snapshot": validate.Optional(validate.IsBool),
-
 		// lxdmeta:generate(entities=replicator; group=conf; key=schedule)
 		// Specify a cron expression for the replication schedule. For example, `@daily` or `0 6 * * *`.
 		// ---

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -666,7 +666,7 @@ func replicatorStatePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Replicator %q has no cluster link configured", name))
 	}
 
-	opArgs, err := prepareReplicatorRunOperation(r.Context(), s, projectName, name, clusterLinkName, restore, dbReplicator.Row.ID, shared.IsTrue(apiReplicator.Config["snapshot"]))
+	opArgs, err := prepareReplicatorRunOperation(r.Context(), s, projectName, name, clusterLinkName, restore, dbReplicator.Row.ID)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1002,7 +1002,7 @@ func runScheduledReplicatorsTask(stateFunc func() *state.State) (task.Func, task
 }
 
 // prepareReplicatorRunOperation builds the operation used to run a replicator.
-func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectName string, name string, clusterLinkName string, restore bool, replicatorID int64, snapshot bool) (operations.OperationArgs, error) {
+func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectName string, name string, clusterLinkName string, restore bool, replicatorID int64) (operations.OperationArgs, error) {
 	// Load all DB state in a single transaction before any network I/O.
 	var clusterLink *api.ClusterLink
 	var targetCert *x509.Certificate
@@ -1127,7 +1127,7 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 				dstClient = dstClient.UseProject(projectName)
 
-				return replicateInstance(ctx, s, op, inst, memberAddress, snapshot, dstClient, targetCertPEM)
+				return replicateInstance(ctx, s, op, inst, memberAddress, dstClient, targetCertPEM)
 			}
 
 			childArgs = append(childArgs, &operations.OperationArgs{
@@ -1439,17 +1439,17 @@ func replicatorCheckInstancesStopped(allInsts []instance.Instance) error {
 // replicateInstance handles forward replication of a single instance to the
 // destination cluster. It handles both instances on the local cluster member
 // and instances on other cluster members.
-func replicateInstance(ctx context.Context, s *state.State, op *operations.Operation, inst instance.Instance, memberAddress string, snapshot bool, dstClient lxd.InstanceServer, targetCertPEM string) error {
+func replicateInstance(ctx context.Context, s *state.State, op *operations.Operation, inst instance.Instance, memberAddress string, dstClient lxd.InstanceServer, targetCertPEM string) error {
 	instName := inst.Name()
 	projectName := inst.Project().Name
-	// Only snapshot if requested and the instance has no snapshot schedule; if a schedule is
-	// defined, scheduled snapshots already provide point-in-time history so an extra one here
-	// would be redundant.
-	createSnapshot := snapshot && inst.ExpandedConfig()["snapshots.schedule"] == ""
+	// Snapshotting is unconditional; the only exception is when the instance already has a
+	// snapshot schedule defined, since scheduled snapshots provide point-in-time history so
+	// an extra one here would be redundant.
+	createSnapshot := inst.ExpandedConfig()["snapshots.schedule"] == ""
 
 	// Instance on another cluster member: connect to the hosting cluster member and
-	// drive the snapshot + push migration through its API so the migration
-	// source has direct access to the instance's storage.
+	// drive the snapshot (if needed) and push migration through its API so the
+	// migration source has direct access to the instance's storage.
 	if inst.Location() != s.ServerName {
 		if memberAddress == "" {
 			return fmt.Errorf("Failed resolving cluster member address for instance %q", instName)
@@ -1534,9 +1534,6 @@ func replicateInstance(ctx context.Context, s *state.State, op *operations.Opera
 	}
 
 	// Local instance: handle replication directly.
-	// Only take a snapshot if snapshot is requested and the instance has no snapshot schedule;
-	// if a schedule is defined, scheduled snapshots already provide point-in-time history
-	// so creating an extra one here would be redundant.
 	if createSnapshot {
 		snapName, err := instance.NextSnapshotName(s, inst, "snap%d")
 		if err != nil {
@@ -1759,7 +1756,7 @@ func triggerScheduledReplicator(ctx context.Context, s *state.State, replicator 
 		return fmt.Errorf("Replicator %q has no cluster link configured", replicator.Name)
 	}
 
-	opArgs, err := prepareReplicatorRunOperation(ctx, s, replicator.Project, replicator.Name, clusterLinkName, false, row.Row.ID, shared.IsTrue(replicator.Config["snapshot"]))
+	opArgs, err := prepareReplicatorRunOperation(ctx, s, replicator.Project, replicator.Name, clusterLinkName, false, row.Row.ID)
 	if err != nil {
 		return err
 	}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5141,14 +5141,6 @@
 							"shortdesc": "Cron expression for the replication schedule.",
 							"type": "string"
 						}
-					},
-					{
-						"snapshot": {
-							"longdesc": "",
-							"scope": "global",
-							"shortdesc": "Whether to snapshot instances before replication.",
-							"type": "bool"
-						}
 					}
 				]
 			},

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -127,6 +127,7 @@ var patches = []patch{
 	{name: "clustering_event_hub_role_to_control_plane", stage: patchPreLoadClusterConfig, run: patchClusteringEventHubRoleToControlPlane},
 	{name: "storage_zfs_remove_local_bucket_datasets", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "storage_rename_nvme_mode", stage: patchPreLoadClusterConfig, run: patchStoragePoolConnectorNVMeMode},
+	{name: "replicators_remove_snapshot_config_key", stage: patchPreLoadClusterConfig, run: patchReplicatorsRemoveSnapshotConfigKey},
 }
 
 type patch struct {
@@ -2453,6 +2454,17 @@ func patchStoragePoolConnectorNVMeMode(_ string, d *Daemon) error {
 			if err != nil {
 				return fmt.Errorf("Failed updating storage pool %q: %w", pool.Name, err)
 			}
+		}
+
+		return nil
+	})
+}
+
+func patchReplicatorsRemoveSnapshotConfigKey(_ string, d *Daemon) error {
+	return d.State().DB.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err := tx.Tx().ExecContext(ctx, `DELETE FROM replicators_config WHERE key = 'snapshot'`)
+		if err != nil {
+			return fmt.Errorf("Failed removing replicator snapshot config: %w", err)
 		}
 
 		return nil

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6218,7 +6218,7 @@ test_clustering_replicator_snapshot() {
 
   # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two snapshot=true --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
@@ -6231,7 +6231,7 @@ test_clustering_replicator_snapshot() {
 
   LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
 
-  sub_test "Verify snapshot=true creates a snapshot when instance has no snapshot schedule"
+  sub_test "Verify snapshotting creates a snapshot when instance has no snapshot schedule"
 
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
 
@@ -6243,7 +6243,7 @@ test_clustering_replicator_snapshot() {
   # Instance and snapshot must also have been replicated to LXD_TWO.
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,1'
 
-  sub_test "Verify snapshot=true skips snapshot creation when instance has a snapshot schedule"
+  sub_test "Verify snapshotting is skipped when instance has a snapshot schedule"
 
   LXD_DIR="${LXD_ONE_DIR}" lxc config set c1 snapshots.schedule="@daily" --project replicator-project
 
@@ -6333,19 +6333,19 @@ test_clustering_replicator_multi_member() {
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
 
-  sub_test "Verify snapshot=true works for instances on other cluster members"
+  sub_test "Verify snapshotting works for instances on other cluster members"
 
   LXD_DIR="${LXD_THREE_DIR}" lxc delete c1 c2 --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator set my-replicator snapshot=true --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
 
-  # Snapshots must have been created on both source instances.
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
+  # Snapshots must have been created on both source instances (the first run already took one,
+  # so each instance now has two snapshots total).
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
 
   # Both instances and their snapshots must be on the target.
-  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,1'
-  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,1'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,2'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,2'
 
   sub_test "Verify idempotent run with instances on other cluster members"
 
@@ -6353,13 +6353,13 @@ test_clustering_replicator_multi_member() {
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
 
-  # Snapshot count must have incremented on both source instances after the second snapshot=true run.
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+  # Snapshot count must have incremented on both source instances after the third run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c1/snapshots?project=replicator-project" | jq --exit-status 'length == 3'
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/c2/snapshots?project=replicator-project" | jq --exit-status 'length == 3'
 
   # Target must also reflect the new snapshots.
-  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,2'
-  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,2'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,3'
+  LXD_DIR="${LXD_THREE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,3'
 
   sub_test "Verify --restore rejects running instances on other members"
 
@@ -6386,8 +6386,8 @@ test_clustering_replicator_multi_member() {
   jq --exit-status '.status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
 
   # Both instances must be present on the source cluster with their snapshots.
-  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,2'
-  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,2'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c1,STOPPED,3'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nsS | grep -xF 'c2,STOPPED,3'
 
   # Verify instances were restored to their original cluster members.
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c1,node1'
@@ -6611,20 +6611,19 @@ test_clustering_replicator_vm() {
   # Run replicator.
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
 
-  # VM must appear on the target cluster.
-  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,0'
+  # VM must appear on the target cluster with its snapshot (the first run snapshots unconditionally).
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,1'
 
-  sub_test "Verify VM replication with snapshot=true"
+  sub_test "Verify VM replication creates a snapshot"
 
   LXD_DIR="${LXD_TWO_DIR}" lxc delete v1 --project replicator-project
-  LXD_DIR="${LXD_ONE_DIR}" lxc replicator set vm-replicator snapshot=true --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run vm-replicator --project replicator-project
 
-  # A snapshot must have been created on the source VM.
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 1'
+  # Source now has two snapshots: one from the first run, one from this run.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
 
-  # VM and snapshot must be on the target.
-  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,1'
+  # VM and both snapshots must be on the target.
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,2'
 
   sub_test "Verify idempotent second run for VM replication"
 
@@ -6636,11 +6635,11 @@ test_clustering_replicator_vm() {
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq -e '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '.status == "Success" and ((.children // []) | length) == 1 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
 
-  # snapshot=true creates a second snapshot, so source now has 2.
-  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 2'
+  # Each run adds a snapshot; source now has three.
+  LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/v1/snapshots?project=replicator-project" | jq --exit-status 'length == 3'
 
-  # VM must still exist with both snapshots on the target.
-  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,2'
+  # VM must still exist with all three snapshots on the target.
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ntS | grep -xF 'v1,VIRTUAL-MACHINE,3'
 
   # Cleanup
   LXD_DIR="${LXD_TWO_DIR}" lxc delete v1 --project replicator-project


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

The `snapshot` config key was introduced to give operators control over whether replication runs created a point-in-time snapshot before migrating each instance. In practice, skipping the snapshot creates a replication window where the destination may receive a partially-written filesystem state, which defeats the purpose of DR replication. Snapshotting is therefore made unconditional and the config key is removed.

Existing replicators that have a stored `snapshot` value are cleaned up by an upgrade patch so they do not carry a key that is now rejected as unknown.

The only exception to unconditional snapshotting is when an instance already has a `snapshots.schedule` defined: scheduled snapshots already provide point-in-time history, so creating an additional one on each replication run would be redundant.

This is extracted from #18456 (Add custom volume support to replicators) at the request of the reviewer, to allow the removal to land independently before the larger feature is reviewed.

Relates to #18456.

A few notes on the choices made here:

- The commit that removes the bool parameter `(lxd/api_replicators: Remove the snapshot bool parameter`) is slightly different from its counterpart on #18456. On that branch the snapshot creation logic is stripped from `replicateInstance` entirely because the `snapshotVolume` helper takes over; here it is kept but made unconditional. When #18456 rebases on top of this, that commit will become a simple conflict to resolve.
- The test snapshot counts in `test_clustering_replicator_multi_member` increase by one across the board because every replicator run now snapshots, including the first run that previously had no `snapshot=true`.