### PR TITLE
auth: Report TLS and bearer identity credential expiry 

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3631,3 +3631,15 @@ Adds a `child_count` field to the `Operation` struct, indicating the number of c
 
 Adds NVMe/TCP support to the Dell PowerStore storage driver.
 NVMe/TCP is now the default PowerStore mode when `powerstore.mode` is not set.
+
+(extension-access-management-expiry)=
+## `access_management_expiry`
+
+Adds an `expires_at` field to the `Identity` struct, so that the expiry of an identity's credential is reported when identities are listed or individually retrieved, and not only for the current identity.
+
+For identities whose authentication method is `tls`, this is the expiry of the identity's certificate.
+For identities whose authentication method is `bearer`, this is the expiry of the issued token.
+For bearer tokens the expiry is recorded when a token is issued and cleared when a token is revoked.
+The field is omitted for identities whose credential has no expiry, that have no credential yet (pending identities), or whose token has been revoked.
+
+Note that bearer identities created prior to this extension will have an omitted `expires_at` field until a new token is issued.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1083,6 +1083,17 @@ definitions:
                 example: tls
                 type: string
                 x-go-name: AuthenticationMethod
+            expires_at:
+                description: |-
+                    ExpiresAt is the expiration time of the credential belonging to the identity. For TLS identities this is the
+                    expiry of the certificate, and for bearer identities it is the expiry of the most recently issued token.
+                    It is unset for identities whose credential has no expiry, that have no credential yet (pending identities),
+                    or whose token has been revoked.
+
+                    API extension: access_management_expiry.
+                format: date-time
+                type: string
+                x-go-name: ExpiresAt
             groups:
                 description: Groups is the list of groups for which the identity is a member.
                 example:
@@ -1177,8 +1188,12 @@ definitions:
                 x-go-name: EffectivePermissions
             expires_at:
                 description: |-
-                    ExpiresAt is the expiration time of the credential used to authenticate the caller.
-                    It is set only when client is trusted, and authentication method is either bearer or TLS.
+                    ExpiresAt is the expiration time of the credential belonging to the identity. For TLS identities this is the
+                    expiry of the certificate, and for bearer identities it is the expiry of the most recently issued token.
+                    It is unset for identities whose credential has no expiry, that have no credential yet (pending identities),
+                    or whose token has been revoked.
+
+                    API extension: access_management_expiry.
                 format: date-time
                 type: string
                 x-go-name: ExpiresAt

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -276,6 +276,7 @@ func (i *IdentitiesRow) ToAPI(idToGroups map[int64][]string, idToCertificates ma
 	}
 
 	var tlsCertificate string
