### PR TITLE
github: add `go.{mod,sum}` to labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,7 +51,8 @@ d/build-test:
     - Makefile
     - doc/Makefile
     - lxd-qemu-snap/**/*
-    - lxd/Makefile
+    - go.mod
+    - go.sum
     - scripts/**/*
     - snap/**/*
     - snapcraft/**/*


### PR DESCRIPTION
Also remove bogus `lxd/Makefile` entry that doesn't have a corresponding file.