### PR TITLE
lxc/list: Fetch network state when filtering by IP address

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -494,6 +494,12 @@ func (c *cmdList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// The ipv4 and ipv6 filters are applied client side against the instance's network state.
+	filtersNeedNetwork := c.filtersNeedNetwork(filters)
+	if filtersNeedNetwork {
+		needsData = true
+	}
+
 	if needsData && d.HasExtension("container_full") {
 		var instances []api.InstanceFull
 
@@ -503,7 +509,7 @@ func (c *cmdList) run(cmd *cobra.Command, args []string) error {
 		// Initialize as empty slice (not nil) to enable optimization when no fields are needed.
 		recursionFields := []string{}
 		needsDisk := false
-		needsNetwork := false
+		needsNetwork := filtersNeedNetwork
 
 		for _, col := range columns {
 			if col.NeedsDisk {
@@ -1029,4 +1035,21 @@ func (c *cmdList) mapShorthandFilters() {
 		"ipv4":         c.matchByIPV4,
 		"ipv6":         c.matchByIPV6,
 	}
+}
+
+// filtersNeedNetwork returns true if any of the filters is an ipv4 or ipv6 shorthand filter.
+func (c *cmdList) filtersNeedNetwork(filters []string) bool {
+	for _, filter := range filters {
+		key, _, found := strings.Cut(filter, "=")
+		if !found {
+			continue
+		}
+
+		switch strings.ToLower(key) {
+		case "ipv4", "ipv6":
+			return true
+		}
+	}
+
+	return false
 }

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -10,6 +10,12 @@ test_network() {
   sleep 2
   dig @"${v4_addr}" 0abc.lxd
   dig @"${v4_addr}" def0.lxd
+
+  # Filtering by IP must work even when no network column is selected.
+  inst_ipv4="192.0.2.42"
+  lxc exec 0abc -- ip address add "${inst_ipv4}" dev eth0
+  [ "$(lxc list -f csv -c n ipv4="${inst_ipv4}")" = "0abc" ]
+
   lxc delete -f 0abc def0
   lxc network delete lxdt$$
 


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/17055

`lxc list -c n ipv4=<ip>` returned an empty table: the ipv4/ipv6 filters match client side against network state, but only the requested columns decided whether to fetch it. `-c n` needs no state, so it stayed nil and everything was filtered out. It worked without `-c` because the default columns include `4` (IPV4). Now, `needsData` selects the `GetInstancesFull` path & `needsNetwork` adds `state.network` to the recursion fields. Queries without an IP filter still use `recursion=1`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
