### PR TITLE
snap/edk2: bump to 2024.02-2ubuntu0.9 (MS 2023 keys) and switch to 4MB CODE (stable-5.0)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1237,11 +1237,45 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 
 	// Copy OVMF settings firmware to nvram file if needed.
 	// This firmware file can be modified by the VM so it must be copied from the defaults.
-	if d.architectureSupportsUEFI(d.architecture) && (!shared.PathExists(d.nvramPath()) || shared.IsTrue(d.localConfig["volatile.apply_nvram"])) {
-		err = d.setupNvram()
+	if d.architectureSupportsUEFI(d.architecture) {
+		// ovmfNeedsUpdate checks if the nvram file needs to be regenerated using a new template.
+		ovmfNeedsUpdate := func(nvramTarget string) bool {
+			if shared.InSnap() {
+				if filepath.Base(nvramTarget) == "qemu.nvram" {
+					// Older versions of LXD didn't setup a symlink from qemu.nvram to a named
+					// firmware variant specific file, but rather copied the template directly.
+					// So if the resolved target is in fact still just the qemu.nvram file we
+					// know it's an older version of the firmware and it needs regenerating.
+					return true
+				} else if strings.Contains(nvramTarget, "OVMF") && !strings.Contains(nvramTarget, "4MB") {
+					// The 2MB firmware was deprecated in the LXD snap.
+					// Detect this by the absence of "4MB" in the nvram file target.
+					return true
+				}
+			}
+
+			return false
+		}
+
+		// Check if nvram path and its target exist.
+		nvramMissing := false
+		nvramTarget, err := filepath.EvalSymlinks(d.nvramPath())
 		if err != nil {
-			op.Done(err)
-			return err
+			if !os.IsNotExist(err) {
+				op.Done(err)
+				return err
+			}
+
+			nvramMissing = true
+		}
+
+		// Decide if nvram file needs to be setup/refreshed.
+		if nvramMissing || shared.IsTrue(d.localConfig["volatile.apply_nvram"]) || ovmfNeedsUpdate(nvramTarget) {
+			err = d.setupNvram()
+			if err != nil {
+				op.Done(err)
+				return err
+			}
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7913,7 +7913,20 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 	}
 
 	if d.architectureSupportsUEFI(hostArch) {
-		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", filepath.Join(d.ovmfPath(), "OVMF_CODE.fd")))
+		// Locate a UEFI firmware to use for the feature checks.
+		var ovmfCode string
+		for _, firmware := range ovmfGenericFirmwares {
+			if shared.PathExists(filepath.Join(d.ovmfPath(), firmware.code)) {
+				ovmfCode = firmware.code
+				break
+			}
+		}
+
+		if ovmfCode == "" {
+			return nil, fmt.Errorf("Unable to locate a VM UEFI firmware")
+		}
+
+		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", filepath.Join(d.ovmfPath(), ovmfCode)))
 	}
 
 	var stderr bytes.Buffer

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1901,14 +1901,15 @@ func (d *qemu) setupNvram() error {
 		return err
 	}
 
-	// Generate a symlink if needed.
+	// Generate a symlink.
 	// This is so qemu.nvram can always be assumed to be the OVMF vars file.
 	// The real file name is then used to determine what firmware must be selected.
-	if !shared.PathExists(d.nvramPath()) {
-		err = os.Symlink(ovmfVarsName, d.nvramPath())
-		if err != nil {
-			return err
-		}
+	// Always refresh the symlink so that regenerating the NVRAM (e.g. when
+	// transitioning to a different firmware) points it at the new vars file.
+	_ = os.Remove(d.nvramPath())
+	err = os.Symlink(ovmfVarsName, d.nvramPath())
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -277,7 +277,7 @@ parts:
       - qemu
     source: https://git.launchpad.net/ubuntu/+source/edk2
     source-depth: 1
-    source-commit: e5417b4778d9298a546997449df5dfa096a71a7f # import/2024.02-2ubuntu0.7
+    source-commit: d63241dd1f7e26e4b2b8878fa6caf4439cd8a6b5 # import/2024.02-2ubuntu0.9
     source-type: git
     plugin: nil
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -360,9 +360,9 @@ parts:
       # Build the firmware (defaults to a RELEASE build)
       /usr/bin/make -f debian/rules "${BUILD_TARGET}"
 
-      cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.fd"
-      cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.fd"
-      cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.ms.fd"
+      cp "${SRC_DIR}/${SRC_CODE}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_CODE.4MB.fd"
+      cp "${SRC_DIR}/${SRC_VARS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.fd"
+      cp "${SRC_DIR}/${SRC_VARS_MS}" "${CRAFT_PART_INSTALL}/share/qemu/OVMF_VARS.4MB.ms.fd"
     prime:
       - share/qemu/*
 


### PR DESCRIPTION
Update to EDK2 with MS 2023 key injection logic and also switch to using 4MB CODE builds instead of the legacy 2MB variant.