### PR TITLE
Revert "lxd-ui: drop unused localization files"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1670,9 +1670,6 @@ parts:
       yarn install
       yarn build
 
-      # Drop unused localisation files from Monaco Editor (the UI does not allow localization)
-      rm -f build/ui/monaco-editor/min/vs/nls.messages.*.js
-
       mkdir -p "${CRAFT_PART_INSTALL}/share"
       cp -R build/ui "${CRAFT_PART_INSTALL}/share/lxd-ui/"
     prime:


### PR DESCRIPTION
This reverts commit 9c30f77b85b72fdcbc24840941f3450f708af7e3.

The LXD UI no longer ships the Monaco editor.