### PR TITLE
lxd/operations: Fix unprotected write to operation metadata (release-6.9)

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -12,7 +12,7 @@ definitions:
                 x-go-name: AccessEntitlements
             description:
                 description: Description is a short description of the group.
-                example: Viewers of instance c1 in the default project.
+                example: Viewers of instance c1 in the default project
                 type: string
                 x-go-name: Description
             identities:
@@ -62,7 +62,7 @@ definitions:
         properties:
             description:
                 description: Description is a short description of the group.
-                example: Viewers of instance c1 in the default project.
+                example: Viewers of instance c1 in the default project
                 type: string
                 x-go-name: Description
             permissions:
@@ -78,7 +78,7 @@ definitions:
         properties:
             description:
                 description: Description is a short description of the group.
-                example: Viewers of instance c1 in the default project.
+                example: Viewers of instance c1 in the default project
                 type: string
                 x-go-name: Description
             name:
@@ -108,7 +108,10 @@ definitions:
                 type: array
                 x-go-name: AccessEntitlements
             certificate:
-                description: The certificate itself, as PEM encoded X509 certificate
+                description: |-
+                    The certificate itself, as PEM encoded X509 certificate
+
+                    API extension: certificate_self_renewal
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
@@ -124,7 +127,10 @@ definitions:
                 type: string
                 x-go-name: Name
             projects:
-                description: List of allowed projects (applies when restricted)
+                description: |-
+                    List of allowed projects (applies when restricted)
+
+                    API extension: certificate_project
                 example:
                     - default
                     - foo
@@ -134,7 +140,10 @@ definitions:
                 type: array
                 x-go-name: Projects
             restricted:
-                description: Whether to limit the certificate to listed projects
+                description: |-
+                    Whether to limit the certificate to listed projects
+
+                    API extension: certificate_project
                 example: true
                 type: boolean
                 x-go-name: Restricted
@@ -177,7 +186,10 @@ definitions:
                 type: string
                 x-go-name: Secret
             type:
-                description: Type is an indicator for which API (certificates or identities) to send the token.
+                description: |-
+                    Type is an indicator for which API (certificates or identities) to send the token.
+
+                    API extension: access_management_tls
                 example: Client certificate
                 type: string
                 x-go-name: Type
@@ -188,7 +200,10 @@ definitions:
         description: CertificatePut represents the modifiable fields of a LXD certificate
         properties:
             certificate:
-                description: The certificate itself, as PEM encoded X509 certificate
+                description: |-
+                    The certificate itself, as PEM encoded X509 certificate
+
+                    API extension: certificate_self_renewal
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
@@ -198,7 +213,10 @@ definitions:
                 type: string
                 x-go-name: Name
             projects:
-                description: List of allowed projects (applies when restricted)
+                description: |-
+                    List of allowed projects (applies when restricted)
+
+                    API extension: certificate_project
                 example:
                     - default
                     - foo
@@ -208,7 +226,10 @@ definitions:
                 type: array
                 x-go-name: Projects
             restricted:
-                description: Whether to limit the certificate to listed projects
+                description: |-
+                    Whether to limit the certificate to listed projects
+
+                    API extension: certificate_project
                 example: true
                 type: boolean
                 x-go-name: Restricted
@@ -223,7 +244,10 @@ definitions:
         description: CertificatesPost represents the fields of a new LXD certificate
         properties:
             certificate:
-                description: The certificate itself, as base64 encoded X509 PEM certificate
+                description: |-
+                    The certificate itself, as base64 encoded X509 PEM certificate
+
+                    API extension: certificate_self_renewal
                 example: base64 encoded X509 PEM certificate
                 type: string
                 x-go-name: Certificate
@@ -233,12 +257,19 @@ definitions:
                 type: string
                 x-go-name: Name
             password:
-                description: Server trust password (used to add an untrusted client, deprecated, use trust_token)
+                description: |-
+                    Server trust password (used to add an untrusted client, deprecated, use trust_token)
+
+                    Deprecated: Use TrustToken.
                 example: blah
                 type: string
+                x-deprecated: true
                 x-go-name: Password
             projects:
-                description: List of allowed projects (applies when restricted)
+                description: |-
+                    List of allowed projects (applies when restricted)
+
+                    API extension: certificate_project
                 example:
                     - default
                     - foo
@@ -248,17 +279,26 @@ definitions:
                 type: array
                 x-go-name: Projects
             restricted:
-                description: Whether to limit the certificate to listed projects
+                description: |-
+                    Whether to limit the certificate to listed projects
+
+                    API extension: certificate_project
                 example: true
                 type: boolean
                 x-go-name: Restricted
             token:
-                description: Whether to create a certificate add token
+                description: |-
+                    Whether to create a certificate add token
+
+                    API extension: certificate_token
                 example: true
                 type: boolean
                 x-go-name: Token
             trust_token:
-                description: Trust token (used to add an untrusted client)
+                description: |-
+                    Trust token (used to add an untrusted client)
+
+                    API extension: explicit_trust_token
                 example: blah
                 type: string
                 x-go-name: TrustToken
@@ -277,7 +317,10 @@ definitions:
                 type: boolean
                 x-go-name: Enabled
             member_config:
-                description: List of member configuration keys (used during join)
+                description: |-
+                    List of member configuration keys (used during join)
+
+                    API extension: clustering_join
                 example: []
                 items:
                     $ref: '#/definitions/ClusterMemberConfigKey'
@@ -427,7 +470,10 @@ definitions:
                 type: string
                 x-go-name: Type
             used_by:
-                description: UsedBy is a list of LXD entity URLs that reference the cluster link.
+                description: |-
+                    UsedBy is a list of LXD entity URLs that reference the cluster link.
+
+                    API extension: cluster_links_used_by
                 example:
                     - /1.0/replicators/my-replicator?project=default
                 items:
@@ -479,7 +525,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the cluster link.
-                example: Linked cluster.
+                example: Linked cluster
                 type: string
                 x-go-name: Description
         title: ClusterLinkPut represents the modifiable fields of a cluster link.
@@ -529,7 +575,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the cluster link.
-                example: Linked cluster.
+                example: Linked cluster
                 type: string
                 x-go-name: Description
             name:
@@ -556,14 +602,20 @@ definitions:
     ClusterMember:
         properties:
             architecture:
-                description: The primary architecture of the cluster member
+                description: |-
+                    The primary architecture of the cluster member
+
+                    API extension: clustering_architecture
                 example: x86_64
                 type: string
                 x-go-name: Architecture
             config:
                 additionalProperties:
                     type: string
-                description: Additional configuration information
+                description: |-
+                    Additional configuration information
+
+                    API extension: clustering_config
                 example:
                     scheduler.instance: all
                 type: object
@@ -574,17 +626,26 @@ definitions:
                 type: boolean
                 x-go-name: Database
             description:
-                description: Cluster member description
+                description: |-
+                    Cluster member description
+
+                    API extension: clustering_description
                 example: AMD Epyc 32c/64t
                 type: string
                 x-go-name: Description
             failure_domain:
-                description: Name of the failure domain for this cluster member
+                description: |-
+                    Name of the failure domain for this cluster member
+
+                    API extension: clustering_failure_domains
                 example: rack1
                 type: string
                 x-go-name: FailureDomain
             groups:
-                description: List of cluster groups this member belongs to
+                description: |-
+                    List of cluster groups this member belongs to
+
+                    API extension: clustering_groups
                 example:
                     - group1
                     - group2
@@ -598,7 +659,10 @@ definitions:
                 type: string
                 x-go-name: Message
             roles:
-                description: List of roles held by this cluster member
+                description: |-
+                    List of roles held by this cluster member
+
+                    API extension: clustering_roles
                 example:
                     - database
                 items:
@@ -709,23 +773,35 @@ definitions:
             config:
                 additionalProperties:
                     type: string
-                description: Additional configuration information
+                description: |-
+                    Additional configuration information
+
+                    API extension: clustering_config
                 example:
                     scheduler.instance: all
                 type: object
                 x-go-name: Config
             description:
-                description: Cluster member description
+                description: |-
+                    Cluster member description
+
+                    API extension: clustering_description
                 example: AMD Epyc 32c/64t
                 type: string
                 x-go-name: Description
             failure_domain:
-                description: Name of the failure domain for this cluster member
+                description: |-
+                    Name of the failure domain for this cluster member
+
+                    API extension: clustering_failure_domains
                 example: rack1
                 type: string
                 x-go-name: FailureDomain
             groups:
-                description: List of cluster groups this member belongs to
+                description: |-
+                    List of cluster groups this member belongs to
+
+                    API extension: clustering_groups
                 example:
                     - group1
                     - group2
