### PR TITLE
Backport ACME tests (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,6 +248,7 @@ jobs:
             /home/runner/go/bin/lxd-client
             /home/runner/go/bin/lxd-migrate
             /home/runner/go/bin/lxd-user
+            /home/runner/go/bin/mini-acme
             /home/runner/go/bin/mini-oidc
             /home/runner/go/bin/sysinfo
           retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,11 @@ fuidshift:
 	go install -v -trimpath -buildvcs=false $(COVER) ./fuidshift
 	@echo "$@ built successfully"
 
+.PHONY: mini-acme
+mini-acme:
+	go install -C test -v -trimpath -buildvcs=false $(COVER) ./mini-acme
+	@echo "$@ built successfully"
+
 .PHONY: mini-oidc
 mini-oidc:
 	go install -C test -v -trimpath -buildvcs=false $(COVER) ./mini-oidc
@@ -115,7 +120,7 @@ sysinfo:
 	@echo "$@ built successfully"
 
 .PHONY: test-binaries
-test-binaries: devlxd-client lxd-client fuidshift mini-oidc sysinfo
+test-binaries: devlxd-client lxd-client fuidshift mini-acme mini-oidc sysinfo
 	@echo "$@ built successfully"
 
 .PHONY: dqlite

--- a/lxd/acme/acme_test.go
+++ b/lxd/acme/acme_test.go
@@ -1,10 +1,15 @@
 package acme
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-acme/lego/v4/registration"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,6 +68,61 @@ func Test_certificateNeedsUpdate(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"Domain matches one of multiple DNS names",
+			args{
+				domain: "lxd.example.net",
+				cert: &x509.Certificate{
+					DNSNames: []string{"other.example.net", "lxd.example.net", "extra.example.net"},
+					NotAfter: time.Now().Add(90 * 24 * time.Hour),
+				},
+			},
+			false,
+		},
+		{
+			"Certificate has no DNS names",
+			args{
+				domain: "lxd.example.net",
+				cert: &x509.Certificate{
+					DNSNames: nil,
+					NotAfter: time.Now().Add(90 * 24 * time.Hour),
+				},
+			},
+			true,
+		},
+		{
+			"Certificate expires exactly at the 30 day boundary",
+			args{
+				domain: "lxd.example.net",
+				cert: &x509.Certificate{
+					DNSNames: []string{"lxd.example.net"},
+					NotAfter: time.Now().Add(30 * 24 * time.Hour),
+				},
+			},
+			true,
+		},
+		{
+			"Certificate expires just past the 30 day boundary",
+			args{
+				domain: "lxd.example.net",
+				cert: &x509.Certificate{
+					DNSNames: []string{"lxd.example.net"},
+					NotAfter: time.Now().Add(30*24*time.Hour + time.Hour),
+				},
+			},
+			false,
+		},
+		{
+			"Certificate already expired",
+			args{
+				domain: "lxd.example.net",
+				cert: &x509.Certificate{
+					DNSNames: []string{"lxd.example.net"},
+					NotAfter: time.Now().Add(-24 * time.Hour),
+				},
+			},
+			true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -71,4 +131,113 @@ func Test_certificateNeedsUpdate(t *testing.T) {
 			require.Equal(t, tt.want, needsUpdate)
 		})
 	}
