### PR TITLE
Test: Account for all initial OVN health check states

### DIFF
--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -1165,12 +1165,12 @@ test_network_ovn() {
         fi
 
         # "offline" means that the instance target isn't reachable.
-        #   We don't expect this as the target of the first instance is online.
+        #   This can happen transiently after re-adding the instance to the pool.
         # "unknown" means there is no health check for the instance.
         #   It's not yet added to the LB, but already in the DB so the state endpoint appends it to the list of targets for which a service monitor exists.
         # "pending" means OVN hasn't yet probed the instance target.
         # "" means the yq command didn't find the instance and cannot report a status.
-        if [ "${status}" != "unknown" ] && [ "${status}" != "pending" ] && [ "${status}" != "" ]; then
+        if [ "${status}" != "offline" ] && [ "${status}" != "unknown" ] && [ "${status}" != "pending" ] && [ "${status}" != "" ]; then
           echo "ERROR: Unexpected status '${status}' for c1 target" >&2
           exit 1
         fi


### PR DESCRIPTION
When adding a new target to the load balancer, depending on the timing, various states can be observed until the service monitor settles. In one of the test runs I have observed that sometimes one of the initially reported states can also be `offline`, see https://github.com/canonical/lxd/actions/runs/28475573217/job/84400629707

This PR adds an exception to the list of expected states.
