### PR TITLE
Instance: Adds minimal libkrun wrapper package

### DIFF
--- a/lxd/instance/drivers/libkrun/README.md
+++ b/lxd/instance/drivers/libkrun/README.md
@@ -1,0 +1,10 @@
+# libkrun (reduced)
+
+Minimal Go bindings for libkrun required by LXD.
+
+## Runtime Loading
+
+The package resolves libkrun at runtime with `dlopen(3)`/`dlsym(3)`.
+
+- If `LIBKRUN_PATH` is set, it is used first.
+- Otherwise it falls back to `libkrun.so` then `libkrun.so.0`.

--- a/lxd/instance/drivers/libkrun/cgo.go
+++ b/lxd/instance/drivers/libkrun/cgo.go
@@ -1,0 +1,28 @@
+package libkrun
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+func cStr(s string) *C.char {
+	return C.CString(s)
+}
+
+func optCStr(s string) *C.char {
+	if s == "" {
+		return nil
+	}
+
+	return C.CString(s)
+}
+
+func freeCStr(p *C.char) {
+	if p != nil {
+		C.free(unsafe.Pointer(p))
+	}
+}

--- a/lxd/instance/drivers/libkrun/config.go
+++ b/lxd/instance/drivers/libkrun/config.go
@@ -1,0 +1,11 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// SetVMConfig sets the number of vCPUs and amount of RAM in MiB.
+func (c *Context) SetVMConfig(numVCPUs uint8, ramMiB uint32) error {
+	return check(C.krun_set_vm_config(c.id, C.uint8_t(numVCPUs), C.uint32_t(ramMiB)))
+}

--- a/lxd/instance/drivers/libkrun/console.go
+++ b/lxd/instance/drivers/libkrun/console.go
@@ -1,0 +1,40 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// AddVirtioConsoleDefault adds a default virtio-console device wired to host fds.
+func (c *Context) AddVirtioConsoleDefault(inputFD, outputFD, errFD int) error {
+	return check(C.krun_add_virtio_console_default(
+		c.id,
+		C.int(inputFD),
+		C.int(outputFD),
+		C.int(errFD),
+	))
+}
+
+// AddVirtioConsoleMultiport adds a multiport console and returns its console ID.
+func (c *Context) AddVirtioConsoleMultiport() (uint32, error) {
+	ret := C.krun_add_virtio_console_multiport(c.id)
+	if ret < 0 {
+		return 0, errnoFromRet(ret)
+	}
+
+	return uint32(ret), nil
+}
+
+// AddConsolePortInout adds a named bidirectional port to a multiport console.
+func (c *Context) AddConsolePortInout(consoleID uint32, name string, inputFD, outputFD int) error {
+	cName := cStr(name)
+	defer freeCStr(cName)
+
+	return check(C.krun_add_console_port_inout(
+		c.id,
+		C.uint32_t(consoleID),
+		cName,
+		C.int(inputFD),
+		C.int(outputFD),
+	))
+}

--- a/lxd/instance/drivers/libkrun/disk.go
+++ b/lxd/instance/drivers/libkrun/disk.go
@@ -1,0 +1,17 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// AddDisk adds a raw disk image as a block device.
+func (c *Context) AddDisk(blockID, diskPath string, readOnly bool) error {
+	cBlockID := cStr(blockID)
+	defer freeCStr(cBlockID)
+
+	cDiskPath := cStr(diskPath)
+	defer freeCStr(cDiskPath)
+
+	return check(C.krun_add_disk(c.id, cBlockID, cDiskPath, C.bool(readOnly)))
+}