+	var expiresAt *time.Time
 	if i.AuthMethod == api.AuthenticationMethodTLS && !identityType.IsPending() {
 		if idToCertificates == nil {
 			return nil, errors.New("Missing required certificate data")
@@ -288,6 +289,15 @@ func (i *IdentitiesRow) ToAPI(idToGroups map[int64][]string, idToCertificates ma
 
 		// Expect that the zeroth entry is the most recent.
 		tlsCertificate = certs[0]
+
+		// The expiry of a TLS certificate determines identity expiry.
+		cert, err := shared.ParseCert([]byte(tlsCertificate))
+		if err != nil {
+			return nil, fmt.Errorf("Failed parsing certificate of identity %q: %w", i.Identifier, err)
+		}
+
+		notAfter := cert.NotAfter.UTC()
+		expiresAt = &notAfter
 	}
 
 	groups, ok := idToGroups[i.ID]
@@ -302,6 +312,7 @@ func (i *IdentitiesRow) ToAPI(idToGroups map[int64][]string, idToCertificates ma
 		Name:                 i.Name,
 		Groups:               groups,
 		TLSCertificate:       tlsCertificate,
+		ExpiresAt:            expiresAt,
 	}, nil
 }
 

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -264,6 +264,68 @@ func (i IdentitiesRow) PendingTLSMetadata() (*PendingTLSMetadata, error) {
 	return &metadata, nil
 }
 
+// BearerMetadata contains metadata for bearer identity types.
+type BearerMetadata struct {
+	// TokenExpiry is the expiry of the issued token for the identity.
+	// It is nil when no token has been issued, or when the token has been revoked.
+	TokenExpiry *time.Time `json:"token_expiry,omitempty"`
+}
+
+// BearerMetadata returns the identity metadata as [BearerMetadata]. The [AuthMethod] of the
+// [IdentitiesRow] must be [api.AuthenticationMethodBearer].
+func (i IdentitiesRow) BearerMetadata() (*BearerMetadata, error) {
+	if i.AuthMethod != api.AuthenticationMethodBearer {
+		return nil, fmt.Errorf("Cannot extract bearer metadata from identity: Identity has authentication method %q (%q required)", i.AuthMethod, api.AuthenticationMethodBearer)
+	}
+
+	// Bearer identities created before token expiry was recorded have empty metadata.
+	if i.Metadata == "" {
+		return &BearerMetadata{}, nil
+	}
+
+	var metadata BearerMetadata
+	err := json.Unmarshal([]byte(i.Metadata), &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("Failed unmarshaling bearer metadata: %w", err)
+	}
+
+	return &metadata, nil
+}
+
+// SetBearerIdentityTokenExpiry records the expiry of the issued token for a bearer identity.
+func SetBearerIdentityTokenExpiry(ctx context.Context, tx *sql.Tx, identityID int64, expiry *time.Time) error {
+	// A non-nil expiry is signed into the token as a JWT NumericDate, which has second
+	// precision, so we truncate to second precision before storing it to ensure the expiry
+	// reported for a listed identity is identical to the one the token itself carries.
+	var value any
+	if expiry != nil {
+		value = expiry.UTC().Truncate(time.Second).Format(time.RFC3339Nano)
+	}
+
+	// Update token_expiry in place so any other metadata fields are preserved.
+	// A nil expiry is stored as JSON null, which unmarshals back to a nil TokenExpiry,
+	// representing "no active token".
+	q := `
+UPDATE identities
+SET metadata = json_set(CASE WHEN metadata = '' THEN '{}' ELSE metadata END, '$.token_expiry', ?)
+WHERE id = ? AND auth_method = ?`
+	res, err := tx.ExecContext(ctx, q, value, identityID, AuthMethod(api.AuthenticationMethodBearer))
+	if err != nil {
+		return fmt.Errorf("Failed setting bearer identity token expiry: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed checking bearer identity token expiry update: %w", err)
+	}
+
+	if rowsAffected != 1 {
+		return fmt.Errorf("Failed setting bearer identity token expiry: Expected to update 1 row, updated %d", rowsAffected)
+	}
+
+	return nil
+}
+
 // ToAPI converts an [IdentitiesRow] to an [api.Identity], executing database queries as necessary.
 func (i *IdentitiesRow) ToAPI(idToGroups map[int64][]string, idToCertificates map[int64][]string) (*api.Identity, error) {
 	if idToGroups == nil {
@@ -298,6 +360,17 @@ func (i *IdentitiesRow) ToAPI(idToGroups map[int64][]string, idToCertificates ma
 
 		notAfter := cert.NotAfter.UTC()
 		expiresAt = &notAfter
+	} else if i.AuthMethod == api.AuthenticationMethodBearer {
+		metadata, err := i.BearerMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		// A nil expiry means no token has been issued, or the last issued token was revoked.
+		if metadata.TokenExpiry != nil {
+			tokenExpiry := metadata.TokenExpiry.UTC()
+			expiresAt = &tokenExpiry
+		}
 	}
 
 	groups, ok := idToGroups[i.ID]

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1622,6 +1622,13 @@ func identityGetCurrent(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Populate metadata expiry from the requestor. This ensures bearer tokens issued before their
+	// expiry was recorded have the field correctly populated from the authenticating token/request.
+	expiresAt := requestor.ExpiresAt()
+	if expiresAt != nil {
+		apiIdentity.ExpiresAt = expiresAt
+	}
+
 	effectivePermissions := make([]api.Permission, 0, len(permissions))
 	for _, permission := range permissions {
 		effectivePermissions = append(effectivePermissions, api.Permission{
@@ -1636,7 +1643,6 @@ func identityGetCurrent(d *Daemon, r *http.Request) response.Response {
 		EffectiveGroups:      effectiveGroups,
 		EffectivePermissions: effectivePermissions,
 		FineGrained:          identityType.IsFineGrained(),
-		ExpiresAt:            requestor.ExpiresAt(),
 	})
 }
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -530,7 +530,8 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		return nil
+		// Record the expiry alongside the new signing key so that it can be reported when the identity is listed.
+		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, &expiresAt)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -610,7 +611,8 @@ func identityBearerTokenDelete(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed revoking token: %w", err)
 		}
 
-		return nil
+		// Clear the recorded expiry so that the revoked token is no longer reported when the identity is listed.
+		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, nil)
 	})
 	if err != nil {
 		return response.SmartError(err)

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -112,6 +112,14 @@ type Identity struct {
 	//
 	// API extension: access_management_tls.
 	TLSCertificate string `json:"tls_certificate" yaml:"tls_certificate"`
+
+	// ExpiresAt is the expiration time of the credential belonging to the identity. For TLS identities this is the
+	// expiry of the certificate, and for bearer identities it is the expiry of the most recently issued token.
+	// It is unset for identities whose credential has no expiry, that have no credential yet (pending identities),
+	// or whose token has been revoked.
+	//
+	// API extension: access_management_expiry.
+	ExpiresAt *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
 // Writable converts a Identity struct into a IdentityPut struct (filters read-only fields).
@@ -149,10 +157,6 @@ type IdentityInfo struct {
 	// FineGrained is a boolean indicating whether the identity is fine-grained,
 	// meaning that permissions are managed via group membership.
 	FineGrained bool `json:"fine_grained" yaml:"fine_grained"`
-
-	// ExpiresAt is the expiration time of the credential used to authenticate the caller.
-	// It is set only when client is trusted, and authentication method is either bearer or TLS.
-	ExpiresAt *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
 // IdentityPut contains the editable fields of an IdentityInfo.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -499,6 +499,7 @@ var APIExtensions = []string{
 	"network_load_balancer_pool_health_checks",
 	"operation_child_count",
 	"storage_driver_powerstore_nvme",
+	"access_management_expiry",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -213,6 +213,10 @@ fine_grained: true"
   certExpiresAt="$(printf '%s\n' "${currentIdentity}" | sed -n 's/^expires_at: //p')"
   [[ "${certExpiresAt}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
 
+  # The certificate expiry is derived from the presented peer certificate for the current identity, but from the
+  # stored certificate when the identity is shown. Both describe the same certificate, so their expiry must match.
+  [ "$(date -u -d "$(lxc query "/1.0/auth/identities/tls/${tls_identity_fingerprint}" | jq --exit-status --raw-output '.expires_at')" +%s)" = "$(date -u -d "${certExpiresAt}" +%s)" ]
+
   expectedBearerInfo="authentication_method: bearer
 type: Client token bearer
 id: ${bearer_identity_id}
@@ -276,7 +280,24 @@ fine_grained: true"
   # Use curl instead of lxc to ensure API interaction is correct.
   lxc auth identity create bearer/tmp
   tmp_bearer_identity_id="$(lxc auth identity show bearer/tmp | grep "^id:" | cut -d' ' -f2)"
+
+  # A bearer identity with no issued token has no expiry to report.
+  lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
+
   tmp_bearer_identity_token="$(lxc auth identity token issue bearer/tmp --quiet)"
+
+  # Once a token is issued, the identity reports its expiry when shown, not only via the current identity endpoint.
+  # The reported expiry must match the "exp" claim of the issued token exactly, so that the identity and the token
+  # it was issued cannot describe different expiries.
+  tmp_bearer_token_payload="$(printf '%s' "${tmp_bearer_identity_token}" | cut -d. -f2 | base64 -d 2>/dev/null || true)"
+  tmp_bearer_token_exp="$(jq --exit-status --raw-output '.exp' <<< "${tmp_bearer_token_payload}")"
+  tmp_bearer_listed_expiry="$(lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status --raw-output '.expires_at')"
+  [ "$(date -u -d "${tmp_bearer_listed_expiry}" +%s)" = "${tmp_bearer_token_exp}" ]
+
+  # The expiry is also reported when listing identities recursively.
+  tmp_bearer_recursive_expiry="$(lxc query "/1.0/auth/identities/bearer?recursion=1" | jq --exit-status --raw-output --arg id "${tmp_bearer_identity_id}" '.[] | select(.id == $id) | .expires_at')"
+  [ "$(date -u -d "${tmp_bearer_recursive_expiry}" +%s)" = "${tmp_bearer_token_exp}" ]
+
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.auth == "trusted"'
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.auth_user_method == "bearer"'
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status --arg id "${tmp_bearer_identity_id}" '.metadata.auth_user_name == $id'
@@ -284,6 +305,10 @@ fine_grained: true"
   # Check that bearer token revocation works.
   lxc auth identity token revoke bearer/tmp
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.error_code == 403'
+
+  # Revoking the token clears the reported expiry, so that a revoked token is not advertised as still valid.
+  lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
+
   lxc auth identity delete bearer/tmp
 
   # Ensure DevLXD token cannot be to authenticate with main LXD API.


### PR DESCRIPTION
Reports identity credential expiry when identities are listed or shown, not just for the current identity.

For TLS identities the expiry is derived from the stored certificate and for bearer identities it is now recorded in the identity metadata on token issue and cleared on revoke.

Note that bearer identities with a token issued before this change report no expiry until the token is reissued.

API extension: `access_management_expiry`
