### PR TITLE
VM: Don't hang on FS attach with idmap set

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -313,9 +313,11 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 		return nil, errors.New("Failed getting UnixListener for virtiofsd")
 	}
 
-	revert.Add(func() {
-		_ = unixListener.Close()
-	})
+	defer func() { _ = unixListener.Close() }()
+
+	// Don't unlink the socket file on close after virtiofsd has started.
+	// The socket should remain for qemu to connect to.
+	unixListener.SetUnlinkOnClose(false)
 
 	unixFile, err := unixListener.File()
 	if err != nil {

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -242,17 +242,17 @@ func diskAddRootUserNSEntry(idmaps []idmap.IdmapEntry, hostRootID int64) []idmap
 	return idmaps
 }
 
-// DiskVMVirtiofsdStart starts a new virtiofsd process.
+// DiskVMVirtiofsdStart starts a new virtiofsd process with a socket present at the supplied path.
 // If the idmaps slice is supplied then the proxy process is run inside a user namespace using the supplied maps.
 // Returns UnsupportedError error if the host system or instance does not support virtiofsd, returns normal error
 // type if process cannot be started for other reasons.
-// Returns revert function and listener file handle on success.
-func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath string, logPath string, sharePath string, idmaps []idmap.IdmapEntry, threadPoolSize uint16) (func(), net.Listener, error) {
+// Returns a revert function on success.
+func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath string, logPath string, sharePath string, idmaps []idmap.IdmapEntry, threadPoolSize uint16) (func(), error) {
 	revert := revert.New()
 	defer revert.Fail()
 
 	if !filepath.IsAbs(sharePath) {
-		return nil, nil, fmt.Errorf("Share path not absolute: %q", sharePath)
+		return nil, fmt.Errorf("Share path not absolute: %q", sharePath)
 	}
 
 	// Remove old socket if needed.
@@ -271,27 +271,27 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 	}
 
 	if cmd == "" {
-		return nil, nil, ErrMissingVirtiofsd
+		return nil, ErrMissingVirtiofsd
 	}
 
 	// Currently, virtiofs is broken on at least the ARM architecture.
 	// We therefore restrict virtiofs to 64BIT_INTEL_X86.
 	if inst.Architecture() != osarch.ARCH_64BIT_INTEL_X86 {
-		return nil, nil, UnsupportedError{msg: "Architecture unsupported"}
+		return nil, UnsupportedError{msg: "Architecture unsupported"}
 	}
 
 	if shared.IsTrue(inst.ExpandedConfig()["migration.stateful"]) {
-		return nil, nil, UnsupportedError{"Stateful migration unsupported"}
+		return nil, UnsupportedError{"Stateful migration unsupported"}
 	}
 
 	if shared.IsTrue(inst.ExpandedConfig()["security.sev"]) || shared.IsTrue(inst.ExpandedConfig()["security.sev.policy.es"]) {
-		return nil, nil, UnsupportedError{"SEV unsupported"}
+		return nil, UnsupportedError{"SEV unsupported"}
 	}
 
 	// Trickery to handle paths > 108 chars.
 	socketFileDir, err := os.Open(filepath.Dir(socketPath))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	defer func() { _ = socketFileDir.Close() }()