--- a/lxd/instance/drivers/libkrun/dynload.c
+++ b/lxd/instance/drivers/libkrun/dynload.c
@@ -1,0 +1,260 @@
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libkrun_fwd.h"
+
+struct krun_api {
+    __typeof__(krun_create_ctx) *create_ctx;
+    __typeof__(krun_free_ctx) *free_ctx;
+    __typeof__(krun_set_vm_config) *set_vm_config;
+    __typeof__(krun_add_virtio_console_default) *add_virtio_console_default;
+    __typeof__(krun_add_virtio_console_multiport) *add_virtio_console_multiport;
+    __typeof__(krun_add_console_port_inout) *add_console_port_inout;
+    __typeof__(krun_set_kernel) *set_kernel;
+    __typeof__(krun_add_disk) *add_disk;
+    __typeof__(krun_add_virtiofs3) *add_virtiofs3;
+    __typeof__(krun_add_vsock) *add_vsock;
+    __typeof__(krun_add_vsock_port) *add_vsock_port;
+    __typeof__(krun_add_vsock_port2) *add_vsock_port2;
+    __typeof__(krun_add_net_tap) *add_net_tap;
+    __typeof__(krun_start_enter) *start_enter;
+};
+
+static struct {
+    pthread_once_t once;
+    void *handle;
+    int init_ok;
+    char err[1024];
+    struct krun_api api;
+} loader = {
+    .once = PTHREAD_ONCE_INIT,
+    .init_ok = 0,
+    .err = "Failed loading libkrun: uninitialized",
+};
+
+static void loader_set_err(const char *fmt, ...) {
+    va_list ap;
+
+    va_start(ap, fmt);
+    vsnprintf(loader.err, sizeof(loader.err), fmt, ap);
+    va_end(ap);
+}
+
+static void *loader_open(const char *path) {
+    void *handle;
+
+    dlerror();
+    handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) {
+        const char *derr = dlerror();
+        loader_set_err("libkrun loader: dlopen(%s) failed: %s", path, derr ? derr : "unknown error");
+    }
+
+    return handle;
+}
+
+static bool loader_resolve(void **target, const char *name) {
+    void *sym;
+    const char *derr;
+
+    dlerror();
+    sym = dlsym(loader.handle, name);
+    derr = dlerror();
+    if (derr != NULL || sym == NULL) {
+        loader_set_err("libkrun loader: required symbol %s missing: %s", name, derr ? derr : "unknown error");
+        return false;
+    }
+
+    *target = sym;
+    return true;
+}
+
+#define RESOLVE_REQUIRED(field, symbol) \
+    do { \
+        if (!loader_resolve((void **)&loader.api.field, #symbol)) { \
+            return; \
+        } \
+    } while (0)
+
+static void loader_init_once(void) {
+    const char *override;
+    const char *candidates[] = {
+        "libkrun.so",
+        "libkrun.so.0",
+        NULL,
+    };
+    size_t i;
+
+    override = getenv("LIBKRUN_PATH");
+    if (override != NULL && override[0] != '\0') {
+        loader.handle = loader_open(override);
+        if (loader.handle == NULL) {
+            return;
+        }
+    } else {
+        for (i = 0; candidates[i] != NULL; i++) {
+            loader.handle = loader_open(candidates[i]);
+            if (loader.handle != NULL) {
+                break;
+            }
+        }
+
+        if (loader.handle == NULL) {
+            loader_set_err("libkrun loader: cannot open %s or %s (set LIBKRUN_PATH to an explicit .so path)",
+                           candidates[0], candidates[1]);
+            return;
+        }
+    }
+
+    RESOLVE_REQUIRED(create_ctx, krun_create_ctx);
+    RESOLVE_REQUIRED(free_ctx, krun_free_ctx);
+    RESOLVE_REQUIRED(set_vm_config, krun_set_vm_config);
+    RESOLVE_REQUIRED(add_virtio_console_default, krun_add_virtio_console_default);
+    RESOLVE_REQUIRED(add_virtio_console_multiport, krun_add_virtio_console_multiport);
+    RESOLVE_REQUIRED(add_console_port_inout, krun_add_console_port_inout);
+    RESOLVE_REQUIRED(set_kernel, krun_set_kernel);
+    RESOLVE_REQUIRED(add_disk, krun_add_disk);
+    RESOLVE_REQUIRED(add_virtiofs3, krun_add_virtiofs3);
+    RESOLVE_REQUIRED(add_vsock, krun_add_vsock);
+    RESOLVE_REQUIRED(add_vsock_port, krun_add_vsock_port);
+    RESOLVE_REQUIRED(add_vsock_port2, krun_add_vsock_port2);
+    RESOLVE_REQUIRED(add_net_tap, krun_add_net_tap);
+    RESOLVE_REQUIRED(start_enter, krun_start_enter);
+
+    loader.init_ok = 1;
+}
+
+static bool loader_ready(void) {
+    pthread_once(&loader.once, loader_init_once);
+    return loader.init_ok == 1;
+}
+
+const char *goKrunLoaderLastError(void) {
+    pthread_once(&loader.once, loader_init_once);
+    return loader.err;
+}
+
+int32_t krun_create_ctx(void) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.create_ctx();
+}
+
+int32_t krun_free_ctx(uint32_t ctx_id) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.free_ctx(ctx_id);
+}
+
+int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.set_vm_config(ctx_id, num_vcpus, ram_mib);
+}
+
+int32_t krun_add_virtio_console_default(uint32_t ctx_id, int input_fd, int output_fd, int err_fd) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_virtio_console_default(ctx_id, input_fd, output_fd, err_fd);
+}
+
+int32_t krun_add_virtio_console_multiport(uint32_t ctx_id) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_virtio_console_multiport(ctx_id);
+}
+
+int32_t krun_add_console_port_inout(uint32_t ctx_id, uint32_t console_id, const char *name, int input_fd, int output_fd) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_console_port_inout(ctx_id, console_id, name, input_fd, output_fd);
+}
+
+int32_t krun_set_kernel(uint32_t ctx_id,
+                        const char *kernel_path,
+                        uint32_t kernel_format,
+                        const char *initramfs,
+                        const char *cmdline) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.set_kernel(ctx_id, kernel_path, kernel_format, initramfs, cmdline);
+}
+
+int32_t krun_add_disk(uint32_t ctx_id, const char *block_id, const char *disk_path, bool read_only) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_disk(ctx_id, block_id, disk_path, read_only);
+}
+
+int32_t krun_add_virtiofs3(uint32_t ctx_id, const char *c_tag, const char *c_path, uint64_t shm_size, bool read_only) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_virtiofs3(ctx_id, c_tag, c_path, shm_size, read_only);
+}
+
+int32_t krun_add_vsock(uint32_t ctx_id, uint32_t tsi_features) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_vsock(ctx_id, tsi_features);
+}
+
+int32_t krun_add_vsock_port(uint32_t ctx_id, uint32_t port, const char *c_filepath) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_vsock_port(ctx_id, port, c_filepath);
+}
+
+int32_t krun_add_vsock_port2(uint32_t ctx_id, uint32_t port, const char *c_filepath, bool listen) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_vsock_port2(ctx_id, port, c_filepath, listen);
+}
+
+int32_t krun_add_net_tap(uint32_t ctx_id,
+                         char *c_tap_name,
+                         uint8_t *const c_mac,
+                         uint32_t features,
+                         uint32_t flags) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.add_net_tap(ctx_id, c_tap_name, c_mac, features, flags);
+}
+
+int32_t krun_start_enter(uint32_t ctx_id) {
+    if (!loader_ready()) {
+        return KRUN_LOADER_ERR;
+    }
+
+    return loader.api.start_enter(ctx_id);
+}

