### PR TITLE
lxd/device/utils_network: use numeric IPv6 zone for NDP neighbour probe

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -1073,7 +1073,36 @@ func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) 
 		return false, err
 	}
 
-	conn, _, err := ndp.Listen(networkInterface, ndp.LinkLocal)
+	// Use the interface's numeric index as its name when probing. The ndp
+	// library derives the IPv6 scope zone from the interface name, which Go's
+	// net package resolves to a scope ID via a name-based cache. Under heavy
+	// interface churn that cache can return a stale or zero index, causing the
+	// kernel to reject the scoped link-local bind ("no such device") or the
+	// solicited-node multicast send ("invalid argument"). A numeric zone is
+	// resolved directly to the scope ID, bypassing the name cache. Interface
+	// address lookups used by ndp.Listen key off the index, so this is safe.
+	probeInterface := &net.Interface{
+		Index:        networkInterface.Index,
+		MTU:          networkInterface.MTU,
+		Name:         strconv.Itoa(networkInterface.Index),
+		HardwareAddr: networkInterface.HardwareAddr,
+		Flags:        networkInterface.Flags,
+	}
+
+	// Prefer binding to the interface's link-local address so that neighbour
+	// solicitations carry a proper source and elicit a unicast advertisement.
+	// If no link-local address is available (e.g. a bridge that has not yet
+	// configured one), fall back to other unicast address types assigned to the
+	// interface. ndp.Unspecified (::) is intentionally excluded: sending from ::
+	// causes EINVAL on newer kernels.
+	var conn *ndp.Conn
+	for _, addrType := range []ndp.Addr{ndp.LinkLocal, ndp.Global, ndp.UniqueLocal} {
+		conn, _, err = ndp.Listen(probeInterface, addrType)
+		if err == nil {
+			break
+		}
+	}
+
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The ndp library derives the IPv6 scope zone from the interface name, which Go's net package resolves through a name-based `zoneCache`. Under heavy interface churn that cache can return a stale zero index, causing `bind` or `sendmsg` to fail on Ubuntu 26.04. Using the numeric index as the zone bypasses the cache entirely avoiding the problem.

In CI, this would show in the `container_devices_nic_routed` test:

```
+ lxc stop nt8217 -f
+ timeout --foreground 120 /home/runner/go/bin/lxc --verbose stop nt8217 -f
time="2026-06-23T23:12:35Z" level=info msg="Stopping instance" action=stop created="2026-06-23 23:12:33.974090551 +0000 UTC" ephemeral=false instance=nt8217 instanceType=container project=default stateful=false used="2026-06-23 23:12:35.54660323 +0000 UTC"
time="2026-06-23T23:12:35Z" level=info msg=instance-stopped name=nt8217 project=default requestor=unix/root source=/1.0/instances/nt8217
+ lxc config device set nt8217 eth0 ipv4.address= ipv6.address=2001:db8::FFFF
+ timeout --foreground 120 /home/runner/go/bin/lxc --verbose config device set nt8217 eth0 ipv4.address= ipv6.address=2001:db8::FFFF
time="2026-06-23T23:12:35Z" level=info msg=instance-updated name=nt8217 project=default requestor=unix/root source=/1.0/instances/nt8217
+ lxc start nt8217
+ timeout --foreground 120 /home/runner/go/bin/lxc --verbose start nt8217
time="2026-06-23T23:12:36Z" level=info msg="Starting instance" action=start created="2026-06-23 23:12:33.974090551 +0000 UTC" ephemeral=false instance=nt8217 instanceType=container project=default stateful=false used="2026-06-23 23:12:35.54660323 +0000 UTC"
time="2026-06-23T23:12:36Z" level=warning msg="Failed checking IP address available on parent network" IP="2001:db8::ffff" device=eth0 driver=nic err="listen ip6:ipv6-icmp fe80::216:3eff:fe38:5e9f%nt8217: bind: no such device" instance=nt8217 parent=nt8217 project=default
time="2026-06-23T23:12:36Z" level=info msg="Started instance" action=start created="2026-06-23 23:12:33.974090551 +0000 UTC" ephemeral=false instance=nt8217 instanceType=container project=default stateful=false used="2026-06-23 23:12:35.54660323 +0000 UTC"
time="2026-06-23T23:12:36Z" level=info msg=instance-started name=nt8217 project=default requestor=unix/root source=/1.0/instances/nt8217
+ false
+ cleanup
```