### PR TITLE
Doc: Add warning to raw.* (excluding raw.idmap and raw.mount.options) explaining they are not recommend for production use

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1955,6 +1955,7 @@ used to determine eligible cluster members during LXD scheduling events.
 :shortdesc: "AppArmor profile entries"
 :type: "blob"
 The specified entries are appended to the generated profile.
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 ```
 
 ```{config:option} raw.idmap instance-raw
@@ -1969,7 +1970,8 @@ For example: `both 1000 1000`
 :liveupdate: "no"
 :shortdesc: "Raw LXC configuration to be appended to the generated one"
 :type: "blob"
-
+Additional LXC configuration is appended to the generated configuration.
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 ```
 
 ```{config:option} raw.qemu instance-raw
@@ -1977,7 +1979,8 @@ For example: `both 1000 1000`
 :liveupdate: "no"
 :shortdesc: "Raw QEMU configuration to be appended to the generated command line"
 :type: "blob"
-
+Additional QEMU command line configuration is appended to the generated command line.
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 ```
 
 ```{config:option} raw.qemu.conf instance-raw
@@ -1985,6 +1988,7 @@ For example: `both 1000 1000`
 :liveupdate: "no"
 :shortdesc: "Addition/override to the generated `qemu.conf` file"
 :type: "blob"
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 See {ref}`instance-options-qemu` for more information.
 ```
 
@@ -1993,7 +1997,8 @@ See {ref}`instance-options-qemu` for more information.
 :liveupdate: "no"
 :shortdesc: "Raw Seccomp configuration"
 :type: "blob"
-
+Additional Seccomp configuration is appended to the generated policy.
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 ```
 
 <!-- config group instance-raw end -->
@@ -3236,7 +3241,8 @@ Specify a comma-separated list of IPv6 CIDR subnets.
 :scope: "global"
 :shortdesc: "Additional `dnsmasq` configuration to append to the configuration file"
 :type: "string"
-
+Additional `dnsmasq` configuration is appended to the generated configuration file.
+This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 ```
 
 ```{config:option} security.acls network-bridge-network-conf

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -305,6 +305,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.apparmor)
 	// The specified entries are appended to the generated profile.
+	// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 	// ---
 	//  type: blob
 	//  liveupdate: yes
@@ -693,7 +694,8 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	// Caller is responsible for full validation of any raw.* value.
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.lxc)
-	//
+	// Additional LXC configuration is appended to the generated configuration.
+	// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 	// ---
 	//  type: blob
 	//  liveupdate: no
@@ -702,7 +704,8 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	"raw.lxc": validate.IsAny,
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.seccomp)
-	//
+	// Additional Seccomp configuration is appended to the generated policy.
+	// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 	// ---
 	//  type: blob
 	//  liveupdate: no
@@ -1058,7 +1061,8 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	// Caller is responsible for full validation of any raw.* value.
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.qemu)
-	//
+	// Additional QEMU command line configuration is appended to the generated command line.
+	// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 	// ---
 	//  type: blob
 	//  liveupdate: no
@@ -1067,6 +1071,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	"raw.qemu": validate.IsAny,
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.qemu.conf)
+	// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 	// See {ref}`instance-options-qemu` for more information.
 	// ---
 	//  type: blob

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2215,7 +2215,7 @@
 					{
 						"raw.apparmor": {
 							"liveupdate": "yes",
-							"longdesc": "The specified entries are appended to the generated profile.",
+							"longdesc": "The specified entries are appended to the generated profile.\nThis is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.",
 							"shortdesc": "AppArmor profile entries",
 							"type": "blob"
 						}
@@ -2232,7 +2232,7 @@
 						"raw.lxc": {
 							"condition": "container",
 							"liveupdate": "no",
-							"longdesc": "",
+							"longdesc": "Additional LXC configuration is appended to the generated configuration.\nThis is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.",
 							"shortdesc": "Raw LXC configuration to be appended to the generated one",
 							"type": "blob"
 						}
@@ -2241,7 +2241,7 @@
 						"raw.qemu": {
 							"condition": "virtual machine",
 							"liveupdate": "no",
-							"longdesc": "",
+							"longdesc": "Additional QEMU command line configuration is appended to the generated command line.\nThis is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.",
 							"shortdesc": "Raw QEMU configuration to be appended to the generated command line",
 							"type": "blob"
 						}
@@ -2250,7 +2250,7 @@
 						"raw.qemu.conf": {
 							"condition": "virtual machine",
 							"liveupdate": "no",
-							"longdesc": "See {ref}`instance-options-qemu` for more information.",
+							"longdesc": "This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.\nSee {ref}`instance-options-qemu` for more information.",
 							"shortdesc": "Addition/override to the generated `qemu.conf` file",
 							"type": "blob"
 						}
@@ -2259,7 +2259,7 @@
 						"raw.seccomp": {
 							"condition": "container",
 							"liveupdate": "no",
-							"longdesc": "",
+							"longdesc": "Additional Seccomp configuration is appended to the generated policy.\nThis is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.",
 							"shortdesc": "Raw Seccomp configuration",
 							"type": "blob"
 						}
@@ -3596,7 +3596,7 @@
 					},
 					{
 						"raw.dnsmasq": {
-							"longdesc": "",
+							"longdesc": "Additional `dnsmasq` configuration is appended to the generated configuration file.\nThis is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.",
 							"scope": "global",
 							"shortdesc": "Additional `dnsmasq` configuration to append to the configuration file",
 							"type": "string"

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -596,7 +596,8 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  scope: global
 		"dns.zone.reverse.ipv6": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=raw.dnsmasq)
-		//
+		// Additional `dnsmasq` configuration is appended to the generated configuration file.
+		// This is a low-level option and is not recommended for production use, as it allows for unsupported configurations that may cease to work in future versions.
 		// ---
 		//  type: string
 		//  shortdesc: Additional `dnsmasq` configuration to append to the configuration file


### PR DESCRIPTION
As they allow for unsupported (and thus untested) configurations that may cease to work in future versions.