--- a/lxd/instance/drivers/libkrun/errors.go
+++ b/lxd/instance/drivers/libkrun/errors.go
@@ -1,0 +1,60 @@
+package libkrun
+
+/*
+#include <stdint.h>
+#include "libkrun_fwd.h"
+
+const char *goKrunLoaderLastError(void);
+*/
+import "C"
+
+import (
+	"syscall"
+)
+
+// loaderErrorCode mirrors the C sentinel used by the local runtime loader wrapper.
+const loaderErrorCode int32 = int32(C.KRUN_LOADER_ERR)
+
+// LoaderError reports runtime libkrun loader failures (dlopen/dlsym).
+type LoaderError struct {
+	message string
+}
+
+func (e LoaderError) Error() string {
+	if e.message == "" {
+		return "libkrun loader failure"
+	}
+
+	return e.message
+}
+
+// Errno wraps a negative libkrun return code as a POSIX errno.
+type Errno syscall.Errno
+
+func (e Errno) Error() string {
+	return syscall.Errno(e).Error()
+}
+
+func errnoFromRet(ret C.int32_t) error {
+	return errnoFromCode(int32(ret))
+}
+
+func check(ret C.int32_t) error {
+	return checkCode(int32(ret))
+}
+
+func errnoFromCode(code int32) error {
+	if code == loaderErrorCode {
+		return LoaderError{message: C.GoString(C.goKrunLoaderLastError())}
+	}
+
+	return Errno(-code)
+}
+
+func checkCode(code int32) error {
+	if code < 0 {
+		return errnoFromCode(code)
+	}
+
+	return nil
+}

