### PR TITLE
doc: fix default for initial ui access

### DIFF
--- a/doc/howto/access_ui.md
+++ b/doc/howto/access_ui.md
@@ -55,7 +55,7 @@ When the server address is configured during the initialization process, LXD off
 Would you like the LXD server to be available over the network? (yes/no) [default=no]: yes
 Address to bind LXD to (not including port) [default=all]:
 Port to bind LXD to [default=8443]:
-Would you like to create an initial LXD UI access link? (yes/no) [default=no]: yes
+Would you like to create an initial LXD UI access link? (yes/no) [default=yes]
 ...
 UI initial identity (type: Initial UI token bearer): ui-admin-initial
 UI initial access link (expires: 2026-01-17 16:36): https://127.0.0.1:8443/?token=<bearer_token>


### PR DESCRIPTION
## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ x] I have checked and added or updated relevant documentation.