+}
+
+func Test_user(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	reg := &registration.Resource{
+		URI: "https://acme.example.com/reg/1",
+	}
+
+	u := user{
+		Email:        "test@example.com",
+		Registration: reg,
+		Key:          privateKey,
+	}
+
+	t.Run("GetEmail", func(t *testing.T) {
+		require.Equal(t, "test@example.com", u.GetEmail())
+	})
+
+	t.Run("GetRegistration", func(t *testing.T) {
+		require.Equal(t, reg, u.GetRegistration())
+	})
+
+	t.Run("GetPrivateKey", func(t *testing.T) {
+		require.Equal(t, privateKey, u.GetPrivateKey())
+	})
+
+	t.Run("Zero value fields", func(t *testing.T) {
+		empty := user{}
+		require.Empty(t, empty.GetEmail())
+		require.Nil(t, empty.GetRegistration())
+		require.Nil(t, empty.GetPrivateKey())
+	})
+}
+
+func TestHTTP01Provider(t *testing.T) {
+	t.Run("NewHTTP01Provider returns non-nil provider", func(t *testing.T) {
+		p := NewHTTP01Provider()
+		require.NotNil(t, p)
+	})
+
+	t.Run("Initial values are empty", func(t *testing.T) {
+		p := NewHTTP01Provider()
+		require.Empty(t, p.Domain())
+		require.Empty(t, p.Token())
+		require.Empty(t, p.KeyAuth())
+	})
+
+	t.Run("Present sets values", func(t *testing.T) {
+		p := NewHTTP01Provider()
+
+		err := p.Present("lxd.example.net", "test-token", "test-key-auth")
+		require.NoError(t, err)
+
+		require.Equal(t, "lxd.example.net", p.Domain())
+		require.Equal(t, "test-token", p.Token())
+		require.Equal(t, "test-key-auth", p.KeyAuth())
+	})
+
+	t.Run("CleanUp clears values", func(t *testing.T) {
+		p := NewHTTP01Provider()
+
+		err := p.Present("lxd.example.net", "test-token", "test-key-auth")
+		require.NoError(t, err)
+
+		err = p.CleanUp("lxd.example.net", "test-token", "test-key-auth")
+		require.NoError(t, err)
+
+		require.Empty(t, p.Domain())
+		require.Empty(t, p.Token())
+		require.Empty(t, p.KeyAuth())
+	})
+
+	t.Run("Present overwrites previous values", func(t *testing.T) {
+		p := NewHTTP01Provider()
+
+		err := p.Present("first.example.net", "token-1", "key-auth-1")
+		require.NoError(t, err)
+
+		err = p.Present("second.example.net", "token-2", "key-auth-2")
+		require.NoError(t, err)
+
+		require.Equal(t, "second.example.net", p.Domain())
+		require.Equal(t, "token-2", p.Token())
+		require.Equal(t, "key-auth-2", p.KeyAuth())
+	})
+
+	t.Run("Concurrent access is safe", func(t *testing.T) {
+		p := NewHTTP01Provider()
+
+		var wg sync.WaitGroup
+
+		for i := range 50 {
+			wg.Add(1)
+
+			go func(i int) {
+				defer wg.Done()
+
+				_ = p.Present("domain.example.net", "token", "keyauth")
+				_ = p.Domain()
+				_ = p.Token()
+				_ = p.KeyAuth()
+				_ = p.CleanUp("domain.example.net", "token", "keyauth")
+			}(i)
+		}
+
+		wg.Wait()
+	})
 }

--- a/test/includes/acme.sh
+++ b/test/includes/acme.sh
@@ -1,0 +1,30 @@
+# mini-acme related test helpers.
+
+# spawn_acme [<validation-addr>]
+# Start mini-acme with optional HTTP-01 validation against the given address.
+spawn_acme() {
+  # Return if ACME is already set up.
+  [ -e "${TEST_DIR}/acme.pid" ] && return
+
+  local port
+  port="$(local_tcp_port)"
+  echo "${port}" > "${TEST_DIR}/acme.port"
+
+  mini-acme "${port}" "${TEST_DIR}/mini-acme-ca.crt" "${1:-}" &
+  echo $! > "${TEST_DIR}/acme.pid"
+
+  # Wait for the server to be ready.
+  for _ in $(seq 3); do
+    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://127.0.0.1:${port}/directory" 2>/dev/null && break
+    sleep 0.1
+  done
+}
+
+kill_acme() {
+  [ ! -e "${TEST_DIR}/acme.pid" ] && return
+
+  kill -9 "$(< "${TEST_DIR}/acme.pid")"
+  rm -f "${TEST_DIR}/acme.pid"
+  rm -f "${TEST_DIR}/acme.port"
+  rm -f "${TEST_DIR}/mini-acme-ca.crt"
+}