--- a/lxd/instance/drivers/libkrun/fs.go
+++ b/lxd/instance/drivers/libkrun/fs.go
@@ -1,0 +1,17 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// AddVirtioFS3 adds a virtio-fs export with optional read-only mode.
+func (c *Context) AddVirtioFS3(tag, path string, shmSize uint64, readOnly bool) error {
+	cTag := cStr(tag)
+	defer freeCStr(cTag)
+
+	cPath := cStr(path)
+	defer freeCStr(cPath)
+
+	return check(C.krun_add_virtiofs3(c.id, cTag, cPath, C.uint64_t(shmSize), C.bool(readOnly)))
+}

--- a/lxd/instance/drivers/libkrun/kernel.go
+++ b/lxd/instance/drivers/libkrun/kernel.go
@@ -1,0 +1,33 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// KernelFormat identifies kernel image format.
+type KernelFormat uint32
+
+// KernelFormat* values map to libkrun kernel image formats.
+const (
+	KernelFormatRaw       KernelFormat = C.KRUN_KERNEL_FORMAT_RAW
+	KernelFormatELF       KernelFormat = C.KRUN_KERNEL_FORMAT_ELF
+	KernelFormatPEGZ      KernelFormat = C.KRUN_KERNEL_FORMAT_PE_GZ
+	KernelFormatImageBZ2  KernelFormat = C.KRUN_KERNEL_FORMAT_IMAGE_BZ2
+	KernelFormatImageGZ   KernelFormat = C.KRUN_KERNEL_FORMAT_IMAGE_GZ
+	KernelFormatImageZstd KernelFormat = C.KRUN_KERNEL_FORMAT_IMAGE_ZSTD
+)
+
+// SetKernel sets kernel image, format, and optional initramfs/cmdline.
+func (c *Context) SetKernel(kernelPath string, format KernelFormat, initramfs, cmdline string) error {
+	cKernel := cStr(kernelPath)
+	defer freeCStr(cKernel)
+
+	cInitramfs := optCStr(initramfs)
+	defer freeCStr(cInitramfs)
+
+	cCmdline := optCStr(cmdline)
+	defer freeCStr(cCmdline)
+
+	return check(C.krun_set_kernel(c.id, cKernel, C.uint32_t(format), cInitramfs, cCmdline))
+}

