### PR TITLE
github: Use git force push when syncing to lxd-private (stable-4.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -421,8 +421,7 @@ jobs:
 
           # Sync the rebased lxd-private branch back to the lxd-private repo so that it is kept in sync with the public repo.
           # Do this before any snapcraft.yaml modifications made below.
-          # Use --force-with-lease and --force-if-includes to ensure local branch includes contents from lxd-private remote.
-          git push --quiet --force-with-lease="refs/heads/${GITHUB_REF_NAME}" --force-if-includes lxd-private HEAD:"${GITHUB_REF_NAME}"
+          git push --quiet --force lxd-private HEAD:"${GITHUB_REF_NAME}"
 
           # Extract a strict major.minor[.patch] version from shared/version/flex.go.
           version="$(sed -nE 's/^var Version = "([0-9]+\.[0-9]+(\.[0-9]+)?)"$/\1/p' "${GITHUB_WORKSPACE}/shared/version/flex.go")"


### PR DESCRIPTION
This is required because the history order may be changing after rebasing private fixes atop the current public branch HEAD.


(cherry picked from commit b0bcf002ecc0e53f3b9838a42439997777b10dc8) 