@@ -734,7 +810,10 @@ definitions:
                 type: array
                 x-go-name: Groups
             roles:
-                description: List of roles held by this cluster member
+                description: |-
+                    List of roles held by this cluster member
+
+                    API extension: clustering_roles
                 example:
                     - database
                 items:
@@ -763,7 +842,10 @@ definitions:
                 type: string
                 x-go-name: Action
             force:
-                description: Permit evacuation even if it would drop the cluster below the required voter majority.
+                description: |-
+                    Permit evacuation even if it would drop the cluster below the required voter majority.
+
+                    API extension: clustering_evacuation_force
                 example: false
                 type: boolean
                 x-go-name: Force
@@ -772,6 +854,8 @@ definitions:
                     Override the configured evacuation mode.
                     Valid modes for the "evacuate" action are "stop", "migrate", and "live-migrate".
                     Valid modes for the "restore" action are "skip".
+
+                    API extension: clustering_evacuation_mode
                 example: stop
                 type: string
                 x-go-name: Mode
@@ -851,7 +935,10 @@ definitions:
                 type: string
                 x-go-name: ClusterCertificate
             cluster_token:
-                description: The cluster join token for the cluster you're trying to join
+                description: |-
+                    The cluster join token for the cluster you're trying to join
+
+                    API extension: explicit_trust_token
                 example: blah
                 type: string
                 x-go-name: ClusterToken
@@ -861,14 +948,20 @@ definitions:
                 type: boolean
                 x-go-name: Enabled
             member_config:
-                description: List of member configuration keys (used during join)
+                description: |-
+                    List of member configuration keys (used during join)
+
+                    API extension: clustering_join
                 example: []
                 items:
                     $ref: '#/definitions/ClusterMemberConfigKey'
                 type: array
                 x-go-name: MemberConfig
             server_address:
-                description: The local address to use for cluster communication
+                description: |-
+                    The local address to use for cluster communication
+
+                    API extension: clustering_join
                 example: 10.0.0.2:8443
                 type: string
                 x-go-name: ServerAddress
@@ -883,20 +976,22 @@ definitions:
         description: Event represents an event entry (over websocket)
         properties:
             location:
-                description: Originating cluster member
+                description: |-
+                    Originating cluster member
+
+                    API extension: event_location
                 example: lxd01
                 type: string
                 x-go-name: Location
             metadata:
                 description: JSON encoded metadata (see EventLogging, EventLifecycle, Operation or EventSecurity)
-                example:
-                    action: instance-started
-                    context: {}
-                    source: /1.0/instances/c1
-                type: object
+                example: '{"action": "instance-started", "source": "/1.0/instances/c1", "context": {}}'
                 x-go-name: Metadata
             project:
-                description: Project the event belongs to.
+                description: |-
+                    Project the event belongs to.
+
+                    API extension: event_project
                 example: default
                 type: string
                 x-go-name: Project
@@ -1258,7 +1353,10 @@ definitions:
                 type: string
                 x-go-name: CreatedAt
             expires_at:
-                description: When the image becomes obsolete
+                description: |-
+                    When the image becomes obsolete
+
+                    API extension: images_expiry
                 example: "2025-03-23T20:00:00-04:00"
                 format: date-time
                 type: string
@@ -1280,7 +1378,10 @@ definitions:
                 type: string
                 x-go-name: LastUsedAt
             profiles:
-                description: List of profiles to use when creating from this image (if none provided by user)
+                description: |-
+                    List of profiles to use when creating from this image (if none provided by user)
+
+                    API extension: image_profiles
                 example:
                     - default
                 items:
@@ -1288,7 +1389,10 @@ definitions:
                 type: array
                 x-go-name: Profiles
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: images_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
@@ -1308,12 +1412,18 @@ definitions:
                 type: boolean
                 x-go-name: Public
             release_codename:
-                description: OS release codename
+                description: |-
+                    OS release codename
+
+                    API extension: image_extended_metadata
                 example: jammy
                 type: string
                 x-go-name: ReleaseCodename
             release_title:
-                description: OS release title
+                description: |-
+                    OS release title
+
+                    API extension: image_extended_metadata
                 example: 22.04 LTS
                 type: string
                 x-go-name: ReleaseTitle
@@ -1324,7 +1434,10 @@ definitions:
                 type: integer
                 x-go-name: Size
             type:
-                description: Type of image (container or virtual-machine)
+                description: |-
+                    Type of image (container or virtual-machine)
+
+                    API extension: image_types
                 example: container
                 type: string
                 x-go-name: Type
@@ -1381,7 +1494,10 @@ definitions:
                 type: string
                 x-go-name: Target
             type:
-                description: Alias type (container or virtual-machine)
+                description: |-
+                    Alias type (container or virtual-machine)
+
+                    API extension: image_types
                 example: container
                 type: string
                 x-go-name: Type
@@ -1440,7 +1556,10 @@ definitions:
                 type: string
                 x-go-name: Target
             type:
-                description: Alias type (container or virtual-machine)
+                description: |-
+                    Alias type (container or virtual-machine)
+
+                    API extension: image_types
                 example: container
                 type: string
                 x-go-name: Type
@@ -1461,7 +1580,10 @@ definitions:
                 type: string
                 x-go-name: Certificate
             profiles:
-                description: List of profiles to use
+                description: |-
+                    List of profiles to use
+
+                    API extension: image_copy_profile
                 example:
                     - default
                 items:
@@ -1469,7 +1591,10 @@ definitions:
                 type: array
                 x-go-name: Profiles
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: image_target_project
                 example: project1
                 type: string
                 x-go-name: Project
@@ -1562,13 +1687,19 @@ definitions:
                 type: boolean
                 x-go-name: AutoUpdate
             expires_at:
-                description: When the image becomes obsolete
+                description: |-
+                    When the image becomes obsolete
+
+                    API extension: images_expiry
                 example: "2025-03-23T20:00:00-04:00"
                 format: date-time
                 type: string
                 x-go-name: ExpiresAt
             profiles:
-                description: List of profiles to use when creating from this image (if none provided by user)
+                description: |-
+                    List of profiles to use when creating from this image (if none provided by user)
+
+                    API extension: image_profiles
                 example:
                     - default
                 items:
@@ -1606,7 +1737,10 @@ definitions:
                 type: string
                 x-go-name: Certificate
             image_type:
-                description: Type of image (container or virtual-machine)
+                description: |-
+                    Type of image (container or virtual-machine)
+
+                    API extension: image_types
                 example: container
                 type: string
                 x-go-name: ImageType
@@ -1626,7 +1760,10 @@ definitions:
         description: ImagesPost represents the fields available for a new LXD image
         properties:
             aliases:
-                description: Aliases to add to the image
+                description: |-
+                    Aliases to add to the image
+
+                    API extension: image_create_aliases
                 example:
                     - name: foo
                     - name: bar
@@ -1640,12 +1777,18 @@ definitions:
                 type: boolean
                 x-go-name: AutoUpdate
             compression_algorithm:
-                description: Compression algorithm to use when turning an instance into an image
+                description: |-
+                    Compression algorithm to use when turning an instance into an image
+
+                    API extension: image_compression_algorithm
                 example: gzip
                 type: string
                 x-go-name: CompressionAlgorithm
             expires_at:
-                description: When the image becomes obsolete
+                description: |-
+                    When the image becomes obsolete
+
+                    API extension: images_expiry
                 example: "2025-03-23T20:00:00-04:00"
                 format: date-time
                 type: string
@@ -1656,7 +1799,10 @@ definitions:
                 type: string
                 x-go-name: Filename
             profiles:
-                description: List of profiles to use when creating from this image (if none provided by user)
+                description: |-
+                    List of profiles to use when creating from this image (if none provided by user)
+
+                    API extension: image_profiles
                 example:
                     - default
                 items:
@@ -1701,7 +1847,10 @@ definitions:
                 type: string
                 x-go-name: Fingerprint
             image_type:
-                description: Type of image (container or virtual-machine)
+                description: |-
+                    Type of image (container or virtual-machine)
+
+                    API extension: image_types
                 example: container
                 type: string
                 x-go-name: ImageType
@@ -1716,7 +1865,10 @@ definitions:
                 type: string
                 x-go-name: Name
             project:
-                description: Source project name
+                description: |-
+                    Source project name
+
+                    API extension: image_source_project
                 example: project1
                 type: string
                 x-go-name: Project
@@ -1738,9 +1890,13 @@ definitions:
             type:
                 $ref: '#/definitions/SourceType'
             url:
