### PR TITLE
Change entity type for the testing "wait" operation to "server"

### DIFF
--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -414,7 +414,7 @@ func (t Type) EntityType() entity.Type {
 		BackupsExpire, SnapshotsExpire, ClusterJoinToken, CertificateAddToken, RenewServerCertificate,
 		ClusterHeal, ImagesUpdate, VolumeSnapshotsCreateScheduled, SnapshotsCreateScheduled,
 		PruneExpiredOperations, RefreshClusterLinkVolatileAddresses,
-		StoragePoolCreate:
+		StoragePoolCreate, Wait:
 		return entity.TypeServer
 
 	// Project level operations.
@@ -440,8 +440,7 @@ func (t Type) EntityType() entity.Type {
 	// Instance operations.
 	case BackupCreate, ConsoleShow, InstanceFreeze, InstanceUpdate, InstanceUnfreeze,
 		InstanceStart, InstanceStop, InstanceRestart, InstanceRename, InstanceMigrate, InstanceLiveMigrate,
-		InstanceDelete, InstanceRebuild, SnapshotRestore, CommandExec, SnapshotCreate, InstanceCopy,
-		Wait:
+		InstanceDelete, InstanceRebuild, SnapshotRestore, CommandExec, SnapshotCreate, InstanceCopy:
 		return entity.TypeInstance
 
 	// Instance backup operations.

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1224,9 +1224,14 @@ func operationWaitHandler(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	u, err := url.Parse(req.EntityURL)
-	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed parsing operation entity URL: %w", err))
+	var entityURL *api.URL
+	if req.EntityURL != "" {
+		u, err := url.Parse(req.EntityURL)
+		if err != nil {
+			return response.BadRequest(fmt.Errorf("Failed parsing operation entity URL: %w", err))
+		}
+
+		entityURL = &api.URL{URL: *u}
 	}
 
 	var onConnect func(op *operations.Operation, r *http.Request, w http.ResponseWriter) error
@@ -1243,7 +1248,7 @@ func operationWaitHandler(d *Daemon, r *http.Request) response.Response {
 		Class:             req.OpClass,
 		RunHook:           run,
 		ConnectHook:       onConnect,
-		EntityURL:         &api.URL{URL: *u},
+		EntityURL:         entityURL,
 		ConflictReference: req.ConflictReference,
 	}
 

--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -88,13 +88,8 @@ test_bulk_operation_children() {
 test_operations_conflict_reference() {
   conflictRef="test-conflict-ref"
 
-  # operation-wait requires instance for entity_type
-  lxc init --empty c1
-
   # Create two operations with the same conflict_reference. The second creation should fail.
   # op_type 75 is "Wait" operation.
-  lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "entity_url": "/1.0/instances/c1", "conflict_reference": "'"${conflictRef}"'"}'
-  ! lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "entity_url": "/1.0/instances/c1", "conflict_reference": "'"${conflictRef}"'"}' || false
-
-  lxc delete c1 --force
+  lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}'
+  ! lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}' || false
 }


### PR DESCRIPTION
The wait operation doesn't affect any resources, so there is no reason to create an instance just to run this operation.

This was initially part of #17045 so I'm just trying to make the PR smaller.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
