### PR TITLE
Instance: Fix booting Windows in BIOS boot mode (partially disable hv_passthrough)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1528,10 +1528,11 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 	cpuExtensions := []string{}
 
 	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
-		// If using Linux 5.10 or later, use HyperV optimizations.
+		// If using Linux 5.10 or later, use HyperV optimizations when not using migration.stateful or BIOS mode.
+		// Hyper-V extensions can cause problems with live migration and Windows booting in BIOS mode.
 		minVer, _ := version.NewDottedVersion("5.10.0")
-		if d.state.OS.KernelVersion.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
-			// x86_64 can use hv_time to improve Windows guest performance.
+		if d.state.OS.KernelVersion.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) && d.effectiveBootMode() != instancetype.BootModeBIOS {
+			// x86_64 with UEFI can use hv_time (bundled in hv_passthrough) to improve Windows guest performance.
 			cpuExtensions = append(cpuExtensions, "hv_passthrough")
 		}
 


### PR DESCRIPTION
When booting a VM with `migration.stateful=false` and `boot.mode=bios` the `hv_passthrough` CPU flag being passed through was causing QEMU to activate features that caused Windows that caused a freeze during early boot.

Fixes https://github.com/canonical/lxd/issues/18536