--- a/lxd/instance/drivers/libkrun/libkrun.go
+++ b/lxd/instance/drivers/libkrun/libkrun.go
@@ -1,0 +1,33 @@
+package libkrun
+
+/*
+#cgo linux LDFLAGS: -ldl -lpthread
+#include <stdlib.h>
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// Context is a libkrun configuration context used to build and start a single microVM.
+type Context struct {
+	id C.uint32_t
+}
+
+// CreateContext creates a new libkrun configuration context.
+func CreateContext() (*Context, error) {
+	ret := C.krun_create_ctx()
+	if ret < 0 {
+		return nil, errnoFromRet(ret)
+	}
+
+	return &Context{id: C.uint32_t(ret)}, nil
+}
+
+// Close releases the libkrun configuration context.
+func (c *Context) Close() error {
+	return check(C.krun_free_ctx(c.id))
+}
+
+// StartEnter starts and enters the microVM.
+func (c *Context) StartEnter() error {
+	return check(C.krun_start_enter(c.id))
+}

--- a/lxd/instance/drivers/libkrun/libkrun_fwd.h
+++ b/lxd/instance/drivers/libkrun/libkrun_fwd.h
@@ -1,0 +1,68 @@
+/*
+ * Minimal forward declarations for libkrun bundled with this package.
+ *
+ * This replaces the system <libkrun.h> so that the package compiles without
+ * libkrun installed. The library itself is resolved at runtime via dlopen(3).
+ */
+
+#ifndef LIBKRUN_FWD_H
+#define LIBKRUN_FWD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Sentinel return code used by the local libkrun runtime loader wrapper. */
+/* It is a deliberately unique 32-bit negative code reserved to mean loader failure. */
+#define KRUN_LOADER_ERR INT32_C(-1879048192)
+
+/* Kernel image formats */
+#define KRUN_KERNEL_FORMAT_RAW        0
+#define KRUN_KERNEL_FORMAT_ELF        1
+#define KRUN_KERNEL_FORMAT_PE_GZ      2
+#define KRUN_KERNEL_FORMAT_IMAGE_BZ2  3
+#define KRUN_KERNEL_FORMAT_IMAGE_GZ   4
+#define KRUN_KERNEL_FORMAT_IMAGE_ZSTD 5
+
+/* virtio-net feature bits (from uapi/linux/virtio_net.h) */
+#define NET_FEATURE_CSUM       (1 << 0)
+#define NET_FEATURE_GUEST_CSUM (1 << 1)
+#define NET_FEATURE_GUEST_TSO4 (1 << 7)
+#define NET_FEATURE_GUEST_UFO  (1 << 10)
+#define NET_FEATURE_HOST_TSO4  (1 << 11)
+#define NET_FEATURE_HOST_UFO   (1 << 14)
+
+#define COMPAT_NET_FEATURES (NET_FEATURE_CSUM | NET_FEATURE_GUEST_CSUM | \
+                             NET_FEATURE_GUEST_TSO4 | NET_FEATURE_GUEST_UFO | \
+                             NET_FEATURE_HOST_TSO4 | NET_FEATURE_HOST_UFO)
+
+/* Context lifecycle */
+int32_t krun_create_ctx();
+int32_t krun_free_ctx(uint32_t ctx_id);
+int32_t krun_start_enter(uint32_t ctx_id);
+
+/* VM configuration */
+int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib);
+
+/* virtio-console */
+int32_t krun_add_virtio_console_default(uint32_t ctx_id, int input_fd, int output_fd, int err_fd);
+int32_t krun_add_virtio_console_multiport(uint32_t ctx_id);
+int32_t krun_add_console_port_inout(uint32_t ctx_id, uint32_t console_id, const char *name, int input_fd, int output_fd);
+
+/* Disk */
+int32_t krun_add_disk(uint32_t ctx_id, const char *block_id, const char *disk_path, bool read_only);
+
+/* virtio-fs */
+int32_t krun_add_virtiofs3(uint32_t ctx_id, const char *c_tag, const char *c_path, uint64_t shm_size, bool read_only);
+
+/* Kernel */
+int32_t krun_set_kernel(uint32_t ctx_id, const char *kernel_path, uint32_t kernel_format, const char *initramfs, const char *cmdline);
+
+/* vsock */
+int32_t krun_add_vsock(uint32_t ctx_id, uint32_t tsi_features);
+int32_t krun_add_vsock_port(uint32_t ctx_id, uint32_t port, const char *c_filepath);
+int32_t krun_add_vsock_port2(uint32_t ctx_id, uint32_t port, const char *c_filepath, bool listen);
+
+/* Network */
+int32_t krun_add_net_tap(uint32_t ctx_id, char *c_tap_name, uint8_t *const c_mac, uint32_t features, uint32_t flags);
+
+#endif /* LIBKRUN_FWD_H */

