### PR TITLE
Enforce project restrictions during instance move (stable-5.21)

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/instance/operationlock"
@@ -235,6 +236,42 @@ func instanceRebuildFromEmpty(inst instance.Instance, op *operations.Operation) 
 	return nil
 }
 
+// adjustSnapRootDiskPool returns a clone of snapLocalDevices with the root-disk pool rewritten
+// to parentRootDiskPool when it diverges from the snapshot's expanded root disk pool.
+// parentRootDiskKey is used as the device name when a new local root device must be injected.
+// This is the canonical logic for aligning a snapshot's root disk with its new parent instance
+// before persisting; call it in both the copy path and any pre-flight validation.
+func adjustSnapRootDiskPool(snapLocalDevices deviceConfig.Devices, snapExpandedDevices deviceConfig.Devices, parentRootDiskKey, parentRootDiskPool string) deviceConfig.Devices {
+	result := snapLocalDevices.Clone()
+
+	snapRootKey, snapRootDev, err := instancetype.GetRootDiskDevice(snapExpandedDevices.CloneNative())
+	if err == nil {
+		if snapRootDev["pool"] != parentRootDiskPool {
+			localRoot, found := result[snapRootKey]
+			if found {
+				localRoot["pool"] = parentRootDiskPool
+				result[snapRootKey] = localRoot
+			} else {
+				result[parentRootDiskKey] = deviceConfig.Device{
+					"type": "disk",
+					"path": "/",
+					"pool": parentRootDiskPool,
+				}
+			}
+		}
+	} else if errors.Is(err, instancetype.ErrNoRootDisk) {
+		result[parentRootDiskKey] = deviceConfig.Device{
+			"type": "disk",
+			"path": "/",
+			"pool": parentRootDiskPool,
+		}
+	}
+	// If err is anything else (e.g. multiple root disks) leave result unmodified;
+	// instanceCreateAsCopy cannot safely fix that case either.
+
+	return result
+}
+
 // instanceCreateAsCopyOpts options for copying an instance.
 type instanceCreateAsCopyOpts struct {
 	sourceInstance           instance.Instance // Source instance.
@@ -349,41 +386,10 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 		}
 
 		for _, srcSnap := range snapshots {
-			snapLocalDevices := srcSnap.LocalDevices().Clone()
-
-			// Load snap root disk from expanded devices (in case it doesn't have its own root disk).
-			snapExpandedRootDiskDevKey, snapExpandedRootDiskDev, err := instancetype.GetRootDiskDevice(srcSnap.ExpandedDevices().CloneNative())
-			if err == nil {
-				// If the expanded devices has a root disk, but its pool doesn't match our new
-				// parent instance's pool, then either modify the device if it is local or add a
-				// new one to local devices if its coming from the profiles.
-				if snapExpandedRootDiskDev["pool"] != instRootDiskDevice["pool"] {
-					localRootDiskDev, found := snapLocalDevices[snapExpandedRootDiskDevKey]
-					if found {
-						// Modify exist local device's pool.
-						localRootDiskDev["pool"] = instRootDiskDevice["pool"]
-						snapLocalDevices[snapExpandedRootDiskDevKey] = localRootDiskDev
-					} else {
-						// Add a new local device using parent instance's pool.
-						snapLocalDevices[instRootDiskDeviceKey] = map[string]string{
-							"type": "disk",
-							"path": "/",
-							"pool": instRootDiskDevice["pool"],
-						}
-					}
-				}
-			} else if errors.Is(err, instancetype.ErrNoRootDisk) {
-				// If no root disk defined in either local devices or profiles, then add one to the
-				// snapshot local devices using the same device name from the parent instance.
-				snapLocalDevices[instRootDiskDeviceKey] = map[string]string{
-					"type": "disk",
-					"path": "/",
-					"pool": instRootDiskDevice["pool"],
-				}
-			} else { //nolint:staticcheck,revive // (keep the empty branch for the comment)
-				// Snapshot has multiple root disk devices, we can't automatically fix this so
-				// leave alone so we don't prevent copy.
-			}
+			snapLocalDevices := adjustSnapRootDiskPool(
+				srcSnap.LocalDevices(), srcSnap.ExpandedDevices(),
+				instRootDiskDeviceKey, instRootDiskDevice["pool"],
+			)
 
 			_, origSnapName, _ := strings.Cut(srcSnap.Name(), shared.SnapshotDelimiter)
 			newSnapName := inst.Name() + "/" + origSnapName

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -683,6 +683,11 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 		Stateful:     inst.IsStateful(),
 	}
 
