### PR TITLE
lxd/operations: Fix unprotected write to operation metadata

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -915,8 +915,7 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 	}
 
 	// Get current metadata.
-	newMetadata := op.metadata
-	op.lock.Unlock()
+	newMetadata := maps.Clone(op.metadata)
 
 	// Merge with current one.
 	if op.metadata == nil {
@@ -927,11 +926,11 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 
 	newMetadata, err := validateMetadata(newMetadata)
 	if err != nil {
+		op.lock.Unlock()
 		return fmt.Errorf("Failed extending operation metadata: %w", err)
 	}
 
 	// Update the operation.
-	op.lock.Lock()
 	op.updatedAt = time.Now()
 	op.metadata = newMetadata
 	op.lock.Unlock()


### PR DESCRIPTION
`newMetadata` is assigned to `op.metadata` within the lock, but this is a pointer, so the call to `maps.Copy` is writing to the actual `op.metadata` outside of the lock. Fix by cloning `op.metadata` while the lock is held.

Closes #18534

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
