### PR TITLE
go: Update Go minimum version to 1.26.5

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # LXD Copilot Instructions
 
 LXD is a modern, secure system container and virtual machine manager.
-LXD requires Go 1.26.4 or higher and is only tested with the Golang compiler.
+LXD requires Go 1.26.5 or higher and is only tested with the Golang compiler.
 See `AGENTS.md` for the full development runbook.
 
 ## Repository layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Module: `github.com/canonical/lxd`.
 
 ## Prerequisites
 
-LXD requires Go 1.26.4 or higher and is only tested with the Golang compiler.
+LXD requires Go 1.26.5 or higher and is only tested with the Golang compiler.
 - CGO native dependencies (dqlite, liblxc). Fetch them once with:
 
   ```bash

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH ?= $(shell go env GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
-GOMIN=1.26.4
+GOMIN=1.26.5
 GOTOOLCHAIN=local
 export GOTOOLCHAIN
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -4,7 +4,7 @@
 (requirements-go)=
 ## Go
 
-LXD requires Go 1.26.4 or higher and is only tested with the Golang compiler.
+LXD requires Go 1.26.5 or higher and is only tested with the Golang compiler.
 
 We recommend having at least 2GiB of RAM to allow the build to complete.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/NVIDIA/go-nvml v0.13.2-0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd/tools
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	fillmore-labs.com/errortype


### PR DESCRIPTION
Will fix:
* https://github.com/canonical/lxd/security/code-scanning/2769
* https://github.com/canonical/lxd/security/code-scanning/2767
* https://github.com/canonical/lxd/security/code-scanning/2740
* https://github.com/canonical/lxd/security/code-scanning/2746
* https://github.com/canonical/lxd/security/code-scanning/2760
* https://github.com/canonical/lxd/security/code-scanning/2762
* https://github.com/canonical/lxd/security/code-scanning/2765