### PR TITLE
Reintroduce hybrid curves support for TLS handshakes to simplestreams

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -280,10 +280,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 	}
 
 	// Setup the HTTP client
-	// Do not include modern post-quantum curves in the ClientHello to avoid
-	// compatibility issues (connection resets) with broken middleboxes that
-	// can't handle large ClientHello messages split over multiple TCP packets.
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, true, args.Proxy, args.TransportWrapper, "")
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper, "")
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +468,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, false, args.Proxy, args.TransportWrapper, serverFingerprint)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper, serverFingerprint)
 	if err != nil {
 		return nil, err
 	}

--- a/client/util.go
+++ b/client/util.go
@@ -22,7 +22,7 @@ import (
 
 // tlsHTTPClient creates an HTTP client with a specified Transport Layer Security (TLS) configuration.
 // It takes in parameters for client certificates, keys, Certificate Authority, server certificates,
-// proxy function, and a transport wrapper function.
+// a boolean for skipping verification, a proxy function, a transport wrapper function and the server certificate fingerprint.
 // It returns the HTTP client with the provided configurations and handles any errors that might occur during the setup process.
 func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter, serverCertFingerprint string) (*http.Client, error) {
 	// Get the TLS configuration

--- a/client/util.go
+++ b/client/util.go
@@ -22,10 +22,9 @@ import (
 
 // tlsHTTPClient creates an HTTP client with a specified Transport Layer Security (TLS) configuration.
 // It takes in parameters for client certificates, keys, Certificate Authority, server certificates,
-// a boolean for skipping verification, a boolean for including only legacy curves in ClientHello, a
 // proxy function, and a transport wrapper function.
 // It returns the HTTP client with the provided configurations and handles any errors that might occur during the setup process.
-func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, legacyCurvesOnly bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter, serverCertFingerprint string) (*http.Client, error) {
+func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter, serverCertFingerprint string) (*http.Client, error) {
 	// Get the TLS configuration
 	tlsConfig, err := shared.GetTLSConfigMem(tlsClientCert, tlsClientKey, tlsCA, tlsServerCert, insecureSkipVerify)
 	if err != nil {
@@ -67,21 +66,6 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 			}
 
 			return nil
-		}
-	}
-
-	// If legacyCurvesOnly is true, don't include the post-quantum curve
-	// (`X25519MLKEM768` or `X25519Kyber768Draft00`) in the list of supported
-	// curves. Those extra curves causes the ClientHello message to be too
-	// large to fit in a single packet, causing some broken middleboxes to reset
-	// the connection because they failed to reassemble the TCP packets.
-	if legacyCurvesOnly {
-		// Matches the default list of curves in Go 1.23 with `GODEBUG=tlskyber=0,tlsmlkem=0`
-		tlsConfig.CurvePreferences = []tls.CurveID{
-			tls.X25519,
-			tls.CurveP256,
-			tls.CurveP384,
-			tls.CurveP521,
 		}
 	}
 

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -293,7 +293,7 @@ func Test_tlsHTTPClient_Fingerprint(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := tlsHTTPClient(nil, "", "", "", test.serverCert, test.insecureSkip, false, nil, nil, test.fingerprint)
+			client, err := tlsHTTPClient(nil, "", "", "", test.serverCert, test.insecureSkip, nil, nil, test.fingerprint)
 			require.NoError(t, err)
 
 			resp, err := client.Get(server.URL)
@@ -387,7 +387,7 @@ func Test_tlsHTTPClient_CertificateValidity(t *testing.T) {
 			fingerprint := certInfo.Fingerprint()
 			require.NotEmpty(t, fingerprint)
 
-			client, err := tlsHTTPClient(nil, "", "", "", "", test.insecureSkip, false, nil, nil, fingerprint)
+			client, err := tlsHTTPClient(nil, "", "", "", "", test.insecureSkip, nil, nil, fingerprint)
 			require.NoError(t, err)
 
 			// Try connecting to the server.


### PR DESCRIPTION
This reverts https://github.com/canonical/lxd/pull/15250 now in preparation of an upcoming LTS release. Any client behind a broken middle box will be affected by the issue described in https://github.com/canonical/lxd/issues/14839 and explained [here](https://tldr.fail/). The issue should manifest as aborted TLS/HTTPS connections (`read: connection reset by peer`) to public **simplestreams** image servers (`images:`, or `ubuntu:` and co).

The HTTPS/TLS ecosystem is moving forward with mitigations for an eventual Cryptographically Relevant Quantum Computer (CRQC) and LXD should not indefinitely weaken the security of TLS communications for a small number of broken client environments.

Image downloads over simplestreams are not susceptible to ["harvest now, decrypt later"](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) threats mitigated by hybrid curves but disabling those risks complicating security audits and use in regulated environments.