### PR TITLE
Cluster: Don't use the proxy for internal connections (from Incus) (stable-5.21)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -583,6 +583,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		TLSClientKey:  string(serverCert.PrivateKey()),
 		TLSServerCert: string(req.ClusterCertificate),
 		UserAgent:     version.UserAgent,
+		// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return nil, nil
+		},
 	}
 
 	// Asynchronously join the cluster.

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/canonical/lxd/client"
@@ -51,9 +52,15 @@ func Connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 		args.UserAgent = request.UserAgentNotifier
 	}
 
-	requestor, err := request.GetRequestor(ctx)
-	if err == nil {
-		args.Proxy = requestor.ForwardProxy()
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		// Forward the requestor details if this is a user-initiated request.
+		requestor, err := request.GetRequestor(ctx)
+		if err == nil {
+			request.SetRequestorHeaders(requestor, req)
+		}
+
+		return nil, nil
 	}
 
 	url := "https://" + address
@@ -104,6 +111,11 @@ func SetupTrust(serverCert *shared.CertInfo, clusterPut api.ClusterPut) error {
 		UserAgent:     version.UserAgent,
 	}
 
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		return nil, nil
+	}
+
 	target, err := lxd.ConnectLXD("https://"+clusterPut.ClusterAddress, args)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to target cluster node %q: %w", clusterPut.ClusterAddress, err)
@@ -144,6 +156,11 @@ func UpdateTrust(serverCert *shared.CertInfo, serverName string, targetAddress s
 		TLSClientKey:  string(serverCert.PrivateKey()),
 		TLSServerCert: targetCert,
 		UserAgent:     version.UserAgent,
+	}
+
+	// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+	args.Proxy = func(req *http.Request) (*url.URL, error) {
+		return nil, nil
 	}
 
 	target, err := lxd.ConnectLXD("https://"+targetAddress, args)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -63,8 +63,8 @@ func Connect(ctx context.Context, address string, networkCert *shared.CertInfo, 
 		return nil, nil
 	}
 
-	url := "https://" + address
-	return lxd.ConnectLXDWithContext(ctx, url, args)
+	clusterURL := "https://" + address
+	return lxd.ConnectLXDWithContext(ctx, clusterURL, args)
 }
 
 // ConnectIfInstanceIsRemote figures out the address of the cluster member which is running the instance with the

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -50,6 +51,9 @@ type ImageDownloadArgs struct {
 	Budget            int64
 	SourceProjectName string
 	UserRequested     bool
+	// Proxy overrides the daemon-level proxy function when set.
+	// Use a no-op proxy function for intra-cluster connections to bypass the configured HTTP proxy.
+	Proxy func(req *http.Request) (*url.URL, error)
 }
 
 // imageOperationLock acquires a lock for operating on an image and returns the unlock function.
