### PR TITLE
Enable `virtiofsd` on non-amd64 arches (from Incus)

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -21,7 +21,6 @@ import (
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/subprocess"
 	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/osarch"
 	"github.com/canonical/lxd/shared/revert"
 )
 
@@ -272,12 +271,6 @@ func DiskVMVirtiofsdStart(inst instance.Instance, socketPath string, pidPath str
 
 	if cmd == "" {
 		return nil, ErrMissingVirtiofsd
-	}
-
-	// Currently, virtiofs is broken on at least the ARM architecture.
-	// We therefore restrict virtiofs to 64BIT_INTEL_X86.
-	if inst.Architecture() != osarch.ARCH_64BIT_INTEL_X86 {
-		return nil, UnsupportedError{msg: "Architecture unsupported"}
 	}
 
 	if shared.IsTrue(inst.ExpandedConfig()["migration.stateful"]) {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -4096,7 +4097,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 // If sb is nil then no config is written.
 func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error {
 	cpuOpts := qemuCPUOpts{
-		architecture:        d.architectureName,
+		architecture:        d.architecture,
 		qemuMemObjectFormat: "indexed", // Supported by QEMU 6.0+
 	}
 
@@ -4145,7 +4146,13 @@ func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error
 		//nolint:prealloc
 		numaIDs := []uint64{}
 		numaNode := uint64(0)
-		for hostNode, entry := range cpuInfo.nodes {
+
+		// Iterate the host NUMA nodes in a stable order so the generated QEMU
+		// config (node IDs, memory backends and vCPU mappings) stays consistent
+		// across runs. cpuInfo.nodes is a map, whose iteration order is random.
+		sortedHostNodes := slices.Sorted(maps.Keys(cpuInfo.nodes))
+		for _, hostNode := range sortedHostNodes {
+			entry := cpuInfo.nodes[hostNode]
 			hostNodes = append(hostNodes, hostNode)
 
 			numaIDs = append(numaIDs, numaNode)
@@ -4194,7 +4201,12 @@ func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error
 
 	// Determine per-node memory limit.
 	memSizeMB := memSizeBytes / 1024 / 1024
-	nodeMemory := int64(memSizeMB / int64(len(hostNodes)))
+	nodeMemory := memSizeMB
+	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
+		// On x86_64 the memory is split across one backend per NUMA node.
+		nodeMemory = memSizeMB / int64(len(hostNodes))
+	}
+
 	cpuOpts.memory = nodeMemory
 
 	if cfg != nil {

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -78,6 +78,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			gic-version = "max"
 			accel = "kvm"
 			usb = "off"
+			memory-backend = "mach-virt.ram"
 
 			[boot-opts]
 			strict = "on"`,
@@ -90,6 +91,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			cap-large-decr = "off"
 			accel = "kvm"
 			usb = "off"
+			memory-backend = "ppc_spapr.ram"
 
 			[boot-opts]
 			strict = "on"`,
@@ -102,6 +104,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			accel = "kvm"
 			acpi = "off"
 			usb = "off"
+			memory-backend = "riscv_virt_board.ram"
 
 			[boot-opts]
 			strict = "on"`,
@@ -113,6 +116,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			type = "s390-ccw-virtio"
 			accel = "kvm"
 			usb = "off"
+			memory-backend = "s390.ram"
 
 			[boot-opts]
 			strict = "on"`,
@@ -444,7 +448,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			expected string
 		}{{
 			qemuCPUOpts{
-				architecture:        "x86_64",
+				architecture:        osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:            8,
 				cpuSockets:          1,
 				cpuCores:            4,
@@ -474,7 +478,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			memdev = "mem0"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     2,
 				cpuSockets:   1,
 				cpuCores:     2,
@@ -548,7 +552,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			thread-id = "23"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     2,
 				cpuSockets:   1,
 				cpuCores:     2,
@@ -610,7 +614,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			thread-id = "23"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     4,
 				cpuSockets:   1,
 				cpuCores:     4,
@@ -680,7 +684,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			thread-id = "23"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "arm64",
+				architecture: osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN,
 				cpuCount:     4,
 				cpuSockets:   1,
 				cpuCores:     4,
@@ -700,7 +704,19 @@ func TestQemuConfigTemplates(t *testing.T) {
 			cpus = "4"
 			sockets = "1"
 			cores = "4"
-			threads = "1"`,
+			threads = "1"
+
+			[object "mach-virt.ram"]
+			qom-type = "memory-backend-file"
+			mem-path = "/hugepages"
+			prealloc = "on"
+			discard-data = "on"
+			size = "12000M"
+			share = "on"
+			policy = "bind"
+			host-nodes.0 = "8"
+			host-nodes.1 = "9"
+			host-nodes.2 = "10"`,
 		}}
 		for _, tc := range testCases {
 			runTest(tc.expected, qemuCPU(&tc.opts, true))
@@ -1610,4 +1626,51 @@ func TestQemuConfigTemplates(t *testing.T) {
 			t.Errorf("Expected: %v. Got: %v", expected, actual)
 		}
 	})
+}
+
+func TestQemuBase_UnmappedArchitectureOmitsMemoryBackend(t *testing.T) {
+	sections := qemuBase(&qemuBaseOpts{architecture: -1})
+
+	for _, entry := range sections[0].entries {
+		if entry.key == "memory-backend" {
+			t.Fatal("Expected unmapped architecture to omit memory-backend")
+		}
+	}
+}
+
+// TestQemuCPU_NumaHostNodesPreservesOrder verifies that qemuCPU emits host-nodes.*
+// entries in the exact order provided by the caller. Deterministic ordering is the
+// responsibility of addCPUMemoryConfig, which iterates the host NUMA nodes in sorted
+// order so that the QEMU node IDs, memory backends and vCPU mappings stay consistent.
+func TestQemuCPU_NumaHostNodesPreservesOrder(t *testing.T) {
+	opts := qemuCPUOpts{
+		architecture:     osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN,
+		cpuCount:         4,
+		cpuSockets:       1,
+		cpuCores:         4,
+		cpuThreads:       1,
+		cpuNumaHostNodes: []uint64{10, 8, 9},
+		hugepages:        "/hugepages",
+		memory:           12000,
+	}
+
+	config := qemuStringifyCfg(qemuCPU(&opts, true)...).String()
+
+	// The caller's order must be preserved verbatim, proving qemuCPU does not reorder.
+	first := strings.Index(config, `host-nodes.0 = "10"`)
+	second := strings.Index(config, `host-nodes.1 = "8"`)
+	third := strings.Index(config, `host-nodes.2 = "9"`)
+
+	if first < 0 || second < 0 || third < 0 {
+		t.Fatalf("Expected host-nodes entries in caller order, got: %s", config)
+	}
+
+	if first >= second || second >= third {
+		t.Fatalf("Expected host-nodes entries in caller order, got: %s", config)
+	}
+
+	// The caller's slice must not be mutated.
+	if !reflect.DeepEqual(opts.cpuNumaHostNodes, []uint64{10, 8, 9}) {
+		t.Fatalf("Expected input slice to be unchanged, got: %v", opts.cpuNumaHostNodes)
+	}
 }

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -114,6 +114,26 @@ func qemuMachineType(architecture int) string {
 	return machineType
 }
 
+// qemuDefaultRAMObject returns QEMU's default RAM object name for the architecture.
+// Reusing that name for an explicit main memory backend preserves migration compatibility.
+// An empty string is returned for architectures without a known default RAM object.
+func qemuDefaultRAMObject(architecture int) string {
+	switch architecture {
+	case osarch.ARCH_64BIT_INTEL_X86:
+		return "pc.ram"
+	case osarch.ARCH_32BIT_ARMV7_LITTLE_ENDIAN, osarch.ARCH_32BIT_ARMV8_LITTLE_ENDIAN, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
+		return "mach-virt.ram"
+	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
+		return "ppc_spapr.ram"
+	case osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN:
+		return "riscv_virt_board.ram"
+	case osarch.ARCH_64BIT_S390_BIG_ENDIAN:
+		return "s390.ram"
+	}
+
+	return ""
+}
+
 type qemuBaseOpts struct {
 	architecture int
 }
@@ -134,18 +154,31 @@ func qemuBase(opts *qemuBaseOpts) []cfgSection {
 		acpi = "off"
 	}
 
+	entries := []cfgEntry{
+		{key: "graphics", value: "off"},
+		{key: "type", value: machineType},
+		{key: "gic-version", value: gicVersion},
+		{key: "cap-large-decr", value: capLargeDecr},
+		{key: "accel", value: "kvm"},
+		{key: "acpi", value: acpi},
+		{key: "usb", value: "off"},
+	}
+
+	// On non-x86_64 architectures with a known default RAM object, the guest's main RAM
+	// is defined as an explicit shared memory backend (see qemuCPU) so that vhost-user
+	// devices such as virtiofsd can map it.
+	// The backend is attached to the machine through the "memory-backend" property.
+	if opts.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+		memoryBackend := qemuDefaultRAMObject(opts.architecture)
+		if memoryBackend != "" {
+			entries = append(entries, cfgEntry{key: "memory-backend", value: memoryBackend})
+		}
+	}
+
 	sections := []cfgSection{{
 		name:    "machine",
 		comment: "Machine",
-		entries: []cfgEntry{
-			{key: "graphics", value: "off"},
-			{key: "type", value: machineType},
-			{key: "gic-version", value: gicVersion},
-			{key: "cap-large-decr", value: capLargeDecr},
-			{key: "accel", value: "kvm"},
-			{key: "acpi", value: acpi},
-			{key: "usb", value: "off"},
-		},
+		entries: entries,
 	}}
 
 	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 {
@@ -484,7 +517,7 @@ type qemuNumaEntry struct {
 }
 
 type qemuCPUOpts struct {
-	architecture        string
+	architecture        int
 	cpuCount            int
 	cpuRequested        int
 	cpuSockets          int
@@ -567,8 +600,38 @@ func qemuCPU(opts *qemuCPUOpts, pinning bool) []cfgSection {
 		entries: entries,
 	}}
 
-	if opts.architecture != "x86_64" {
-		return sections
+	if opts.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+		ramObjectName := qemuDefaultRAMObject(opts.architecture)
+		if ramObjectName == "" {
+			// Architecture without a known default RAM object; leave the guest
+			// memory as QEMU's implicit default.
+			return sections
+		}
+
+		// Define the guest's main RAM as a shared memory backend so that vhost-user
+		// devices such as virtiofsd can map it. It is attached to the machine through
+		// the "memory-backend" property set in qemuBase.
+		numaNodes := qemuCPUNumaHostNode(opts, 0)
+		if len(numaNodes) == 0 {
+			return sections
+		}
+
+		ramObject := numaNodes[0]
+		ramObject.name = fmt.Sprintf("object %q", ramObjectName)
+		ramObject.entries = append(ramObject.entries, cfgEntry{key: "share", value: "on"})
+
+		// Apply NUMA memory pinning if configured.
+		if len(opts.cpuNumaHostNodes) > 0 {
+			ramObject.entries = append(ramObject.entries, cfgEntry{key: "policy", value: "bind"})
+			for index, element := range opts.cpuNumaHostNodes {
+				ramObject.entries = append(ramObject.entries, cfgEntry{
+					key:   fmt.Sprintf("host-nodes.%d", index),
+					value: strconv.FormatUint(element, 10),
+				})
+			}
+		}
+
+		return append(sections, ramObject)
 	}
 
 	share := cfgEntry{key: "share", value: "on"}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1153,7 +1153,8 @@ parts:
   virtiofsd:
     plugin: nil
     stage-packages:
-      - to amd64:
+      - to armhf: []
+      - else:
         - virtiofsd
     organize:
       usr/libexec/: bin/


### PR DESCRIPTION
Inspired-by: https://github.com/lxc/incus/commit/d416f3c6216ce63d23c4ac8f8e289d15438cd273