### PR TITLE
lxd/db/cluster: Include server operations when listing in the default project

### DIFF
--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -202,7 +202,8 @@ func (OperationsResourcesRow) APIName() string {
 
 // GetOperations returns slice of [Operation] based on given filters. If includeChildren is false, only operations that
 // do not reference parent operations are returned. If the project is non-nil, only operations in the given project are
-// returned.
+// returned if the project is not [api.ProjectDefaultName]. If the project is non-nil, and equal to [api.ProjectDefaultName]
+// then server-level operations are returned along with all operations in the default project. This is to match legacy behaviour.
 func GetOperations(ctx context.Context, tx *sql.Tx, includeChildren bool, project *string) ([]Operation, error) {
 	clauses := make([]string, 0, 2)
 	args := make([]any, 0, 1)
@@ -211,7 +212,16 @@ func GetOperations(ctx context.Context, tx *sql.Tx, includeChildren bool, projec
 	}
 
 	if project != nil {
-		clauses = append(clauses, "projects.name = ?")
+		// Unfortunately, since there is no way to request "no project" via the API (e.g. it always defaults to the default project)
+		// we need to include server-level operations when the requested project is default. Server level operations will always
+		// be included in requests for `all-projects`. They are filtered out in the API handler depending on what the caller is
+		// able to view.
+		projectClause := "projects.name = ?"
+		if *project == api.ProjectDefaultName {
+			projectClause = "(projects.name = ? OR operations.project_id IS NULL)"
+		}
+
+		clauses = append(clauses, projectClause)
 		args = append(args, *project)
 	}
 


### PR DESCRIPTION
This is to maintain existing behaviour. The CLI lists operations in the default project when listing cluster join or certificate add tokens.

Follow up fix for #18453.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
