### PR TITLE
storage: Add NVMe/TCP support for PowerStore

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3625,3 +3625,9 @@ In addition a new endpoint [`GET /1.0/networks/{networkName}/load-balancer-pools
 ## `operation_child_count`
 
 Adds a `child_count` field to the `Operation` struct, indicating the number of child operations. This allows clients to determine whether an operation has children without requiring `recursion=2`.
+
+(extension-storage-driver-powerstore-nvme)=
+## `storage_driver_powerstore_nvme`
+
+Adds NVMe/TCP support to the Dell PowerStore storage driver.
+NVMe/TCP is now the default PowerStore mode when `powerstore.mode` is not set.

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -241,17 +241,25 @@ Create a storage pool named `pool5` that explicitly uses the PowerFlex SDC:
 ````
 ````{group-tab} powerstore
 
-Create a storage pool named `pool1` that uses iSCSI to connect to PowerStore array:
+Create a storage pool named `pool1` that uses NVMe/TCP by default:
 
-    lxc storage create pool1 powerstore powerstore.mode=iscsi powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo
+    lxc storage create pool1 powerstore powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo
 
-Create a storage pool named `pool2` that uses SCSI/FC to connect to PowerStore array:
+Create a storage pool named `pool2` that uses a PowerStore gateway with a certificate that is not trusted:
 
-    lxc storage create pool2 powerstore powerstore.mode=scsi/fc powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo
+    lxc storage create pool2 powerstore powerstore.gateway=https://powerstore powerstore.gateway.verify=false powerstore.user.name=lxd powerstore.user.password=foo
 
-Create a storage pool named `pool3` that uses a PowerStore gateway with a certificate that is not trusted:
+Create a storage pool named `pool3` that uses iSCSI to connect to PowerStore array:
 
-    lxc storage create pool3 powerstore powerstore.mode=iscsi powerstore.gateway=https://powerstore powerstore.gateway.verify=false powerstore.user.name=lxd powerstore.user.password=foo
+    lxc storage create pool3 powerstore powerstore.mode=iscsi powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo
+
+Create a storage pool named `pool4` that uses SCSI/FC to connect to PowerStore array:
+
+    lxc storage create pool4 powerstore powerstore.mode=scsi/fc powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo
+
+Create a storage pool named `pool5` that uses NVMe/TCP to connect to PowerStore array via specific target addresses:
+
+    lxc storage create pool5 powerstore powerstore.mode=nvme/tcp powerstore.gateway=https://powerstore powerstore.user.name=lxd powerstore.user.password=foo powerstore.target=<target_address_1>,<target_address_2>
 
 ````
 ````{group-tab} pure

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6559,12 +6559,12 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```
 
 ```{config:option} powerstore.mode storage-powerstore-pool-conf
-:required: "true"
+:defaultdesc: "`nvme/tcp`"
 :scope: "global"
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode to use to map PowerStore volumes to the local server.
-Supported values are `iscsi` and `scsi/fc`.
+Supported values are `iscsi`, `scsi/fc`, and `nvme/tcp`.
 ```
 
 ```{config:option} powerstore.target storage-powerstore-pool-conf

--- a/doc/reference/storage_powerstore.md
+++ b/doc/reference/storage_powerstore.md
@@ -4,9 +4,10 @@
 Dell PowerStore is a storage solution from [Dell Technologies](https://www.dell.com/).
 It offers the consumption of block storage across the network.
 
-LXD supports connecting to PowerStore storage through {abbr}`iSCSI` (Internet Small Computer Systems Interface) or {abbr}`FC` (Fibre Channel).
+LXD supports connecting to PowerStore storage through {abbr}`NVMe/TCP` (Non-Volatile Memory Express over Transmission Control Protocol), {abbr}`iSCSI` (Internet Small Computer Systems Interface), or {abbr}`FC` (Fibre Channel).
 
-For iSCSI, ensure that the required kernel modules and the iSCSI CLI (`iscsiadm`) are installed on your host system.
+Ensure that the required kernel modules for the selected protocol are installed on your host system.
+For iSCSI, also ensure that the iSCSI CLI (`iscsiadm`) is installed on your host system.
 
 ## Terminology
 
@@ -28,7 +29,7 @@ This driver provides remote storage.
 As a result, and depending on the internal network, storage access might be a bit slower compared to local storage.
 On the other hand, using remote storage has significant advantages in a cluster setup: all cluster members have access to the same storage pools with the exact same contents, without requiring the storage pools to be synchronized between members.
 
-For iSCSI, when a volume is first mapped to the LXD host, LXD discovers the available targets from the PowerStore array and connects to them.
+For NVMe/TCP and iSCSI, when a volume is first mapped to the LXD host, LXD discovers the available targets from the PowerStore array and connects to them.
 You can optionally restrict connections to specific targets using {config:option}`storage-powerstore-pool-conf:powerstore.target`.
 For Fibre Channel, targets are discovered automatically through the FC {abbr}`HBA` (Host Bus Adapter). The {config:option}`storage-powerstore-pool-conf:powerstore.target` option does not apply to FC mode.
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7242,8 +7242,8 @@
 					},
 					{
 						"powerstore.mode": {
-							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported values are `iscsi` and `scsi/fc`.",
-							"required": "true",
+							"defaultdesc": "`nvme/tcp`",
+							"longdesc": "The mode to use to map PowerStore volumes to the local server.\nSupported values are `iscsi`, `scsi/fc`, and `nvme/tcp`.",
 							"scope": "global",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"

--- a/lxd/storage/drivers/clients/powerstore.go
+++ b/lxd/storage/drivers/clients/powerstore.go
@@ -81,10 +81,11 @@ type PowerStoreVolume struct {
 	Size        int64  `json:"size,omitempty"`
 	LogicalUsed int64  `json:"logical_used,omitempty"`
 	WWN         string `json:"wwn,omitempty"`
+	NGUID       string `json:"nguid,omitempty"`
 }
 
 func (PowerStoreVolume) selector() string {
-	return "id,name,type,size,logical_used,wwn"
+	return "id,name,type,size,logical_used,wwn,nguid"
 }
 
 // PowerStoreApplianceMetrics represents metrics collected from a PowerStore appliance.

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -25,6 +25,9 @@ var alletraSupportedConnectors = []string{
 	connectors.TypeISCSI,
 }
 
+// alletraDefaultMode represents the default HPE Alletra Storage mode.
+const alletraDefaultMode = connectors.TypeNVMeTCP
+
 type alletra struct {
 	common
 
@@ -120,7 +123,7 @@ func (d *alletra) Info() Info {
 func (d *alletra) FillConfig() error {
 	// Use NVMe by default.
 	if d.config["alletra.mode"] == "" {
-		d.config["alletra.mode"] = connectors.TypeNVMeTCP
+		d.config["alletra.mode"] = alletraDefaultMode
 	}
 
 	return nil
@@ -192,6 +195,12 @@ func (d *alletra) Validate(config map[string]string) error {
 	newMode := config["alletra.mode"]
 	oldMode := d.config["alletra.mode"]
 
+	// If mode is not provided, use default mode. This is needed for cluster pool creation to
+	// ensure required modules are available and loaded on all cluster members.
+	if newMode == "" {
+		newMode = alletraDefaultMode
+	}
+
 	// Ensure alletra.mode cannot be changed to avoid leaving volume mappings
 	// and prevent disturbing running instances.
 	if oldMode != "" && oldMode != newMode {
@@ -204,16 +213,14 @@ func (d *alletra) Validate(config map[string]string) error {
 	// on the other cluster members too. This can be done here since Validate
 	// gets executed on every cluster member when receiving the cluster
 	// notification to finally create the pool.
-	if newMode != "" {
-		connector, err := connectors.NewConnector(newMode, "")
-		if err != nil {
-			return fmt.Errorf("Alletra Storage mode %q is not supported: %w", newMode, err)
-		}
+	connector, err := connectors.NewConnector(newMode, "")
+	if err != nil {
+		return fmt.Errorf("Alletra Storage mode %q is not supported: %w", newMode, err)
+	}
 
-		err = connector.LoadModules()
-		if err != nil {
-			return fmt.Errorf("Alletra Storage mode %q is not supported due to missing kernel modules: %w", newMode, err)
-		}
+	err = connector.LoadModules()
+	if err != nil {
+		return fmt.Errorf("Alletra Storage mode %q is not supported due to missing kernel modules: %w", newMode, err)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -27,6 +27,7 @@ var powerStoreVersion string
 var powerStoreSupportedConnectors = []string{
 	connectors.TypeISCSI,
 	connectors.TypeSCSIFC,
+	connectors.TypeNVMeTCP,
 }
 
 // powerStoreDefaultUser represents the default PowerStore user name.
@@ -135,6 +136,10 @@ func (d *powerstore) FillConfig() error {
 		d.config["powerstore.user.name"] = powerStoreDefaultUser
 	}
 
+	if d.config["powerstore.mode"] == "" {
+		d.config["powerstore.mode"] = connectors.TypeNVMeTCP
+	}
+
 	return nil
 }
 
@@ -173,12 +178,12 @@ func (d *powerstore) Validate(config map[string]string) error {
 		"powerstore.gateway.verify": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.mode)
 		// The mode to use to map PowerStore volumes to the local server.
-		// Supported values are `iscsi` and `scsi/fc`.
+		// Supported values are `iscsi`, `scsi/fc`, and `nvme/tcp`.
 		// ---
 		//  type: string
+		//  defaultdesc: `nvme/tcp`
 		//  shortdesc: How volumes are mapped to the local server
 		//  scope: global
-		//  required: true
 		"powerstore.mode": validate.Optional(validate.IsOneOf(powerStoreSupportedConnectors...)),
 		// lxdmeta:generate(entities=storage-powerstore; group=pool-conf; key=powerstore.target)
 		// A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
@@ -257,10 +262,6 @@ func (d *powerstore) ValidateSource() error {
 
 	if d.config["powerstore.user.password"] == "" {
 		return errors.New("The powerstore.user.password cannot be empty")
-	}
-
-	if d.config["powerstore.mode"] == "" {
-		return errors.New("The powerstore.mode cannot be empty")
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -33,6 +33,9 @@ var powerStoreSupportedConnectors = []string{
 // powerStoreDefaultUser represents the default PowerStore user name.
 const powerStoreDefaultUser = "admin"
 
+// powerStoreDefaultMode represents the default PowerStore mode.
+const powerStoreDefaultMode = connectors.TypeNVMeTCP
+
 // Common prefix for resource names in PowerStore.
 const powerStoreResourcePrefix = "lxd-"
 
@@ -137,7 +140,7 @@ func (d *powerstore) FillConfig() error {
 	}
 
 	if d.config["powerstore.mode"] == "" {
-		d.config["powerstore.mode"] = connectors.TypeNVMeTCP
+		d.config["powerstore.mode"] = powerStoreDefaultMode
 	}
 
 	return nil
@@ -210,6 +213,12 @@ func (d *powerstore) Validate(config map[string]string) error {
 	newMode := config["powerstore.mode"]
 	oldMode := d.config["powerstore.mode"]
 
+	// If mode is not provided, use default mode. This is needed for cluster pool creation to
+	// ensure required modules are available and loaded on all cluster members.
+	if newMode == "" {
+		newMode = powerStoreDefaultMode
+	}
+
 	// Ensure powerstore.mode cannot be changed to avoid leaving volume mappings
 	// and prevent disturbing running instances.
 	if oldMode != "" && oldMode != newMode {
@@ -221,16 +230,14 @@ func (d *powerstore) Validate(config map[string]string) error {
 	// host needs to be validated on the other cluster members as well. This can be done here
 	// since Validate gets executed on every cluster member when receiving the cluster
 	// notification to finally create the pool.
-	if newMode != "" {
-		connector, err := connectors.NewConnector(newMode, "")
-		if err != nil {
-			return fmt.Errorf("PowerStore mode %q is not supported: %w", newMode, err)
-		}
+	connector, err := connectors.NewConnector(newMode, "")
+	if err != nil {
+		return fmt.Errorf("PowerStore mode %q is not supported: %w", newMode, err)
+	}
 
-		err = connector.LoadModules()
-		if err != nil {
-			return fmt.Errorf("PowerStore mode %q is not supported due to missing kernel modules: %w", newMode, err)
-		}
+	err = connector.LoadModules()
+	if err != nil {
+		return fmt.Errorf("PowerStore mode %q is not supported due to missing kernel modules: %w", newMode, err)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_powerstore.go
+++ b/lxd/storage/drivers/driver_powerstore.go
@@ -345,7 +345,7 @@ func (d *powerstore) targets() (map[string][]string, error) {
 		case connectors.TypeISCSI:
 			defaultPort = connectors.ISCSIDefaultPort
 		case connectors.TypeNVMeTCP:
-			defaultPort = connectors.NVMeDefaultDiscoveryPort
+			defaultPort = connectors.NVMeDefaultTransportPort
 		default:
 			return nil, fmt.Errorf("Unsupported PowerStore mode %q", mode)
 		}

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -597,6 +597,10 @@ func (d *powerstore) DeleteVolume(vol Volume, progressReporter ioprogress.Progre
 
 	volID, err := d.getVolumeID(vol)
 	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/lxd/storage/drivers/driver_powerstore_volumes.go
+++ b/lxd/storage/drivers/driver_powerstore_volumes.go
@@ -1570,14 +1570,30 @@ func (d *powerstore) getMappedDevicePath(vol Volume, mapVolume bool) (string, re
 		return "", nil, fmt.Errorf("Failed retrieving volume %q: %w", vol.name, err)
 	}
 
-	_, wwn, ok := strings.Cut(psVol.WWN, ".")
-	if !ok {
-		return "", nil, fmt.Errorf("Failed parsing WWN for volume %q: Invalid format %q", vol.name, psVol.WWN)
+	// The device is identified by a different identifier depending on the connector type.
+	// Over NVMe-oF the device is identified by the namespace globally unique identifier
+	// (NGUID) rather than the WWN. Both encode the same volume and are reported by
+	// PowerStore in the form "<prefix>.<id>".
+	deviceID := psVol.WWN
+	if connector.Type() == connectors.TypeNVMeTCP {
+		deviceID = psVol.NGUID
 	}
 
-	// Filters devices by matching the device path with the WWN.
+	_, diskSuffix, ok := strings.Cut(deviceID, ".")
+	if !ok {
+		return "", nil, fmt.Errorf("Failed parsing device identifier for volume %q: Invalid format %q", vol.name, deviceID)
+	}
+
+	// Ensure the identifier is exactly 32 characters long, as it uniquely identifies the device.
+	if len(diskSuffix) != 32 {
+		return "", nil, fmt.Errorf("Failed locating device for volume %q: Unexpected length of device identifier %q (%d)", vol.name, diskSuffix, len(diskSuffix))
+	}
+
+	// Filters devices by matching the device path with the lowercase disk suffix,
+	// as the device symlinks are always in lowercase.
+	diskSuffix = strings.ToLower(diskSuffix)
 	devicePathFilter := func(path string) bool {
-		return strings.Contains(path, wwn)
+		return strings.Contains(path, diskSuffix)
 	}
 
 	var devicePath string

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -28,6 +28,9 @@ var pureSupportedConnectors = []string{
 	connectors.TypeNVMeTCP,
 }
 
+// pureDefaultMode represents the default Pure Storage mode.
+const pureDefaultMode = connectors.TypeNVMeTCP
+
 // pureMinVolumeSizeBytes defines the minimum size of a Pure Storage volume, which is 1MiB.
 const pureMinVolumeSizeBytes = 1024 * 1024
 
@@ -122,7 +125,7 @@ func (d *pure) Info() Info {
 func (d *pure) FillConfig() error {
 	// Use NVMe by default.
 	if d.config["pure.mode"] == "" {
-		d.config["pure.mode"] = connectors.TypeNVMeTCP
+		d.config["pure.mode"] = pureDefaultMode
 	}
 
 	return nil
@@ -183,6 +186,12 @@ func (d *pure) Validate(config map[string]string) error {
 	newMode := config["pure.mode"]
 	oldMode := d.config["pure.mode"]
 
+	// If mode is not provided, use default mode. This is needed for cluster pool creation to
+	// ensure required modules are available and loaded on all cluster members.
+	if newMode == "" {
+		newMode = pureDefaultMode
+	}
+
 	// Ensure pure.mode cannot be changed to avoid leaving volume mappings
 	// and prevent disturbing running instances.
 	if oldMode != "" && oldMode != newMode {
@@ -195,16 +204,14 @@ func (d *pure) Validate(config map[string]string) error {
 	// on the other cluster members too. This can be done here since Validate
 	// gets executed on every cluster member when receiving the cluster
 	// notification to finally create the pool.
-	if newMode != "" {
-		connector, err := connectors.NewConnector(newMode, "")
-		if err != nil {
-			return fmt.Errorf("Pure Storage mode %q is not supported: %w", newMode, err)
-		}
+	connector, err := connectors.NewConnector(newMode, "")
+	if err != nil {
+		return fmt.Errorf("Pure Storage mode %q is not supported: %w", newMode, err)
+	}
 
-		err = connector.LoadModules()
-		if err != nil {
-			return fmt.Errorf("Pure Storage mode %q is not supported due to missing kernel modules: %w", newMode, err)
-		}
+	err = connector.LoadModules()
+	if err != nil {
+		return fmt.Errorf("Pure Storage mode %q is not supported due to missing kernel modules: %w", newMode, err)
 	}
 
 	return nil

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -498,6 +498,7 @@ var APIExtensions = []string{
 	"cluster_links_unidirectional",
 	"network_load_balancer_pool_health_checks",
 	"operation_child_count",
+	"storage_driver_powerstore_nvme",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for mode `nvme/tcp` in PowerStore.
Additionally, it makes `nvme/tcp` the default mode if `powerstore.mode` is not set.

API extension: `storage_driver_powerstore_nvme`