### PR TITLE
doc: specify that LXD uses the Go TLS stack

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -33,6 +33,7 @@ On the next connection, a new certificate is generated.
 ### Communication protocol
 
 The supported protocol must be TLS 1.3 or better.
+LXD uses the [Go TLS stack](https://pkg.go.dev/crypto/tls) as the TLS implementation.
 
 All communications must use perfect forward secrecy, and ciphers must be limited to strong elliptic curve ones (such as ECDHE-RSA or ECDHE-ECDSA).
 

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -9,6 +9,7 @@ LXD uses an image-based workflow.
 Each instance is based on an image, which contains a basic operating system (for example, a Linux distribution) and some LXD-related information.
 
 Images are available from remote image stores (see {ref}`remote-image-servers` for an overview), but you can also create your own images, either based on an existing instances or a rootfs image.
+LXD uses the [Go TLS stack](https://pkg.go.dev/crypto/tls) to connect to remote image servers.
 
 You can copy images from remote servers to your local image store, or copy local images to remote servers.
 You can also use a local image to create a remote instance.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
