### PR TITLE
test/suites/console: poll for the console address URL

### DIFF
--- a/test/suites/console.sh
+++ b/test/suites/console.sh
@@ -63,8 +63,12 @@ test_console_vm() {
   OUTPUT="$(mktemp -p "${TEST_DIR}" console_output.XXX)"
   lxc console --type vga v1 > "${OUTPUT}" &
   CONSOLE_PID=$!
-  sleep 0.1
-  grep -F "spice+unix:///" < "${OUTPUT}"
+
+  # Wait for the console output to contain the SPICE socket address
+  for _ in 1 2 3; do
+    grep -F "spice+unix:///" < "${OUTPUT}" && break
+    sleep 0.1
+  done
 
   SPICE_UNIX_SOCKET="$(sed -n '/spice+unix/ s|^\s\+spice+unix://|| p' < "${OUTPUT}")"
   [ -S "${SPICE_UNIX_SOCKET}" ]


### PR DESCRIPTION
On slow runners, it's suspected that the short sleep was too short as this has been seen once:

```
++ mktemp -p /tmp/lxd-test.tmp.fgLm console_output.XXX
+ OUTPUT=/tmp/lxd-test.tmp.fgLm/console_output.J7e
+ CONSOLE_PID=26577
+ sleep 0.1
+ lxc console --type vga v1
+ timeout --foreground 120 /home/runner/go/bin/lxc --verbose console --type vga v1
+ grep -F spice+unix:///
+ cleanup
```

The `grep` check is now used for polling only and if the URL does not show, the socket presence test will fail.