### PR TITLE
Revert "daemon.start: the LXD UI is now always enabled." (stable-5.21)

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -551,8 +551,11 @@ if [ "${criu_enable:-"false"}" = "true" ]; then
     export PATH="${SNAP_CURRENT}/criu:${PATH}"
 fi
 
-echo "==> Exposing LXD UI"
-export LXD_UI="${SNAP_CURRENT}/share/lxd-ui/"
+# Setup UI
+if [ "${ui_enable:-"false"}" = "true" ]; then
+    echo "==> Enabling LXD UI"
+    export LXD_UI="${SNAP_CURRENT}/share/lxd-ui/"
+fi
 
 # Setup documentation
 echo "==> Exposing LXD documentation"


### PR DESCRIPTION
This reverts commit 048ff3b3ca2f7b56fb347b7e2b0ef46d72066a7f.

In 5.21, the UI is enabled by default. Shortly after release (12 days), it was made unconditionally enabled despite what the documentation said.

Reintroduce the ability to turn it off if desired. Fixes #18729