@@ -300,7 +300,7 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	listener, err := net.Listen("unix", socketFile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed creating unix listener for virtiofsd: %w", err)
+		return nil, fmt.Errorf("Failed creating unix listener for virtiofsd: %w", err)
 	}
 
 	revert.Add(func() {
@@ -310,7 +310,7 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	unixListener, ok := listener.(*net.UnixListener)
 	if !ok {
-		return nil, nil, errors.New("Failed getting UnixListener for virtiofsd")
+		return nil, errors.New("Failed getting UnixListener for virtiofsd")
 	}
 
 	revert.Add(func() {
@@ -319,7 +319,7 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	unixFile, err := unixListener.File()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed getting unix listener file for virtiofsd: %w", err)
+		return nil, fmt.Errorf("Failed getting unix listener file for virtiofsd: %w", err)
 	}
 
 	defer func() { _ = unixFile.Close() }()
@@ -336,7 +336,7 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	proc, err := subprocess.NewProcess(cmd, args, logPath, logPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if len(idmaps) > 0 {
@@ -345,19 +345,19 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	err = proc.StartWithFiles(context.Background(), []*os.File{unixFile})
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed starting virtiofsd: %w", err)
+		return nil, fmt.Errorf("Failed starting virtiofsd: %w", err)
 	}
 
 	revert.Add(func() { _ = proc.Stop() })
 
 	err = proc.Save(pidPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed saving virtiofsd state: %w", err)
+		return nil, fmt.Errorf("Failed saving virtiofsd state: %w", err)
 	}
 
 	cleanup := revert.Clone().Fail
 	revert.Success()
-	return cleanup, listener, err
+	return cleanup, nil
 }
 
 // DiskVMVirtiofsdStop stops an existing virtiofsd process and cleans up.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1288,16 +1288,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					logPath := filepath.Join(d.inst.LogPath(), "disk."+filesystem.PathNameEncode(d.name)+".log")
 					_ = os.Remove(logPath) // Remove old log if needed.
 
-					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, mountedPath, rawIDMaps, virtiofsdThreadPoolSize)
+					revertFunc, err := DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, mountedPath, rawIDMaps, virtiofsdThreadPoolSize)
 					if err != nil {
 						return err
 					}
 
 					revert.Add(revertFunc)
-					runConf.Revert = func() { _ = unixListener.Close() }
-
-					// Request the unix listener is closed after QEMU has connected on startup.
-					runConf.PostHooks = append(runConf.PostHooks, unixListener.Close)
 
 					// Resolve previous warning
 					_ = warnings.ResolveWarningsByLocalNodeAndProjectAndType(d.state.DB.Cluster, d.inst.Project().Name, warningtype.MissingVirtiofsd)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1465,7 +1465,7 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, configPIDPath := d.configVirtiofsdPaths()
-	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath, nil, 0)
+	revertFunc, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath, nil, 0)
 	if err != nil {
 		var errUnsupported device.UnsupportedError
 		if !errors.As(err, &errUnsupported) {
@@ -1489,9 +1489,6 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 		}
 	} else {
 		revert.Add(revertFunc)
-
-		// Request the unix listener is closed after QEMU has connected on startup.
-		defer func() { _ = unixListener.Close() }()
 	}
 
 	// Get qemu configuration and check qemu is installed.

--- a/test/suites/storage_volume_attach.sh
+++ b/test/suites/storage_volume_attach.sh
@@ -174,18 +174,40 @@ test_storage_volume_attach_vm() {
 
   ! lxc exec v1 -- findmnt /mnt || false
 
-  # Cleanup
+  # Cleanup.
   lxc storage volume delete "${pool}" vol1
   lxc storage volume delete "${pool}" vol2
   lxc storage volume delete "${pool}" vol3
 
-  # Coverage data requires clean lxd-agent stop
+  # Coverage data requires clean lxd-agent stop.
   prepare_vm_for_hard_stop v1
-
   lxc delete -f v1
 
+  # Specifically test for https://github.com/canonical/lxd/issues/18561.
+  sub_test "Attaching a shifted filesystem volume must fail fast, not hang"
+  lxc init ubuntu-vm v1 --vm -c limits.memory=384MiB -d "${SMALL_VM_ROOT_DISK}"
+  lxc storage volume create "${pool}" volshift size=1MiB
+
+  # Maps a non-root host ID.
+  lxc config set v1 raw.idmap="both 1000000 1000"
+
+  # We cannot use the setup_instance_gocoverage coverage helper here because it will
+  # trigger the same code path that we are trying to test here.
+  lxc start v1
+  waitInstanceReady v1
+
+  # Verify the volume cannot be attached.
+  # Depending on the timing when we attach the device, we may get different errors depending on whether or not virtiofsd already died:
+  # -> Error: Failed starting device "volshift": Failed adding the virtiofs device to port "qemu_pcie5": GenericError: vhost_backend_init failed: Protocol error
+  # -> Error: Failed starting device "volshift": Error connecting to virtiofs socket "/tmp/lxd-test.tmp.cx0h/WLq/devices/v1/virtio-fs.volshift.sock": dial unix /dev/fd/37: connect: connection refused
+  [[ "$(! "${_LXC}" storage volume attach "${pool}" volshift v1 /shift 2>&1 1>/dev/null)" == 'Error: Failed starting device "volshift"'* ]]
+
+  # Cleanup.
+  lxc delete -f v1
+  lxc storage volume delete "${pool}" volshift
+
   if [ -n "${orig_volume_size:-}" ]; then
-    # Restore the volume.size
+    # Restore the volume.size.
     lxc storage set "${pool}" volume.size "${orig_volume_size}"
   fi
 }


### PR DESCRIPTION
Fix https://github.com/canonical/lxd/issues/18561 (the hang) and return an error instead if adding the device to the instance fails. 

I have added another check to the `test_storage_volume_attach_vm` to explicitly check that we don't cause a hang but instead get an error.