### PR TITLE
test: wait for the cluster leader before evacuating a member

### DIFF
--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -366,6 +366,28 @@ respawn_lxd_cluster_member() {
   LXD_NETNS="${1}" respawn_lxd "${2}" true
 }
 
+# Wait until the cluster reports an elected database-leader as seen from the provided LXD_DIR.
+# `lxd waitready` only confirms the API is responsive; immediately after a member restart the
+# cluster may still be electing a leader, causing cluster operations to fail with
+# "Failed getting the address of the cluster leader".
+wait_for_cluster_leader() {
+  local lxdDir="${1}"
+  local i members
+
+  for i in $(seq "${MAX_WAIT_SECONDS:-120}"); do
+    # `lxc cluster list` itself resolves the leader address so it can fail while electing.
+    members="$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${lxdDir}" lxc cluster list --format json 2>/dev/null || true)"
+    if [ -n "${members}" ] && jq --exit-status 'any(.[]; any(.roles[]; . == "database-leader"))' <<< "${members}" > /dev/null; then
+      return 0
+    fi
+
+    sleep 1
+  done
+
+  echo "Cluster leader not elected after ${i}s"
+  return 1
+}
+
 is_uuid_v4() {
   # Case insensitive match for a v4 UUID. The third group must start with 4, and the fourth group must start with 8, 9,
   # a, or b. This accounts for the version and variant. See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4.

--- a/test/suites/clustering_waitready.sh
+++ b/test/suites/clustering_waitready.sh
@@ -171,6 +171,8 @@ test_clustering_waitready() {
   LXD_NETNS="${ns1}" respawn_lxd "${LXD_ONE_DIR}" true
 
   # The cluster member can now be evacuated.
+  # Wait for a leader first as `lxd waitready` returns before the cluster has finished electing one.
+  wait_for_cluster_leader "${LXD_ONE_DIR}"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --yes
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore "node1" --force
 


### PR DESCRIPTION
`lxd waitready` returns as soon as the API is responsive, but immediately
after a cluster member restart the cluster may still be electing a leader.
As `lxc cluster evacuate` resolves the leader address, it can transiently
fail with "Failed getting the address of the cluster leader" in
clustering_waitready.

Add a `wait_for_cluster_leader` helper polling `lxc cluster list` until a
member reports the `database-leader` role, and call it before the evacuate.
That role is derived from the very leader address lookup the evacuate
needs, so this waits on exactly the condition that was racing.