### PR TITLE
github: add domain labeling and reviewer assignment

### DIFF
--- a/.github/domain-owners.json
+++ b/.github/domain-owners.json
@@ -1,0 +1,105 @@
+{
+  "domains": [
+    {
+      "name": "Build, GitHub workflows and test system",
+      "label": "d/build-test",
+      "description": "Everything around the LXD build system, including snap packaging, general test systems and GitHub workflows.",
+      "owners": [
+        "simondeziel",
+        "tomponline",
+        "kadinsayani"
+      ]
+    },
+    {
+      "name": "Networking",
+      "label": "d/networking",
+      "description": "Handles container/VM network interfaces, firewalls, routing, ACLs, load balancers, and DNS.",
+      "owners": [
+        "tomponline",
+        "roosterfish"
+      ]
+    },
+    {
+      "name": "Database",
+      "label": "d/database",
+      "description": "Manages the local and distributed configuration schema and state using SQLite and dqlite.",
+      "owners": [
+        "tomponline",
+        "kadinsayani",
+        "markylaing"
+      ]
+    },
+    {
+      "name": "Clustering",
+      "label": "d/clustering",
+      "description": "Synchronizes state and coordinates workloads across highly available, multi-node LXD deployments.",
+      "owners": [
+        "kadinsayani",
+        "roosterfish"
+      ]
+    },
+    {
+      "name": "Auth",
+      "label": "d/auth",
+      "description": "Governs role-based access control, identity providers, OIDC integration, and client certificates.",
+      "owners": [
+        "markylaing",
+        "MusicDin"
+      ]
+    },
+    {
+      "name": "Images",
+      "label": "d/images",
+      "description": "Manages container/VM image downloading, local caching, exporting, and metadata templates.",
+      "owners": [
+        "nmezhenskyi",
+        "tugbataluy"
+      ]
+    },
+    {
+      "name": "Instance",
+      "label": "d/instance",
+      "description": "Coordinates container and virtual machine lifecycles, configuration, execution, and backups.",
+      "owners": [
+        "tomponline",
+        "MusicDin"
+      ]
+    },
+    {
+      "name": "Storage",
+      "label": "d/storage",
+      "description": "Controls storage pools, volumes, snapshots, and backends like ZFS, Ceph, and Btrfs.",
+      "owners": [
+        "tugbataluy",
+        "roosterfish",
+        "MusicDin"
+      ]
+    },
+    {
+      "name": "Documentation",
+      "label": "d/docs",
+      "description": "Maintains project documentation, user manuals, and technical guides.",
+      "owners": [
+        "elijahgreenstein"
+      ]
+    },
+    {
+      "name": "CLI",
+      "label": "d/cli",
+      "description": "Command-line interface and associated command tools.",
+      "owners": [
+        "MusicDin",
+        "nmezhenskyi"
+      ]
+    },
+    {
+      "name": "API",
+      "label": "d/api",
+      "description": "Public and internal REST API endpoints and schemas.",
+      "owners": [
+        "markylaing",
+        "tomponline"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/domain-label.yml
+++ b/.github/workflows/domain-label.yml
@@ -1,0 +1,84 @@
+name: Domain label check
+
+on:
+  # Safe: only checks out .github/domain-owners.json from the base branch.
+  # No PR-supplied code is executed. Write permission is needed to manage labels on fork PRs.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+
+permissions: {}
+
+jobs:
+  check-domain-label:
+    if: ${{ github.repository == 'canonical/lxd' }}
+    permissions:
+      pull-requests: write
+    name: Verify domain label
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/domain-owners.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Check for domain label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Read valid domain labels from domain-owners.json.
+          mapfile -t DOMAIN_LABELS < <(jq -r '.domains[].label' .github/domain-owners.json)
+
+          # Fetch current PR labels.
+          mapfile -t PR_LABELS < <(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json labels --jq '.labels[].name')
+
+          # Check whether any domain label is present.
+          FOUND=false
+          for pr_label in "${PR_LABELS[@]}"; do
+            for domain_label in "${DOMAIN_LABELS[@]}"; do
+              if [[ "${pr_label}" == "${domain_label}" ]]; then
+                FOUND=true
+                break 2
+              fi
+            done
+          done
+
+          if [[ "${FOUND}" == "true" ]]; then
+            echo "Domain label found — removing 'd/missing' if present."
+            gh pr edit "${PR_NUMBER}" --repo "${REPO}" --remove-label "d/missing" || echo "::warning::Failed to remove 'd/missing' label."
+            exit 0
+          fi
+
+          # Check whether d/missing is already applied (to avoid duplicate comments).
+          ALREADY_MISSING=false
+          for pr_label in "${PR_LABELS[@]}"; do
+            if [[ "${pr_label}" == "d/missing" ]]; then
+              ALREADY_MISSING=true
+              break
+            fi
+          done
+
+          echo "No domain label found — adding 'd/missing' label."
+          gh label create "d/missing" \
+            --repo "${REPO}" \
+            --description "PR is missing a domain label" \
+            --color "E4E669" || echo "::warning::Failed to create 'd/missing' label (may already exist)."
+
+          if [[ "${ALREADY_MISSING}" == "false" ]]; then
+            gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-label "d/missing"
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+              --body "This PR has no domain label assigned. @canonical/lxd-maintainers please set the appropriate domain labels."
+          else
+            echo "'d/missing' label already present — skipping comment."
+          fi

--- a/.github/workflows/domain-reviewers.yml
+++ b/.github/workflows/domain-reviewers.yml
@@ -1,0 +1,81 @@
+name: Assign domain reviewers
+
+on:
+  # Safe: only checks out .github/domain-owners.json from the base branch.
+  # No PR-supplied code is executed. Write permission is needed to request
+  # reviewers on fork PRs.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - labeled
+      - unlabeled
+
+permissions: {}
+
+jobs:
+  assign-reviewers:
+    if: ${{ github.repository == 'canonical/lxd' }}
+    permissions:
+      pull-requests: write
+    name: Assign domain reviewers
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/domain-owners.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Sync domain reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Fetch current PR labels.
+          mapfile -t PR_LABELS < <(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json labels --jq '.labels[].name')
+
+          # Build the desired reviewer set: union of owners for every domain
+          # label currently on the PR, excluding the PR author, deduplicated.
+          declare -A desired
+          for pr_label in "${PR_LABELS[@]}"; do
+            while IFS= read -r owner; do
+              if [[ -n "${owner}" && "${owner}" != "${PR_AUTHOR}" ]]; then
+                desired["${owner}"]=1
+              fi
+            done < <(jq -r \
+              --arg label "${pr_label}" \
+              '.domains[] | select(.label == $label) | .owners[]' \
+              .github/domain-owners.json)
+          done
+
+          # Fetch current requested reviewers on the PR.
+          mapfile -t CURRENT_REVIEWERS < <(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json reviewRequests --jq '.reviewRequests[].login')
+
+          # Determine reviewers to add (desired but not already requested).
+          ADD=()
+          for reviewer in "${!desired[@]}"; do
+            already=false
+            for cur in "${CURRENT_REVIEWERS[@]}"; do
+              if [[ "${cur}" == "${reviewer}" ]]; then
+                already=true
+                break
+              fi
+            done
+            "${already}" || ADD+=("${reviewer}")
+          done
+
+          if [[ ${#ADD[@]} -gt 0 ]]; then
+            REVIEWER_LIST=$(printf '%s,' "${ADD[@]}")
+            echo "Adding reviewers: ${REVIEWER_LIST%,}"
+            gh pr edit "${PR_NUMBER}" --repo "${REPO}" \
+              --add-reviewer "${REVIEWER_LIST%,}"
+          else
+            echo "Reviewer list is already up to date."
+          fi


### PR DESCRIPTION
This implements the domain ownership for doing code reviews as defined in [LX170](https://docs.google.com/document/d/1UQAme66pXWsB518ur9_VzGijAgiMD_AB3Cr6syHfOoU/edit?tab=t.0). The `domain-yaml.yml` workflow checks for domain labels on a PR and assigns `d/missing` if none is found. If labels are found, `d/missing` is removed and the PR left untouched. The second `domain-reviewers.yml` workflow assigns reviewers based on `.github/domain-owners.json` to the PR (domain owners MUST be a member of @canonical/lxd-maintainers) as per labels. 

Members of @canonical/lxd are expected to identify the domain experts they need a review from by themself, for external contributions @canonical/lxd-maintainers is asked to assign the labels. Once we have automatic assignment in place, this serves as a bridge solution.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
