### PR TITLE
test/lint/newline-after-block: rework for speed

### DIFF
--- a/test/lint/newline-after-block.sh
+++ b/test/lint/newline-after-block.sh
@@ -1,30 +1,36 @@
 #!/bin/bash
-set -eu
-set -o pipefail
+set -euo pipefail
 shopt -s inherit_errexit
 
 echo "Checking that functional blocks are followed by newlines..."
 
-# Check all .go files except the protobuf bindings (.pb.go)
-files=$(git ls-files --cached --modified --others '*.go' ':!:*.pb.go' ':!:test/mini-oidc/storage/*.go')
+# Gather all tracked and untracked files, respecting .gitignore
+mapfile -d '' raw_files < <(git ls-files -z --cached --others --exclude-standard '*.go' ':!:*.pb.go' ':!:test/mini-oidc/storage/*.go')
 
-exit_code=0
-for file in $files
-do
-  # This oneliner has a few steps:
-  # 1. sed:
-  #     a. Check for lines that contain a single closing brace (plus whitespace).
-  #     b. Move the pattern space window forward to the next line.
-  #     c. Match lines that start with a word character. This allows for a closing brace on subsequent lines.
-  #     d. Print the line number.
-  # 2. xargs: Print the filename next to the line number of the matches (piped).
-  # 3. If there were no matches, the file name without the line number is printed, use grep to filter it out.
-  # 4. Replace the space with a colon to make a clickable link.
-  RESULT=$(sed -n -e '/^\s*}\s*$/{n;/^\s*\w/{;=}}' "$file" | xargs -L 1 echo "$file" | grep -v '\.go$' | sed 's/ /:/g' || true)
-  if [ -n "${RESULT}" ]; then
-    echo "${RESULT}"
-    exit_code=1
+# Filter out any tracked files that have been deleted locally so sed doesn't crash
+files=()
+for f in "${raw_files[@]}"; do
+  if [ -f "$f" ]; then
+    files+=("$f")
   fi
 done
 
-exit "${exit_code}"
+# Exit early if there are absolutely no files to check
+if [ ${#files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# Process ALL existing files in one single batch
+# This oneliner has a few steps:
+# 1. sed:
+#     a. Check for lines that contain a single closing brace (plus whitespace).
+#     b. Move the pattern space window forward to the next line.
+#     c. Match lines that start with a word character. This allows for a closing brace on subsequent lines.
+#     d. Print the line number (=) and the filename (F) on separate lines
+# 2. Stitch the line numbers and the filenames together to make a clickable link.
+RESULT=$(sed -n -s -e '/^\s*}\s*$/{n;/^\s*\w/{;=;F}}' "${files[@]}" | awk 'NR%2{ln=$0;next} {print $0 ":" ln}')
+
+if [ -n "${RESULT}" ]; then
+  echo "${RESULT}"
+  exit 1
+fi


### PR DESCRIPTION
```
$ hyperfine 'test/lint/newline-after-block.sh' 'test/lint/newline-after-block2.sh'
Benchmark 1: test/lint/newline-after-block.sh
  Time (mean ± σ):      3.685 s ±  0.511 s    [User: 2.874 s, System: 3.652 s]
  Range (min … max):    3.082 s …  4.114 s    10 runs

Benchmark 2: test/lint/newline-after-block2.sh
  Time (mean ± σ):     114.1 ms ±   0.8 ms    [User: 83.7 ms, System: 32.6 ms]
  Range (min … max):   111.4 ms … 115.2 ms    26 runs

Summary
  test/lint/newline-after-block2.sh ran
   32.29 ± 4.49 times faster than test/lint/newline-after-block.sh
```

So from ~3.7s to ~0.1s.