--- a/test/includes/acme.sh
+++ b/test/includes/acme.sh
@@ -19,10 +19,20 @@ spawn_acme() {
   echo $! > "${TEST_DIR}/acme.pid"
 
   # Wait for the server to be ready.
-  for _ in $(seq 3); do
-    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null && break
+  success=0
+  for _ in $(seq 10); do
+    if curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null; then
+      success=1
+      break
+    fi
+
     sleep 0.1
   done
+
+  if [ "${success}" = 0 ]; then
+    echo "mini-acme: Not available within 1 second"
+    false
+  fi
 }
 
 kill_acme() {

--- a/test/includes/acme.sh
+++ b/test/includes/acme.sh
@@ -1,21 +1,26 @@
 # mini-acme related test helpers.
 
-# spawn_acme [<validation-addr>]
+# spawn_acme [<validation-addr> [<listen-addr>]]
 # Start mini-acme with optional HTTP-01 validation against the given address.
 spawn_acme() {
   # Return if ACME is already set up.
   [ -e "${TEST_DIR}/acme.pid" ] && return
 
+  local validation_addr="${1:-}"
+  local listen_addr="${2:-127.0.0.1}"
+
   local port
   port="$(local_tcp_port)"
   echo "${port}" > "${TEST_DIR}/acme.port"
 
-  mini-acme "${port}" "${TEST_DIR}/mini-acme-ca.crt" "${1:-}" &
+  local addr="${listen_addr}:${port}"
+
+  mini-acme "${addr}" "${TEST_DIR}/mini-acme-ca.crt" "${validation_addr}" &
   echo $! > "${TEST_DIR}/acme.pid"
 
   # Wait for the server to be ready.
   for _ in $(seq 3); do
-    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://127.0.0.1:${port}/directory" 2>/dev/null && break
+    curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" -o /dev/null "https://${addr}/directory" 2>/dev/null && break
     sleep 0.1
   done
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -102,7 +102,7 @@ if ! check_dependencies minio mc; then
 fi
 
 echo "==> Checking test dependencies"
-if ! check_dependencies devlxd-client lxd-client fuidshift mini-oidc sysinfo; then
+if ! check_dependencies devlxd-client lxd-client fuidshift mini-oidc mini-acme sysinfo; then
   make -C "${MAIN_DIR}/.." test-binaries
 fi
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -500,6 +500,7 @@ fi
 
 if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "cluster" ]; then
     #run_test test_concurrent "concurrent startup" # Disabled as flaky.
+    run_test test_acme "ACME"
     run_test test_concurrent_exec "concurrent exec"
     run_test test_database_restore "database restore"
     run_test test_database_no_disk_space "database out of disk space"

--- a/test/main.sh
+++ b/test/main.sh
@@ -451,6 +451,7 @@ if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_enable "clustering enable"
     run_test test_clustering_edit_configuration "clustering config edit"
     run_test test_clustering_membership "clustering membership"
+    run_test test_clustering_acme "clustering ACME"
     run_test test_clustering_containers "clustering containers"
     run_test test_clustering_storage "clustering storage"
     run_test test_clustering_storage_single_node "clustering storage single node"

--- a/test/mini-acme/main.go
+++ b/test/mini-acme/main.go
@@ -1,0 +1,573 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// testECCP256 is an insecure, test-only key from RFC 9500, Section 2.3.
+// It can be used in tests to avoid slow key generation.
+var testECCP256 = func() *ecdsa.PrivateKey {
+	block, _ := pem.Decode([]byte(strings.ReplaceAll(
+		`-----BEGIN EC TESTING KEY-----
+MHcCAQEEIObLW92AqkWunJXowVR2Z5/+yVPBaFHnEedDk5WJxk/BoAoGCCqGSM49
+AwEHoUQDQgAEQiVI+I+3gv+17KN0RFLHKh5Vj71vc75eSOkyMsxFxbFsTNEMTLjV
+uKFxOelIgsiZJXKZNCX0FBmrfpCkKklCcg==
+-----END EC TESTING KEY-----`, "TESTING KEY", "PRIVATE KEY")))
+	key, _ := x509.ParseECPrivateKey(block.Bytes)
+	return key
+}()
+
+// mini-acme is a minimal ACME (RFC 8555) server for integration testing.
+// It serves HTTPS (required by RFC 8555) and supports HTTP-01 challenge
+// validation when a validation target address is provided.
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: mini-acme <port> <ca-cert-path> [<validation-addr>]")
+		os.Exit(1)
+	}
+
+	port := os.Args[1]
+	caCertPath := os.Args[2]
+	addr := "127.0.0.1:" + port
+
+	var validationAddr string
+	if len(os.Args) >= 4 {
+		validationAddr = os.Args[3]
+	}
+
+	srv, err := newServer(addr, validationAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write the CA certificate so that ACME clients can trust this server
+	// (e.g. via LEGO_CA_CERTIFICATES).
+	err = os.WriteFile(caCertPath, srv.caCertPEM, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing CA cert: %v\n", err)
+		os.Exit(1)
+	}
+
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, unix.SIGINT, unix.SIGTERM)
+
+	go func() {
+		<-sigchan
+		_ = srv.httpServer.Close()
+	}()
+
+	fmt.Fprintf(os.Stderr, "mini-acme listening on %s (HTTPS)\n", addr)
+
+	err = srv.listenAndServeTLS()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type acmeServer struct {
+	baseURL        string
+	validationAddr string
+	caKey          *ecdsa.PrivateKey
+	caCert         *x509.Certificate
+	caCertPEM      []byte
+	tlsCert        tls.Certificate
+	httpServer     *http.Server
+
+	mu         sync.Mutex
+	orders     map[string]*order
+	challenges map[string]*challenge
+	certs      map[string][]byte
+	nextID     int
+}
+
+type order struct {
+	domain string
+	status string
+	certID string
+}
+
+type challenge struct {
+	orderID string
+	token   string
+	status  string
+}
+
+func newServer(addr string, validationAddr string) (*acmeServer, error) {
+	caKey := testECCP256
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mini-acme CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(6 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating CA certificate: %w", err)
+	}
+
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		return nil, fmt.Errorf("Failed parsing CA certificate: %w", err)
+	}
+
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// Generate a TLS serving certificate for 127.0.0.1 signed by the CA.
+	tlsCertDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "mini-acme"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}, caCert, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating TLS certificate: %w", err)
+	}
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{tlsCertDER},
+		PrivateKey:  caKey,
+	}
+
+	s := &acmeServer{
+		baseURL:        "https://" + addr,
+		validationAddr: validationAddr,
+		caKey:          caKey,
+		caCert:         caCert,
+		caCertPEM:      caCertPEM,
+		tlsCert:        tlsCert,
+		orders:         make(map[string]*order),
+		challenges:     make(map[string]*challenge),
+		certs:          make(map[string][]byte),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /directory", s.handleDirectory)
+	mux.HandleFunc("HEAD /new-nonce", s.handleNewNonce)
+	mux.HandleFunc("GET /new-nonce", s.handleNewNonce)
+	mux.HandleFunc("POST /new-acct", s.handleNewAccount)
+	mux.HandleFunc("POST /new-order", s.handleNewOrder)
+	mux.HandleFunc("POST /authz/{id}", s.handleAuthz)
+	mux.HandleFunc("POST /challenge/{id}", s.handleChallenge)
+	mux.HandleFunc("POST /order/{id}/finalize", s.handleFinalize)
+	mux.HandleFunc("POST /order/{id}", s.handleOrder)
+	mux.HandleFunc("POST /cert/{id}", s.handleCert)
+
+	s.httpServer = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	return s, nil
+}
+
+// listenAndServeTLS starts the HTTPS server using the in-memory TLS certificate.
+func (s *acmeServer) listenAndServeTLS() error {
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{s.tlsCert},
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	ln, err := tls.Listen("tcp", s.httpServer.Addr, tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	return s.httpServer.Serve(ln)
+}
+
+func (s *acmeServer) allocID() string {
+	s.nextID++
+	return strconv.Itoa(s.nextID)
+}
+
+func (s *acmeServer) addNonce(w http.ResponseWriter) {
+	nonce := make([]byte, 16)
+	_, _ = rand.Read(nonce)
+	w.Header().Set("Replay-Nonce", base64.RawURLEncoding.EncodeToString(nonce))
+	w.Header().Set("Cache-Control", "no-store")
+}
+
+func (s *acmeServer) handleDirectory(w http.ResponseWriter, _ *http.Request) {
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"newNonce":   s.baseURL + "/new-nonce",
+		"newAccount": s.baseURL + "/new-acct",
+		"newOrder":   s.baseURL + "/new-order",
+	})
+}
+
+func (s *acmeServer) handleNewNonce(w http.ResponseWriter, _ *http.Request) {
+	s.addNonce(w)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *acmeServer) handleNewAccount(w http.ResponseWriter, _ *http.Request) {
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Location", s.baseURL+"/acct/1")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": "valid",
+	})
+}
+
+func (s *acmeServer) handleNewOrder(w http.ResponseWriter, r *http.Request) {
+	payload := parseJWSPayload(r)
+
+	var req struct {
+		Identifiers []struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		} `json:"identifiers"`
+	}
+
+	domain := "unknown"
+	if json.Unmarshal(payload, &req) == nil && len(req.Identifiers) > 0 {
+		domain = req.Identifiers[0].Value
+	}
+
+	s.mu.Lock()
+	id := s.allocID()
+	s.orders[id] = &order{
+		domain: domain,
+		status: "pending",
+	}
+
+	s.mu.Unlock()
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Location", s.baseURL+"/order/"+id)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": "pending",
+		"identifiers": []map[string]string{
+			{"type": "dns", "value": domain},
+		},
+		"authorizations": []string{s.baseURL + "/authz/" + id},
+		"finalize":       s.baseURL + "/order/" + id + "/finalize",
+	})
+}
+
+func (s *acmeServer) handleAuthz(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	s.mu.Lock()
+	ord := s.orders[id]
+	chal := s.challenges[id]
+	s.mu.Unlock()
+
+	if ord == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	chalStatus := "pending"
+	authzStatus := "pending"
+	if chal != nil && chal.status == "valid" {
+		chalStatus = "valid"
+		authzStatus = "valid"
+	}
+
+	// Auto-approve when no validation address is configured.
+	if s.validationAddr == "" {
+		chalStatus = "valid"
+		authzStatus = "valid"
+	}
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": authzStatus,
+		"identifier": map[string]string{
+			"type":  "dns",
+			"value": ord.domain,
+		},
+		"challenges": []map[string]any{
+			{
+				"type":   "http-01",
+				"url":    s.baseURL + "/challenge/" + id,
+				"token":  "token-" + id,
+				"status": chalStatus,
+			},
+		},
+	})
+}
+
+func (s *acmeServer) handleChallenge(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	s.mu.Lock()
+	ord := s.orders[id]
+	chal := s.challenges[id]
+	if chal == nil {
+		chal = &challenge{
+			orderID: id,
+			token:   "token-" + id,
+			status:  "pending",
+		}
+
+		s.challenges[id] = chal
+	}
+
+	s.mu.Unlock()
+
+	// Perform HTTP-01 validation if a validation address is configured.
+	if s.validationAddr != "" && chal.status == "pending" && ord != nil {
+		valid := s.validateHTTP01(chal.token)
+
+		s.mu.Lock()
+		if valid {
+			chal.status = "valid"
+		} else {
+			chal.status = "invalid"
+		}
+
+		s.mu.Unlock()
+	}
+
+	// Auto-approve when no validation address is configured.
+	if s.validationAddr == "" {
+		chal.status = "valid"
+	}
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":   "http-01",
+		"url":    s.baseURL + "/challenge/" + id,
+		"token":  chal.token,
+		"status": chal.status,
+	})
+}
+
+// validateHTTP01 performs HTTP-01 challenge validation by fetching the token
+// from the validation target's /.well-known/acme-challenge/ endpoint.
+func (s *acmeServer) validateHTTP01(token string) bool {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	url := "https://" + s.validationAddr + "/.well-known/acme-challenge/" + token
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "HTTP-01 validation failed for %s: %v\n", token, err)
+		return false
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "HTTP-01 validation failed for %s: status %d\n", token, resp.StatusCode)
+		return false
+	}
+
+	// The response must start with the token (full format is token.thumbprint).
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	if !strings.HasPrefix(string(buf[:n]), token) {
+		fmt.Fprintf(os.Stderr, "HTTP-01 validation failed for %s: unexpected response\n", token)
+		return false
+	}
+
+	return true
+}
+
+func (s *acmeServer) handleOrder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	s.mu.Lock()
+	ord := s.orders[id]
+	s.mu.Unlock()
+
+	if ord == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+
+	resp := map[string]any{
+		"status": ord.status,
+		"identifiers": []map[string]string{
+			{"type": "dns", "value": ord.domain},
+		},
+		"authorizations": []string{s.baseURL + "/authz/" + id},
+		"finalize":       s.baseURL + "/order/" + id + "/finalize",
+	}
+
+	if ord.certID != "" {
+		resp["certificate"] = s.baseURL + "/cert/" + ord.certID
+	}
+
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *acmeServer) handleFinalize(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	s.mu.Lock()
+	ord := s.orders[id]
+	s.mu.Unlock()
+
+	if ord == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	payload := parseJWSPayload(r)
+
+	var req struct {
+		CSR string `json:"csr"`
+	}
+
+	err := json.Unmarshal(payload, &req)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	csrDER, err := base64.RawURLEncoding.DecodeString(req.CSR)
+	if err != nil {
+		http.Error(w, "bad CSR encoding", http.StatusBadRequest)
+		return
+	}
+
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
+		http.Error(w, "bad CSR", http.StatusBadRequest)
+		return
+	}
+
+	certPEM, err := s.issueCertificate(csr, ord.domain)
+	if err != nil {
+		http.Error(w, "failed issuing cert", http.StatusInternalServerError)
+		return
+	}
+
+	s.mu.Lock()
+	certID := s.allocID()
+	s.certs[certID] = certPEM
+	ord.status = "valid"
+	ord.certID = certID
+	s.mu.Unlock()
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Location", s.baseURL+"/order/"+id)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": "valid",
+		"identifiers": []map[string]string{
+			{"type": "dns", "value": ord.domain},
+		},
+		"authorizations": []string{s.baseURL + "/authz/" + id},
+		"finalize":       s.baseURL + "/order/" + id + "/finalize",
+		"certificate":    s.baseURL + "/cert/" + certID,
+	})
+}
+
+func (s *acmeServer) handleCert(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	s.mu.Lock()
+	certPEM := s.certs[id]
+	s.mu.Unlock()
+
+	if certPEM == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	s.addNonce(w)
+	w.Header().Set("Content-Type", "application/pem-certificate-chain")
+	_, _ = w.Write(certPEM)
+}
+
+func (s *acmeServer) issueCertificate(csr *x509.CertificateRequest, domain string) ([]byte, error) {
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      csr.Subject,
+		DNSNames:     []string{domain},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(90 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, s.caCert, csr.PublicKey, s.caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	// Return the full chain: leaf + CA.
+	return append(leafPEM, s.caCertPEM...), nil
+}
+
+// parseJWSPayload extracts the decoded payload from a JWS request body.
+// Returns nil for POST-as-GET requests (empty payload) or on error.
+func parseJWSPayload(r *http.Request) []byte {
+	var jws struct {
+		Payload string `json:"payload"`
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&jws)
+	if err != nil {
+		return nil
+	}
+
+	if jws.Payload == "" {
+		return nil
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(jws.Payload)
+	if err != nil {
+		return nil
+	}
+
+	return payload
+}

--- a/test/mini-acme/main.go
+++ b/test/mini-acme/main.go
@@ -42,13 +42,12 @@ uKFxOelIgsiZJXKZNCX0FBmrfpCkKklCcg==
 // validation when a validation target address is provided.
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: mini-acme <port> <ca-cert-path> [<validation-addr>]")
+		fmt.Fprintln(os.Stderr, "Usage: mini-acme <listen-addr> <ca-cert-path> [<validation-addr>]")
 		os.Exit(1)
 	}
 
-	port := os.Args[1]
+	addr := os.Args[1]
 	caCertPath := os.Args[2]
-	addr := "127.0.0.1:" + port
 
 	var validationAddr string
 	if len(os.Args) >= 4 {
@@ -139,11 +138,21 @@ func newServer(addr string, validationAddr string) (*acmeServer, error) {
 
 	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
 
-	// Generate a TLS serving certificate for 127.0.0.1 signed by the CA.
+	// Generate a TLS serving certificate for the listen address signed by the CA.
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting listen IP address: %w", err)
+	}
+
+	hostIP := net.ParseIP(host)
+	if hostIP == nil {
+		return nil, fmt.Errorf("Invalid IP %q", host)
+	}
+
 	tlsCertDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
 		SerialNumber: big.NewInt(2),
 		Subject:      pkix.Name{CommonName: "mini-acme"},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		IPAddresses:  []net.IP{hostIP},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/test/suites/acme.sh
+++ b/test/suites/acme.sh
@@ -1,0 +1,30 @@
+test_acme() {
+  # Start the fake ACME server with HTTP-01 validation against LXD.
+  spawn_acme "${LXD_ADDR}"
+
+  # Restart LXD with the LEGO_CA_CERTIFICATES variable set so that it
+  # trusts the mini-acme CA certificate.
+  shutdown_lxd "${LXD_DIR}"
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" respawn_lxd "${LXD_DIR}" true
+
+  local ACME_DOMAIN="lxd$$.example.com"
+  local ACME_PORT
+  ACME_PORT="$(< "${TEST_DIR}/acme.port")"
+
+  sub_test "Set ACME configuration and trigger certificate renewal"
+  lxc config set acme.agree_tos=true acme.ca_url="https://127.0.0.1:${ACME_PORT}/directory" acme.domain="${ACME_DOMAIN}" acme.email=coyote@acme.example.com
+
+  sub_test "Verify LXD serves a certificate signed by the ACME CA"
+  local LXD_PORT="${LXD_ADDR##*:}"
+  curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" --resolve "${ACME_DOMAIN}:${LXD_PORT}:127.0.0.1" -o /dev/null "https://${ACME_DOMAIN}:${LXD_PORT}/"
+
+  sub_test "Clear ACME configuration"
+  lxc config set acme.agree_tos= acme.ca_url="" acme.domain="" acme.email=""
+
+  # Cleanup.
+  kill_acme
+  # Note: for speed considerations the LEGO_CA_CERTIFICATES variable is left in
+  # LXD's environment, but since the mini-acme server is stopped and the file
+  # removed it won't cause any issues. If we were to unset it, it would require
+  # respawning LXD again, which would add unnecessary overhead to the test suite.
+}

--- a/test/suites/acme.sh
+++ b/test/suites/acme.sh
@@ -11,6 +11,9 @@ test_acme() {
   local ACME_PORT
   ACME_PORT="$(< "${TEST_DIR}/acme.port")"
 
+  # Save the old certificate
+  cp "${LXD_DIR}/server.crt" "${LXD_DIR}/server.crt.bak"
+
   sub_test "Set ACME configuration and trigger certificate renewal"
   lxc config set acme.agree_tos=true acme.ca_url="https://127.0.0.1:${ACME_PORT}/directory" acme.domain="${ACME_DOMAIN}" acme.email=coyote@acme.example.com
 
@@ -23,8 +26,8 @@ test_acme() {
 
   # Cleanup.
   kill_acme
-  # Note: for speed considerations the LEGO_CA_CERTIFICATES variable is left in
-  # LXD's environment, but since the mini-acme server is stopped and the file
-  # removed it won't cause any issues. If we were to unset it, it would require
-  # respawning LXD again, which would add unnecessary overhead to the test suite.
+
+  shutdown_lxd "${LXD_DIR}"
+  mv "${LXD_DIR}/server.crt.bak" "${LXD_DIR}/server.crt"
+  respawn_lxd "${LXD_DIR}" true
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5322,3 +5322,101 @@ test_clustering_project_limits() {
 
   kill_lxd "${LXD_ONE_DIR}"
 }
+
+test_clustering_acme() {
+  echo "==> Setting up clustering ACME test"
+
+  # Set up the clustering bridge (100.64.1.1/16)
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  # Start mini-acme on the bridge IP so it's reachable from all cluster nodes.
+  local ACME_DOMAIN="lxd$$.example.com"
+
+  # Syntax: spawn_acme <validation-addr> <listen-addr>
+  # - Listen on bridge IP (100.64.1.1) accessible from all cluster nodes
+  # - Validate against node1 (100.64.1.101:8443) since it is the leader
+  # - Advertise bridge IP in ACME directory URLs
+  spawn_acme "100.64.1.101:8443" "100.64.1.1"
+
+  local ACME_PORT
+  ACME_PORT="$(< "${TEST_DIR}/acme.port")"
+
+  sub_test "Bootstrap cluster with ACME CA certificate"
+
+  local LXD_DIR
+
+  echo "Create cluster with 3 members."
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns1="${prefix}1"
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML has weird rules.
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}"
+
+  # Spawn a third node.
+  setup_clustering_netns 3
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns3="${prefix}3"
+  LEGO_CA_CERTIFICATES="${TEST_DIR}/mini-acme-ca.crt" spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
+
+  sub_test "Configure ACME on cluster node"
+
+  # Configure ACME to use mini-acme server. Use LXD_TWO (leader is LXD_ONE) to update the config so that we test config
+  # forwarding and updating of certificates across the cluster.
+  LXD_DIR="${LXD_TWO_DIR}" lxc config set \
+    acme.agree_tos=true \
+    acme.ca_url="https://100.64.1.1:${ACME_PORT}/directory" \
+    acme.domain="${ACME_DOMAIN}" \
+    acme.email="coyote@acme.example.com"
+
+  sub_test "Verify ACME certificate is served"
+
+  # Verify all members are using the ACME certificate
+  for i in $(seq 3); do
+    success=0
+    for _ in $(seq 10); do
+      # Use --resolve to map domain to the cluster node IP.
+      if curl -s --cacert "${TEST_DIR}/mini-acme-ca.crt" --resolve "${ACME_DOMAIN}:8443:100.64.1.10${i}" -o /dev/null "https://${ACME_DOMAIN}:8443/"; then
+        success=1
+        break
+      fi
+
+      sleep 0.3
+    done
+
+    if [ "${success}" = 0 ]; then
+      echo "Failed verifying ACME certificate on member ${i}"
+      false
+    fi
+  done
+
+  # Cleanup
+  echo "==> Cleaning up clustering ACME test"
+
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_THREE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_ONE_DIR}"
+
+  kill_acme
+}


### PR DESCRIPTION
Backports #17882 and #18702 to 5.21 to catch regressions such as #18508 (tests will fail unless #18697 is merged).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
