### PR TITLE
Test ACME certificate renewal in a cluster

### DIFF
--- a/test/includes/acme.sh
+++ b/test/includes/acme.sh
@@ -19,10 +19,20 @@ spawn_acme() {
   echo $! > "${TEST_DIR}/acme.pid"
 
   # Wait for the server to be ready.
-  for _ in $(seq 3); do
-    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null && break
+  success=0
+  for _ in $(seq 10); do
+    if curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null; then
+      success=1
+      break
+    fi
+
     sleep 0.1
   done
+
+  if [ "${success}" = 0 ]; then
+    echo "mini-acme: Not available within 1 second"
+    false
+  fi
 }
 
 kill_acme() {

--- a/test/includes/acme.sh
+++ b/test/includes/acme.sh
@@ -1,21 +1,26 @@
 # mini-acme related test helpers.
 
-# spawn_acme [<validation-addr>]
+# spawn_acme [<validation-addr> [<listen-addr>]]
 # Start mini-acme with optional HTTP-01 validation against the given address.
 spawn_acme() {
   # Return if ACME is already set up.
   [ -e "${TEST_DIR}/acme.pid" ] && return
 
+  local validation_addr="${1:-}"
+  local listen_addr="${2:-127.0.0.1}"
+
   local port
   port="$(local_tcp_port)"
   echo "${port}" > "${TEST_DIR}/acme.port"
 
-  mini-acme "${port}" "${TEST_DIR}/mini-acme-ca.crt" "${1:-}" &
+  local addr="${listen_addr}:${port}"
+
+  mini-acme "${addr}" "${TEST_DIR}/mini-acme-ca.crt" "${validation_addr}" &
   echo $! > "${TEST_DIR}/acme.pid"
 
   # Wait for the server to be ready.
   for _ in $(seq 3); do
-    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://127.0.0.1:${port}/directory" 2>/dev/null && break
+    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null && break
     sleep 0.1
   done
 }

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -53,6 +53,7 @@ readonly test_group_cluster=(
     "clustering_link_info"
     "clustering_image_proxy_bypass"
     "clustering_link_unidirectional"
+    "clustering_acme"
 )
 
 readonly test_group_cluster_storage=(

--- a/test/mini-acme/main.go
+++ b/test/mini-acme/main.go
@@ -42,13 +42,12 @@ uKFxOelIgsiZJXKZNCX0FBmrfpCkKklCcg==
 // validation when a validation target address is provided.
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: mini-acme <port> <ca-cert-path> [<validation-addr>]")
+		fmt.Fprintln(os.Stderr, "Usage: mini-acme <listen-addr> <ca-cert-path> [<validation-addr>]")
 		os.Exit(1)
 	}
 
-	port := os.Args[1]
+	addr := os.Args[1]
 	caCertPath := os.Args[2]
-	addr := "127.0.0.1:" + port
 
 	var validationAddr string
 	if len(os.Args) >= 4 {
@@ -139,11 +138,21 @@ func newServer(addr string, validationAddr string) (*acmeServer, error) {
 
 	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
 
-	// Generate a TLS serving certificate for 127.0.0.1 signed by the CA.
+	// Generate a TLS serving certificate for the listen address signed by the CA.
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting listen IP address: %w", err)
+	}
+
+	hostIP := net.ParseIP(host)
+	if hostIP == nil {
+		return nil, fmt.Errorf("Invalid IP %q", host)
+	}
+
 	tlsCertDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
 		SerialNumber: big.NewInt(2),
 		Subject:      pkix.Name{CommonName: "mini-acme"},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		IPAddresses:  []net.IP{hostIP},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6944,3 +6944,87 @@ test_clustering_link_unidirectional() {
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_ONE_DIR}"
 }
+
+test_clustering_acme() {
+  echo "==> Setting up clustering ACME test"
+
+  # Set up the clustering bridge (100.64.1.1/16)
+  setup_clustering_bridge
+
+  # Start mini-acme on the bridge IP so it's reachable from all cluster nodes.
+  local ACME_DOMAIN="lxd$$.example.com"
+
+  # Syntax: spawn_acme <validation-addr> <listen-addr>
+  # - Listen on bridge IP (100.64.1.1) accessible from all cluster nodes
+  # - Validate against node1 (100.64.1.101:8443) since it is the leader
+  # - Advertise bridge IP in ACME directory URLs
+  spawn_acme "100.64.1.101:8443" "100.64.1.1"
+
+  local ACME_PORT
+  ACME_PORT="$(< "${TEST_DIR}/acme.port")"
+
+  sub_test "Bootstrap cluster with ACME CA certificate"
+
+  echo "Create cluster with 3 nodes."
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_bootstrap_cluster
+
+  local cert
+  cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
+
+  # Spawn a second node
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_join_cluster "${cert}" 2 1 "${LXD_ONE_DIR}"
+
+  # Spawn a third node
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_join_cluster "${cert}" 3 1 "${LXD_ONE_DIR}"
+
+  sub_test "Configure ACME on cluster node"
+
+  # Configure ACME to use mini-acme server. Use LXD_TWO (leader is LXD_ONE) to update the config so that we test config
+  # forwarding and updating of certificates across the cluster.
+  LXD_DIR="${LXD_TWO_DIR}" lxc config set \
+    acme.agree_tos=true \
+    acme.ca_url="https://100.64.1.1:${ACME_PORT}/directory" \
+    acme.domain="${ACME_DOMAIN}" \
+    acme.email="coyote@acme.example.com"
+
+  sub_test "Verify ACME certificate is served"
+
+  # Verify all members are using the ACME certificate
+  for i in $(seq 3); do
+    success=0
+    for _ in $(seq 10); do
+      # Use --resolve to map domain to the cluster node IP.
+      if curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" --resolve "${ACME_DOMAIN}:8443:100.64.1.10${i}" -o /dev/null "https://${ACME_DOMAIN}:8443/"; then
+        success=1
+        break
+      fi
+
+      sleep 0.3
+    done
+
+    if [ "${success}" = 0 ]; then
+      echo "Failed verifying ACME certificate on member ${i}"
+      false
+    fi
+  done
+
+  # Cleanup
+  echo "==> Cleaning up clustering ACME test"
+
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_THREE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+
+  kill_acme
+}


### PR DESCRIPTION
#18508 is a regression of ACME in a cluster. There are no tests for ACME in 5.21 (no `mini-acme` helper) but this should prevent future regressions 6.9 and forward.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
