### PR TITLE
Resources: Fix bcache device handling

### DIFF
--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -183,8 +183,23 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				// List of recognized virtual device types.
 				// Extending this list should be accommodated by setting the UsedBy field to the actual type.
 				virtualDevices := []string{"bcache"}
-				isVirtualDevicePath := func(v string) bool {
-					return pathExists(filepath.Join(entryPath, v)) && !pathExists(filepath.Join(entryPath, "partition"))
+				isVirtualDevicePath := func(deviceType string) bool {
+					// Skip partitions.
+					if pathExists(filepath.Join(entryPath, "partition")) {
+						return false
+					}
+
+					virtualDeviceTypePath := filepath.Join(entryPath, deviceType)
+					isVirtualDevice := pathExists(virtualDeviceTypePath)
+
+					// Identify if the disk is in use by any virtual device.
+					// In case of bcache the device's own ./bcache path is a link, not a directory.
+					// When adding more virtual types, check the behavior is identical to bcache.
+					if isVirtualDevice && pathIsDir(virtualDeviceTypePath) {
+						disk.UsedBy = deviceType
+					}
+
+					return isVirtualDevice
 				}
 
 				if !slices.ContainsFunc(virtualDevices, isVirtualDevicePath) {
@@ -479,12 +494,6 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			disk.DeviceFSUUID, err = block.DiskFSUUID(devPath)
 			if err != nil && !errors.Is(err, os.ErrPermission) {
 				return nil, err
-			}
-
-			// Identify if the disk is in use by any bcache device.
-			// The bcache device's own 'bcache' path is a link, not a directory.
-			if pathIsDir(filepath.Join(devicePath, "bcache")) {
-				disk.UsedBy = "bcache"
 			}
 
 			// Add to list

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -172,21 +173,28 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			entryPath := filepath.Join(sysClassBlock, entryName)
 			devicePath := filepath.Join(entryPath, "device")
 
-			// Only keep the main entries not partitions.
-			// Also account for bcache devices.
-			if !pathExists(devicePath) {
-				if !pathExists(filepath.Join(entryPath, "bcache")) {
-					continue
-				}
-
-				// The bcache virtual device's info is listed right under its entryPath.
-				devicePath = entryPath
-			}
-
 			// Setup the entry
 			disk := api.ResourcesStorageDisk{}
 			disk.ID = entryName
 			devPath := filepath.Join("/dev", entryName)
+
+			// Only keep the main entries not partitions.
+			if !pathExists(devicePath) {
+				// List of recognized virtual device types.
+				// Extending this list should be accommodated by setting the UsedBy field to the actual type.
+				virtualDevices := []string{"bcache"}
+				isVirtualDevicePath := func(v string) bool {
+					return pathExists(filepath.Join(entryPath, v)) && !pathExists(filepath.Join(entryPath, "partition"))
+				}
+
+				if !slices.ContainsFunc(virtualDevices, isVirtualDevicePath) {
+					continue
+				}
+
+				// For virtual block devices (for example bcache) there is no ./device directory.
+				// Use the entry path itself as the device source.
+				devicePath = entryPath
+			}
 
 			// Firmware revision
 			firmwareRevPath := filepath.Join(devicePath, "firmware_rev")

--- a/test/suites/resources.sh
+++ b/test/suites/resources.sh
@@ -20,15 +20,27 @@ test_resources_bcache() {
   configure_loop_device loop_file_1 loop_device_1 300M
   configure_loop_device loop_file_2 loop_device_2 300M
 
+  # Create a partition on the backing device using the loop device's entire size.
+  # shellcheck disable=SC2154
+  parted -s "${loop_device_2}" mklabel gpt mkpart primary 0% 100%
+
+  # Wait for the partition to be present.
+  # shellcheck disable=SC2154
+  partprobe "${loop_device_2}"
+  udevadm settle
+
+  # shellcheck disable=SC2154
+  backing_device_partition="${loop_device_2}p1"
+
   # Create bcache device.
   # shellcheck disable=SC2154
-  make-bcache -C "${loop_device_1}" -B "${loop_device_2}"
+  make-bcache -C "${loop_device_1}" -B "${backing_device_partition}"
 
   # Register bcache device.
   # shellcheck disable=SC2154
   echo "${loop_device_1}" > /sys/fs/bcache/register
   # shellcheck disable=SC2154
-  echo "${loop_device_2}" > /sys/fs/bcache/register
+  echo "${backing_device_partition}" > /sys/fs/bcache/register
 
   # Print for debugging purposes.
   lxc query /1.0/resources | jq --exit-status '.storage.disks'
@@ -38,19 +50,20 @@ test_resources_bcache() {
 
   # Get the bcache cache and backing devices.
   cache_device_base="$(basename "${loop_device_1}")"
-  backing_device_base="$(basename "${loop_device_2}")"
+  backing_device_base="$(basename "${loop_device_2}")/$(basename "${backing_device_partition}")"
   cache_device="$(< "/sys/block/${cache_device_base}/dev")"
   backing_device="$(< "/sys/block/${backing_device_base}/dev")"
 
   # Check the devices are actually used for the bcache device as cache and backing.
   [ "$(< "/sys/block/bcache0/slaves/${cache_device_base}/dev")" = "${cache_device}" ]
-  [ "$(< "/sys/block/bcache0/slaves/${backing_device_base}/dev")" = "${backing_device}" ]
+  [ "$(< "/sys/block/bcache0/slaves/$(basename "${backing_device_partition}")/dev")" = "${backing_device}" ]
 
   # Check the devices are marked in use by bcache.
   # The actual bcache device should report an unset 'used_by' field.
+  # The backing device is not visible as partitions are not reported as individual disks.
   lxc query /1.0/resources | jq --exit-status '.storage.disks[] | select(.id == "bcache0") | .used_by == null'
   lxc query /1.0/resources | jq --exit-status '.storage.disks[] | select(.device == "'"${cache_device}"'") | .used_by == "bcache"'
-  lxc query /1.0/resources | jq --exit-status '.storage.disks[] | select(.device == "'"${backing_device}"'") | .used_by == "bcache"'
+  lxc query /1.0/resources | jq --exit-status '([.storage.disks[] | select(.device == "'"${backing_device}"'")] | length) == 0'
 
   # Cleanup
   echo 1 > /sys/block/bcache0/bcache/stop


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/18688.

Ensure that if bcache devices using partitions for either backing or cache, those are not treated as actual disks and excluded as we usually do.