### PR TITLE
snap/snapcraft: avoid `uname -m` for arch exclusions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -269,16 +269,16 @@ parts:
       usr/bin/: bin/
       usr/lib/: lib/
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     prime:
       - bin/ceph
@@ -438,16 +438,28 @@ parts:
         - rsync
         - uuid-dev
     override-stage: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "riscv64" ]  && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64|riscv64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "riscv64" ]  && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64|riscv64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "riscv64" ]  && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64|riscv64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "riscv64" ]  && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64|riscv64) ;;
+          *) exit 0 ;;
+      esac
       set -eux
 
       # Ensure staged libraries are found (needed for qemu to generate secure boot vars)
@@ -480,7 +492,7 @@ parts:
       # Install files destination
       mkdir -p "${CRAFT_PART_INSTALL}/share/qemu/"
 
-      if [ "$(uname -m)" = "x86_64" ]; then
+      if [ "${CRAFT_TARGET_ARCH}" = "amd64" ]; then
           DSC="OvmfPkg/OvmfPkgX64.dsc"
           BUILD_TARGETS="install-ovmf-secboot install-ovmf-no-secboot"
           SRC_DIR="debian/tmp/usr/share/OVMF"
@@ -499,7 +511,7 @@ parts:
           # = 0x8000004F
           # Adding 0x00400000 (DEBUG_VERBOSE) gives 0x8040004F
           SED_EXPR="s#PcdDebugPrintErrorLevel|0x8000004F#PcdDebugPrintErrorLevel|0x8040004F#g"
-      elif [ "$(uname -m)" = "aarch64" ]; then
+      elif [ "${CRAFT_TARGET_ARCH}" = "arm64" ]; then
           DSC="ArmVirtPkg/ArmVirt.dsc.inc"
           BUILD_TARGETS="install-qemu-efi-aarch64-secboot install-qemu-efi-aarch64-no-secboot"
           SRC_DIR="debian/tmp/usr/share/AAVMF"
@@ -516,7 +528,7 @@ parts:
           DST_VARS_MS="AAVMF_VARS.ms"
           # See note in `x86_64` section for DEBUG_VERBOSE explanation
           SED_EXPR="s#DEBUG_PRINT_ERROR_LEVEL = 0x8000004F#DEBUG_PRINT_ERROR_LEVEL = 0x8040004F#g"
-      elif [ "$(uname -m)" = "riscv64" ]; then
+      elif [ "${CRAFT_TARGET_ARCH}" = "riscv64" ]; then
           DSC="OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc"
           BUILD_TARGETS="install-qemu-efi-riscv64"
           SRC_DIR="debian/tmp/usr/share/qemu-efi-riscv64"
@@ -573,7 +585,7 @@ parts:
       run_build RELEASE ""
 
       # RISC-V build is already very slow and adding a DEBUG build makes it even slower, so skip it.
-      if [ "$(uname -m)" != "riscv64" ]; then
+      if [ "${CRAFT_TARGET_ARCH}" != "riscv64" ]; then
         # Build Debug (silence the copious build output to avoid doubling it)
         run_build DEBUG ".debug" > /dev/null
       fi
@@ -586,10 +598,16 @@ parts:
   libatomic:
     plugin: nil
     override-stage: |-
-      [ "$(uname -m)" != "riscv64" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          riscv64|s390x) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" != "riscv64" ] && [ "$(uname -m)" != "s390x" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          riscv64|s390x) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     stage-packages:
       - to riscv64:
@@ -705,16 +723,28 @@ parts:
     build-snaps:
       - go/1.26/stable
     override-stage: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       set -ex
 
       # Setup build environment
