### PR TITLE
snap: increase yarn install HTTP timeout

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1710,7 +1710,7 @@ parts:
       craftctl default
 
       npm install yarn --global
-      yarn install
+      yarn install --network-timeout 600000
       yarn build
 
       mkdir -p "${CRAFT_PART_INSTALL}/share"


### PR DESCRIPTION
Yarn's default HTTP timeout is 30 s (defined in src/constants.js). This has led to build failures on RISC-V (ESOCKETTIMEDOUT).

Increase the HTTP timeout for `yarn install` to 10 min (600,000 ms).

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation. *No change*
