### PR TITLE
lxd/firewall/drivers/drivers_nftables_templates: quote network name (stable-5.21)

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -36,9 +36,9 @@ chain pstrt{{.chainSeparator}}{{.networkName}} {
 	# It's important to check for both the destination address and the output interface
 	# to not falsely snat/masquerade multicast traffic whose destination address it outside of the subnet.
 	# In case br_netfilter is loaded on the host multicast traffic also traverses the postrouting chain.
-	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} oifname != {{$.networkName}} snat {{$config.SNATAddress}}
+	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} oifname != "{{$.networkName}}" snat {{$config.SNATAddress}}
 	{{else -}}
-	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} oifname != {{$.networkName}} masquerade
+	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} oifname != "{{$.networkName}}" masquerade
 	{{- end}}
 	{{- end}}
 }


### PR DESCRIPTION
In the Terraform provider, one of the CI run tried to create a network named `monitor`. This caused `nft` to complain:

```
=== RUN   TestAccNetwork_updateConfig
    resource_network_test.go:139: Step 1/2 error: Error running apply: exit status 1

        Error: Failed to create network "monitor"

          with lxd_network.network,
          on terraform_plugin_test.tf line 12, in resource "lxd_network" "network":
          12: resource "lxd_network" "network" {

        Failed to setup firewall: Failed adding outbound NAT rules for network
        "monitor" (inet): Failed apply nftables config: Failed to run: nft -f -: exit
        status 1 (/dev/stdin:5:64-70: Error: syntax error, unexpected monitor
        	ip saddr 10.150.30.0/24 ip daddr != 10.150.30.0/24 oifname != monitor
        masquerade
        	                                                              ^^^^^^^
        /dev/stdin:6:86-92: Error: syntax error, unexpected monitor
        	ip6 saddr fd42:c30d:7217:23c6::/64 ip6 daddr != fd42:c30d:7217:23c6::/64
        oifname != monitor masquerade

        ^^^^^^^)
```

This is because `monitor` is a reserved keyword. Avoid the issue by quoting the value like done in other templates.


(cherry picked from commit 99088cd81f04ef0688cce10ac444164abee3329e)
