### PR TITLE
doc: consistently use "a LXD"

### DIFF
--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -93,7 +93,7 @@ The {ref}`snap:how-to-guides-work-with-snaps-manage-updates` page in the Snap do
 (howto-snap-updates-manual)=
 ### Manual updates
 
-For an LXD snap installed as part of a cluster, see the section on {ref}`synchronizing cluster updates <howto-snap-updates-sync>` below.
+For a LXD snap installed as part of a cluster, see the section on {ref}`synchronizing cluster updates <howto-snap-updates-sync>` below.
 
 Otherwise, run:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -35,7 +35,7 @@ These guides help you manage a standalone LXD server or a cluster of servers, in
 
 ### Workload management
 
-An LXD server runs workloads on containers or virtual machines, which are created using images and can be grouped using projects.
+A LXD server runs workloads on containers or virtual machines, which are created using images and can be grouped using projects.
 
 - **Instances**: {ref}`System containers and virtual machines <containers-and-vms>` • {ref}`Guest OS compatibility matrix <guest-os-compatibility>` • {ref}`Create <instances-create>`, {ref}`configure <instances-configure>`, and {ref}`manage <instances-manage>` instances • {ref}`Configuration options <instance-options>` • {ref}`Store configuration options in profiles <profiles>` • {ref}`Automate configuration with cloud-init <cloud-init>` • {ref}`Back up <instances-backup>`, {ref}`migrate <howto-instances-migrate>`, and {ref}`import <import-machines-to-instances>` instances • {ref}`Live migration <live-migration>`
 - **Images**: {ref}`About local and remote images <about-images>` • {ref}`List of remote image servers <remote-image-servers>` •  {ref}`Manage images <images-manage>`

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -26,7 +26,7 @@ Troubleshoot errors </howto/instances_troubleshoot.md>
 
 ## Attach instances to Ubuntu Pro
 
-An LXD server can automatically attach guest instances to its Ubuntu Pro subscription.
+A LXD server can automatically attach guest instances to its Ubuntu Pro subscription.
 
 ```{toctree}
 :titlesonly:

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -6,7 +6,7 @@ myst:
 
 # Production setup
 
-These how-to guides cover common operations to prepare an LXD server setup for production.
+These how-to guides cover common operations to prepare a LXD server setup for production.
 
 ## Optimize performance
 

--- a/doc/reference/releases-snap.md
+++ b/doc/reference/releases-snap.md
@@ -167,7 +167,7 @@ LXD cluster members must use the same version of the snap at all times. Thus, wh
 (ref-snap-database)=
 #### Database schema update and backup
 
-When the daemon restarts after an LXD update or upgrade, if a new database schema is detected, the database is updated. A backup of the database before the update is created and stored in the same location as the active database. If LXD is installed through the snap, this location is `/var/snap/lxd/common/lxd/database`. If installed by other means, the location is typically `/var/lib/lxd/database/`.
+When the daemon restarts after a LXD update or upgrade, if a new database schema is detected, the database is updated. A backup of the database before the update is created and stored in the same location as the active database. If LXD is installed through the snap, this location is `/var/snap/lxd/common/lxd/database`. If installed by other means, the location is typically `/var/lib/lxd/database/`.
 
 ## Related topics
 


### PR DESCRIPTION
A few small changes to consistently use "a LXD" rather than "an LXD," given the pronunciation "lɛks'di."

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
