### PR TITLE
Centralise operation argument validation

### DIFF
--- a/lxd/db/operationtype/class.go
+++ b/lxd/db/operationtype/class.go
@@ -1,6 +1,8 @@
 package operationtype
 
 import (
+	"fmt"
+
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -16,10 +18,20 @@ const (
 	OperationClassToken Class = 3
 )
 
+// String implements [fmt.Stringer] for [Class].
 func (t Class) String() string {
 	return map[Class]string{
 		OperationClassTask:      api.OperationClassTask,
 		OperationClassWebsocket: api.OperationClassWebsocket,
 		OperationClassToken:     api.OperationClassToken,
 	}[t]
+}
+
+// Validate returns an error if the [Class] is not known.
+func (t Class) Validate() error {
+	if t.String() == "" {
+		return fmt.Errorf(`Unknown operation class "%d"`, t)
+	}
+
+	return nil
 }

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -501,6 +501,16 @@ func (t Type) EntityType() entity.Type {
 	}
 }
 
+// IsBulk returns true if the operation type can have child operations, and false otherwise.
+func (t Type) IsBulk() bool {
+	switch t {
+	case InstanceStateUpdateBulk, ReplicatorRun:
+		return true
+	default:
+		return false
+	}
+}
+
 // ConflictAction returns the action to take if a conflicting operation is already running.
 type ConflictAction int
 

--- a/lxd/operations/args.go
+++ b/lxd/operations/args.go
@@ -1,0 +1,67 @@
+package operations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/db/operationtype"
+	"github.com/canonical/lxd/lxd/metrics"
+	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+)
+
+// OperationArgs contains all the arguments for operation creation.
+type OperationArgs struct {
+	// ProjectName is the name of the project the operation is "running in".
+	// It namespaces the operation so that e.g. a user with `can_view_operations` on the project is able to view it.
+	// It should be left empty for server operations e.g. background tasks that span projects.
+	ProjectName string
+
+	// Type is the operation type. This is used to encapsulate general operation details including the API description.
+	Type operationtype.Type
+
+	// Class describes the kind of operation that is running.
+	Class operationtype.Class
+
+	// EntityURL is URL of the primary entity for the operation. For example, if updating an instance, it should be the
+	// instance URL. The [entity.Type] corresponding to the URL must equal the result of [operationtype.Type.EntityType]
+	// for Type. This is so that the URL can be reconstructed the database record (where it is saved as an entity ID).
+	// This field may only be unset if the result of [operationtype.Type.EntityType] for Type is [entity.TypeServer],
+	// in which case, the entity URL for the operation will be set to the server url (/1.0).
+	EntityURL *api.URL
+
+	// Resources are a map of entity type to URL. This structure is for backwards compatibility.
+	// All given URLs must match their corresponding entity type and must be resources that exist in the database.
+	// This corresponds to the `operations_resources` table, whose intent is to allow logic that restricts concurrent
+	// manipulations of a single resource. This functionality is not yet in use, so this field should not generally be
+	// set.
+	Resources map[entity.Type][]api.URL
+
+	// Metadata is the operation metadata. It may contain e.g. operation secrets. For operations whose entity type is not
+	// "server", the primary entity URL will be set in the api.MetadataEntityURL field (unless set by the caller). This may be nil.
+	Metadata map[string]any
+
+	// RunHook is the function that runs when the operation is scheduled. Token operations may not have a RunHook.
+	RunHook func(ctx context.Context, op *Operation) error
+
+	// ConnectHook is the function that runs when a client calls /1.0/operations/{id}/websocket. It is used for instance
+	// exec and migrations. Only websocket operations can have a ConnectHook.
+	ConnectHook func(op *Operation, r *http.Request, w http.ResponseWriter) error
+
+	// ConflictReference is used to prevent other operations with the same conflict reference from running.
+	// It is not valid to provide a conflict reference if the Type has [operationtype.ConflictActionNone].
+	ConflictReference string
+
+	// Children are sub-operations of a bulk operation. It is not valid to provide children if [operationtype.Type.IsBulk]
+	// returns false for the Type.
+	Children []*OperationArgs
+
+	// requestor represents the "owner" of the operation and is set on calls to ScheduleUserOperationFromRequest or
+	// ScheduleUserOperationFromOperation. It is not set on calls to ScheduleServerOperation.
+	requestor *request.RequestorAuditor
+
+	// metricsCallback is a function that is called when an operation completes. This is only set on calls to
+	// ScheduleUserOperationFromRequest and is used to update ongoing request metrics.
+	metricsCallback func(result metrics.RequestResult)
+}