+	err = checkTargetProjectRestrictions(ctx, s, inst, targetArgs.Project, sourceProject, targetArgs.Name, targetArgs.Config, targetArgs.Devices.CloneNative(), req.Profiles, req.InstanceOnly, req.OverrideSnapshotProfiles, rootDevKey, rootDev["pool"])
+	if err != nil {
+		return err
+	}
+
 	if targetMemberInfo != nil {
 		return migrateInstance(ctx, s, inst, targetMemberInfo.Name, targetGroupName, req, &targetArgs, op)
 	}
@@ -1157,4 +1162,103 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 	}
 
 	return f(op)
+}
+
+// checkTargetProjectRestrictions verifies that inst (with the given target config, devices, and
+// profiles) can be placed in targetProject without violating that project's limits or
+// restrictions. Snapshots are validated when instanceOnly is false. It is a no-op when
+// targetProject and sourceProject are the same. rootDevKey and rootDevPool describe the target
+// instance's root disk, used to adjust snapshot device pools before validation (mirroring what
+// instanceCreateAsCopy persists).
+func checkTargetProjectRestrictions(ctx context.Context, s *state.State, inst instance.Instance, targetProject string, sourceProject string, targetName string, instConfig map[string]string, instDevices map[string]map[string]string, instProfiles []string, instanceOnly bool, overrideSnapshotProfiles bool, rootDevKey string, rootDevPool string) error {
+	if targetProject == sourceProject {
+		return nil
+	}
+
+	var restrictions *limits.ProjectInfo
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		restrictions, err = limits.FetchProject(ctx, tx, targetProject, true)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	if restrictions == nil {
+		return nil
+	}
+
+	// Use a copy of the config: AllowInstanceCreation strips volatile keys from the
+	// config it is given, and this map backs the real instance config.
+	instConfigCopy := make(map[string]string, len(instConfig))
+	maps.Copy(instConfigCopy, instConfig)
+
+	instReq := api.InstancesPost{
+		InstancePut: api.InstancePut{
+			Config:   instConfigCopy,
+			Devices:  instDevices,
+			Profiles: instProfiles,
+		},
+		Name:   targetName,
+		Type:   api.InstanceType(inst.Type().String()),
+		Source: api.InstanceSource{Type: api.SourceTypeMigration},
+	}
+
+	err = limits.AllowInstanceCreation(s.GlobalConfig, *restrictions, instReq)
+	if err != nil {
+		return fmt.Errorf("Instance cannot be placed in project %q: %w", targetProject, err)
+	}
+
+	if instanceOnly {
+		return nil
+	}
+
+	snapshots, err := inst.Snapshots()
+	if err != nil {
+		return err
+	}
+
+	if len(snapshots) > 0 {
+		err = limits.AllowSnapshotCreation(&restrictions.Project)
+		if err != nil {
+			return fmt.Errorf("Instance snapshots cannot be placed in project %q: %w", targetProject, err)
+		}
+	}
+
+	for _, snap := range snapshots {
+		_, snapName, _ := strings.Cut(snap.Name(), shared.SnapshotDelimiter)
+
+		// If snapshot profiles will be overridden with the target instance's profiles
+		// (see instanceCreateAsCopy), validate against those instead of the snapshot's
+		// own profiles, since that's what actually gets persisted.
+		profileNames := instProfiles
+		if !overrideSnapshotProfiles {
+			profileNames = make([]string, 0, len(snap.Profiles()))
+			for _, p := range snap.Profiles() {
+				profileNames = append(profileNames, p.Name)
+			}
+		}
+
+		snapConfig := make(map[string]string, len(snap.LocalConfig()))
+		maps.Copy(snapConfig, snap.LocalConfig())
+
+		snapReq := api.InstancesPost{
+			InstancePut: api.InstancePut{
+				Config:   snapConfig,
+				Devices:  adjustSnapRootDiskPool(snap.LocalDevices(), snap.ExpandedDevices(), rootDevKey, rootDevPool).CloneNative(),
+				Profiles: profileNames,
+			},
+			Name:   targetName + shared.SnapshotDelimiter + snapName,
+			Type:   api.InstanceType(inst.Type().String()),
+			Source: api.InstanceSource{Type: api.SourceTypeMigration},
+		}
+
+		err = limits.AllowInstanceCreation(s.GlobalConfig, *restrictions, snapReq)
+		if err != nil {
+			return fmt.Errorf("Snapshot %q cannot be placed in project %q: %w", snap.Name(), targetProject, err)
+		}
+	}
+
+	return nil
 }

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -502,6 +502,25 @@ func createFromCopy(ctx context.Context, s *state.State, projectName string, pro
 		return response.SmartError(err)
 	}
 