-                description: Source URL (deprecated, image download from URL is no longer supported)
+                description: |-
+                    Source URL (deprecated, image download from URL is no longer supported)
+
+                    Deprecated: Image download from URL is no longer supported.
                 example: https://some-server.com/some-directory/
                 type: string
+                x-deprecated: true
                 x-go-name: URL
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
@@ -1762,7 +1918,10 @@ definitions:
                 type: string
                 x-go-name: ClusterCertificatePath
             cluster_token:
-                description: The cluster join token for the cluster you're trying to join
+                description: |-
+                    The cluster join token for the cluster you're trying to join
+
+                    API extension: explicit_trust_token
                 example: blah
                 type: string
                 x-go-name: ClusterToken
@@ -1772,14 +1931,20 @@ definitions:
                 type: boolean
                 x-go-name: Enabled
             member_config:
-                description: List of member configuration keys (used during join)
+                description: |-
+                    List of member configuration keys (used during join)
+
+                    API extension: clustering_join
                 example: []
                 items:
                     $ref: '#/definitions/ClusterMemberConfigKey'
                 type: array
                 x-go-name: MemberConfig
             server_address:
-                description: The local address to use for cluster communication
+                description: |-
+                    The local address to use for cluster communication
+
+                    API extension: clustering_join
                 example: 10.0.0.2:8443
                 type: string
                 x-go-name: ServerAddress
@@ -1842,7 +2007,7 @@ definitions:
         properties:
             Project:
                 description: Project in which the network will reside
-                example: '"default"'
+                example: default
                 type: string
             config:
                 additionalProperties:
@@ -1855,7 +2020,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the profile
+                description: |-
+                    Description of the profile
+
+                    API extension: entity_description
                 example: My new LXD bridge
                 type: string
                 x-go-name: Description
@@ -1885,11 +2053,11 @@ definitions:
         properties:
             Pool:
                 description: Storage pool in which the volume will reside
-                example: '"default"'
+                example: default
                 type: string
             Project:
                 description: Project in which the volume will reside
-                example: '"default"'
+                example: default
                 type: string
             config:
                 additionalProperties:
@@ -1901,12 +2069,18 @@ definitions:
                 type: object
                 x-go-name: Config
             content_type:
-                description: Volume content type (filesystem or block)
+                description: |-
+                    Volume content type (filesystem or block)
+
+                    API extension: custom_block_volumes
                 example: filesystem
                 type: string
                 x-go-name: ContentType
             description:
-                description: Description of the storage volume
+                description: |-
+                    Description of the storage volume
+
+                    API extension: entity_description
                 example: My custom volume
                 type: string
                 x-go-name: Description
@@ -1916,7 +2090,10 @@ definitions:
                 type: string
                 x-go-name: Name
             restore:
-                description: Name of a snapshot to restore
+                description: |-
+                    Name of a snapshot to restore
+
+                    API extension: storage_api_volume_snapshots
                 example: snap0
                 type: string
                 x-go-name: Restore
@@ -2029,7 +2206,10 @@ definitions:
                 type: array
                 x-go-name: Profiles
             project:
-                description: Instance project name
+                description: |-
+                    Instance project name
+
+                    API extension: instance_all_projects
                 example: foo
                 type: string
                 x-go-name: Project
@@ -2056,9 +2236,13 @@ definitions:
     InstanceBackup:
         properties:
             container_only:
-                description: Whether to ignore snapshots (deprecated, use instance_only)
+                description: |-
+                    Whether to ignore snapshots (deprecated, use instance_only)
+
+                    Deprecated: Use InstanceOnly.
                 example: false
                 type: boolean
+                x-deprecated: true
                 x-go-name: ContainerOnly
             created_at:
                 description: When the backup was created
@@ -2103,14 +2287,21 @@ definitions:
     InstanceBackupsPost:
         properties:
             compression_algorithm:
-                description: What compression algorithm to use
+                description: |-
+                    What compression algorithm to use
+
+                    API extension: backup_compression_algorithm
                 example: gzip
                 type: string
                 x-go-name: CompressionAlgorithm
             container_only:
-                description: Whether to ignore snapshots (deprecated, use instance_only)
+                description: |-
+                    Whether to ignore snapshots (deprecated, use instance_only)
+
+                    Deprecated: Use InstanceOnly.
                 example: false
                 type: boolean
+                x-deprecated: true
                 x-go-name: ContainerOnly
             expires_at:
                 description: When the backup expires (gets auto-deleted)
@@ -2134,7 +2325,10 @@ definitions:
                 type: boolean
                 x-go-name: OptimizedStorage
             version:
-                description: What backup format version to use
+                description: |-
+                    What backup format version to use
+
+                    API extension: backup_metadata_version
                 example: 1
                 format: uint32
                 type: integer
@@ -2151,7 +2345,10 @@ definitions:
                 type: integer
                 x-go-name: Height
             type:
-                description: Type of console to attach to (console or vga)
+                description: |-
+                    Type of console to attach to (console or vga)
+
+                    API extension: console_vga_type
                 example: console
                 type: string
                 x-go-name: Type
@@ -2333,7 +2530,10 @@ definitions:
                 type: array
                 x-go-name: Profiles
             project:
-                description: Instance project name
+                description: |-
+                    Instance project name
+
+                    API extension: instance_all_projects
                 example: foo
                 type: string
                 x-go-name: Project
@@ -2370,7 +2570,10 @@ definitions:
             Config:
                 additionalProperties:
                     type: string
-                description: Instance configuration file.
+                description: |-
+                    Instance configuration file.
+
+                    API extension: instance_move_config
                 example:
                     security.nesting: "true"
                 type: object
@@ -2379,7 +2582,10 @@ definitions:
                     additionalProperties:
                         type: string
                     type: object
-                description: Instance devices.
+                description: |-
+                    Instance devices.
+
+                    API extension: instance_move_config
                 example:
                     root:
                         path: /
@@ -2387,21 +2593,31 @@ definitions:
                         type: disk
                 type: object
             Profiles:
-                description: List of profiles applied to the instance.
+                description: |-
+                    List of profiles applied to the instance.
+
+                    API extension: instance_move_config
                 example:
                     - default
                 items:
                     type: string
                 type: array
             allow_inconsistent:
-                description: AllowInconsistent allow inconsistent copies when migrating.
+                description: |-
+                    AllowInconsistent allow inconsistent copies when migrating.
+
+                    API extension: instance_allow_inconsistent_copy
                 example: false
                 type: boolean
                 x-go-name: AllowInconsistent
             container_only:
-                description: Whether snapshots should be discarded (migration only, deprecated, use instance_only)
+                description: |-
+                    Whether snapshots should be discarded (migration only, deprecated, use instance_only)
+
+                    Deprecated: use InstanceOnly.
                 example: false
                 type: boolean
+                x-deprecated: true
                 x-go-name: ContainerOnly
             instance_only:
                 description: Whether snapshots should be discarded (migration only)
@@ -2424,17 +2640,26 @@ definitions:
                 type: string
                 x-go-name: Name
             override_snapshot_profiles:
-                description: Whether the instances's snapshot should receive target instances profile on copy
+                description: |-
+                    Whether the instances's snapshot should receive target instances profile on copy
+
+                    API extension: override_snapshot_profiles_on_copy
                 example: true
                 type: boolean
                 x-go-name: OverrideSnapshotProfiles
             pool:
-                description: Target pool for local cross-pool move
+                description: |-
+                    Target pool for local cross-pool move
+
+                    API extension: instance_pool_move
                 example: baz
                 type: string
                 x-go-name: Pool
             project:
-                description: Target project for local cross-project move
+                description: |-
+                    Target project for local cross-project move
+
+                    API extension: instance_project_move
                 example: foo
                 type: string
                 x-go-name: Project
@@ -2518,7 +2743,10 @@ definitions:
                 type: string
                 x-go-name: Restore
             restore_disk_volumes_mode:
-                description: Which disk volumes to restore from an instance snapshot. Possible values are "root" or "all-exclusive".
+                description: |-
+                    Which disk volumes to restore from an instance snapshot. Possible values are "root" or "all-exclusive".
+
+                    API extension: instance_snapshot_multi_volume
                 example: all-exclusive
                 type: string
                 x-go-name: RestoreDiskVolumesMode
@@ -2623,7 +2851,10 @@ definitions:
                 type: array
                 x-go-name: Profiles
             size:
-                description: Size of the snapshot in bytes
+                description: |-
+                    Size of the snapshot in bytes
+
+                    API extension: snapshot_disk_usage
                 example: 143360
                 format: int64
                 type: integer
