### PR TITLE
lxc/info: fix snapshot table layout when no vol snapshot exist

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -646,7 +646,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 				row = append(row, "NO")
 			}
 
-			// Display attached volume snapshots
+			// Display attached volume snapshots.
 			if snap.Config["volatile.attached_volumes"] != "" {
 				// Parse the JSON map (device name -> snapshot UUID).
 				var volatileAttachedVolumes map[string]string
@@ -692,6 +692,8 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 				} else {
 					row = append(row, " ")
 				}
+			} else {
+				row = append(row, " ")
 			}
 
 			firstSnapshot = false


### PR DESCRIPTION
`snapHeader` always contains a `VOLUME SNAPSHOTS` column but the corresponding cell was only appended to a row when the snapshot had `volatile.attached_volumes` set. Rows without that key ended up with fewer columns than the header, causing the table renderer to drop the trailing `|`:

```
$ lxc init --quiet --empty c1; lxc snapshot c1; lxc info c1 | tail -n 6
Snapshots:
+-------+----------------------+------------+----------+------------------+
| NAME  |       TAKEN AT       | EXPIRES AT | STATEFUL | VOLUME SNAPSHOTS |
+-------+----------------------+------------+----------+------------------+
| snap0 | 2026/07/10 15:02 EDT |            | NO       |
+-------+----------------------+------------+----------+------------------+
```