### PR TITLE
shared/api: Update operation class descriptions

### DIFF
--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -6,14 +6,19 @@ import (
 	"time"
 )
 
-// OperationClassTask represents the Task OperationClass.
-const OperationClassTask = "task"
+const (
+	// OperationClassTask is shown in the [Operation.Class] field when the operation is an asynchronous background task.
+	// These are used in many places where an API request may take a long time.
+	OperationClassTask = "task"
 
-// OperationClassWebsocket represents the Websocket OperationClass.
-const OperationClassWebsocket = "websocket"
+	// OperationClassWebsocket is shown in the [Operation.Class] field when an operation websocket is available for connection.
+	// These are used for various bi-directional connections such as console.
+	OperationClassWebsocket = "websocket"
 
-// OperationClassToken represents the Token OperationClass.
-const OperationClassToken = "token"
+	// OperationClassToken is shown in the [Operation.Class] field for operations that track tokens that have been issued.
+	// These are used to authenticate later requests.
+	OperationClassToken = "token"
+)
 
 const (
 	// MetadataEntityURL is always set in operation metadata for operations whose associated entity type is not "server".


### PR DESCRIPTION
Updates `api.OperationClass{Task,Websocket,Token}` comments and moves them into a `const` block.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