@@ -2672,12 +2903,18 @@ definitions:
     InstanceSnapshotsPost:
         properties:
             disk_volumes_mode:
-                description: Which disk volumes to include in instance snapshot. Possible values are "root" or "all-exclusive".
+                description: |-
+                    Which disk volumes to include in instance snapshot. Possible values are "root" or "all-exclusive".
+
+                    API extension: instance_snapshot_multi_volume
                 example: all-exclusive
                 type: string
                 x-go-name: DiskVolumesMode
             expires_at:
-                description: When the snapshot expires (gets auto-deleted)
+                description: |-
+                    When the snapshot expires (gets auto-deleted)
+
+                    API extension: snapshot_expiry_creation
                 example: "2021-03-23T17:38:37.753398689-04:00"
                 format: date-time
                 type: string
@@ -2703,7 +2940,10 @@ definitions:
                 type: string
                 x-go-name: Alias
             allow_inconsistent:
-                description: Whether to ignore errors when copying (e.g. for volatile files)
+                description: |-
+                    Whether to ignore errors when copying (e.g. for volatile files)
+
+                    API extension: instance_allow_inconsistent_copy
                 example: false
                 type: boolean
                 x-go-name: AllowInconsistent
@@ -2718,12 +2958,19 @@ definitions:
                 type: string
                 x-go-name: Certificate
             container_only:
-                description: Whether the copy should skip the snapshots (for copy, deprecated, use instance_only)
+                description: |-
+                    Whether the copy should skip the snapshots (for copy, deprecated, use instance_only)
+
+                    Deprecated: Use InstanceOnly.
                 example: false
                 type: boolean
+                x-deprecated: true
                 x-go-name: ContainerOnly
             conversion_options:
-                description: Optional list of options that are used during image conversion (for conversion).
+                description: |-
+                    Optional list of options that are used during image conversion (for conversion).
+
+                    API extension: instance_import_conversion
                 example:
                     - format
                 items:
@@ -2756,7 +3003,10 @@ definitions:
                 type: string
                 x-go-name: Operation
             override_snapshot_profiles:
-                description: Whether the instances's snapshot should receive target instances profile on copy
+                description: |-
+                    Whether the instances's snapshot should receive target instances profile on copy
+
+                    API extension: override_snapshot_profiles_on_copy
                 example: true
                 type: boolean
                 x-go-name: OverrideSnapshotProfiles
@@ -2813,6 +3063,8 @@ definitions:
                 description: |-
                     Source disk size in bytes used to set the instance's volume size to accommodate the transferred root
                     disk. This value is ignored if the root disk device has a size explicitly configured (for conversion).
+
+                    API extension: instance_import_conversion
                 example: 12345
                 format: int64
                 type: integer
@@ -2876,7 +3128,10 @@ definitions:
     InstanceStateDisk:
         properties:
             total:
-                description: Total size in bytes. Uses 0 to convey that the instance has access to the entire pool's storage.
+                description: |-
+                    Total size in bytes. Uses 0 to convey that the instance has access to the entire pool's storage.
+
+                    API extension: instances_state_total
                 example: 502239232
                 format: int64
                 type: integer
@@ -2905,7 +3160,10 @@ definitions:
                 type: integer
                 x-go-name: SwapUsagePeak
             total:
-                description: Total memory size in bytes
+                description: |-
+                    Total memory size in bytes
+
+                    API extension: instances_state_total
                 example: 12297557
                 format: int64
                 type: integer
@@ -3179,14 +3437,20 @@ definitions:
                 type: string
                 x-go-name: Restore
             restore_disk_volumes_mode:
-                description: Which disk volumes to restore from an instance snapshot. Possible values are "root" or "all-exclusive".
+                description: |-
+                    Which disk volumes to restore from an instance snapshot. Possible values are "root" or "all-exclusive".
+
+                    API extension: instance_snapshot_multi_volume
                 example: all-exclusive
                 type: string
                 x-go-name: RestoreDiskVolumesMode
             source:
                 $ref: '#/definitions/InstanceSource'
             start:
-                description: Whether to start the instance after creation
+                description: |-
+                    Whether to start the instance after creation
+
+                    API extension: instance_create_start
                 example: true
                 type: boolean
                 x-go-name: Start
@@ -3233,42 +3497,45 @@ definitions:
         properties:
             condition:
                 description: Condition describes conditions under which the configuration key can be applied.
-                example: Virtual machines only.
+                example: Virtual machines only
                 type: string
                 x-go-name: Condition
             defaultdesc:
                 description: DefaultDescription contains a description of the configuration key.
-                example: A general description of a configuration key.
+                example: A general description of a configuration key
                 type: string
                 x-go-name: DefaultDescription
             longdesc:
                 description: LongDescription contains a long-form description of the configuration key.
-                example: A much more in-depth description of the configuration key, including where and how it is used.
+                example: A much more in-depth description of the configuration key, including where and how it is used
                 type: string
                 x-go-name: LongDescription
             managed:
                 description: Managed describes whether the configuration key is managed by LXD.
-                example: yes.
+                example: "yes"
                 type: string
                 x-go-name: Managed
             required:
                 description: Required describes conditions under which the configuration key is required.
-                example: On device creation.
+                example: On device creation
                 type: string
                 x-go-name: Required
             scope:
-                description: Scope describes the cluster member specificity of a configuration key. Options marked with a `global` scope are applied to all cluster members. Options marked with a `local` scope are set on a per-member basis.
+                description: |-
+                    Scope describes the cluster member specificity of a configuration key. Options marked with a `global` scope are applied to all cluster members. Options marked with a `local` scope are set on a per-member basis.
+
+                    API extension: metadata_configuration_scope
                 example: global
                 type: string
                 x-go-name: Scope
             shortdesc:
                 description: ShortDescription contains a short-form description of the configuration key.
-                example: A key for doing X.
+                example: A key for doing X
                 type: string
                 x-go-name: ShortDescription
             type:
                 description: Type describes the type of the key.
-                example: Comma delimited CIDR format subnets.
+                example: Comma delimited CIDR format subnets
                 type: string
                 x-go-name: Type
         title: MetadataConfigurationConfigKey contains metadata about a LXD server configuration option.
@@ -3306,7 +3573,7 @@ definitions:
         properties:
             description:
                 description: Description describes the entitlement.
-                example: Grants permission to do X, Y, and Z.
+                example: Grants permission to do X, Y, and Z
                 type: string
                 x-go-name: Description
             name:
@@ -3340,12 +3607,18 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the profile
+                description: |-
+                    Description of the profile
+
+                    API extension: entity_description
                 example: My new LXD bridge
                 type: string
                 x-go-name: Description
             locations:
-                description: Cluster members on which the network has been defined
+                description: |-
+                    Cluster members on which the network has been defined
+
+                    API extension: clustering
                 example:
                     - lxd01
                     - lxd02
@@ -3356,7 +3629,10 @@ definitions:
                 type: array
                 x-go-name: Locations
             managed:
-                description: Whether this is a LXD managed network
+                description: |-
+                    Whether this is a LXD managed network
+
+                    API extension: network
                 example: true
                 readOnly: true
                 type: boolean
@@ -3368,12 +3644,18 @@ definitions:
                 type: string
                 x-go-name: Name
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: networks_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
             status:
-                description: The state of the network (for managed network in clusters)
+                description: |-
+                    The state of the network (for managed network in clusters)
+
+                    API extension: clustering
                 example: Created
                 readOnly: true
                 type: string
@@ -3438,7 +3720,10 @@ definitions:
                 type: string
                 x-go-name: Name
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: network_acls_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
@@ -3763,12 +4048,18 @@ definitions:
                 type: string
                 x-go-name: Hwaddr
             location:
-                description: What cluster member this record was found on
+                description: |-
+                    What cluster member this record was found on
+
+                    API extension: network_leases_location
                 example: lxd01
                 type: string
                 x-go-name: Location
             project:
-                description: Name of the project of the entity related to the hostname
+                description: |-
+                    Name of the project of the entity related to the hostname
+
+                    API extension: network_allocations_ovn_uplink
                 example: default
                 type: string
                 x-go-name: Project
@@ -3856,7 +4147,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the load balancer pool.
-                example: My HTTPS load balancer pool.
+                example: My HTTPS load balancer pool
                 type: string
                 x-go-name: Description
             instances:
@@ -3895,7 +4186,7 @@ definitions:
                 x-go-name: Name
             target_port:
                 description: Optional target port to override the pool's default target port.
-                example: '"8443"'
+                example: "8443"
                 type: string
                 x-go-name: TargetPort
         title: NetworkLoadBalancerPoolInstance represents an instance in a load balancer pool.
