### PR TITLE
Improve safety around `rsync` usage

### DIFF
--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -29,6 +29,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   capability fsetid,
   capability mknod,
   capability setfcap,
+  # CAP_SYS_ADMIN is needed to set 'trusted.*' and 'security.*' extended attributes
   capability sys_admin,
 
   unix (connect, send, receive) type=stream,

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -62,8 +63,37 @@ func rsync(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
+// assertSafePath returns an error if the provided path is not absolute or if it
+// contains a ".." segment. rsync treats arguments beginning with "-" as
+// options, so source and destination paths must always be absolute (and
+// therefore begin with "/"). Rejecting ".." segments additionally prevents a
+// crafted path from traversing outside of its intended directory.
+func assertSafePath(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("Rsync path %q must be absolute", path)
+	}
+
+	for segment := range strings.SplitSeq(path, "/") {
+		if segment == ".." {
+			return fmt.Errorf("Rsync path %q must not contain %q segments", path, "..")
+		}
+	}
+
+	return nil
+}
+
 func runRsync(source string, dest string, bwlimit string, xattrs bool, rsyncArgs ...string) (string, error) {
-	err := os.MkdirAll(dest, 0755)
+	err := assertSafePath(source)
+	if err != nil {
+		return "", err
+	}
+
+	err = assertSafePath(dest)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(dest, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -136,6 +166,11 @@ func CopyFile(source string, dest string, bwlimit string, xattrs bool, rsyncArgs
 // Send sets up the sending half of an rsync, to recursively send the
 // directory pointed to by path over the websocket.
 func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.ReaderWrapper, features []string, bwlimit string, execPath string, rsyncArgs ...string) error {
+	err := assertSafePath(path)
+	if err != nil {
+		return err
+	}
+
 	/*
 	 * The way rsync works, it invokes a subprocess that does the actual
 	 * talking (given to it by a -E argument). Since there isn't an easy
@@ -313,6 +348,11 @@ func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.
 // half set up by rsync.Send), putting the contents in the directory specified
 // by path.
 func Recv(path string, conn io.ReadWriteCloser, readWrapper ioprogress.ReaderWrapper, features []string) error {
+	err := assertSafePath(path)
+	if err != nil {
+		return err
+	}
+
 	args := []string{
 		"--server",
 		"-vlogDtpre.iLsfx",

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -96,8 +96,12 @@ func runRsync(source string, dest string, bwlimit string, xattrs bool, rsyncArgs
 		args = append(args, rsyncArgs...)
 	}
 
+	// Add an end of options marker ("--") so that the source and destination
+	// paths are never interpreted as rsync options, even if they begin with a
+	// "-".
 	args = append(args,
 		rsyncVerbosity,
+		"--",
 		source,
 		dest)
 
@@ -188,11 +192,13 @@ func Send(name string, path string, conn io.ReadWriteCloser, wrapper ioprogress.
 		args = append(args, rsyncArgs...)
 	}
 
-	args = append(args, []string{
-		path,
-		"localhost:/tmp/foo",
-		"-e",
-		rsyncCmd}...)
+	// The remote shell command (-e) must be passed as an option, so it has to
+	// come before the end of options marker ("--") below.
+	args = append(args, "-e", rsyncCmd)
+
+	// Add an end of options marker ("--") so that the source path is never
+	// interpreted as an rsync option, even if it begins with a "-".
+	args = append(args, "--", path, "localhost:/tmp/foo")
 
 	cmd := exec.Command("rsync", args...)
 
@@ -323,7 +329,9 @@ func Recv(path string, conn io.ReadWriteCloser, readWrapper ioprogress.ReaderWra
 		args = append(args, rsyncFeatureArgs(features)...)
 	}
 
-	args = append(args, []string{".", path}...)
+	// Add an end of options marker ("--") so that the destination path is never
+	// interpreted as an rsync option, even if it begins with a "-".
+	args = append(args, "--", ".", path)
 
 	cmd := exec.Command("rsync", args...)
 

--- a/lxd/rsync/rsync_test.go
+++ b/lxd/rsync/rsync_test.go
@@ -1,0 +1,75 @@
+package rsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test assertSafePath.
+func TestAssertSafePath(t *testing.T) {
+	// Absolute paths without ".." segments are accepted.
+	assert.NoError(t, assertSafePath("/"))
+	assert.NoError(t, assertSafePath("/var/lib/lxd/storage-pools/default/custom/vol"))
+	assert.NoError(t, assertSafePath("/var/lib/lxd/storage-pools/default/custom/vol/"))
+
+	// A ".." that is part of a path component (not its own segment) is fine.
+	assert.NoError(t, assertSafePath("/var/lib/lxd/vol..name"))
+
+	// Non-absolute paths are rejected.
+	assert.Error(t, assertSafePath(""))
+	assert.Error(t, assertSafePath("."))
+	assert.Error(t, assertSafePath("relative/path"))
+
+	// Option-like paths, which rsync could otherwise interpret as flags, are
+	// rejected because they are not absolute.
+	assert.Error(t, assertSafePath("-e/tmp/x"))
+	assert.Error(t, assertSafePath("--rsh=/tmp/x"))
+	assert.Error(t, assertSafePath("--rsync-path=touch /tmp/pwn"))
+
+	// Paths containing a ".." segment, which could traverse outside of the
+	// intended directory, are rejected.
+	assert.Error(t, assertSafePath("/foo/bar/baz/../../../etc/passwd"))
+	assert.Error(t, assertSafePath("/var/lib/lxd/storage-pools/default/custom/../../../../etc"))
+	assert.Error(t, assertSafePath("/.."))
+}
+
+// Test that the rsync entry points reject option-like paths before invoking
+// rsync, so that a path beginning with "-" can never be treated as an option.
+func TestRsyncRejectsOptionLikePaths(t *testing.T) {
+	// A path beginning with "-" looks like an rsync option such as --rsh.
+	const optionLikePath = "--rsh=/tmp/x"
+
+	_, err := LocalCopy(optionLikePath, "/tmp/dest", "", false)
+	assert.ErrorContains(t, err, "must be absolute")
+
+	_, err = CopyFile(optionLikePath, "/tmp/dest", "", false)
+	assert.ErrorContains(t, err, "must be absolute")
+
+	err = Send("vol", optionLikePath, nil, nil, nil, "", "")
+	assert.ErrorContains(t, err, "must be absolute")
+
+	err = Recv(optionLikePath, nil, nil, nil)
+	assert.ErrorContains(t, err, "must be absolute")
+}
+
+// Test that the rsync entry points reject paths containing ".." segments before
+// invoking rsync, so that a crafted path cannot traverse outside of its
+// intended directory.
+func TestRsyncRejectsTraversalPaths(t *testing.T) {
+	// A path with ".." segments could otherwise escape the source or
+	// destination directory.
+	const traversalPath = "/var/lib/lxd/storage-pools/default/custom/../../../../etc"
+
+	_, err := LocalCopy(traversalPath, "/tmp/dest", "", false)
+	assert.ErrorContains(t, err, "must not contain")
+
+	_, err = CopyFile(traversalPath, "/tmp/dest", "", false)
+	assert.ErrorContains(t, err, "must not contain")
+
+	err = Send("vol", traversalPath, nil, nil, nil, "", "")
+	assert.ErrorContains(t, err, "must not contain")
+
+	err = Recv(traversalPath, nil, nil, nil)
+	assert.ErrorContains(t, err, "must not contain")
+}


### PR DESCRIPTION
Close https://github.com/canonical/lxd/security/code-scanning/1