### PR TITLE
GitHub: Cope with non-default branches in label assignment

### DIFF
--- a/.github/workflows/domain-reviewers.yml
+++ b/.github/workflows/domain-reviewers.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Always check out the repositories default branch.
+          # This is also important on non-default branches which might not have the domain owners file.
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github/domain-owners.json
           sparse-checkout-cone-mode: false
           persist-credentials: false


### PR DESCRIPTION
Should then be backported to all the non-default branches.