--- a/lxd/operations/args.go
+++ b/lxd/operations/args.go
@@ -2,6 +2,8 @@ package operations
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/db/operationtype"
@@ -64,4 +66,99 @@ type OperationArgs struct {
 	// metricsCallback is a function that is called when an operation completes. This is only set on calls to
 	// ScheduleUserOperationFromRequest and is used to update ongoing request metrics.
 	metricsCallback func(result metrics.RequestResult)
+}
+
+// validate returns an error if the [OperationArgs] are invalid.
+func (a OperationArgs) validate(isChild bool) error {
+	err := a.Class.Validate()
+	if err != nil {
+		return err
+	}
+
+	err = operationtype.Validate(a.Type)
+	if err != nil {
+		return err
+	}
+
+	// Validate that the primary entity URL matches the operation entity type to ensure that the operation entity URL
+	// can be reconstructed from a database record (where it is saved as an entity ID).
+	operationEntityType := a.Type.EntityType()
+	if a.EntityURL != nil {
+		entityType, _, _, _, err := entity.ParseURL(a.EntityURL.URL)
+		if err != nil {
+			return fmt.Errorf("Invalid operation entity URL: %w", err)
+		}
+
+		if entityType != operationEntityType {
+			return fmt.Errorf("Entity type for URL %q does not match operation entity type %q", a.EntityURL, operationEntityType)
+		}
+	} else if operationEntityType != entity.TypeServer {
+		return errors.New("Operation entity URL required")
+	}
+
+	isBulkOperation := a.Type.IsBulk()
+
+	// Child operations cannot be bulk operations (they can't be nested).
+	if isChild && isBulkOperation {
+		return errors.New("Bulk operations cannot have nested bulk operations")
+	}
+
+	if isBulkOperation && len(a.Children) == 0 {
+		return errors.New("Bulk operations must have children")
+	}
+
+	if !isBulkOperation && len(a.Children) > 0 {
+		return fmt.Errorf("Child operations not allowed for operation type %q", a.Type.Description())
+	}
+
+	switch a.Class {
+	case operationtype.OperationClassTask:
+		// If this is a single task operation without children, it must have a run hook.
+		if len(a.Children) == 0 && a.RunHook == nil {
+			return errors.New("Task operations must have a Run hook")
+		}
+
+	case operationtype.OperationClassWebsocket:
+		if a.ConnectHook == nil {
+			return errors.New("Websocket operations must have a Connect hook")
+		}
+
+	case operationtype.OperationClassToken:
+		if a.RunHook != nil {
+			return errors.New("Token operations cannot have a Run hook")
+		}
+	}
+
+	if a.Class != operationtype.OperationClassWebsocket && a.ConnectHook != nil {
+		return errors.New("Only websocket operations can have a Connect hook")
+	}
+
+	if a.Class != operationtype.OperationClassTask && isBulkOperation {
+		return errors.New("Only task operations can have children")
+	}
+
+	if a.Class != operationtype.OperationClassTask && isChild {
+		return errors.New("Only task operations can be child operations")
+	}
+
+	if a.ConflictReference != "" && a.Type.ConflictAction() == operationtype.ConflictActionNone {
+		return fmt.Errorf("Conflict reference %q provided for operation type %q that does not support conflicts", a.ConflictReference, a.Type.Description())
+	}
+
+	for i, child := range a.Children {
+		if child == nil {
+			return errors.New("Operation children cannot be nil")
+		}
+
+		if child.ProjectName != a.ProjectName {
+			return errors.New("Child operations cannot have a different project to the parent operation")
+		}
+
+		err := child.validate(true)
+		if err != nil {
+			return fmt.Errorf(`Failed validating child operation "%d": %w`, i, err)
+		}
+	}
+
+	return nil
 }

