### PR TITLE
Release: Add notes for 4.0.12 LTS

### DIFF
--- a/doc/reference/release-notes/4.0/index.md
+++ b/doc/reference/release-notes/4.0/index.md
@@ -16,6 +16,7 @@ This page lists recent release notes for LXD 4.0 LTS.
 :titlesonly:
 :maxdepth: 1
 
+LXD 4.0.12 LTS <release-notes-4.0.12>
 LXD 4.0.11 LTS <release-notes-4.0.11>
 ```
 

--- a/doc/reference/release-notes/4.0/release-notes-4.0.12.md
+++ b/doc/reference/release-notes/4.0/release-notes-4.0.12.md
@@ -1,0 +1,41 @@
+---
+myst:
+  html_meta:
+    description: Release notes for LXD 4.0.12, including highlights about new features, bugfixes, and other updates from the LXD project.
+---
+
+(ref-release-notes-4.0.12)=
+# LXD 4.0.12 release notes
+
+This is a {ref}`LTS release <ref-releases-lts>` and is recommended for production use.
+
+```{admonition} Release notes content
+:class: note
+These release notes cover updates in the [core LXD repository](https://github.com/canonical/lxd) and the [LXD snap package](https://snapcraft.io/lxd).
+```
+
+This is a maintenance release for the 4.0 LTS series. It includes improvements to the GitHub Actions CI/CD pipeline backported from the main development branch.
+
+(ref-release-notes-4.0.12-highlights)=
+## Highlights
+
+(ref-release-notes-4.0.12-bugfixes)=
+## Bug fixes
+
+No user-facing bug fixes are included in this release.
+
+(ref-release-notes-4.0.12-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/lxd/compare/lxd-4.0.11...lxd-4.0.12).
+
+(ref-release-notes-4.0.12-downloads)=
+## Downloads
+
+The source tarballs and binary clients can be found on our [download page](https://github.com/canonical/lxd/releases/tag/lxd-4.0.12).
+
+Binary packages are also available for:
+
+- **Linux:** `snap install lxd --channel=4.0/stable`
+- **MacOS client:** `brew install lxc`
+- **Windows client:** `choco install lxc`


### PR DESCRIPTION
Generated with:
```
/... lxd-release-notes version=4.0.12 branch=stable-4.0 start=lxd-4.0.11 end=137609681187ec9f2f700efd76fb84fc26f9468b is_lts=yes
```

I realized afterward that I could/should have used `end=stable-4.0`.