### PR TITLE
snap: remove unnecessary handling of monaco editor

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1670,9 +1670,6 @@ parts:
       yarn install
       yarn build
 
-      # Drop unused localisation files from Monaco Editor (the UI does not allow localization)
-      rm -f build/ui/monaco-editor/min/vs/nls.messages.*.js
-
       mkdir -p "${CRAFT_PART_INSTALL}/share"
       cp -R build/ui "${CRAFT_PART_INSTALL}/share/lxd-ui/"
     prime:


### PR DESCRIPTION
## Done
- Remove unnecessary handling of monaco editor in snapcraft.yaml after it was removed from the UI in https://github.com/canonical/lxd-ui/pull/2068

## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x ] I have checked and added or updated relevant documentation.