--- a/lxd/instance/drivers/libkrun/libkrun_test.go
+++ b/lxd/instance/drivers/libkrun/libkrun_test.go
@@ -1,0 +1,33 @@
+package libkrun
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func TestCheckCodeErrnoMapping(t *testing.T) {
+	err := checkCode(0)
+	if err != nil {
+		t.Fatalf("checkCode(0) = %v, want nil", err)
+	}
+
+	err = checkCode(1)
+	if err != nil {
+		t.Fatalf("checkCode(1) = %v, want nil", err)
+	}
+
+	err = checkCode(-int32(syscall.EINVAL))
+	if err == nil {
+		t.Fatal("checkCode(-EINVAL) = nil, want error")
+	}
+
+	var eno Errno
+	if !errors.As(err, &eno) {
+		t.Fatalf("checkCode(-EINVAL) error type = %T, want Errno", err)
+	}
+
+	if syscall.Errno(eno) != syscall.EINVAL {
+		t.Fatalf("errno = %v, want %v", syscall.Errno(eno), syscall.EINVAL)
+	}
+}

--- a/lxd/instance/drivers/libkrun/loader_test.go
+++ b/lxd/instance/drivers/libkrun/loader_test.go
@@ -1,0 +1,102 @@
+package libkrun
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoaderSubprocess(t *testing.T) {
+	if os.Getenv("GO_LIBKRUN_HELPER") != "1" {
+		t.Skip("helper subprocess only")
+	}
+
+	switch os.Getenv("GO_LIBKRUN_CASE") {
+	case "missing-lib":
+		_, err := CreateContext()
+		if err == nil {
+			t.Fatalf("CreateContext() = nil error, want LoaderError")
+		}
+
+		var le LoaderError
+		if !errors.As(err, &le) {
+			t.Fatalf("CreateContext() error type = %T, want LoaderError", err)
+		}
+
+		if !strings.Contains(le.Error(), "dlopen(") {
+			t.Fatalf("LoaderError = %q, want dlopen detail", le.Error())
+		}
+
+	case "missing-required-symbol":
+		_, err := CreateContext()
+		if err == nil {
+			t.Fatalf("CreateContext() = nil error, want LoaderError")
+		}
+
+		var le LoaderError
+		if !errors.As(err, &le) {
+			t.Fatalf("CreateContext() error type = %T, want LoaderError", err)
+		}
+
+		if !strings.Contains(le.Error(), "required symbol") {
+			t.Fatalf("LoaderError = %q, want missing required symbol detail", le.Error())
+		}
+
+	default:
+		t.Fatalf("unknown GO_LIBKRUN_CASE=%q", os.Getenv("GO_LIBKRUN_CASE"))
+	}
+}
+
+func TestLoaderMissingLibraryPath(t *testing.T) {
+	runLoaderScenario(t, "missing-lib", filepath.Join(t.TempDir(), "does-not-exist-libkrun.so"))
+}
+
+func TestLoaderMissingRequiredSymbol(t *testing.T) {
+	_, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("cc not available")
+	}
+
+	libPath := buildSharedLibrary(t, "int not_krun(void) { return 0;}\n")
+	runLoaderScenario(t, "missing-required-symbol", libPath)
+}
+
+func runLoaderScenario(t *testing.T, scenario string, libPath string) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestLoaderSubprocess$")
+	cmd.Env = append(os.Environ(),
+		"GO_LIBKRUN_HELPER=1",
+		"GO_LIBKRUN_CASE="+scenario,
+		"LIBKRUN_PATH="+libPath,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scenario %q failed: %v\noutput:\n%s", scenario, err, string(out))
+	}
+}
+
+func buildSharedLibrary(t *testing.T, source string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "fakekrun.c")
+	soPath := filepath.Join(tmp, "libkrun.so")
+
+	err := os.WriteFile(srcPath, []byte(source), 0600)
+	if err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cmd := exec.Command("cc", "-shared", "-fPIC", "-O2", "-o", soPath, srcPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build fake libkrun.so: %v\noutput:\n%s", err, string(out))
+	}
+
+	return soPath
+}

