### PR TITLE
snap/wrappers: detect the AppArmor userns restriction

### DIFF
--- a/snapcraft/wrappers/editor
+++ b/snapcraft/wrappers/editor
@@ -28,6 +28,7 @@ SNAP_BASE="$(sed -n '/^name:/ s/^name:\s*\(core[0-9]\{2\}\)/\1/p' /meta/snap.yam
 
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
 
 find_and_spawn() {
     for path in / /usr/ /usr/local/; do

--- a/snapcraft/wrappers/remote-viewer
+++ b/snapcraft/wrappers/remote-viewer
@@ -13,6 +13,7 @@ run_cmd() {
 
 USERNS=1
 [ -e /proc/sys/kernel/unprivileged_userns_clone ] && grep -qxF 0 /proc/sys/kernel/unprivileged_userns_clone && USERNS=0
+[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && grep -qxF 1 /proc/sys/kernel/apparmor_restrict_unprivileged_userns && USERNS=0
 
 find_and_spawn() {
     for path in /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin; do


### PR DESCRIPTION
Fall back to bundled editor when AppArmor restricts userns.

The editor and remote-viewer wrappers only detected the `kernel.unprivileged_userns_clone` sysctl. On kernels that mediate unprivileged user namespaces through AppArmor
(`kernel.apparmor_restrict_unprivileged_userns`, default 1), the wrappers still took the host-editor path and exec'd `unshare -U`, which is denied until the LXD daemon starts and relaxes the restriction. Because the call was exec'd, the `vim.tiny` fallback was never reached.

Closes #18780
Closes #18781