@@ -3913,7 +4204,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the load balancer pool.
-                example: My HTTPS load balancer pool.
+                example: My HTTPS load balancer pool
                 type: string
                 x-go-name: Description
             instances:
@@ -3941,7 +4232,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the load balancer pool.
-                example: My HTTPS load balancer pool.
+                example: My HTTPS load balancer pool
                 type: string
                 x-go-name: Description
             instances:
@@ -4188,7 +4479,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the profile
+                description: |-
+                    Description of the profile
+
+                    API extension: entity_description
                 example: My new LXD bridge
                 type: string
                 x-go-name: Description
@@ -4433,7 +4727,10 @@ definitions:
                 type: string
                 x-go-name: Name
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: network_zones_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
@@ -4608,7 +4905,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the profile
+                description: |-
+                    Description of the profile
+
+                    API extension: entity_description
                 example: My new LXD bridge
                 type: string
                 x-go-name: Description
@@ -4691,7 +4991,10 @@ definitions:
                 type: string
                 x-go-name: Err
             err_code:
-                description: Operation error code
+                description: |-
+                    Operation error code
+
+                    API extension: bulk_operations
                 example: 404
                 format: int64
                 type: integer
@@ -4702,7 +5005,10 @@ definitions:
                 type: string
                 x-go-name: ID
             location:
-                description: Which cluster member this record was found on
+                description: |-
+                    Which cluster member this record was found on
+
+                    API extension: operation_location
                 example: lxd01
                 type: string
                 x-go-name: Location
@@ -4788,7 +5094,10 @@ definitions:
                 type: string
                 x-go-name: Err
             err_code:
-                description: Operation error code
+                description: |-
+                    Operation error code
+
+                    API extension: bulk_operations
                 example: 404
                 format: int64
                 type: integer
@@ -4799,7 +5108,10 @@ definitions:
                 type: string
                 x-go-name: ID
             location:
-                description: Which cluster member this record was found on
+                description: |-
+                    Which cluster member this record was found on
+
+                    API extension: operation_location
                 example: lxd01
                 type: string
                 x-go-name: Location
@@ -4976,12 +5288,18 @@ definitions:
                 type: string
                 x-go-name: Name
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: profiles_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
             used_by:
-                description: List of URLs of objects using this profile
+                description: |-
+                    List of URLs of objects using this profile
+
+                    API extension: profile_usedby
                 example:
                     - /1.0/instances/c1
                     - /1.0/instances/v1
@@ -5112,7 +5430,11 @@ definitions:
                 type: string
                 x-go-name: Name
             replica_mode:
-                description: Replica mode for the project (leader, standby, or empty)
+                description: |-
+                    Replica mode for the project (leader, standby, or empty)
+                    This field is updated via PUT /1.0/projects/<name>/state
+
+                    API extension: project_replica_mode
                 example: leader
                 readOnly: true
                 type: string
@@ -5309,7 +5631,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the replicator.
-                example: Backup cluster.
+                example: Backup cluster
                 type: string
                 x-go-name: Description
         title: ReplicatorPut represents the modifiable fields of a replicator.
@@ -5347,7 +5669,7 @@ definitions:
                 x-go-name: Config
             description:
                 description: Description of the replicator.
-                example: Backup cluster.
+                example: Backup cluster
                 type: string
                 x-go-name: Description
             name:
@@ -5383,7 +5705,10 @@ definitions:
         description: ResourcesCPU represents the cpu resources available on the system
         properties:
             architecture:
-                description: Architecture name
+                description: |-
+                    Architecture name
+
+                    API extension: resources_v2
                 example: x86_64
                 type: string
                 x-go-name: Architecture
@@ -5433,7 +5758,10 @@ definitions:
                 type: integer
                 x-go-name: Core
             die:
-                description: What die the CPU is a part of (for chiplet designs)
+                description: |-
+                    What die the CPU is a part of (for chiplet designs)
+
+                    API extension: resources_cpu_core_die
                 example: 0
                 format: uint64
                 type: integer
@@ -5513,7 +5841,10 @@ definitions:
                 type: integer
                 x-go-name: ID
             isolated:
-                description: Whether the thread has been isolated (outside of normal scheduling)
+                description: |-
+                    Whether the thread has been isolated (outside of normal scheduling)
+
+                    API extension: resource_cpu_isolated
                 example: false
                 type: boolean
                 x-go-name: Isolated
@@ -5571,7 +5902,10 @@ definitions:
             mdev:
                 additionalProperties:
                     $ref: '#/definitions/ResourcesGPUCardMdev'
-                description: Map of available mediated device profiles
+                description: |-
+                    Map of available mediated device profiles
+
+                    API extension: resources_gpu_mdev
                 example: null
                 type: object
                 x-go-name: Mdev
@@ -5601,7 +5935,10 @@ definitions:
             sriov:
                 $ref: '#/definitions/ResourcesGPUCardSRIOV'
             usb_address:
-                description: USB address (for USB cards)
+                description: |-
+                    USB address (for USB cards)
+
+                    API extension: resources_gpu_usb
                 example: "2:7"
                 type: string
                 x-go-name: USBAddress
@@ -5707,12 +6044,18 @@ definitions:
                 type: string
                 x-go-name: Brand
             card_device:
-                description: Card device number
+                description: |-
+                    Card device number
+
+                    API extension: resources_v2
                 example: "195:0"
                 type: string
                 x-go-name: CardDevice
             card_name:
-                description: Card device name
+                description: |-
+                    Card device name
+
+                    API extension: resources_v2
                 example: nvidia0
                 type: string
                 x-go-name: CardName
@@ -5784,7 +6127,10 @@ definitions:
                 type: integer
                 x-go-name: HugepagesUsed
             nodes:
-                description: List of NUMA memory nodes
+                description: |-
+                    List of NUMA memory nodes
+
+                    API extension: resources_v2
                 example: null
                 items:
                     $ref: '#/definitions/ResourcesMemoryNode'
@@ -5870,7 +6216,10 @@ definitions:
                 type: string
                 x-go-name: DriverVersion
             firmware_version:
-                description: Current firmware version
+                description: |-
+                    Current firmware version
+
+                    API extension: resources_network_firmware
                 example: 3.1.100
                 type: string
                 x-go-name: FirmwareVersion
@@ -5904,7 +6253,10 @@ definitions:
             sriov:
                 $ref: '#/definitions/ResourcesNetworkCardSRIOV'
             usb_address:
-                description: USB address (for USB cards)
+                description: |-
+                    USB address (for USB cards)
+
+                    API extension: resources_network_usb
                 example: "2:7"
                 type: string
                 x-go-name: USBAddress
@@ -5912,7 +6264,7 @@ definitions:
                 $ref: '#/definitions/ResourcesNetworkCardVDPA'
             vendor:
                 description: Name of the vendor
-                example: Aquantia Corp.
+                example: Aquantia Corp
                 type: string
                 x-go-name: Vendor
             vendor_id:
@@ -6104,7 +6456,10 @@ definitions:
                 type: string
                 x-go-name: DriverVersion
             iommu_group:
-                description: IOMMU group number
+                description: |-
+                    IOMMU group number
+
+                    API extension: resources_pci_iommu
                 example: 20
                 format: uint64
                 type: integer
@@ -6132,7 +6487,7 @@ definitions:
                 x-go-name: ProductID
             vendor:
                 description: Name of the vendor
-                example: Matrox Electronics Systems Ltd.
+                example: Matrox Electronics Systems Ltd
                 type: string
                 x-go-name: Vendor
             vendor_id:
@@ -6182,7 +6537,10 @@ definitions:
         description: ResourcesStorageDisk represents a disk
         properties:
             block_size:
-                description: Block size
+                description: |-
+                    Block size
+
+                    API extension: resources_disk_sata
                 example: 512
                 format: uint64
                 type: integer
@@ -6193,22 +6551,34 @@ definitions:
                 type: string
                 x-go-name: Device
             device_fs_uuid:
-                description: UUID of the filesystem on the device
+                description: |-
+                    UUID of the filesystem on the device
+
+                    API extension: resources_device_fs_uuid
                 example: 9313518c-0e13-4067-9746-5c1703830b78
                 type: string
                 x-go-name: DeviceFSUUID
             device_id:
-                description: Device by-id identifier
+                description: |-
+                    Device by-id identifier
+
+                    API extension: resources_disk_id
                 example: nvme-eui.0000000001000000e4d25cafae2e4c00
                 type: string
                 x-go-name: DeviceID
             device_path:
