### PR TITLE
lxd/instance_file: avoid dead code in switch case

### DIFF
--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -261,9 +261,9 @@ func instanceFileGet(ctx context.Context, s *state.State, inst instance.Instance
 
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(ctx, inst, logger.Ctx{"path": path}))
 		return response.SyncResponseHeaders(true, dirEnts, headers)
-	default:
-		return response.InternalError(fmt.Errorf("Bad file type: %s", fileType))
 	}
+
+	return response.InternalError(fmt.Errorf("Bad file type: %s", fileType))
 }
 
 // swagger:operation HEAD /1.0/instances/{name}/files instances instance_files_head


### PR DESCRIPTION
TiCS rightly flagged this branch was dead. Moving the fallback out of the switch should appease it.