+	// For cross-project copies, validate that the instance and its snapshots satisfy the target
+	// project's restrictions before starting the copy operation. This check must run before any
+	// cluster-redirect early returns so that cross-cluster copies are also covered.
+	if sourceProject != targetProject {
+		profileNames := make([]string, 0, len(profiles))
+		for _, p := range profiles {
+			profileNames = append(profileNames, p.Name)
+		}
+
+		rootDevKey, rootDev, _ := instancetype.GetRootDiskDevice(source.ExpandedDevices().CloneNative())
+
+		// We keep the ContainerOnly for backward compatibility.
+		copyInstanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly //nolint:staticcheck,unused
+		err = checkTargetProjectRestrictions(ctx, s, source, targetProject, sourceProject, req.Name, req.Config, req.Devices, profileNames, copyInstanceOnly, req.Source.OverrideSnapshotProfiles, rootDevKey, rootDev["pool"])
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	// When clustered, use the node name, otherwise use the hostname.
 	if s.ServerClustered {
 		serverName := s.ServerName

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -820,6 +820,14 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 			return response.SmartError(err)
 		}
 
+		// Verify snapshot creation is permitted before iterating over individual snapshots.
+		if len(bInfo.Config.Snapshots) > 0 {
+			err = limits.AllowSnapshotCreation(&restrictions.Project)
+			if err != nil {
+				return response.SmartError(err)
+			}
+		}
+
 		for i, snapshot := range bInfo.Config.Snapshots {
 			if snapshot == nil {
 				return response.SmartError(fmt.Errorf("Nil instance snapshot definition found at index %d", i))

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1169,8 +1169,11 @@ test_backup_inconsistent_config() {
   poolName="lxdtest-$(basename "${LXD_DIR}")"
 
   # Create a restricted project and switch to it.
+  # Allow snapshots so that backup archives containing snapshots can be imported;
+  # this test is about config reconciliation, not snapshot restriction enforcement.
   lxc project create restricted \
-    -c restricted=true
+    -c restricted=true \
+    -c restricted.snapshots=allow
   lxc profile device add default root disk path=/ pool="${poolName}" --project restricted
 
   # Switch to restricted project to test imports.

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -935,20 +935,28 @@ run_projects_restrictions() {
   # Create a project
   lxc project create local:p1 -c features.storage.volumes=false
 
-  # Grant access to the project.
+  # A second, unrestricted project used to construct instances with config that would be
+  # forbidden in "p1", so that moving them into "p1" can be checked.
+  lxc project create local:p2 -c features.storage.volumes=false -c features.profiles=false
+
+  # Grant access to the projects.
   if [ "${remote}" = "restricted" ]; then
-    # For the restricted client we need to grant access to the project first.
+    # For the restricted client we need to grant access to the projects first.
     # shellcheck disable=SC2153
     fingerprint="$(cert_fingerprint "${LXD_CONF}/client.crt")"
-    lxc config trust show "${fingerprint}" | sed -e 's/projects: \[\]/projects: ["p1"]/' | lxc config trust edit "local:${fingerprint}"
+    lxc config trust show "${fingerprint}" | sed -e 's/projects: \[\]/projects: ["p1", "p2"]/' | lxc config trust edit "local:${fingerprint}"
   elif [ "${remote}" = "fine-grained" ]; then
     # For the fine grained client we'll grant (almost) equivalent access to the restricted certificate, with the exception
     # that networks in the default project can never be modified by this user via the "punching through" that the feature flags allow
     # with restricted certs.
     lxc auth group permission add local:test-group project p1 operator
+    lxc auth group permission add local:test-group project p2 operator
     lxc auth group permission add local:test-group project default can_view
     lxc auth group permission add local:test-group project default can_view_networks
     lxc auth group permission add local:test-group server can_view_unmanaged_networks
+    # p2 has features.profiles=false, so it borrows the default project's profiles. Project-level
+    # can_view does not cascade to viewing individual profiles, so grant that explicitly.
+    lxc auth group permission add local:test-group profile default can_view project=default
   fi
 
   # Switch to the project. Also switch the local remote if not already set.
@@ -1194,6 +1202,40 @@ run_projects_restrictions() {
   lxc delete c1
   lxc project set local:p1 restricted.containers.lowlevel="" restricted.snapshots=""
 
+  # An instance (or one of its snapshots) created with a forbidden low-level key in an
+  # unrestricted project must not be usable to bypass restricted.containers.lowlevel=block by
+  # being moved into the restricted project. The move itself must validate the resulting
+  # config, the same way direct config changes and snapshot restores already are, otherwise
+  # simply starting the moved instance would apply the forbidden config without ever going
+  # through a check.
+  lxc --project p2 init --empty c1 -c "raw.idmap=both 0 0" -d "${SMALL_ROOT_DISK}"
+  ! lxc --project p2 move c1 --target-project p1 || false
+  # The instance must be left untouched in its original project.
+  lxc --project p2 config get c1 raw.idmap | grep -wF "both 0 0"
+  ! lxc --project p1 info c1 || false
+  lxc --project p2 delete c1
+
+  # A snapshot carrying the forbidden key must also be checked at move time, even when the
+  # live instance's config no longer has the key set (e.g. it was unset after the snapshot
+  # was taken).
+  lxc --project p2 init --empty c1 -c "raw.idmap=both 0 0" -d "${SMALL_ROOT_DISK}"
+  lxc --project p2 snapshot c1 snap0
+  lxc --project p2 config unset c1 raw.idmap
+  ! lxc --project p2 move c1 --target-project p1 || false
+  ! lxc --project p1 info c1 || false
+  lxc --project p2 delete c1
+
+  # restricted.snapshots=block must also be enforced at move time: an instance carrying a
+  # snapshot must not be movable into a project that disallows snapshots outright, even if
+  # nothing about the snapshot's config violates restricted.containers.lowlevel.
+  lxc project set local:p1 restricted.containers.lowlevel=allow restricted.snapshots=block
+  lxc --project p2 init --empty c1 -d "${SMALL_ROOT_DISK}"
+  lxc --project p2 snapshot c1 snap0
+  ! lxc --project p2 move c1 --target-project p1 || false
+  ! lxc --project p1 info c1 || false
+  lxc --project p2 delete c1
+  lxc project set local:p1 restricted.containers.lowlevel="" restricted.snapshots=""
+
   # Setting restricted.containers.privilege to 'allow' makes it possible to create
   # privileged containers.
   lxc project set local:p1 restricted.containers.privilege=allow
@@ -1270,6 +1312,7 @@ run_projects_restrictions() {
   lxc remote switch local
   lxc project switch default
   lxc project delete p1
+  lxc project delete p2
 
   lxc network delete "${netManaged}"
   lxc storage volume delete "${pool}" "v-proj$$"


### PR DESCRIPTION
Backports https://github.com/canonical/lxd/pull/18605. Further hardening for GHSA-47w9-6r3f-938g.
