### PR TITLE
docs: fix mismatch in the method to revoke a bearer identity token

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -9009,7 +9009,7 @@ paths:
             tags:
                 - identities
     /1.0/auth/identities/bearer/{nameOrID}/token:
-        post:
+        delete:
             consumes:
                 - application/json
             description: Revokes any existing token for the identity.
@@ -9024,6 +9024,34 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Revoke a bearer identity token.
+            tags:
+                - identities
+        post:
+            consumes:
+                - application/json
+            description: Issues a new token for the bearer identity and revokes any existing token.
+            operationId: identity_post_bearer_token
+            parameters:
+                - description: Parameters of token creation
+                  in: body
+                  name: Token request
+                  required: true
+                  schema:
+                    $ref: '#/definitions/IdentityBearerTokenPost'
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/IdentityBearerToken'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Issue a token for a bearer identity.
             tags:
                 - identities
     /1.0/auth/identities/bearer/{nameOrIdentifier}:

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -578,7 +578,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponse(true, api.IdentityBearerToken{Token: token})
 }
 
-// swagger:operation POST /1.0/auth/identities/bearer/{nameOrID}/token identities identity_delete_bearer_token
+// swagger:operation DELETE /1.0/auth/identities/bearer/{nameOrID}/token identities identity_delete_bearer_token
 //
 //	Revoke a bearer identity token.
 //


### PR DESCRIPTION
## Checklist

- [ x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ x] I have checked and added or updated relevant documentation.
