### PR TITLE
doc: backport SSDLC documentation updates (stable-5.21)

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -1,3 +1,4 @@
+(events)=
 # Events
 
 ## Introduction

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -36,6 +36,8 @@ Never use unsupported LXD versions in a production environment.
     :end-before: <!-- Include end supported versions -->
 ```
 
+See {ref}`ref-releases-snap` for the currently supported releases as well as information about updates and upgrades to the LXD snap.
+
 (security-daemon-access)=
 ## Access to the LXD daemon
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -18,7 +18,13 @@ relatedlinks: "[Linux&#32;containers&#32;security](https://linuxcontainers.org/l
 
 See the following sections for detailed information. Also see: {ref}`howto-security-harden`.
 
-If you discover a security issue, see the [LXD security policy](https://github.com/canonical/lxd/blob/main/SECURITY.md) for information on how to report the issue.
+## Reporting vulnerabilities
+
+LXD adheres to the [Ubuntu disclosure policy](https://ubuntu.com/security/disclosure-policy).
+If you discover a security issue, see the [LXD security policy](https://github.com/canonical/lxd/blob/main/SECURITY.md) for information about how to report the issue.
+
+[LXD security advisories](https://github.com/canonical/lxd/security/advisories) are published on GitHub.
+For additional information about about LXD releases and development, refer to our {ref}`ref-release-notes` and [LXD news on Discourse](https://discourse.ubuntu.com/c/project/lxd/news/143).
 
 ## Supported versions
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -55,16 +55,13 @@ The root user and all members of the `lxd` group can interact with the local dae
 (security_remote_access)=
 ### Access to the remote API
 
-By default, access to the daemon is only possible locally.
-By setting the {config:option}`server-core:core.https_address` configuration option, you can expose the same API over the network on a {abbr}`TLS (Transport Layer Security)` socket.
-See {ref}`server-expose` for instructions.
+By default, access to the daemon is only possible locally, but you can also {ref}`expose LXD to the network <server-expose>` on a {abbr}`TLS` (Transport Layer Security) socket.
 Remote clients can then connect to LXD and access any image that is marked for public use.
 
 There are several ways to authenticate remote clients as trusted clients to allow them to access the API.
 See {ref}`authentication` for details.
+To increase your security posture in a production setup, you can also {ref}`harden remote API access <howto-security-harden-remote>` and {ref}`configure your firewall <network-bridge-firewall>`.
 
-In a production setup, you should set {config:option}`server-core:core.https_address` to the single address where the server should be available (rather than any address on the host).
-In addition, you should set firewall rules to allow access to the LXD port only from authorized hosts/subnets.
 
 (container-security)=
 ## Container security

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -163,6 +163,13 @@ In this networking mode, the LXD host functions as a router, and static routes a
 By default, the `veth` interface created on the host has its `accept_ra` setting disabled to prevent router advertisements from the container modifying the IPv6 routing table on the LXD host.
 In addition to that, the `rp_filter` on the host is set to `1` to prevent source address spoofing for IPs that the host does not know the container has.
 
+(security-logging)=
+## Events and logging
+
+LXD emits {ref}`events <events>` that track actions in your system.  In a production environment, you can {ref}`monitor these events with Loki <logs_loki>` or another centralized logging system to maintain a persistent audit trail.
+
+For additional logging methods, consult the {ref}`Logging <howto-security-harden-logging>` section in {ref}`howto-security-harden`. For details on metrics, including how to gather metrics with Prometheus, consult {ref}`metrics`. You can also {ref}`set up Grafana <grafana>` to visualize metrics and logging data.
+
 (security-cryptography)=
 ## Cryptography
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -166,6 +166,11 @@ In this networking mode, the LXD host functions as a router, and static routes a
 By default, the `veth` interface created on the host has its `accept_ra` setting disabled to prevent router advertisements from the container modifying the IPv6 routing table on the LXD host.
 In addition to that, the `rp_filter` on the host is set to `1` to prevent source address spoofing for IPs that the host does not know the container has.
 
+(security-cryptography)=
+## Cryptography
+
+LXD uses cryptographic technologies to authenticate, encrypt, and decrypt communication between servers, and to verify images copied from remote servers. For details, see {ref}`authentication` and {ref}`about-images`, as well as the guides to common operations related to {ref}`lxd-server` and {ref}`images`.
+
 ## Related topics
 
 {{security_how}}
@@ -173,3 +178,4 @@ In addition to that, the `rp_filter` on the host is set to `1` to prevent source
 Explanation:
 
 - {ref}`authentication`
+- {ref}`about-images`

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -10,13 +10,9 @@ relatedlinks: "[Linux&#32;containers&#32;security](https://linuxcontainers.org/l
 :title: LXD security
 ```
 
