### PR TITLE
Fix listing images with `--all-projects` flag (stable-5.21)

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1618,42 +1618,45 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 	}
 
 	for fingerprint, projects := range imagesProjectsMap {
-		hasAccess := false
-
-		image, err := doImageGet(ctx, tx, projects[0], fingerprint, public)
-		if err != nil {
-			continue
-		}
-
 		for _, project := range projects {
-			if image.Public || hasPermission(entity.ImageURL(project, fingerprint)) {
-				hasAccess = true
-				break
-			}
-		}
-
-		if !hasAccess {
-			continue
-		}
-
-		if !mustLoadObjects {
-			resultString = append(resultString, api.NewURL().Path(version.APIVersion, "images", fingerprint).String())
-		} else {
-			if clauses != nil && len(clauses.Clauses) > 0 {
-				match, err := filter.Match(*image, *clauses)
-				if err != nil {
-					return nil, err
-				}
-
-				if !match {
-					continue
-				}
+			image, err := doImageGet(ctx, tx, project, fingerprint, public)
+			if err != nil {
+				continue
 			}
 
-			if recursion {
-				resultMap = append(resultMap, image)
+			if !image.Public && !hasPermission(entity.ImageURL(project, fingerprint)) {
+				continue
+			}
+
+			if !mustLoadObjects {
+				url := api.NewURL().Path(version.APIVersion, "images", fingerprint)
+				if allProjects {
+					url = url.Project(project)
+				}
+
+				resultString = append(resultString, url.String())
 			} else {
-				resultString = append(resultString, api.NewURL().Path(version.APIVersion, "images", image.Fingerprint).String())
+				if clauses != nil && len(clauses.Clauses) > 0 {
+					match, err := filter.Match(*image, *clauses)
+					if err != nil {
+						return nil, err
+					}
+
+					if !match {
+						continue
+					}
+				}
+
+				if recursion {
+					resultMap = append(resultMap, image)
+				} else {
+					url := api.NewURL().Path(version.APIVersion, "images", image.Fingerprint)
+					if allProjects {
+						url = url.Project(project)
+					}
+
+					resultString = append(resultString, url.String())
+				}
 			}
 		}
 	}

--- a/test/main.sh
+++ b/test/main.sh
@@ -560,6 +560,7 @@ if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "cluster" ]; then
     run_test test_apparmor "apparmor restrictions"
     run_test test_image_expiry "image expiry"
     run_test test_image_list_all_aliases "image list all aliases"
+    run_test test_image_list_all_projects "image list all projects"
     run_test test_image_list_remotes "image list of simplestream remotes"
     run_test test_image_auto_update "image auto-update"
     run_test test_image_prefer_cached "image prefer cached"

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -147,6 +147,34 @@ test_image_list_all_aliases() {
     lxc image alias delete zzz
 }
 
+test_image_list_all_projects() {
+    ensure_import_testimage
+
+    local fingerprint
+    fingerprint="$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
+    local fp_short
+    fp_short="$(echo "${fingerprint}" | cut -c1-12)"
+
+    sub_test "Same image in two projects appears twice in --all-projects output"
+
+    # Create a second project and copy the same image into it.
+    lxc project create p1 -c features.images=true -c features.profiles=false
+    lxc image copy "${fingerprint}" local: --target-project p1
+
+    # Verify both entries appear in the table.
+    local count
+    count="$(lxc image list --all-projects -f csv -c f | grep -cxF "${fp_short}")"
+    [ "${count}" -eq 2 ]
+
+    # Verify the project names are correct.
+    lxc image list --all-projects -f csv -c ef | grep -xF "default,${fp_short}"
+    lxc image list --all-projects -f csv -c ef | grep -xF "p1,${fp_short}"
+
+    # Clean up.
+    lxc image delete "${fingerprint}" --project p1
+    lxc project delete p1
+}
+
 test_image_list_remotes() {
     # list images from the `images:` and `ubuntu-minimal:`  builtin remotes if they are reachable
 


### PR DESCRIPTION
This PR is a backport of the https://github.com/canonical/lxd/pull/18371 to `stable-5.21`.

It makes `lxc image list --all-projects` correctly display images shared by multiple projects.