### PR TITLE
lxd/operations: Fix unprotected write to operation metadata (stable-5.21)

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -620,8 +620,7 @@ func (op *Operation) ExtendMetadata(metadata any) error {
 	}
 
 	// Get current metadata.
-	newMetadata := op.metadata
-	op.lock.Unlock()
+	newMetadata := maps.Clone(op.metadata)
 
 	// Merge with current one.
 	if op.metadata == nil {
@@ -631,7 +630,6 @@ func (op *Operation) ExtendMetadata(metadata any) error {
 	}
 
 	// Update the operation.
-	op.lock.Lock()
 	op.updatedAt = time.Now()
 	op.metadata = newMetadata
 	op.lock.Unlock()


### PR DESCRIPTION
`newMetadata` is assigned to `op.metadata` within the lock, but this is a pointer, so the call to `maps.Copy` is writing to the actual `op.metadata` outside of the lock.

This fixes the issue by a) using `maps.Clone` on `op.metadata` to get `newMetadata`, so that existing metadata is not overwritten if the merged metadata is not valid, and b) holding the operations lock for the whole update.

Closes #18534 (for 5.21)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