--- a/lxd/operations/args_test.go
+++ b/lxd/operations/args_test.go
@@ -1,0 +1,430 @@
+package operations
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/lxd/lxd/db/operationtype"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+)
+
+type argsSuite struct {
+	suite.Suite
+}
+
+func TestArgsSuite(t *testing.T) {
+	suite.Run(t, new(argsSuite))
+}
+
+// validTaskOperationArgs returns a valid OperationArgs for a task operation.
+func validTaskOperationArgs() OperationArgs {
+	return OperationArgs{
+		ProjectName: "default",
+		Type:        operationtype.InstanceCreate,
+		Class:       operationtype.OperationClassTask,
+		EntityURL:   entity.ProjectURL("default"),
+		RunHook: func(ctx context.Context, op *Operation) error {
+			return nil
+		},
+	}
+}
+
+// validWebsocketOperationArgs returns a valid OperationArgs for a websocket operation.
+func validWebsocketOperationArgs() OperationArgs {
+	return OperationArgs{
+		ProjectName: "default",
+		Type:        operationtype.ConsoleShow,
+		Class:       operationtype.OperationClassWebsocket,
+		EntityURL:   entity.InstanceURL("default", "test-instance"),
+		ConnectHook: func(op *Operation, r *http.Request, w http.ResponseWriter) error {
+			return nil
+		},
+	}
+}
+
+// validTokenOperationArgs returns a valid OperationArgs for a token operation.
+func validTokenOperationArgs() OperationArgs {
+	return OperationArgs{
+		ProjectName: "default",
+		Type:        operationtype.ClusterJoinToken,
+		Class:       operationtype.OperationClassToken,
+		EntityURL:   entity.ServerURL(),
+	}
+}
+
+// validServerLevelOperationArgs returns a valid server-level task operation.
+func validServerLevelOperationArgs() OperationArgs {
+	return OperationArgs{
+		ProjectName: "",
+		Type:        operationtype.ClusterBootstrap,
+		Class:       operationtype.OperationClassTask,
+		EntityURL:   nil,
+		RunHook: func(ctx context.Context, op *Operation) error {
+			return nil
+		},
+	}
+}
+
+func (s *argsSuite) TestValidate() {
+	type testCase struct {
+		name      string
+		args      OperationArgs
+		isChild   bool
+		expectErr bool
+		errMsg    string
+	}
+
+	tests := []testCase{
+		// Happy paths
+		{
+			name:      "valid task operation with RunHook",
+			args:      validTaskOperationArgs(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
+			name: "valid task operation with children",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.RunHook = nil
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "default",
+						Type:        operationtype.InstanceStop,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.InstanceURL("default", "test-instance-1"),
+						RunHook: func(ctx context.Context, op *Operation) error {
+							return nil
+						},
+					},
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
+			name:      "valid websocket operation",
+			args:      validWebsocketOperationArgs(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
+			name:      "valid token operation",
+			args:      validTokenOperationArgs(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
+			name:      "valid server-level operation",
+			args:      validServerLevelOperationArgs(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
+			name: "valid operation with EntityURL matching operation type",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.NetworkUpdate
+				args.EntityURL = entity.NetworkURL("default", "lxdbr0")
+				return args
+			}(),
+			isChild:   false,
+			expectErr: false,
+		},
+		// Unhappy paths - invalid Class and Type
+		{
+			name: "invalid Class value",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Class = 99
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Unknown operation class",
+		},
+		{
+			name: "invalid Type value",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.Type(9999)
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Unknown operation type code",
+		},
+		// Unhappy paths - EntityURL validation
+		{
+			name: "EntityURL with wrong entity type",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceCreate
+				args.EntityURL = entity.NetworkURL("default", "test-network")
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    `Entity type for URL "/1.0/networks/test-network?project=default" does not match operation entity type "project"`,
+		},
+		{
+			name: "missing EntityURL for non-server operation",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceCreate
+				args.EntityURL = nil
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Operation entity URL required",
+		},
+		{
+			name: "invalid EntityURL format",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.EntityURL = api.NewURL().Path("invalid-url")
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Invalid operation entity URL",
+		},
+		// Unhappy paths - conflict reference
+		{
+			name: "conflict reference with action none",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.ConflictReference = "foo"
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    `Conflict reference "foo" provided for operation type "Creating instance" that does not support conflicts`,
+		},
+		// Unhappy paths - nested bulk operations
+		{
+			name: "nested bulk operations",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "default",
+						Type:        operationtype.InstanceCreate,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.InstanceURL("default", "test-instance-1"),
+						RunHook: func(ctx context.Context, op *Operation) error {
+							return nil
+						},
+					},
+				}
+
+				return args
+			}(),
+			isChild:   true,
+			expectErr: true,
+			errMsg:    `Child operations not allowed for operation type "Creating instance"`,
+		},
+		{
+			name: "bulk operation without children",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.RunHook = nil
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Bulk operations must have children",
+		},
+		{
+			name: "bulk operation as a child",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.RunHook = nil
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "default",
+						Type:        operationtype.InstanceStateUpdateBulk,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.ProjectURL("default"),
+						RunHook: func(ctx context.Context, op *Operation) error {
+							return nil
+						},
+					},
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Bulk operations cannot have nested bulk operations",
+		},
+		// Unhappy paths - Task operation requirements
+		{
+			name: "task operation without RunHook and without children",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.RunHook = nil
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Task operations must have a Run hook",
+		},
+		// Unhappy paths - Websocket operation requirements
+		{
+			name: "websocket operation without ConnectHook",
+			args: func() OperationArgs {
+				args := validWebsocketOperationArgs()
+				args.ConnectHook = nil
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Websocket operations must have a Connect hook",
+		},
+		// Unhappy paths - Token operation requirements
+		{
+			name: "token operation with RunHook",
+			args: func() OperationArgs {
+				args := validTokenOperationArgs()
+				args.RunHook = func(ctx context.Context, op *Operation) error {
+					return nil
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Token operations cannot have a Run hook",
+		},
+		// Unhappy paths - hook restrictions
+		{
+			name: "non-websocket operation with ConnectHook",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.ConnectHook = func(op *Operation, r *http.Request, w http.ResponseWriter) error {
+					return nil
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Only websocket operations can have a Connect hook",
+		},
+		// Unhappy paths - children restrictions
+		{
+			name: "non-task operation with children",
+			args: func() OperationArgs {
+				args := validWebsocketOperationArgs()
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "default",
+						Type:        operationtype.InstanceCreate,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.InstanceURL("default", "test-instance-1"),
+						RunHook: func(ctx context.Context, op *Operation) error {
+							return nil
+						},
+					},
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    `Child operations not allowed for operation type "Showing console"`,
+		},
+		// Unhappy paths - child operation restrictions
+		{
+			name: "non-task operation as child",
+			args: func() OperationArgs {
+				args := validWebsocketOperationArgs()
+				return args
+			}(),
+			isChild:   true,
+			expectErr: true,
+			errMsg:    "Only task operations can be child operations",
+		},
+		{
+			name: "nil child",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.Children = append(args.Children, nil)
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Operation children cannot be nil",
+		},
+		{
+			name: "child with different to parent",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "foo",
+						Type:        operationtype.InstanceCreate,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.InstanceURL("foo", "test-instance-1"),
+						RunHook: func(ctx context.Context, op *Operation) error {
+							return nil
+						},
+					},
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Child operations cannot have a different project to the parent operation",
+		},
+		// Unhappy paths - child validation failure propagation
+		{
+			name: "child operation validation failure",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.RunHook = nil
+				args.Children = []*OperationArgs{
+					{
+						ProjectName: "default",
+						Type:        operationtype.InstanceCreate,
+						Class:       operationtype.OperationClassTask,
+						EntityURL:   entity.InstanceURL("default", "test-instance-1"),
+						RunHook:     nil,
+					},
+				}
+
+				return args
+			}(),
+			isChild:   false,
+			expectErr: true,
+			errMsg:    "Failed validating child operation",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := tt.args.validate(tt.isChild)
+			if tt.expectErr {
+				s.Error(err)
+				s.Contains(err.Error(), tt.errMsg)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -27,11 +27,6 @@ func registerDBOperation(ctx context.Context, op *Operation) error {
 	}
 
 	registerSingleOperation := func(ctx context.Context, tx *db.ClusterTx, op *Operation, parentOpID *int64, projectID *int64) (int64, error) {
-		// Conflict reference should only be provided for operation types that support conflicts.
-		if op.dbOpType.ConflictAction() == operationtype.ConflictActionNone && op.conflictReference != "" {
-			return 0, fmt.Errorf("Conflict reference %q provided for operation type %q that does not support conflicts", op.conflictReference, op.dbOpType.Description())
-		}
-
 		operationsRow := cluster.OperationsRow{
 			UUID:              op.id,
 			Type:              op.dbOpType,

--- a/lxd/operations/db.go
+++ b/lxd/operations/db.go
@@ -69,13 +69,6 @@ func registerDBOperation(ctx context.Context, op *Operation) error {
 			operationsRow.EntityID = int64(entityReference.EntityID)
 		}
 
-		inputsJSON, err := json.Marshal(op.inputs)
-		if err != nil {
-			return 0, fmt.Errorf("Failed marshalling operation inputs: %w", err)
-		}
-
-		operationsRow.Inputs = string(inputsJSON)
-
 		metadataJSON, err := json.Marshal(op.metadata)
 		if err != nil {
 			return 0, fmt.Errorf("Failed marshalling operation metadata: %w", err)
@@ -207,16 +200,6 @@ func ConstructOperationFromDB(ctx context.Context, tx *sql.Tx, s *state.State, d
 	op.logger = logger.AddContext(logger.Ctx{"operation": op.id, "project": op.projectName, "class": op.class.String(), "description": op.description})
 
 	op.events = s.Events
-
-	// Load operation inputs.
-	var inputs map[string]any
-	var err error
-	err = json.Unmarshal([]byte(dbOp.Row.Inputs), &inputs)
-	if err != nil {
-		return nil, fmt.Errorf("Failed unmarshalling operation inputs for operation %d: %w", dbOp.Row.ID, err)
-	}
-
-	op.inputs = inputs
 
 	// Load operation entity URL.
 	// Note that we rely on the entity_type of the operation and the entityURL being the same. This is enforced by a check in the initOperation().

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -104,24 +104,6 @@ type Operation struct {
 	events *events.Server
 }
 
-// OperationArgs contains all the arguments for operation creation.
-type OperationArgs struct {
-	ProjectName     string
-	Type            operationtype.Type
-	Class           operationtype.Class
-	EntityURL       *api.URL
-	Resources       map[entity.Type][]api.URL
-	Metadata        map[string]any
-	RunHook         func(ctx context.Context, op *Operation) error
-	ConnectHook     func(op *Operation, r *http.Request, w http.ResponseWriter) error
-	requestor       *request.RequestorAuditor
-	metricsCallback func(result metrics.RequestResult)
-	// ConflictReference allows to create the operation only if no other operation with the same conflict reference is running.
-	// Empty ConflictReference means the operation can be started anytime.
-	ConflictReference string
-	Children          []*OperationArgs
-}
-
 // OperationScheduler is a signature used in function arguments where the function is used to deduplicate operation
 // argument initialisation logic where the operation can be scheduled within an HTTP request or within an operation.
 type OperationScheduler func(s *state.State, args OperationArgs) (*Operation, error)

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -150,29 +150,16 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		return nil, errors.New("State must be provided")
 	}
 
+	err := args.validate(false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed validating operation arguments: %w", err)
+	}
+
 	// initOperation initializes a single operation structure.
 	initOperation := func(s *state.State, args OperationArgs) (*Operation, error) {
 		// Don't allow new operations when LXD is shutting down.
 		if s.ShutdownCtx.Err() != nil {
 			return nil, errors.New("LXD is shutting down")
-		}
-
-		// Validate that the primary entity URL matches the operation entity type to ensure that the operation entity URL
-		// can be reconstructed from a database record (where it is saved as an entity ID).
-		operationEntityType := args.Type.EntityType()
-		if args.EntityURL != nil {
-			entityType, _, _, _, err := entity.ParseURL(args.EntityURL.URL)
-			if err != nil {
-				return nil, fmt.Errorf("Invalid operation entity URL: %w", err)
-			}
-
-			if entityType != operationEntityType {
-				return nil, fmt.Errorf("Entity type for URL %q does not match operation entity type %q", args.EntityURL, operationEntityType)
-			}
-		} else if operationEntityType != entity.TypeServer {
-			return nil, errors.New("Operation entity URL required")
-		} else {
-			args.EntityURL = entity.ServerURL()
 		}
 
 		// Use a v7 UUID for the operation ID.
@@ -204,6 +191,15 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		op.events = s.Events
 		op.location = s.ServerName
 
+		// The call to args.validate already validated the entity URL. If it is nil, then it should be set to the
+		// server URL (/1.0).
+		entityURL := args.EntityURL
+		if entityURL == nil {
+			entityURL = entity.ServerURL()
+		}
+
+		op.entityURL = entityURL
+
 		metadata := args.Metadata
 		if metadata == nil {
 			metadata = make(map[string]any)
@@ -212,6 +208,7 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		// If the entity_url field is not already populated, populate it with the entity url of the operation.
 		// This allows the caller to override the entity URL if e.g. creating a new entity but ensures the field is populated.
 		// Skip if the entity type is "server". This doesn't give any useful information to the requestor (since the url will just be "/1.0").
+		operationEntityType := args.Type.EntityType()
 		_, ok := metadata[api.MetadataEntityURL]
 		if !ok && operationEntityType != entity.TypeServer {
 			// The project that is present in the operation entity URL is always the effective project (e.g. the actual
@@ -239,32 +236,7 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		op.onRun = args.RunHook
 		op.onConnect = args.ConnectHook
 
-		// Quick check.
-		if op.class != operationtype.OperationClassWebsocket && op.onConnect != nil {
-			return nil, errors.New("Only websocket operations can have a Connect hook")
-		}
-
-		if op.class == operationtype.OperationClassWebsocket && op.onConnect == nil {
-			return nil, errors.New("Websocket operations must have a Connect hook")
-		}
-
-		if op.class == operationtype.OperationClassToken && op.onRun != nil {
-			return nil, errors.New("Token operations cannot have a Run hook")
-		}
-
 		return &op, nil
-	}
-
-	// If this is a bulk operation, don't allow more than one level of nesting.
-	for _, child := range args.Children {
-		if len(child.Children) > 0 {
-			return nil, errors.New("Bulk operations cannot have nested bulk operations")
-		}
-	}
-
-	// If this is a single task operation without children, it must have a run hook.
-	if !slices.Contains([]operationtype.Class{operationtype.OperationClassWebsocket, operationtype.OperationClassToken}, args.Class) && args.Children == nil && args.RunHook == nil {
-		return nil, errors.New("Task operations must have a Run hook")
 	}
 
 	// Create the parent operation

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -228,10 +228,12 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 			metadata[api.MetadataEntityURL] = metadataURL.String()
 		}
 
-		op.metadata, err = validateMetadata(metadata)
+		err = validateMetadata(metadata)
 		if err != nil {
 			return nil, fmt.Errorf("Failed validating operation metadata: %w", err)
 		}
+
+		op.metadata = metadata
 
 		// Callback functions
 		op.onRun = args.RunHook
@@ -822,11 +824,11 @@ func (op *Operation) updateStatus(ctx context.Context, newStatus api.StatusCode)
 	return updateDBOperation(ctx, op)
 }
 
-// UpdateMetadata updates the metadata of the operation. It returns an error
-// if the operation is not pending or running, or the operation is read-only.
+// UpdateMetadata updates the metadata of the operation. It returns an error if the operation has completed.
 // The api.MetadataEntityURL field is retained unless the caller sets api.MetadataEntityURL in the input map.
+// If a nil map is passed in, metadata is set to an empty map.
 func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
-	opMetadata, err := validateMetadata(opMetadata)
+	err := validateMetadata(opMetadata)
 	if err != nil {
 		return fmt.Errorf("Failed updating operation metadata: %w", err)
 	}
@@ -840,6 +842,10 @@ func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
 	if op.readonly {
 		op.lock.Unlock()
 		return errors.New("Read-only operations cannot be updated")
+	}
+
+	if opMetadata == nil {
+		opMetadata = make(map[string]any)
 	}
 
 	// Retain entity URL unless it is set in the input map.
@@ -892,6 +898,12 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 		return errors.New("Read-only operations cannot be updated")
 	}
 
+	// Nothing to do.
+	if len(metadata) == 0 {
+		op.lock.Unlock()
+		return nil
+	}
+
 	// Get current metadata.
 	newMetadata := maps.Clone(op.metadata)
 
@@ -902,7 +914,7 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 		maps.Copy(newMetadata, metadata)
 	}
 
-	newMetadata, err := validateMetadata(newMetadata)
+	err := validateMetadata(newMetadata)
 	if err != nil {
 		op.lock.Unlock()
 		return fmt.Errorf("Failed extending operation metadata: %w", err)
@@ -975,11 +987,11 @@ func (op *Operation) Children() []*Operation {
 	return op.children
 }
 
-// validateMetadata is used to enforce some consistency in operation metadata.
-func validateMetadata(metadata map[string]any) (map[string]any, error) {
-	// Ensure metadata is never nil.
+// validateMetadata returns an error if the metadata contains a known key with an invalid value (such as
+// [api.MetadataEntityURL] with a non-url value).
+func validateMetadata(metadata map[string]any) error {
 	if metadata == nil {
-		metadata = make(map[string]any)
+		return nil
 	}
 
 	// If any url fields are used, they must always be a string and must always be a valid URL.
@@ -989,17 +1001,17 @@ func validateMetadata(metadata map[string]any) (map[string]any, error) {
 		if ok {
 			urlString, ok := urlAny.(string)
 			if !ok {
-				return nil, fmt.Errorf("Operation metadata field %q must be a string (got %T)", urlField, urlAny)
+				return fmt.Errorf("Operation metadata field %q must be a string (got %T)", urlField, urlAny)
 			}
 
 			err := validate.IsRequestURL(urlString)
 			if err != nil {
-				return nil, fmt.Errorf("Operation metadata field %q must be a valid request URL: %w", urlField, err)
+				return fmt.Errorf("Operation metadata field %q must be a valid request URL: %w", urlField, err)
 			}
 		}
 	}
 
-	return metadata, nil
+	return nil
 }
 
 // ProgressHandler implements [ioprogress.ProgressReporter]. This is used by instance and storage drivers to

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -82,9 +82,6 @@ type Operation struct {
 	onRun     func(context.Context, *Operation) error
 	onConnect func(*Operation, *http.Request, http.ResponseWriter) error
 
-	// Inputs for the operation, which are stored in the database.
-	inputs map[string]any
-
 	// Operations which conflict with each other share the same conflict reference.
 	conflictReference string
 
@@ -119,7 +116,6 @@ type OperationArgs struct {
 	ConnectHook     func(op *Operation, r *http.Request, w http.ResponseWriter) error
 	requestor       *request.RequestorAuditor
 	metricsCallback func(result metrics.RequestResult)
-	Inputs          map[string]any
 	// ConflictReference allows to create the operation only if no other operation with the same conflict reference is running.
 	// Empty ConflictReference means the operation can be started anytime.
 	ConflictReference string
@@ -222,7 +218,6 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		op.requestor = args.requestor
 		op.metricsCallback = args.metricsCallback
 		op.logger = logger.AddContext(logger.Ctx{"operation": op.id, "project": op.projectName, "class": op.class.String(), "description": op.description})
-		op.inputs = args.Inputs
 		op.conflictReference = args.ConflictReference
 		op.events = s.Events
 		op.location = s.ServerName
@@ -986,11 +981,6 @@ func (op *Operation) Class() operationtype.Class {
 // Type returns the db operation type.
 func (op *Operation) Type() operationtype.Type {
 	return op.dbOpType
-}
-
-// Inputs returns the operation inputs from the database.
-func (op *Operation) Inputs() map[string]any {
-	return op.inputs
 }
 
 // Parent returns the parent operation if this operation is a child operation, or nil if this operation is not a child operation.


### PR DESCRIPTION
Validation of operation arguments is currently haphazard. This PR centralises it as a function defined against OperationArgs. Further validation will be added here (e.g. validation of stages in #18730).

Additionally, `OperationArgs.Inputs` was essentially unused. The type for this field will change in the upcoming durable operations PR #17045, so for now I have removed it.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