--- a/lxd/instance/drivers/libkrun/net.go
+++ b/lxd/instance/drivers/libkrun/net.go
@@ -1,0 +1,41 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// NetFlag holds virtio-net interface flags.
+type NetFlag uint32
+
+// NetFeature holds virtio-net feature bits.
+type NetFeature uint32
+
+// CompatNetFeatures contains the libkrun default compatibility feature mask.
+const (
+	CompatNetFeatures NetFeature = C.COMPAT_NET_FEATURES
+)
+
+func macPtr(mac [6]byte, buf *[6]C.uint8_t) *C.uint8_t {
+	for i, b := range mac {
+		buf[i] = C.uint8_t(b)
+	}
+
+	return &buf[0]
+}
+
+// AddNetTap adds a virtio-net device backed by a host tap device.
+func (c *Context) AddNetTap(tapName string, mac [6]byte, features NetFeature, flags NetFlag) error {
+	cTapName := cStr(tapName)
+	defer freeCStr(cTapName)
+
+	// Safe: krun_add_net_tap copies the MAC synchronously, so macBuf may stay stack-allocated.
+	var macBuf [6]C.uint8_t
+	return check(C.krun_add_net_tap(
+		c.id,
+		cTapName,
+		macPtr(mac, &macBuf),
+		C.uint32_t(features),
+		C.uint32_t(flags),
+	))
+}

--- a/lxd/instance/drivers/libkrun/vsock.go
+++ b/lxd/instance/drivers/libkrun/vsock.go
@@ -1,0 +1,30 @@
+package libkrun
+
+/*
+#include "libkrun_fwd.h"
+*/
+import "C"
+
+// TSIFeature holds TSI feature bits for vsock.
+type TSIFeature uint32
+
+// AddVsock adds a vsock device with optional TSI features.
+func (c *Context) AddVsock(tsiFeatures TSIFeature) error {
+	return check(C.krun_add_vsock(c.id, C.uint32_t(tsiFeatures)))
+}
+
+// AddVsockPort maps a guest vsock port to a host unix socket path.
+func (c *Context) AddVsockPort(port uint32, filepath string) error {
+	cPath := cStr(filepath)
+	defer freeCStr(cPath)
+
+	return check(C.krun_add_vsock_port(c.id, C.uint32_t(port), cPath))
+}
+
+// AddVsockPort2 maps a guest vsock port with explicit listen mode.
+func (c *Context) AddVsockPort2(port uint32, filepath string, listen bool) error {
+	cPath := cStr(filepath)
+	defer freeCStr(cPath)
+
+	return check(C.krun_add_vsock_port2(c.id, C.uint32_t(port), cPath, C.bool(listen)))
+}


### PR DESCRIPTION
This is the first part of the MicroVM functionality.

It adds a minimal cgo wrapper to libkrun library.

It uses dlopen to dynamically load libkrun library from LIBKRUN_PATH env var rather than loading it at linker time, because we do not intend to bundle the libkrun library in the snap at this time.