-                description: Device by-path identifier
+                description: |-
+                    Device by-path identifier
+
+                    API extension: resources_disk_sata
                 example: pci-0000:05:00.0-nvme-1
                 type: string
                 x-go-name: DevicePath
             firmware_version:
-                description: Current firmware version
+                description: |-
+                    Current firmware version
+
+                    API extension: resources_disk_sata
                 example: PSF121C
                 type: string
                 x-go-name: FirmwareVersion
@@ -6240,7 +6610,10 @@ definitions:
                 type: array
                 x-go-name: Partitions
             pci_address:
-                description: PCI address
+                description: |-
+                    PCI address
+
+                    API extension: resources_disk_address
                 example: "0000:05:00.0"
                 type: string
                 x-go-name: PCIAddress
@@ -6255,13 +6628,19 @@ definitions:
                 type: boolean
                 x-go-name: Removable
             rpm:
-                description: Rotation speed (RPM)
+                description: |-
+                    Rotation speed (RPM)
+
+                    API extension: resources_disk_sata
                 example: 0
                 format: uint64
                 type: integer
                 x-go-name: RPM
             serial:
-                description: Serial number
+                description: |-
+                    Serial number
+
+                    API extension: resources_disk_sata
                 example: BTPY63440ARH256D
                 type: string
                 x-go-name: Serial
@@ -6277,12 +6656,18 @@ definitions:
                 type: string
                 x-go-name: Type
             usb_address:
-                description: USB address
+                description: |-
+                    USB address
+
+                    API extension: resources_disk_address
                 example: "3:5"
                 type: string
                 x-go-name: USBAddress
             used_by:
-                description: Parent device type
+                description: |-
+                    Parent device type
+
+                    API extension: resources_disk_used_by
                 example: bcache
                 type: string
                 x-go-name: UsedBy
@@ -6302,7 +6687,10 @@ definitions:
                 type: string
                 x-go-name: Device
             device_fs_uuid:
-                description: UUID of the filesystem on the device
+                description: |-
+                    UUID of the filesystem on the device
+
+                    API extension: resources_device_fs_uuid
                 example: 9313518c-0e13-4067-9746-5c1703830b78
                 type: string
                 x-go-name: DeviceFSUUID
@@ -6549,7 +6937,10 @@ definitions:
                 type: string
                 x-go-name: ProductID
             serial:
-                description: USB serial number
+                description: |-
+                    USB serial number
+
+                    API extension: device_usb_serial.
                 example: DAE005fp
                 type: string
                 x-go-name: Serial
@@ -6657,7 +7048,10 @@ definitions:
                 type: string
                 x-go-name: Auth
             auth_methods:
-                description: List of supported authentication methods
+                description: |-
+                    List of supported authentication methods
+
+                    API extension: oidc
                 example:
                     - bearer
                     - tls
@@ -6668,19 +7062,28 @@ definitions:
                 type: array
                 x-go-name: AuthMethods
             auth_user_method:
-                description: The current user login method as seen by LXD
+                description: |-
+                    The current user login method as seen by LXD
+
+                    API extension: auth_user
                 example: unix
                 readOnly: true
                 type: string
                 x-go-name: AuthUserMethod
             auth_user_name:
-                description: The current user username as seen by LXD
+                description: |-
+                    The current user username as seen by LXD
+
+                    API extension: auth_user
                 example: uid=201105
                 readOnly: true
                 type: string
                 x-go-name: AuthUserName
             client_certificate:
-                description: Whether the requester sent a client certificate with the request
+                description: |-
+                    Whether the requester sent a client certificate with the request
+
+                    API extension: client_cert_presence
                 example: false
                 readOnly: true
                 type: boolean
@@ -6722,7 +7125,10 @@ definitions:
                 type: array
                 x-go-name: Architectures
             backup_metadata_version_range:
-                description: Range of supported backup metadata versions
+                description: |-
+                    Range of supported backup metadata versions
+
+                    API extension: backup_metadata_version
                 example:
                     - 1
                     - 2
@@ -6752,12 +7158,18 @@ definitions:
                 type: string
                 x-go-name: DriverVersion
             firewall:
-                description: Current firewall driver
+                description: |-
+                    Current firewall driver
+
+                    API extension: firewall_driver
                 example: nftables
                 type: string
                 x-go-name: Firewall
             instance_types:
-                description: List of supported instance types
+                description: |-
+                    List of supported instance types
+
+                    API extension: server_instance_type_info
                 example:
                     - container
                     - virtual-machine
@@ -6778,7 +7190,10 @@ definitions:
             kernel_features:
                 additionalProperties:
                     type: string
-                description: Map of kernel features that were tested on startup
+                description: |-
+                    Map of kernel features that were tested on startup
+
+                    API extension: kernel_features
                 example:
                     netnsid_getifaddrs: "true"
                     seccomp_listener: "true"
@@ -6792,7 +7207,10 @@ definitions:
             lxc_features:
                 additionalProperties:
                     type: string
-                description: Map of LXC features that were tested on startup
+                description: |-
+                    Map of LXC features that were tested on startup
+
+                    API extension: lxc_features
                 example:
                     cgroup2: "true"
                     devpts_fd: "true"
@@ -6800,17 +7218,26 @@ definitions:
                 type: object
                 x-go-name: LXCFeatures
             os_name:
-                description: Name of the operating system (Linux distribution)
+                description: |-
+                    Name of the operating system (Linux distribution)
+
+                    API extension: api_os
                 example: Ubuntu
                 type: string
                 x-go-name: OSName
             os_version:
-                description: Version of the operating system (Linux distribution)
+                description: |-
+                    Version of the operating system (Linux distribution)
+
+                    API extension: api_os
                 example: "24.04"
                 type: string
                 x-go-name: OSVersion
             project:
-                description: Current project name
+                description: |-
+                    Current project name
+
+                    API extension: projects
                 example: default
                 type: string
                 x-go-name: Project
@@ -6820,7 +7247,10 @@ definitions:
                 type: string
                 x-go-name: Server
             server_clustered:
-                description: Whether the server is part of a cluster
+                description: |-
+                    Whether the server is part of a cluster
+
+                    API extension: clustering
                 example: false
                 type: boolean
                 x-go-name: ServerClustered
@@ -6828,6 +7258,8 @@ definitions:
                 description: |-
                     Mode that the event distribution subsystem is operating in on this server.
                     Either "full-mesh", "hub-server" or "hub-client".
+
+                    API extension: event_hub
                 example: full-mesh
                 type: string
                 x-go-name: ServerEventMode
@@ -6837,7 +7269,10 @@ definitions:
                 type: boolean
                 x-go-name: ServerLTS
             server_name:
-                description: Server hostname
+                description: |-
+                    Server hostname
+
+                    API extension: clustering
                 example: castiana
                 type: string
                 x-go-name: ServerName
@@ -6887,15 +7322,24 @@ definitions:
         description: ServerStorageDriverInfo represents the read-only info about a storage driver
         properties:
             Name:
-                description: Name of the driver
+                description: |-
+                    Name of the driver
+
+                    API extension: server_supported_storage_drivers
                 example: zfs
                 type: string
             Remote:
-                description: Whether the driver has remote volumes
+                description: |-
+                    Whether the driver has remote volumes
+
+                    API extension: server_supported_storage_drivers
                 example: false
                 type: boolean
             Version:
-                description: Version of the driver
+                description: |-
+                    Version of the driver
+
+                    API extension: server_supported_storage_drivers
                 example: 0.8.4-1ubuntu11
                 type: string
         type: object
@@ -6934,7 +7378,10 @@ definitions:
                 type: string
                 x-go-name: Auth
             auth_methods:
-                description: List of supported authentication methods
+                description: |-
+                    List of supported authentication methods
+
+                    API extension: oidc
                 example:
                     - bearer
                     - tls
@@ -6945,7 +7392,10 @@ definitions:
                 type: array
                 x-go-name: AuthMethods
             client_certificate:
-                description: Whether the requester sent a client certificate with the request
+                description: |-
+                    Whether the requester sent a client certificate with the request
+
+                    API extension: client_cert_presence
                 example: false
                 readOnly: true
                 type: boolean
@@ -6989,33 +7439,51 @@ definitions:
             config:
                 additionalProperties:
                     type: string
-                description: Storage bucket configuration map
+                description: |-
+                    Storage bucket configuration map
+
+                    API extension: storage_buckets
                 example:
                     size: 50GiB
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage bucket
+                description: |-
+                    Description of the storage bucket
+
+                    API extension: storage_buckets
                 example: My custom bucket
                 type: string
                 x-go-name: Description
             location:
-                description: What cluster member this record was found on
+                description: |-
+                    What cluster member this record was found on
+
+                    API extension: storage_buckets
                 example: lxd01
                 type: string
                 x-go-name: Location
             name:
-                description: Bucket name
+                description: |-
+                    Bucket name
+
+                    API extension: storage_buckets
                 example: foo
                 type: string
                 x-go-name: Name
             project:
-                description: Project name
+                description: |-
+                    Project name
+
+                    API extension: storage_buckets_all_projects
                 example: project1
                 type: string
                 x-go-name: Project
             s3_url:
-                description: Bucket S3 URL
+                description: |-
+                    Bucket S3 URL
+
+                    API extension: storage_buckets
                 example: https://127.0.0.1:8080/foo
                 type: string
                 x-go-name: S3URL
@@ -7025,27 +7493,42 @@ definitions:
         description: StorageBucketKey represents the fields of a LXD storage pool bucket key
         properties:
             access-key:
-                description: Access key
+                description: |-
+                    Access key
+
+                    API extension: storage_buckets
                 example: 33UgkaIBLBIxb7O1
                 type: string
                 x-go-name: AccessKey
             description:
-                description: Description of the storage bucket key
+                description: |-
+                    Description of the storage bucket key
+
+                    API extension: storage_buckets
                 example: My read-only bucket key
                 type: string
                 x-go-name: Description
             name:
-                description: Key name
+                description: |-
+                    Key name
+
+                    API extension: storage_buckets
                 example: my-read-only-key
                 type: string
                 x-go-name: Name
             role:
-                description: Whether the key can perform write actions or not.
+                description: |-
+                    Whether the key can perform write actions or not.
+
+                    API extension: storage_buckets
                 example: read-only
                 type: string
                 x-go-name: Role
             secret-key:
-                description: Secret key
+                description: |-
+                    Secret key
+
+                    API extension: storage_buckets
                 example: kDQD6AOgwHgaQI1UIJBJpPaiLgZuJbq0
                 type: string
                 x-go-name: SecretKey
@@ -7055,22 +7538,34 @@ definitions:
         description: StorageBucketKeyPut represents the modifiable fields of a LXD storage pool bucket key
         properties:
             access-key:
-                description: Access key
+                description: |-
+                    Access key
+
+                    API extension: storage_buckets
                 example: 33UgkaIBLBIxb7O1
                 type: string
                 x-go-name: AccessKey
             description:
-                description: Description of the storage bucket key
+                description: |-
+                    Description of the storage bucket key
+
+                    API extension: storage_buckets
                 example: My read-only bucket key
                 type: string
                 x-go-name: Description
             role:
-                description: Whether the key can perform write actions or not.
+                description: |-
+                    Whether the key can perform write actions or not.
+
+                    API extension: storage_buckets
                 example: read-only
                 type: string
                 x-go-name: Role
             secret-key:
-                description: Secret key
+                description: |-
+                    Secret key
+
+                    API extension: storage_buckets
                 example: kDQD6AOgwHgaQI1UIJBJpPaiLgZuJbq0
                 type: string
                 x-go-name: SecretKey
@@ -7080,27 +7575,42 @@ definitions:
         description: StorageBucketKeysPost represents the fields of a new LXD storage pool bucket key
         properties:
             access-key:
-                description: Access key
+                description: |-
+                    Access key
+
+                    API extension: storage_buckets
                 example: 33UgkaIBLBIxb7O1
                 type: string
                 x-go-name: AccessKey
             description:
-                description: Description of the storage bucket key
+                description: |-
+                    Description of the storage bucket key
+
+                    API extension: storage_buckets
                 example: My read-only bucket key
                 type: string
                 x-go-name: Description
             name:
-                description: Key name
+                description: |-
+                    Key name
+
+                    API extension: storage_buckets
                 example: my-read-only-key
                 type: string
                 x-go-name: Name
             role:
-                description: Whether the key can perform write actions or not.
+                description: |-
+                    Whether the key can perform write actions or not.
+
+                    API extension: storage_buckets
                 example: read-only
                 type: string
                 x-go-name: Role
             secret-key:
-                description: Secret key
+                description: |-
+                    Secret key
+
+                    API extension: storage_buckets
                 example: kDQD6AOgwHgaQI1UIJBJpPaiLgZuJbq0
                 type: string
                 x-go-name: SecretKey
@@ -7112,13 +7622,19 @@ definitions:
             config:
                 additionalProperties:
                     type: string
-                description: Storage bucket configuration map
+                description: |-
+                    Storage bucket configuration map
+
+                    API extension: storage_buckets
                 example:
                     size: 50GiB
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage bucket
+                description: |-
+                    Description of the storage bucket
+
+                    API extension: storage_buckets
                 example: My custom bucket
                 type: string
                 x-go-name: Description
@@ -7130,18 +7646,27 @@ definitions:
             config:
                 additionalProperties:
                     type: string
-                description: Storage bucket configuration map
+                description: |-
+                    Storage bucket configuration map
+
+                    API extension: storage_buckets
                 example:
                     size: 50GiB
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage bucket
+                description: |-
+                    Description of the storage bucket
+
+                    API extension: storage_buckets
                 example: My custom bucket
                 type: string
                 x-go-name: Description
             name:
-                description: Bucket name
+                description: |-
+                    Bucket name
+
+                    API extension: storage_buckets
                 example: foo
                 type: string
                 x-go-name: Name
@@ -7168,7 +7693,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage pool
+                description: |-
+                    Description of the storage pool
+
+                    API extension: entity_description
                 example: Local SSD pool
                 type: string
                 x-go-name: Description
@@ -7178,7 +7706,10 @@ definitions:
                 type: string
                 x-go-name: Driver
             locations:
-                description: Cluster members on which the storage pool has been defined
+                description: |-
+                    Cluster members on which the storage pool has been defined
+
+                    API extension: clustering
                 example:
                     - lxd01
                     - lxd02
@@ -7194,7 +7725,10 @@ definitions:
                 type: string
                 x-go-name: Name
             status:
-                description: Pool status (Pending, Created, Errored or Unknown)
+                description: |-
+                    Pool status (Pending, Created, Errored or Unknown)
+
+                    API extension: clustering
                 example: Created
                 readOnly: true
                 type: string
@@ -7223,7 +7757,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage pool
+                description: |-
+                    Description of the storage pool
+
+                    API extension: entity_description
                 example: Local SSD pool
                 type: string
                 x-go-name: Description
@@ -7306,7 +7843,10 @@ definitions:
                 type: boolean
                 x-go-name: OptimizedStorage
             version:
-                description: What backup format version to use
+                description: |-
+                    What backup format version to use
+
+                    API extension: backup_metadata_version
                 example: 1
                 format: uint32
                 type: integer
@@ -7331,7 +7871,10 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage pool
+                description: |-
+                    Description of the storage pool
+
+                    API extension: entity_description
                 example: Local SSD pool
                 type: string
                 x-go-name: Description
@@ -7368,23 +7911,34 @@ definitions:
                 type: object
                 x-go-name: Config
             content_type:
-                description: Volume content type (filesystem or block)
+                description: |-
+                    Volume content type (filesystem or block)
+
+                    API extension: custom_block_volumes
                 example: filesystem
                 type: string
                 x-go-name: ContentType
             created_at:
-                description: Volume creation timestamp
+                description: |-
+                    Volume creation timestamp
+                    API extension: storage_volumes_created_at
                 example: "2021-03-23T20:00:00-04:00"
                 format: date-time
                 type: string
                 x-go-name: CreatedAt
             description:
-                description: Description of the storage volume
+                description: |-
+                    Description of the storage volume
+
+                    API extension: entity_description
                 example: My custom volume
                 type: string
                 x-go-name: Description
             location:
-                description: What cluster member this record was found on
+                description: |-
+                    What cluster member this record was found on
+
+                    API extension: clustering
                 example: lxd01
                 type: string
                 x-go-name: Location
@@ -7394,12 +7948,18 @@ definitions:
                 type: string
                 x-go-name: Name
             pool:
-                description: Name of the pool the volume is using
-                example: '"default"'
+                description: |-
+                    Name of the pool the volume is using
+
+                    API extension: storage_volumes_all
+                example: default
                 type: string
                 x-go-name: Pool
             project:
-                description: Project containing the volume.
+                description: |-
+                    Project containing the volume.
+
+                    API extension: storage_volumes_all_projects
                 example: default
                 type: string
                 x-go-name: Project
@@ -7423,7 +7983,10 @@ definitions:
         description: StorageVolumePost represents the fields required to rename a LXD storage pool volume
         properties:
             migration:
