### PR TITLE
Busy zfs prevents rebuild

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2764,6 +2764,9 @@ func (d *lxc) Restart(ctx context.Context, timeout time.Duration, progressReport
 
 // Rebuild rebuilds the instance using the supplied image fingerprint as source.
 func (d *lxc) Rebuild(ctx context.Context, img *api.Image, op *operations.Operation) error {
+	// Rebuild assumes instance is stopped.  But a stopped instance could still have a running
+	// forkfile.  So stop the forkfile.
+	d.StopForkFile(false)
 	return d.rebuildCommon(ctx, d, img, op)
 }
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -830,6 +830,12 @@ test_basic_usage() {
   [ "$(lxc config get c1 image.os || echo fail)" = "" ]
   lxc delete c1
 
+  # Test that rebuild succeeds after a file operation.
+  lxc init testimage c1
+  lxc file create c1/foo
+  lxc rebuild testimage c1
+  lxc delete c1
+
   # Test assigning an empty profile (with no root disk device) to an instance.
   lxc init --empty c1
   lxc profile create foo


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Root cause

A file operation will cause forkfile process to be spawned and linger (until inactivity shutdown).  An instance rebuild call does not stop the forkfile and will cause unmount to fail.

## Fix

Stop the forkfile at the beginning of rebuild.

## Validation

Added test case.  Fails w/o the fix.  Passes with the fix.

Test command `LXD_BACKEND=zfs ./main.sh basic_usage`