### PR TITLE
github: Sync to lxd-private on push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1420,7 +1420,7 @@ jobs:
   snap:
     name: Trigger snap build
     runs-on: ubuntu-24.04
-    needs: [code-tests, system-tests, client, documentation]
+    #needs: [code-tests, system-tests, client, documentation]
     if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -1456,7 +1456,7 @@ jobs:
           # Sync the rebased lxd-private branch back to the lxd-private repo so that it is kept in sync with the public repo.
           # Do this before any snapcraft.yaml modifications made below.
           # Use --force-with-lease and --force-if-includes to ensure local branch includes contents from lxd-private remote.
-          git push --quiet --force-with-lease="refs/heads/lxd-private-${GITHUB_REF_NAME}" --force-if-includes lxd-private HEAD:"${GITHUB_REF_NAME}"
+          git push --quiet --force-with-lease="refs/heads/${GITHUB_REF_NAME}" --force-if-includes lxd-private HEAD:"${GITHUB_REF_NAME}"
 
           # Extract a strict major.minor[.patch] version from shared/version/flex.go.
           version="$(sed -nE 's/^var Version = "([0-9]+\.[0-9]+(\.[0-9]+)?)"$/\1/p' "${GITHUB_WORKSPACE}/shared/version/flex.go")"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1453,6 +1453,11 @@ jobs:
           git checkout --quiet -B "lxd-private-${GITHUB_REF_NAME}" "lxd-private/${GITHUB_REF_NAME}"
           git rebase --quiet --no-stat "origin/${GITHUB_REF_NAME}"
 
+          # Sync the rebased lxd-private branch back to the lxd-private repo so that it is kept in sync with the public repo.
+          # Do this before any snapcraft.yaml modifications made below.
+          # Use --force-with-lease and --force-if-includes to ensure local branch includes contents from lxd-private remote.
+          git push --quiet --force-with-lease="refs/heads/lxd-private-${GITHUB_REF_NAME}" --force-if-includes lxd-private HEAD:"${GITHUB_REF_NAME}"
+
           # Extract a strict major.minor[.patch] version from shared/version/flex.go.
           version="$(sed -nE 's/^var Version = "([0-9]+\.[0-9]+(\.[0-9]+)?)"$/\1/p' "${GITHUB_WORKSPACE}/shared/version/flex.go")"
 


### PR DESCRIPTION
So that lxd-private branches are kept up to date.