-                description: Initiate volume migration
+                description: |-
+                    Initiate volume migration
+
+                    API extension: storage_api_remote_volume_handling
                 example: false
                 type: boolean
                 x-go-name: Migration
@@ -7433,12 +7996,18 @@ definitions:
                 type: string
                 x-go-name: Name
             pool:
-                description: New storage pool
+                description: |-
+                    New storage pool
+
+                    API extension: storage_api_local_volume_handling
                 example: remote
                 type: string
                 x-go-name: Pool
             project:
-                description: New project name
+                description: |-
+                    New project name
+
+                    API extension: storage_volume_project_move
                 example: foo
                 type: string
                 x-go-name: Project
@@ -7447,7 +8016,10 @@ definitions:
             target:
                 $ref: '#/definitions/StorageVolumePostTarget'
             volume_only:
-                description: Whether snapshots should be discarded (migration only)
+                description: |-
+                    Whether snapshots should be discarded (migration only)
+
+                    API extension: storage_api_remote_volume_snapshots
                 example: false
                 type: boolean
                 x-go-name: VolumeOnly
@@ -7489,12 +8061,18 @@ definitions:
                 type: object
                 x-go-name: Config
             description:
-                description: Description of the storage volume
+                description: |-
+                    Description of the storage volume
+
+                    API extension: entity_description
                 example: My custom volume
                 type: string
                 x-go-name: Description
             restore:
-                description: Name of a snapshot to restore
+                description: |-
+                    Name of a snapshot to restore
+
+                    API extension: storage_api_volume_snapshots
                 example: snap0
                 type: string
                 x-go-name: Restore
@@ -7513,12 +8091,17 @@ definitions:
                 type: object
                 x-go-name: Config
             content_type:
-                description: The content type (filesystem or block)
+                description: |-
+                    The content type (filesystem or block)
+
+                    API extension: custom_block_volumes
                 example: filesystem
                 type: string
                 x-go-name: ContentType
             created_at:
-                description: Volume snapshot creation timestamp
+                description: |-
+                    Volume snapshot creation timestamp
+                    API extension: storage_volumes_created_at
                 example: "2021-03-23T20:00:00-04:00"
                 format: date-time
                 type: string
@@ -7529,7 +8112,10 @@ definitions:
                 type: string
                 x-go-name: Description
             expires_at:
-                description: When the snapshot expires (gets auto-deleted)
+                description: |-
+                    When the snapshot expires (gets auto-deleted)
+
+                    API extension: custom_volume_snapshot_expiry
                 example: "2021-03-23T17:38:37.753398689-04:00"
                 format: date-time
                 type: string
@@ -7545,7 +8131,10 @@ definitions:
         description: StorageVolumeSnapshotPost represents the fields required to rename/move a LXD storage volume snapshot
         properties:
             migration:
-                description: Initiate volume snapshot migration
+                description: |-
+                    Initiate volume snapshot migration
+
+                    API extension: storage_api_remote_volume_snapshot_copy
                 example: false
                 type: boolean
                 x-go-name: Migration
@@ -7567,7 +8156,10 @@ definitions:
                 type: string
                 x-go-name: Description
             expires_at:
-                description: When the snapshot expires (gets auto-deleted)
+                description: |-
+                    When the snapshot expires (gets auto-deleted)
+
+                    API extension: custom_volume_snapshot_expiry
                 example: "2021-03-23T17:38:37.753398689-04:00"
                 format: date-time
                 type: string
@@ -7583,7 +8175,10 @@ definitions:
                 type: string
                 x-go-name: Description
             expires_at:
-                description: When the snapshot expires (gets auto-deleted)
+                description: |-
+                    When the snapshot expires (gets auto-deleted)
+
+                    API extension: custom_volume_snapshot_expiry
                 example: "2021-03-23T17:38:37.753398689-04:00"
                 format: date-time
                 type: string
@@ -7599,17 +8194,26 @@ definitions:
         description: StorageVolumeSource represents the creation source for a new storage volume
         properties:
             certificate:
-                description: Certificate (for migration)
+                description: |-
+                    Certificate (for migration)
+
+                    API extension: storage_api_remote_volume_handling
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
             location:
-                description: What cluster member this record was found on
+                description: |-
+                    What cluster member this record was found on
+
+                    API extension: cluster_internal_custom_volume_copy
                 example: lxd01
                 type: string
                 x-go-name: Location
             mode:
-                description: Whether to use pull or push mode (for migration)
+                description: |-
+                    Whether to use pull or push mode (for migration)
+
+                    API extension: storage_api_remote_volume_handling
                 example: pull
                 type: string
                 x-go-name: Mode
@@ -7619,7 +8223,10 @@ definitions:
                 type: string
                 x-go-name: Name
             operation:
-                description: Remote operation URL (for migration)
+                description: |-
+                    Remote operation URL (for migration)
+
+                    API extension: storage_api_remote_volume_handling
                 example: https://1.2.3.4:8443/1.0/operations/1721ae08-b6a8-416a-9614-3f89302466e1
                 type: string
                 x-go-name: Operation
@@ -7629,19 +8236,28 @@ definitions:
                 type: string
                 x-go-name: Pool
             project:
-                description: Source project name
+                description: |-
+                    Source project name
+
+                    API extension: storage_api_project
                 example: foo
                 type: string
                 x-go-name: Project
             refresh:
-                description: Whether existing destination volume should be refreshed
+                description: |-
+                    Whether existing destination volume should be refreshed
+
+                    API extension: custom_volume_refresh
                 example: false
                 type: boolean
                 x-go-name: Refresh
             secrets:
                 additionalProperties:
                     type: string
-                description: Map of migration websockets (for migration)
+                description: |-
+                    Map of migration websockets (for migration)
+
+                    API extension: storage_api_remote_volume_handling
                 example:
                     rsync: RANDOM-STRING
                 type: object
@@ -7649,7 +8265,10 @@ definitions:
             type:
                 $ref: '#/definitions/SourceType'
             volume_only:
-                description: Whether snapshots should be discarded (for migration)
+                description: |-
+                    Whether snapshots should be discarded (for migration)
+
+                    API extension: storage_api_volume_snapshots
                 example: false
                 type: boolean
                 x-go-name: VolumeOnly
@@ -7666,7 +8285,10 @@ definitions:
         description: StorageVolumeStateUsage represents the disk usage of a volume
         properties:
             total:
-                description: Storage volume size in bytes. Uses 0 to convey that the volume has access to the entire pool's storage.
+                description: |-
+                    Storage volume size in bytes. Uses 0 to convey that the volume has access to the entire pool's storage.
+
+                    API extension: storage_volume_state_total
                 example: 5189222192
                 format: int64
                 type: integer
@@ -7692,12 +8314,18 @@ definitions:
                 type: object
                 x-go-name: Config
             content_type:
-                description: Volume content type (filesystem or block)
+                description: |-
+                    Volume content type (filesystem or block)
+
+                    API extension: custom_block_volumes
                 example: filesystem
                 type: string
                 x-go-name: ContentType
             description:
-                description: Description of the storage volume
+                description: |-
+                    Description of the storage volume
+
+                    API extension: entity_description
                 example: My custom volume
                 type: string
                 x-go-name: Description
@@ -7707,7 +8335,10 @@ definitions:
                 type: string
                 x-go-name: Name
             restore:
-                description: Name of a snapshot to restore
+                description: |-
+                    Name of a snapshot to restore
+
+                    API extension: storage_api_volume_snapshots
                 example: snap0
                 type: string
                 x-go-name: Restore

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -946,8 +946,7 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 	}
 
 	// Get current metadata.
-	newMetadata := op.metadata
-	op.lock.Unlock()
+	newMetadata := maps.Clone(op.metadata)
 
 	// Merge with current one.
 	if op.metadata == nil {
@@ -958,11 +957,11 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 
 	newMetadata, err := validateMetadata(newMetadata)
 	if err != nil {
+		op.lock.Unlock()
 		return fmt.Errorf("Failed extending operation metadata: %w", err)
 	}
 
 	// Update the operation.
-	op.lock.Lock()
 	op.updatedAt = time.Now()
 	op.metadata = newMetadata
 	op.lock.Unlock()


### PR DESCRIPTION
`newMetadata` is assigned to `op.metadata` within the lock, but this is a pointer, so the call to `maps.Copy` is writing to the actual `op.metadata` outside of the lock.

This fixes the issue by a) using `maps.Clone` on `op.metadata` to get `newMetadata`, so that existing metadata is not overwritten if the merged metadata is not valid, and b) holding the operations lock for the whole update.

Closes #18534 (for 6.9)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
