### PR TITLE
doc: update LXD documentation URLs

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,2 +1,2 @@
 The LXD team uses GitHub for issue and feature tracking, not for user support.
-For information on how to get support, see [Support](https://documentation.ubuntu.com/lxd/latest/support/).
+For information on how to get support, see [Support](https://canonical.com/lxd/docs/latest/support/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,4 +216,4 @@ The LXD repository includes a [Copilot instructions file](https://github.com/can
 
 ## More information
 
-For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/latest/contributing/) in the documentation.
+For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://canonical.com/lxd/docs/latest/contributing/) in the documentation.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You should consider using LXD if you want to containerize different environments
 
 ## Get started
 
-See [Getting started](https://documentation.ubuntu.com/lxd/latest/getting_started/) in the LXD documentation for installation instructions and first steps.
+See [Getting started](https://canonical.com/lxd/docs/latest/getting_started/) in the LXD documentation for installation instructions and first steps.
 
 - Release announcements: [`https://discourse.ubuntu.com/tags/c/project/lxd/news/143/release`](https://discourse.ubuntu.com/tags/c/project/lxd/news/143/release)
 - Release tarballs: [`https://github.com/canonical/lxd/releases/`](https://github.com/canonical/lxd/releases/)
-- Documentation: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)
+- Documentation: [`https://canonical.com/lxd/docs/latest/`](https://canonical.com/lxd/docs/latest/)
 
 ## Status
 
@@ -40,7 +40,7 @@ macOS               | [Homebrew](https://formulae.brew.sh/formula/lxc)  | `brew 
 
 The LXD snap packaging repository is available [here](https://github.com/canonical/lxd-pkg-snap).
 
-For more instructions on installing LXD for a wide variety of Linux distributions and operating systems, and to install LXD from source, see [How to install LXD](https://documentation.ubuntu.com/lxd/latest/installing/) in the documentation.
+For more instructions on installing LXD for a wide variety of Linux distributions and operating systems, and to install LXD from source, see [How to install LXD](https://canonical.com/lxd/docs/latest/installing/) in the documentation.
 
 ## Client SDK packages
 
@@ -53,7 +53,7 @@ Language  | URL
 Go        | https://pkg.go.dev/github.com/canonical/lxd/client
 Python    | https://github.com/canonical/pylxd
 
-For more information on using the LXD API, see [REST API](https://documentation.ubuntu.com/lxd/latest/restapi_landing/) in the documentation.
+For more information on using the LXD API, see [REST API](https://canonical.com/lxd/docs/latest/restapi_landing/) in the documentation.
 
 ## Tools for managing LXD
 
@@ -80,9 +80,9 @@ Consider the following aspects to ensure that your LXD installation is secure:
 - Configure your network interfaces to be secure.
 - Do not use privileged containers unless required. If you use privileged containers, put appropriate security measures in place.
   <!-- Include end security -->
-  See [Container security](https://documentation.ubuntu.com/lxd/latest/explanation/security/#container-security) for more information.
+  See [Container security](https://canonical.com/lxd/docs/latest/explanation/security/#container-security) for more information.
 
-See [Security](https://documentation.ubuntu.com/lxd/latest/explanation/security/) for detailed information.
+See [Security](https://canonical.com/lxd/docs/latest/explanation/security/) for detailed information.
 
 **IMPORTANT:**
 <!-- Include start security note -->
@@ -103,7 +103,7 @@ Ask questions or engage in discussions: [`https://discourse.ubuntu.com/c/project
 
 ### Documentation
 
-Access the official documentation: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)
+Access the official documentation: [`https://canonical.com/lxd/docs/latest/`](https://canonical.com/lxd/docs/latest/)
 
 ### Bug reports and feature requests
 
@@ -115,7 +115,7 @@ You can find additional resources on the [LXD website](https://canonical.com/lxd
 
 ## Commercial support
 
-LTS releases of LXD receive standard support for five years, which means they receive continuous updates. Commercial support for LXD is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro), including for [attached LXD instances running Ubuntu](https://documentation.ubuntu.com/lxd/latest/howto/instances_ubuntu_pro_attach/). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
+LTS releases of LXD receive standard support for five years, which means they receive continuous updates. Commercial support for LXD is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro), including for [attached LXD instances running Ubuntu](https://canonical.com/lxd/docs/latest/howto/instances_ubuntu_pro_attach/). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
 
 Managed solutions and firefighting support are also available for LXD deployments. See: [Managed services](https://ubuntu.com/managed).
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,8 +1,8 @@
 # LXD documentation
 
-The LXD documentation is available at: <https://documentation.ubuntu.com/lxd/latest/>
+The LXD documentation is available at: <https://canonical.com/lxd/docs/latest/>
 
-GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://documentation.ubuntu.com/lxd/latest/).
+GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://canonical.com/lxd/docs/latest/).
 
 ## How it works
 

--- a/doc/howto/access_documentation.md
+++ b/doc/howto/access_documentation.md
@@ -1,7 +1,7 @@
 (access-documentation)=
 # How to access the local LXD documentation
 
-The latest version of the LXD documentation is available at [`documentation.ubuntu.com/lxd`](https://documentation.ubuntu.com/lxd/).
+The latest version of the LXD documentation is available at [`canonical.com/lxd/docs`](https://canonical.com/lxd/docs/).
 
 Alternatively, you can access a local version of the LXD documentation that is embedded in the LXD snap.
 This version of the documentation exactly matches the version of your LXD deployment, but might be missing additions, fixes, or clarifications that were added after the release of the snap.

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -266,4 +266,4 @@ Following the CLI prompts, a working MicroCloud will be ready within minutes.
 
 When the initialization is complete, you’ll have an OVN cluster, a Ceph cluster and a LXD cluster, and LXD itself will have been configured with both networking and storage suitable for use in a cluster.
 
-See the [MicroCloud documentation](https://documentation.ubuntu.com/microcloud/latest/) for more information.
+See the [MicroCloud documentation](https://canonical.com/microcloud/docs/latest/) for more information.

--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -94,7 +94,7 @@
       "targetBlank": true,
       "title": "Documentation",
       "type": "link",
-      "url": "https://documentation.ubuntu.com/lxd/latest/"
+      "url": "https://canonical.com/lxd/docs/latest/"
     }
   ],
   "liveNow": false,

--- a/lxd/api_root.go
+++ b/lxd/api_root.go
@@ -132,7 +132,7 @@ var documentationRedirectCmd = APIEndpoint{
 }
 
 // uiUnavailableMessage is the HTML body returned when the LXD web UI is not available.
-const uiUnavailableMessage = `<html><title>The UI is not available</title><body><p>The UI is not available in this installation of LXD. For more information check: <a href="https://documentation.ubuntu.com/lxd/latest/howto/access_ui/">How to access the LXD web UI</a></p></body></html>`
+const uiUnavailableMessage = `<html><title>The UI is not available</title><body><p>The UI is not available in this installation of LXD. For more information check: <a href="https://canonical.com/lxd/docs/latest/howto/access_ui/">How to access the LXD web UI</a></p></body></html>`
 
 func rootGet(d *Daemon, r *http.Request) response.Response {
 	if isBrowserClient(r) {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3174,7 +3174,7 @@ func (d *qemu) generateConfigShare() error {
 # LXD VM, rather than being enabled at boot.
 [Unit]
 Description=LXD - agent
-Documentation=https://documentation.ubuntu.com/lxd/latest/
+Documentation=https://canonical.com/lxd/docs/latest/
 Before=multi-user.target cloud-init-local.service shutdown.target umount.target
 After=local-fs.target systemd-journald.socket
 Conflicts=shutdown.target

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -126,7 +126,7 @@ const clusterEditPrompt = `You should run this command only if:
  - You are *absolutely* sure all LXD daemons are stopped
  - This instance has the most up to date database
 
-See https://documentation.ubuntu.com/lxd/latest/howto/cluster_recover/#reconfigure-the-cluster for more info.`
+See https://canonical.com/lxd/docs/latest/howto/cluster_recover/#reconfigure-the-cluster for more info.`
 
 const clusterEditComment = `# Member roles can be modified. Unrecoverable nodes should be given the role "spare".
 #
@@ -441,7 +441,7 @@ database, so you can possibly inspect it for further recovery.
 You'll be able to permanently delete from the database all information about
 former cluster members by running "lxc cluster remove <member-name> --force".
 
-See https://documentation.ubuntu.com/lxd/latest/howto/cluster_recover/#recover-from-quorum-loss for more
+See https://canonical.com/lxd/docs/latest/howto/cluster_recover/#recover-from-quorum-loss for more
 info.`
 
 type cmdClusterRecoverFromQuorumLoss struct {

--- a/scripts/setup-grafana.sh
+++ b/scripts/setup-grafana.sh
@@ -12,7 +12,7 @@ SERVER_NAME="$(lxc info | awk '{if ($1 == "server_name:") print $2}')"
 IS_LXD_CLUSTERED=$(lxc info | grep "server_clustered:" | grep "false")
 if [ -z "$IS_LXD_CLUSTERED" ]; then
     echo "Error: LXD is clustered, this script only works for single node installations."
-    echo "See https://documentation.ubuntu.com/lxd/latest/metrics/ for more information."
+    echo "See https://canonical.com/lxd/docs/latest/metrics/ for more information."
     exit 1
 fi
 
@@ -118,4 +118,4 @@ echo "Next steps:"
 echo "1. Wait for the container to finish booting"
 echo "2. Sign in with admin/admin to grafana at https://$CONTAINER_IP:3000"
 echo "3. Change password"
-echo "4. Create a dashboard, see https://documentation.ubuntu.com/lxd/latest/howto/grafana/ for more details."
+echo "4. Create a dashboard, see https://canonical.com/lxd/docs/latest/howto/grafana/ for more details."


### PR DESCRIPTION
Updates URLs across the LXD repo following the migration of the documentation from documentation.ubuntu.com/lxd to canonical.com/lxd/docs.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
