### PR TITLE
Add project level filtering to `lxd recover`

### DIFF
--- a/doc/howto/disaster_recovery.md
+++ b/doc/howto/disaster_recovery.md
@@ -30,6 +30,9 @@ Any unknown storage pools (those that exist on disk but do not exist in the data
 are printed so they can be created manually using the `lxc storage create ... source.recover=true` command.
 Concrete examples for each storage driver can be found in {ref}`howto-storage-pools-recover`.
 
+To restrict recovery to a single project, run `lxd recover --project <project>`.
+The scan then only considers volumes belonging to that project and all other volumes are left untouched.
+
 After mounting the specified storage pools (if not already mounted), the tool scans them for unknown volumes that look like they are associated with LXD.
 LXD maintains a `backup.yaml` file in each instance's storage volume, which contains all necessary information to recover a given instance (including instance configuration, attached devices, storage volume, and pool configuration).
 This data can be used to rebuild the instance, storage volume, attached custom volumes, and storage pool database records.

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -50,7 +50,8 @@ func init() {
 
 // internalRecoverValidatePost is used to initiate a recovery validation scan.
 type internalRecoverValidatePost struct {
-	Pools []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+	Pools   []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+	Project string                 `json:"project" yaml:"project"` // Optional project to restrict the scan to.
 }
 
 // internalRecoverValidateVolume provides info about a missing volume that the recovery validation scan found.
@@ -70,7 +71,8 @@ type internalRecoverValidateResult struct {
 
 // internalRecoverImportPost is used to initiate a recovert import.
 type internalRecoverImportPost struct {
-	Pools []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+	Pools   []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+	Project string                 `json:"project" yaml:"project"` // Optional project to restrict the import to.
 }
 
 // volumeConfigIsLatest checks whether the given volumeConfig's volume is newer than the existingVolumeConfig's volume.
@@ -245,7 +247,8 @@ func identifyCustomVolumePool(s *state.State, volConfig *backupConfig.Config, ex
 }
 
 // internalRecoverScan provides the discovery and import functionality for both recovery validate and import steps.
-func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.StoragePoolsPost, validateOnly bool) response.Response {
+// If filterProjectName is non-empty, only volumes belonging to that project are considered.
+func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.StoragePoolsPost, filterProjectName string, validateOnly bool) response.Response {
 	var err error
 	var projects map[string]*api.Project
 	var projectProfiles map[string][]*api.Profile
@@ -381,6 +384,11 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 		// Some of the volumes might be actually located on another pool if they have been discovered from an instance on the current pool.
 		// Therefore we have to check each unknown volume separately.
 		for projectName, volConfigs := range poolProjectVols {
+			// Skip volumes from other projects if a project filter was requested.
+			if filterProjectName != "" && projectName != filterProjectName {
+				continue
+			}
+
 			for i, volConfig := range volConfigs {
 				if volConfig == nil {
 					return response.SmartError(fmt.Errorf("Invalid nil backup volume config in volumes list at index %d for project %q", i, projectName))
@@ -756,7 +764,7 @@ func internalRecoverValidate(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	return internalRecoverScan(r.Context(), d.State(), req.Pools, true)
+	return internalRecoverScan(r.Context(), d.State(), req.Pools, req.Project, true)
 }
 
 // internalRecoverImport performs the pool volume recovery.
@@ -768,5 +776,5 @@ func internalRecoverImport(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	return internalRecoverScan(r.Context(), d.State(), req.Pools, false)
+	return internalRecoverScan(r.Context(), d.State(), req.Pools, req.Project, false)
 }

--- a/lxd/main_recover.go
+++ b/lxd/main_recover.go
@@ -16,6 +16,8 @@ import (
 
 type cmdRecover struct {
 	global *cmdGlobal
+
+	flagProject string
 }
 
 func (c *cmdRecover) command() *cobra.Command {
@@ -30,6 +32,7 @@ func (c *cmdRecover) command() *cobra.Command {
   pools but are not in the LXD database. It will then offer to recreate these database records.
 `
 	cmd.RunE = c.run
+	cmd.Flags().StringVar(&c.flagProject, "project", "", "Restrict the recovery scan to volumes in this project")
 
 	return cmd
 }
@@ -76,7 +79,8 @@ func (c *cmdRecover) run(cmd *cobra.Command, args []string) error {
 
 		// Send /internal/recover/validate request to LXD.
 		reqValidate = internalRecoverValidatePost{
-			Pools: make([]api.StoragePoolsPost, 0, len(existingPools)),
+			Pools:   make([]api.StoragePoolsPost, 0, len(existingPools)),
+			Project: c.flagProject,
 		}
 
 		// Add existing pools to request.
@@ -138,7 +142,8 @@ func (c *cmdRecover) run(cmd *cobra.Command, args []string) error {
 	// Don't lint next line with staticcheck. It says we should convert reqValidate directly to an internalRecoverImportPost
 	// because their types are identical. This is less clear and will not work if either type changes in the future.
 	reqImport := internalRecoverImportPost{ //nolint:staticcheck
-		Pools: reqValidate.Pools,
+		Pools:   reqValidate.Pools,
+		Project: reqValidate.Project,
 	}
 
 	_, _, err = d.RawQuery(http.MethodPost, "/internal/recover/import", reqImport, "")

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -276,6 +276,7 @@ readonly test_group_standalone_storage=(
     "snapshot_volume_db_recovery"
     "snapshot_fail"
     "snapshot_multi_volume"
+    "recover_project_filter"
     "storage_volume_recover"
     "storage_volume_recover_by_container"
     "storage"

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -264,6 +264,68 @@ EOF
   lxc storage delete "${poolName3}"
 }
 
+test_recover_project_filter() {
+  local poolName poolDriver
+  poolName="lxdtest-$(basename "${LXD_DIR}")"
+  poolDriver="$(storage_backend "${LXD_DIR}")"
+
+  if [ "${poolDriver}" = "pure" ]; then
+    export TEST_UNMET_REQUIREMENT="pure driver does not support recovery"
+    return 0
+  fi
+
+  # Use the default project's profiles so instances get the default root disk.
+  lxc project create proj-a --config features.images=false --config features.profiles=false
+  lxc project create proj-b --config features.images=false --config features.profiles=false
+
+  # Create an instance and a custom volume in each project.
+  lxc init --empty c1 --project proj-a --device "${SMALL_ROOT_DISK}"
+  lxc init --empty c2 --project proj-b --device "${SMALL_ROOT_DISK}"
+  lxc storage volume create "${poolName}" vola --project proj-a size=1MiB
+  lxc storage volume create "${poolName}" volb --project proj-b size=1MiB
+
+  # Delete the database records so recovery treats everything as unknown.
+  lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM instances WHERE name='c1'"
+  lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM instances WHERE name='c2'"
+  lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name IN ('c1','c2','vola','volb')"
+
+  ! lxc info c1 --project proj-a || false
+  ! lxc info c2 --project proj-b || false
+  ! lxc storage volume show "${poolName}" vola --project proj-a || false
+  ! lxc storage volume show "${poolName}" volb --project proj-b || false
+
+  # Recover proj-a only.
+  lxd recover --project proj-a <<EOF
+yes
+yes
+EOF
+
+  # Ensure proj-a was recovered.
+  lxc info c1 --project proj-a
+  lxc storage volume show "${poolName}" vola --project proj-a
+
+  # Ensure proj-b was left untouched.
+  ! lxc info c2 --project proj-b || false
+  ! lxc storage volume show "${poolName}" volb --project proj-b || false
+
+  # Ensure a recover without the filter still picks up the rest.
+  lxd recover <<EOF
+yes
+yes
+EOF
+
+  lxc info c2 --project proj-b
+  lxc storage volume show "${poolName}" volb --project proj-b
+
+  # Cleanup.
+  lxc delete c1 --project proj-a
+  lxc delete c2 --project proj-b
+  lxc storage volume delete "${poolName}" vola --project proj-a
+  lxc storage volume delete "${poolName}" volb --project proj-b
+  lxc project delete proj-a
+  lxc project delete proj-b
+}
+
 test_container_recover() {
   local LXD_IMPORT_DIR
   LXD_IMPORT_DIR="$(mktemp -d -p "${TEST_DIR}" XXX)"


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

Adds an optional project filter to disaster recovery. `lxd recover --project <name>` restricts the scan and import to volumes belonging to that project. Without the flag, behaviour is unchanged.

## Why

This is part of project level Ceph RBD replication. When a secondary cluster is promoted, only the replicated project should be recovered. Today recovery is scoped by pool only, so recovering after promoting one project would import every unknown volume found on the pool.

Discovery already groups unknown volumes by project, so the filter is applied to the discovery output before validation and import. No new metadata source is needed. The filter also works for all storage drivers since it operates on the discovery output rather than anything driver specific.

## Implementation

* The internal endpoints `/internal/recover/validate` and `/internal/recover/import` accept an optional `project` field. The filter is applied at the single point where discovery results are collected, so validation, the reported volume list and both import phases all honour it. Internal endpoints need no API extension.
* `lxd recover` gains a `--project` flag. A flag rather than a new interactive question keeps existing scripted invocations working, since the tool is driven by piped answers.
* New test `test_recover_project_filter` recovers one of two projects with the filter, asserts the other project stays untouched, then asserts a plain `lxd recover` still picks up the rest.
* Short note added to the disaster recovery how-to.

## Notes

* With `features.storage.volumes=false`, a project's custom volumes belong to the default project. Discovery groups them under `default`, so a project filter will not select them. This matches how effective storage projects behave elsewhere in LXD.
* The upcoming Ceph RBD replication improvements may extend this recovery path, for example promotion pre-flight checks and cross checking discovered volumes against a replication manifest. Those will come as follow-up PRs; this PR only adds the project filter.
