### PR TITLE
doc: specify that LXD uses the Go TLS stack (stable-5.21)

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -169,6 +169,7 @@ Mibit
 MicroCeph
 MicroCloud
 MicroOVN
+middleboxes
 MII
 MinIO
 MITM

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -32,6 +32,7 @@ On the next connection, a new certificate is generated.
 ### Communication protocol
 
 The supported protocol must be TLS 1.3 or better.
+LXD uses the [Go TLS stack](https://pkg.go.dev/crypto/tls) as the TLS implementation.
 
 It's possible to force LXD to accept TLS 1.2 by setting the `LXD_INSECURE_TLS` environment variable on both client and server.
 However this isn't a supported setup and should only ever be used when forced to use an outdated corporate proxy.

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -16,6 +16,11 @@ You can also use a local image to create a remote instance.
 Each image is identified by a fingerprint (SHA256).
 To make it easier to manage images, LXD allows defining one or more aliases for each image.
 
+LXD uses the [Go TLS stack](https://pkg.go.dev/crypto/tls) to connect to remote image servers, but with post-quantum cryptography ({abbr}`PQC`) disabled.
+This restriction of SimpleStreams connections to legacy TLS curves was implemented to accommodate users operating behind broken network middleboxes.
+PQC hybrid curves require larger keys, and, as a result, the TLS `ClientHello` message can exceed the size of a single TCP packet.
+Broken middleboxes that fail to properly reassemble fragmented TCP packets often abruptly terminate these handshakes.
+
 ## Caching
 
 When you create an instance using a remote image, LXD downloads the image and caches it locally.


### PR DESCRIPTION
Backports #18761 , with an edit to clarify that PQC is disabled for connecting to image servers.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