@@ -750,20 +780,20 @@ parts:
       - go/1.26/stable
     plugin: make
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "riscv64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "riscv64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "riscv64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
-      [ "$(uname -m)" = "riscv64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "riscv64" ] && exit 0
       set -ex
 
       # Setup build environment
@@ -797,16 +827,16 @@ parts:
         - openvswitch-common
         - openvswitch-switch
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     organize:
       usr/bin/: bin/
@@ -826,16 +856,16 @@ parts:
       - else:
         - ovn-common
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     organize:
       usr/bin/: bin/
@@ -881,16 +911,16 @@ parts:
         - libjpeg-turbo8
         - libpixman-1-0
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
 
       # Apply patches from Ubuntu sources.
       cd ../src
@@ -1019,17 +1049,17 @@ parts:
         - seabios # This is needed due to --disable-install-blobs.
         - qemu-system-data # This is needed due to --disable-install-blobs.
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
 
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       set -ex
       # If configure finds a `.git` dir, it enables -Werror (`--enable-werror` and Git submodules are validated).
       # When building the deb on LP, this `.git` dir is not present because a tarball is used.
@@ -1037,8 +1067,12 @@ parts:
       [ -d .git ] && rm -rf .git
 
       # Mangle the configure a bit
-      QEMUARCH="$(uname -m)"
-      [ "${QEMUARCH}" = "ppc64le" ] && QEMUARCH="ppc64"
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64) QEMUARCH="x86_64" ;;
+          arm64) QEMUARCH="aarch64" ;;
+          ppc64el) QEMUARCH="ppc64" ;;
+          *) QEMUARCH="${CRAFT_TARGET_ARCH}" ;;
+      esac
 
       # Apply patches from Ubuntu sources.
       QUILT_PATCHES=debian/patches quilt push -a
@@ -1126,16 +1160,16 @@ parts:
     prime:
       - bin/virtiofsd*
     override-stage: |-
-      [ "$(uname -m)" != "x86_64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" != "x86_64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && exit 0
       craftctl default
 
   xfs:
@@ -1202,16 +1236,16 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       set -ex
       RAW_VER="${CRAFT_PART_NAME#zfs-}"
       ZFS_VER="${RAW_VER/-/.}"
@@ -1243,16 +1277,16 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       set -ex
       RAW_VER="${CRAFT_PART_NAME#zfs-}"
       ZFS_VER="${RAW_VER/-/.}"
@@ -1284,16 +1318,16 @@ parts:
         - zlib1g-dev
         - libtirpc-dev
     override-stage: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-build: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       set -ex
       RAW_VER="${CRAFT_PART_NAME#zfs-}"
       ZFS_VER="${RAW_VER/-/.}"
@@ -1464,16 +1498,28 @@ parts:
       - to arm64:
         - python3-uefivars
     override-stage: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-prime: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     override-build: |-
-      [ "$(uname -m)" != "x86_64" ] && [ "$(uname -m)" != "aarch64" ] && exit 0
+      case "${CRAFT_TARGET_ARCH}" in
+          amd64|arm64) ;;
+          *) exit 0 ;;
+      esac
       craftctl default
     organize:
       usr/bin/uefivars: bin/uefivars.py
@@ -1583,7 +1629,7 @@ parts:
 
       # Some python dependencies are not available for armhf or just require a build from source.
       # Not worth the effort for now.
-      if [ "$(uname -m)" != "armv7l" ]; then
+      if [ "${CRAFT_TARGET_ARCH}" != "armhf" ]; then
         # Build the static website
         # XXX: needed for snapcraft 8.x only
         PATH="/usr/bin:${PATH}" make doc # ensure python3 is found in PATH
@@ -1652,14 +1698,14 @@ parts:
       - nodejs
       - npm
     override-prime: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
       craftctl default
     override-pull: |-
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
 
       craftctl default
     override-build: |
-      [ "$(uname -m)" = "armv7l" ] && exit 0
+      [ "${CRAFT_TARGET_ARCH}" = "armhf" ] && exit 0
 
       craftctl default
 


### PR DESCRIPTION
On Launchpad, builds targetting `armhf` are done on `aarch64` hosts. Launchpad uses LXD under the hood and it sets the kernel personality to match that of the container which is why `uname -m` works despite executing on a `aarch64` host/kernel.

However, rather than relying on this kernel personality, it's better to use the `snapcraft` provided `CRAFT_TARGET_ARCH` which directly maps to the target architecture for a given build.

For multiple arch exclusions, also use switch case for improved readability.