### PR TITLE
lxd: skip member-role handover in Stop() when cluster DB never opened

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2220,7 +2220,12 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 
 	s := d.State()
 
-	if d.gateway != nil {
+	// Skip the member-role handover if the cluster DB never opened (e.g. init()
+	// failed between gateway creation and db.OpenCluster): there is no
+	// membership state to hand over, and handoverMemberRole would dereference
+	// the nil cluster DB. The gateway itself is still torn down below via
+	// Kill() and Shutdown().
+	if d.gateway != nil && d.db.Cluster != nil {
 		d.stopClusterTasks()
 
 		err := handoverMemberRole(d.State(), d.gateway)

--- a/lxd/daemon_integration_test.go
+++ b/lxd/daemon_integration_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,6 +15,54 @@ import (
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/shared/api"
 )
+
+// TestDaemon_Stop_NilClusterDB reproduces the nil-pointer panic that occurs
+// when Stop() is called after Init() fails in the window between gateway
+// creation and cluster-DB open (e.g. a dqlite race or schema mismatch), on a
+// cluster member. In that window d.gateway is non-nil but d.db.Cluster is
+// nil; before the fix, handoverMemberRole would reach
+// getClusterMemberRolesAndEvacuatedMembers(), which calls
+// s.DB.Cluster.Transaction() on the nil *db.Cluster and SIGSEGV. The fix
+// makes Stop() skip the member-role handover when the cluster DB never
+// opened, while still tearing the gateway down. Since handoverMemberRole()
+// only touches the cluster DB when the member is clustered, the test forces
+// d.serverClustered = true after Init() fails, to exercise that path (a
+// freshly-initialized test daemon is never clustered by default).
+func TestDaemon_Stop_NilClusterDB(t *testing.T) {
+	testOS, osCleanup := sys.NewTestOS(t)
+	defer osCleanup()
+
+	// Block the unix socket path with a non-empty directory so that
+	// endpoints.Up() fails deterministically inside Daemon.init(), after the
+	// gateway is created but before the cluster database is opened. This
+	// reproduces the window the fix targets: d.gateway is non-nil while
+	// d.db.Cluster is still nil. A plain (empty) directory would not do, since
+	// os.Remove() (used to clear stale sockets) succeeds on those.
+	require.NoError(t, os.MkdirAll(testOS.GetUnixSocket(), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(testOS.GetUnixSocket(), "blocker"), nil, 0o600))
+
+	daemon := newDaemon(newConfig(), testOS)
+
+	err := daemon.Init()
+	require.Error(t, err)
+
+	// The window the fix targets: init() failed with a live gateway but no
+	// cluster DB. The gateway is left in place for Stop() to tear down in the
+	// correct order.
+	require.Nil(t, daemon.db.Cluster)
+	require.NotNil(t, daemon.gateway)
+
+	// Simulate a cluster member so Stop() actually exercises the
+	// handoverMemberRole() path that dereferences the cluster DB; that path
+	// is skipped entirely for standalone servers, which a freshly
+	// initialized test daemon always is.
+	daemon.serverClustered = true
+
+	// Must not panic; the originally-reported symptom.
+	require.NotPanics(t, func() {
+		_ = daemon.Stop(context.Background(), unix.SIGINT)
+	})
+}
 
 // The daemon is started and a client can connect to it via unix socket.
 func TestIntegration_UnixSocket(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/18455.
