### PR TITLE
client/simplestreams_images: detect download cancelation with `errors.Is`

### DIFF
--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -168,8 +168,8 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 
 		size, err := shared.DownloadFileHash(context.TODO(), &httpClient, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, url, hash, sha256.New(), &multiTarget)
 		if err != nil {
-			// Handle cancelation
-			if err.Error() == "net/http: request canceled" {
+			// If the download was canceled, return immediately instead of retrying over HTTPS.
+			if errors.Is(err, context.Canceled) {
 				return -1, err
 			}
 


### PR DESCRIPTION
Replace the fragile `err.Error() == "net/http: request canceled"` check with `errors.Is(err, context.Canceled)`. Cancelation here is context-based (`CancelableDownload` wraps the request with `context.WithCancel`), so this matches reliably whether the error surfaces at request time or during the body read, and avoids depending on an internal `net/http` error string.