-% Include content from [../../README.md](../../README.md)
-```{include} ../../README.md
-    :start-after: <!-- Include start security -->
-    :end-before: <!-- Include end security -->
-```
-
-See the following sections for detailed information. Also see: {ref}`howto-security-harden`.
+Security considerations are critical when you install and deploy LXD.
+This page provides a high-level overview of information and concepts related to LXD security.
+To further increase your security posture, see {ref}`howto-security-harden`.
 
 ## Reporting vulnerabilities
 
@@ -24,7 +20,7 @@ LXD adheres to the [Ubuntu disclosure policy](https://ubuntu.com/security/disclo
 If you discover a security issue, see the [LXD security policy](https://github.com/canonical/lxd/blob/main/SECURITY.md) for information about how to report the issue.
 
 [LXD security advisories](https://github.com/canonical/lxd/security/advisories) are published on GitHub.
-For additional information about about LXD releases and development, refer to our {ref}`ref-release-notes` and [LXD news on Discourse](https://discourse.ubuntu.com/c/project/lxd/news/143).
+For additional information about LXD releases and development, refer to our {ref}`ref-release-notes` and [LXD news on Discourse](https://discourse.ubuntu.com/c/project/lxd/news/143).
 
 ## Supported versions
 

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -194,6 +194,6 @@ The certificate is stored at `/var/snap/lxd/common/lxd/cluster.crt` (if you use 
 You can replace the standard certificate with another one, such as a valid certificate obtained through ACME services (see {ref}`authentication-server-certificate` for more information).
 To do so, run the following command on any cluster member:
 
-    lxc cluster update-certificate
+    lxc cluster update-certificate <cert.crt> <cert.key>
 
 This command replaces the certificate on all cluster members. For more information, see: [`lxc cluster update-certificate`](lxc_cluster_update-certificate.md).

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -145,6 +145,7 @@ To cleanly delete a member from the cluster, use the following command:
 
 You can only cleanly delete members that are online and that don't have any instances located on them.
 
+(cluster-manage-offline-members)=
 ### Deal with offline cluster members
 
 If a cluster member goes permanently offline, you can force-remove it from the cluster.
@@ -183,6 +184,7 @@ Run [`lxc cluster list`](lxc_cluster_list.md) on a cluster member that is not bl
 As you proceed updating or upgrading the rest of the cluster members, they will all transition to the "blocked" state.
 When you update or upgrade the last member, the blocked members will notice that all LXD versions now match, and the blocked members become operational again.
 
+(cluster-manage-update-certificate)=
 ## Update the cluster certificate
 
 In a LXD cluster, the API on all servers responds with the same shared certificate, which is usually a standard self-signed certificate with an expiry set to ten years.

--- a/doc/howto/decommission.md
+++ b/doc/howto/decommission.md
@@ -1,0 +1,288 @@
+---
+myst:
+  html_meta:
+    description: How to securely decommission a LXD server, cluster member, or cluster.
+---
+
+(howto-decommission)=
+# How to securely decommission a LXD deployment
+
+Follow these steps to securely decommission your LXD deployment on a standalone server, cluster member, or cluster.
+
+```{important}
+This process will erase all data associated with your LXD deployment.
+Make copies of any data that you need to preserve before proceeding.
+Refer to {ref}`instances-backup` and {ref}`howto-storage-backup-volume` for relevant details.
+```
+
+To decommission a standalone server, proceed directly to {ref}`howto-decommission-revoke-remote`.
+To decommission a single member of a cluster, proceed to {ref}`howto-decommission-remove-offline-member` or {ref}`howto-decommission-remove-online-member`, depending on the member's status.
+To decommission an entire cluster, first {ref}`remove any offline cluster members <howto-decommission-remove-offline-member>`.
+
+(howto-decommission-remove-offline-member)=
+## Remove offline cluster members
+
+To decommission an entire cluster or a single offline member, {ref}`remove offline cluster members <cluster-manage-offline-members>` with the `--force` flag:
+
+```bash
+lxc cluster remove --force <member_name>
+```
+
+````{important}
+If you are only decommissioning the offline member, {ref}`update the cluster certificate <cluster-manage-update-certificate>` on the cluster.
+After removing the offline member, run this command on any member of the cluster remaining in production:
+
+```bash
+lxc cluster update-certificate <cert.crt> <cert.key>
+```
+````
+
+Then, to decommission the cluster member, proceed to {ref}`howto-decommission-remove-lxd`.
+To decommission the remaining cluster, proceed to {ref}`howto-decommission-revoke-remote` (you will remove online cluster members after you delete data).
+
+(howto-decommission-remove-online-member)=
+## Remove an online cluster member
+
+To decommission a single, online cluster member, first {ref}`evacuate instances <cluster-evacuate>` from the cluster member to other members:
+
+```bash
+lxc cluster evacuate <member_name>
+```
+
+Instances that are not suitable for migration may remain on the cluster member.
+Verify that no instances remain on the cluster member:
+
+```bash
+lxc list location=<member_name> --all-projects
+```
+
+If instances remain on the cluster member, {ref}`migrate those instances <howto-instances-migrate>` to another cluster member:
+
+```bash
+lxc move <instance_name> --target <target_member_name>
+```
+
+{ref}`Remove the member <cluster-manage-delete-members>` from the cluster:
+
+```bash
+lxc cluster remove <member_name>
+```
+
+Then, {ref}`update the cluster certificate <cluster-manage-update-certificate>` by running this command on any member of the cluster remaining in production:
+
+```bash
+lxc cluster update-certificate <cert.crt> <cert.key>
+```
+
+Now proceed to {ref}`howto-decommission-remove-lxd` to decommission the removed member.
+
+(howto-decommission-revoke-remote)=
+## Revoke remote access
+
+```{note}
+To decommission an entire cluster, run the commands in this section on any cluster member.
+```
+
+List all identities that have access to LXD, then delete each one:
+
+```bash
+lxc auth identity list
+lxc auth identity delete <type>/<name_or_identifier>
+```
+
+To decommission a deployment {ref}`configured for single sign-on with OIDC <authentication-openid>`, remove the corresponding profile from your OIDC identity provider.
+
+(howto-decommission-delete-data)=
+## Delete data
+
+```{important}
+Data deleted by LXD physically remains on disks and can be recovered by users with access to the disks.
+To prevent unauthorized data recovery, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
+
+To decommission a single cluster member, run these commands **after** removing the member from the cluster.
+Do **not** run these commands on any member of a cluster that will remain in production.
+```
+
+```{note}
+To decommission an entire cluster, run the commands in this section on any cluster member.
+```
+
+### List projects
+
+Instances, profiles, custom volumes, and buckets are scoped by {ref}`project <projects>`.
+For deployments with more than one project, you must repeat some steps for **each** project, using the `--project` flag.
+You do not need to use the `--project` flag to decommission deployments with only one project.
+
+View all projects:
+
+```bash
+lxc project list
+```
+
+````{note}
+You can also delete a project (except the `default` project) and all of its project-level entities with:
+
+```bash
+lxc project delete <project_name> --force
+```
+````
+
+### Stop and delete instances
+
+For each project, stop all instances:
+
+```bash
+lxc stop --all --project <project_name>
+```
+
+Next, list the instances for each project, then delete each instance:
+
+```bash
+lxc list --project <project_name>
+lxc delete <instance_name> --project <project_name>
+```
+
+````{note}
+If you are unable to stop or delete an instance, use the `--force` flag:
+
+```bash
+lxc stop --force <instance_name> --project <project_name>
+lxc delete --force <instance_name> --project <project_name>
+```
+````
+
+### Delete profiles
+
+For each project, list all profiles, then delete every profile but the `default` profile:
+
+```bash
+lxc profile list --project <project_name>
+lxc profile delete <profile_name> --project <project_name>
+```
+
+```{note}
+The `default` profile cannot be deleted.
+```
+
+### Delete custom volumes and buckets
+
+You must specify storage pools to delete {ref}`custom volumes <storage-volume-types>` or {ref}`buckets <storage-buckets>`.
+First, list all storage pools:
+
+```bash
+lxc storage list
+```
+
+```{note}
+You do not need to specify a project.
+This command lists all storage pools across projects.
+```
+
+Next, list the custom volumes on each storage pool.
+Use the `--all-projects` flag to view all custom volumes across projects:
+
+```bash
+lxc storage volume list <pool_name> type=custom --all-projects
+```
+
+Then, for {ref}`Ceph Object <storage-cephobject>` pools only, list the buckets:
+
+```bash
+lxc storage bucket list <pool_name> --all-projects
+```
+
+Use the `PROJECT` column in the output to identify the project associated with each custom volume or bucket.
+
+Finally, delete all custom volumes and buckets, specifying the storage pool and project:
+
+```bash
+lxc storage volume delete <pool_name> <volume_name> --project <project_name>
+lxc storage bucket delete <pool_name> <bucket_name> --project <project_name>
+```
+
+### Delete storage pools
+
+Storage pools cannot be deleted if they are used by an instance, profile, custom volume, or bucket.
+The `default` profile cannot be deleted; therefore, the storage pool used by the `default` profile cannot be deleted.
+To identify this storage pool, view information about the `default` profile and find the pool listed under `devices` > `root` > `pool`:
+
+```bash
+lxc profile show default
+```
+
+Next, list all storage pools, then delete every pool but the one used by the `default` profile.
+
+```bash
+lxc storage list
+lxc storage delete <pool_name>
+```
+
+```{note}
+You do not need to specify a project when running these commands.
+```
+
+### Delete monitoring data
+
+Delete data from any external systems that you used to {ref}`monitor events <logs_loki>` or {ref}`monitor metrics <metrics>`, such as [Loki](https://grafana.com/oss/loki/), [Prometheus](https://prometheus.io/), or [Grafana](https://grafana.com/).
+Refer to the documentation for those systems for details.
+
+(howto-decommission-remove-remaining-members)=
+## Remove remaining cluster members
+
+To decommission an entire cluster, list all cluster members, then remove each one:
+
+```bash
+lxc cluster list
+lxc cluster remove <member_name>
+```
+
+```{note}
+Iterate over every cluster member name except the name of the member on which you are running the commands.
+
+Offline cluster members should have been removed before revoking remote access.
+See {ref}`howto-decommission-remove-offline-member`.
+```
+
+(howto-decommission-remove-lxd)=
+## Remove the LXD snap
+
+```{important}
+Run these commands on **every** machine that you decommission.
+
+Removing LXD **does not** erase dedicated disks/partitions, {ref}`ZFS pools (zpools) <storage-zfs>`, {ref}`LVM volume groups <storage-lvm>`, or {ref}`remote storage <storage-drivers-remote>`.
+To securely decommission LXD, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
+```
+
+Remove the LXD snap.
+Use the `--purge` flag, or a snapshot of your data will be preserved:
+
+```bash
+sudo snap remove lxd --purge
+```
+
+Verify that the snap and associated data were removed.
+The following commands should report that LXD is not installed and that the `/var/snap/lxd/` directory does not exist:
+
+```bash
+snap list lxd
+ls /var/snap/lxd/
+```
+
+```{note}
+If you followed a different method to {ref}`install LXD <installing>`, use your package manager to remove LXD.
+Then, delete the data in `/var/lib/lxd/`.
+```
+
+(howto-decommission-destroy-data)=
+## Destroy and sanitize data
+
+Data deleted by LXD remains readable and can be recovered by users with access to disks used in your deployment.
+To prevent unauthorized recovery, you must physically overwrite the data.
+
+Follow your data destruction policy to securely erase and destroy disks used by LXD, as well as disks on machines used to monitor LXD events or metrics.
+Consult storage providers for details about how to securely sanitize data on {ref}`remote storage <storage-drivers-remote>`.
+For deployments {ref}`configured for single sign-on with OIDC <authentication-openid>`, consult your OIDC identity provider for the steps to remove any associated data.
+
+```{important}
+Sanitized data is irreversibly destroyed and cannot be recovered.
+```

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -195,9 +195,9 @@ Configure the audit daemon to track all commands to the LXD daemon:
 -a always,exit -F path=/snap/bin/lxd.lxc -p x -k lxd_execution
 ```
 
-### `lxc monitor` and Loki
+### Monitor LXD events
 
-The`lxc monitor` command is used to view information about logging and life cycle LXD events. Consider using a dedicated system that allows you to keep a record of these events, such as Loki. See: {ref}`logs_loki`.
+Use the `lxc monitor` command to view information about logging and life cycle LXD events. Consider {ref}`sending logs to Loki <logs_loki>` or another dedicated system to keep a record of these events.
 
 (howto-security-harden-multi-user)=
 ## Multi-user environment

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -195,7 +195,7 @@ Configure the audit daemon to track all commands to the LXD daemon:
 -a always,exit -F path=/snap/bin/lxd.lxc -p x -k lxd_execution
 ```
 
-### `lxc` `monitor` and Loki
+### `lxc monitor` and Loki
 
 The`lxc monitor` command is used to view information about logging and life cycle LXD events. Consider using a dedicated system that allows you to keep a record of these events, such as Loki. See: {ref}`logs_loki`.
 

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -5,6 +5,11 @@ To increase the security posture of your LXD deployment, review the following ha
 
 ## General
 
+(howto-security-harden-update-operating-system)=
+### Update the operating system
+
+Keep your operating system up-to-date and install available security patches.
+
 (howto-security-harden-supported)=
 ### Use a supported version
 
@@ -23,7 +28,7 @@ Delete unused networks and storage pools to reduce the attack surface.
 
 Users in the `lxd` group who access LXD through the local Unix socket are given full administrative control over LXD. Thus, ensure that only trusted users are members of the `lxd` group (or any custom group you configure via `snap.lxd.daemon.group`). Audit group membership regularly.
 
-Also see: {ref}`howto-security-harden-restricted-group`.
+Also see {ref}`howto-security-harden-restricted-group`.
 
 (howto-security-harden-remote)=
 ### Harden remote API access
@@ -97,7 +102,7 @@ Rather than applying these options on a per-instance basis, use either {ref}`pro
 (howto-security-harden-unprivileged)=
 ### Use unprivileged containers
 
-By default, LXD containers are unprivileged. If you need to use privileged containers, make sure to put appropriate security measures in place. For more information, see: {ref}`container-security`.
+By default, LXD containers are unprivileged. If you need to use privileged containers, make sure to put appropriate security measures in place. For more information, see {ref}`container-security`.
 
 (howto-security-harden-instance-resource-limits)=
 ### Set instance resource limits
@@ -220,7 +225,7 @@ sudo snap set lxd daemon.user.group=lxdusers
 (howto-security-harden-projects)=
 ### Confine users to projects
 
-You can confine users to specific projects, which can be configured with stricter restrictions to prevent misuse. For details, see: {ref}`projects-confine-users`, {ref}`exp-projects`, and {ref}`restricted-tls-certs`.
+You can confine users to specific projects, which can be configured with stricter restrictions to prevent misuse. For details, see {ref}`projects-confine-users`, {ref}`exp-projects`, and {ref}`restricted-tls-certs`.
 
 (howto-security-harden-name-leakage)=
 ### Prevent name leakage

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -8,7 +8,8 @@ To increase the security posture of your LXD deployment, review the following ha
 (howto-security-harden-supported)=
 ### Use a supported version
 
-Use only supported LTS releases or the latest feature release of LXD, and ensure that you update it regularly to receive security updates and bugfixes. See: {ref}`ref-releases`.
+Use only supported LTS releases or the latest feature release of LXD, and update LXD regularly to receive security updates and bugfixes.
+See {ref}`ref-releases-snap` for details.
 
 (howto-security-harden-delete-unused)=
 ### Delete unused resources

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -31,6 +31,15 @@ Recover instances </howto/disaster_recovery>
 Disaster recovery with storage replication </howto/disaster_recovery_replication>
 ```
 
+How to decommission your LXD deployment:
+
+```{toctree}
+:titlesonly:
+
+Decommission LXD </howto/decommission>
+```
+
+
 ## Related topics
 
 {{performance_exp}}

--- a/doc/reference/releases-snap.md
+++ b/doc/reference/releases-snap.md
@@ -8,7 +8,8 @@ relatedlinks: "[Snap&#32;documentation](https://snapcraft.io/docs),[LXD&#32;snap
 (ref-releases)=
 ## Releases
 
-The LXD team maintains both Long Term Support (LTS) and feature releases in parallel. Release notes are published on [Discourse](https://discourse.ubuntu.com/tags/c/lxd/news/143/release).
+The LXD team maintains both Long Term Support (LTS) and feature releases in parallel.
+See our {ref}`ref-release-notes` for details about each release.
 
 (ref-releases-lts)=
 ### LTS releases


### PR DESCRIPTION
This PR backports changes to the documentation introduced in PRs #18444, #18445, #18507, and #18527 to bring the documentation into alignment with the company's SSDLC policies.

In the process, this PR also backports PR #18557.

Commits that referenced features and/or details introduced in LXD 6 were either ignored or amended. For example:

- References to security events were removed
- Instructions to delete replicators and cluster links were removed from the decommissioning guide

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
