### PR TITLE
snap/qemu: reintroduce the KVM vAPIC option ROM for 32-bit BIOS guests

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1075,6 +1075,7 @@ parts:
       usr/local/libexec/: bin/
       usr/local/share/: share/
       usr/share/qemu/efi-virtio.rom: share/qemu/
+      usr/share/qemu/kvmvapic.bin: share/qemu/
       usr/share/qemu/s390-ccw.img: share/qemu/
       usr/share/qemu/slof.bin: share/qemu/
       usr/share/seabios/bios-256k.bin: share/qemu/
@@ -1095,6 +1096,7 @@ parts:
       - to amd64:
         - share/qemu/bios-256k.bin
         - share/qemu/efi-virtio.rom
+        - share/qemu/kvmvapic.bin
         - share/qemu/vgabios-virtio.bin
       - to arm64:
         - share/qemu/vgabios-virtio.bin


### PR DESCRIPTION
The KVM vAPIC option ROM is entirely optional but QEMU unconditionally tries to read it.

It is used to dynamically patch guest kernel APIC related code that old 32-bit guests (Win XP/2003, Linux 2.6/3.x) use heavily and that otherwise causes VM exits if the CPU doesn't support HW assisted APIC virtualization (Intel APICv/AMD AVIC).  CPUs lacking those are from pre-2013.

On modern HW, QEMU's software binary-patching layer (`kvmvapic.bin`) is entirely redundant. KVM will automatically use the hardware acceleration instead.

Reinstating the file will silence the (mostly harmless) error visible in `lxc info --show-log`:

```
$ lxc info --show-log v1

Name: v1
Status: RUNNING
Type: virtual-machine
Architecture: x86_64
...
Log:

rom: file kvmvapic.bin        : error Failed to open file “kvmvapic.bin”: No such file or directory
```

and restore some performance for ancient BIOS-based guests running on old CPUs.