@@ -83,10 +87,17 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 
 	// Attempt to resolve the alias
 	if slices.Contains([]string{"lxd", "simplestreams"}, protocol) {
+		// Use the proxy from args if provided (e.g., a no-op proxy for intra-cluster connections),
+		// otherwise fall back to the daemon-level proxy.
+		proxy := args.Proxy
+		if proxy == nil {
+			proxy = s.Proxy
+		}
+
 		clientArgs := &lxd.ConnectionArgs{
 			TLSServerCert: args.Certificate,
 			UserAgent:     version.UserAgent,
-			Proxy:         s.Proxy,
+			Proxy:         proxy,
 			CachePath:     s.OS.CacheDir,
 			CacheExpiry:   time.Hour,
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -628,7 +628,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	return &info, nil
 }
 
-func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
+func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, project string, budget int64, proxy func(req *http.Request) (*url.URL, error)) (*api.Image, error) {
 	var err error
 	var hash string
 
@@ -653,6 +653,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 		Budget:            budget,
 		SourceProjectName: req.Source.Project,
 		UserRequested:     true,
+		Proxy:             proxy,
 	})
 	if err != nil {
 		return nil, err
@@ -1364,8 +1365,17 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		} else {
 			switch req.Source.Type {
 			case api.SourceTypeImage:
+				// For intra-cluster image copies, bypass the configured HTTP proxy
+				// since cluster members communicate directly.
+				var proxy func(req *http.Request) (*url.URL, error)
+				if isClusterNotification {
+					proxy = func(req *http.Request) (*url.URL, error) {
+						return nil, nil
+					}
+				}
+
 				/* Processing image copy from remote */
-				info, err = imgPostRemoteInfo(r.Context(), s, req, op, projectName, budget)
+				info, err = imgPostRemoteInfo(r.Context(), s, req, op, projectName, budget, proxy)
 			case "url":
 				/* Processing image copy from URL */
 				info, err = imgPostURLInfo(r.Context(), s, req, op, projectName, budget)

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -177,8 +177,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			// Cluster URL
 			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
-			// Cluster certificate
-			cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
+			// Get cluster certificate bypassing any configured HTTP proxy.
+			cert, err := shared.GetRemoteCertificateNoProxy(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 			if err != nil {
 				fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 				continue

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"slices"
@@ -220,8 +222,8 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 				for _, clusterAddress := range joinToken.Addresses {
 					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
-					// Cluster certificate
-					cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
+					// Get cluster certificate bypassing any configured HTTP proxy.
+					cert, err := shared.GetRemoteCertificateNoProxy(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 					if err != nil {
 						fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 						continue
@@ -259,8 +261,8 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 
 					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
-					// Cluster certificate
-					cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
+					// Get cluster certificate bypassing any configured HTTP proxy.
+					cert, err := shared.GetRemoteCertificateNoProxy(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 					if err != nil {
 						fmt.Printf("Error connecting to existing cluster member: %v\n", err)
 						continue
@@ -331,6 +333,10 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 				TLSClientKey:  string(serverCert.PrivateKey()),
 				TLSServerCert: string(config.Cluster.ClusterCertificate),
 				UserAgent:     version.UserAgent,
+				// Always set a proxy function to have cluster traffic bypass any configured HTTP proxy.
+				Proxy: func(_ *http.Request) (*url.URL, error) {
+					return nil, nil
+				},
 			}
 
 			client, err := lxd.ConnectLXD("https://"+config.Cluster.ClusterAddress, args)

--- a/lxd/request/requestor.go
+++ b/lxd/request/requestor.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 
 	"github.com/canonical/lxd/lxd/identity"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -159,30 +157,27 @@ func (r *Requestor) IsForwarded() bool {
 	return r.forwardedOriginAddress != ""
 }
 
-// ForwardProxy returns a proxy function that adds the requestor details as headers to be inspected by the receiving cluster member.
-func (r *Requestor) ForwardProxy() func(req *http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		req.Header.Add(headerForwardedAddress, r.OriginAddress())
+// SetRequestorHeaders adds the requestor details as forwarded headers on the
+// given HTTP request so the receiving cluster member can identify the caller.
+func SetRequestorHeaders(r *Requestor, req *http.Request) {
+	req.Header.Add(headerForwardedAddress, r.OriginAddress())
 
-		username := r.CallerUsername()
-		if username != "" {
-			req.Header.Add(headerForwardedUsername, username)
+	username := r.CallerUsername()
+	if username != "" {
+		req.Header.Add(headerForwardedUsername, username)
+	}
+
+	protocol := r.CallerProtocol()
+	if protocol != "" {
+		req.Header.Add(headerForwardedProtocol, protocol)
+	}
+
+	identityProviderGroups := r.CallerIdentityProviderGroups()
+	if identityProviderGroups != nil {
+		b, err := json.Marshal(identityProviderGroups)
+		if err == nil {
+			req.Header.Add(headerForwardedIdentityProviderGroups, string(b))
 		}
-
-		protocol := r.CallerProtocol()
-		if protocol != "" {
-			req.Header.Add(headerForwardedProtocol, protocol)
-		}
-
-		identityProviderGroups := r.CallerIdentityProviderGroups()
-		if identityProviderGroups != nil {
-			b, err := json.Marshal(identityProviderGroups)
-			if err == nil {
-				req.Header.Add(headerForwardedIdentityProviderGroups, string(b))
-			}
-		}
-
-		return shared.ProxyFromEnvironment(req)
 	}
 }
 

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -507,6 +507,8 @@ func GetRemoteCertificate(ctx context.Context, address string, useragent string)
 		return nil, err
 	}
 
+	defer func() { _ = resp.Body.Close() }()
+
 	// Retrieve the certificate
 	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
 		return nil, errors.New("Unable to read remote TLS certificate")

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -474,6 +475,19 @@ func CertFingerprintStr(c string) (string, error) {
 
 // GetRemoteCertificate returns the unverified peer certificate found at a remote address.
 func GetRemoteCertificate(ctx context.Context, address string, useragent string) (*x509.Certificate, error) {
+	return getRemoteCertificate(ctx, address, useragent, false)
+}
+
+// GetRemoteCertificateNoProxy returns the unverified peer certificate found at a remote address,
+// bypassing any configured HTTP proxy.
+func GetRemoteCertificateNoProxy(ctx context.Context, address string, useragent string) (*x509.Certificate, error) {
+	return getRemoteCertificate(ctx, address, useragent, true)
+}
+
+// getRemoteCertificate returns the unverified peer certificate found at a remote address.
+// If bypassProxy is true, the function bypasses any configured HTTP proxy.
+// Otherwise, the function uses the proxy from the environment to make a request.
+func getRemoteCertificate(ctx context.Context, address string, useragent string, bypassProxy bool) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
 	tlsConfig, err := GetTLSConfig(nil)
 	if err != nil {
@@ -489,6 +503,13 @@ func GetRemoteCertificate(ctx context.Context, address string, useragent string)
 		ExpectContinueTimeout: time.Second * 30,
 		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
+	}
+
+	// Bypass the environment proxy.
+	if bypassProxy {
+		tr.Proxy = func(_ *http.Request) (*url.URL, error) {
+			return nil, nil
+		}
 	}
 
 	// Connect

--- a/test/main.sh
+++ b/test/main.sh
@@ -468,6 +468,7 @@ if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_address "clustering address"
     run_test test_clustering_image_replication "clustering image replication"
     run_test test_clustering_image_proxy_bypass "clustering image proxy bypass"
+    run_test test_clustering_join_proxy_bypass "clustering join proxy bypass"
     run_test test_clustering_dns "clustering DNS"
     run_test test_clustering_fan "clustering FAN"
     run_test test_clustering_recover "clustering recovery"

--- a/test/main.sh
+++ b/test/main.sh
@@ -467,6 +467,7 @@ if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_update_cert_token "clustering update cert token"
     run_test test_clustering_address "clustering address"
     run_test test_clustering_image_replication "clustering image replication"
+    run_test test_clustering_image_proxy_bypass "clustering image proxy bypass"
     run_test test_clustering_dns "clustering DNS"
     run_test test_clustering_fan "clustering FAN"
     run_test test_clustering_recover "clustering recovery"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2629,6 +2629,67 @@ test_clustering_image_replication() {
   kill_lxd "${LXD_THREE_DIR}"
 }
 
+test_clustering_image_proxy_bypass() {
+  local LXD_DIR
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML has weird rules.
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+
+  sub_test "Image replication bypasses configured HTTP proxy"
+  # Set core.proxy_https and core.proxy_http to an unreachable proxy. Intra-cluster
+  # image replication should bypass the proxy entirely.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.proxy_https "http://127.0.0.1:1"
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.proxy_http "http://127.0.0.1:1"
+
+  # Import the test image on node1. Image replication happens across all nodes by default.
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage
+
+  # The image should be visible through both nodes.
+  LXD_DIR="${LXD_ONE_DIR}" lxc image list | grep -wF testimage
+  LXD_DIR="${LXD_TWO_DIR}" lxc image list | grep -wF testimage
+
+  # The image tarball should be replicated to both nodes despite the unreachable proxy.
+  fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info testimage | awk '/^Fingerprint/ {print $2}')
+  [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/images/${fingerprint}" ]
+
+  # Clean up the image.
+  LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
+  [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
+
+  # Unset the proxy configuration.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset core.proxy_https
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset core.proxy_http
+
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+}
+
 test_clustering_dns() {
   local lxdDir
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2690,6 +2690,57 @@ test_clustering_image_proxy_bypass() {
   kill_lxd "${LXD_TWO_DIR}"
 }
 
+test_clustering_join_proxy_bypass() {
+  local LXD_DIR
+
+  # Set HTTP_PROXY and HTTPS_PROXY to an unreachable proxy so that cluster bootstrap
+  # and join fail if they do not bypass the proxy.
+  with_bad_proxy() {
+    HTTP_PROXY="http://127.0.0.1:1" HTTPS_PROXY="http://127.0.0.1:1" \
+    http_proxy="http://127.0.0.1:1" https_proxy="http://127.0.0.1:1" \
+    "$@"
+  }
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  sub_test "Cluster join bypasses HTTP_PROXY and HTTPS_PROXY environment variables"
+
+  # Bootstrap the first node with proxy env vars pointing to an unreachable proxy.
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns1="${prefix}1"
+  with_bad_proxy spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML has weird rules.
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Join a second node with proxy env vars still set.
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  with_bad_proxy spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+
+  # Verify the cluster is functional by checking both nodes are present and online.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -wF node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -wF node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -xF "status: Online"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -xF "status: Online"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+}
+
 test_clustering_dns() {
   local lxdDir
 


### PR DESCRIPTION
This PR is a backport of https://github.com/canonical/lxd/pull/18338, https://github.com/canonical/lxd/pull/18354, and https://github.com/canonical/lxd/pull/17762 to `stable-5.21`.

It makes LXD bypass the configured proxy for cluster connections and cluster join requests.

Inspired-by https://github.com/lxc/incus/pull/2437 and https://github.com/lxc/incus/pull/2528.