### PR TITLE
github: Streamline `dqlite`/`liblxc` dependency caching and build steps

### DIFF
--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -1,6 +1,15 @@
 name: Cache dqlite/liblxc dependencies
 description: Restore dqlite/liblxc from the daily cache or build them
 
+inputs:
+  export-env:
+    description: |
+      Whether to export the CGO/liblxc build variables (CGO_LDFLAGS, LD_LIBRARY_PATH,
+      LD_RUN_PATH, PKG_CONFIG_PATH) to GITHUB_ENV so LXD can be built against the deps.
+      Leave disabled for jobs that only run prebuilt binaries (e.g. system/snap tests).
+    default: "false"
+    required: false
+
 runs:
   using: composite
   steps:
@@ -84,3 +93,21 @@ runs:
           /home/runner/go/bin/dqlite
           /home/runner/go/bin/liblxc
         key: ${{ steps.deps-cache-key.outputs.KEY }}
+
+    # Export the liblxc arch-specific lib dir on top of the statically-known dqlite
+    # paths from the job env. Runs on both cache hit and miss (the deps are present
+    # either way), and only when the caller opts in via export-env.
+    - name: Update env variables for deps
+      if: ${{ inputs.export-env == 'true' }}
+      shell: bash
+      # The values written to GITHUB_ENV are a CI-controlled build-artifact path
+      # (the readlink'd liblxc lib dir) and the caller job's static CGO_* env vars,
+      # none of which are attacker-controllable, so github-env injection is not a risk.
+      run: | # zizmor: ignore[github-env]
+        set -eux
+        LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
+
+        echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
+        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
+        echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
+        echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"

--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -36,43 +36,48 @@ runs:
         restore-keys: |
           ${{ steps.deps-cache-key.outputs.FALLBACK_KEY }}
 
-    - name: Build LXD dependencies
+    - name: Check if deps need building
+      id: check-build
       if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        # When a restore-key fallback is used, cache-hit is false even though the
+        # directories were restored. Check that the specific include/ and libs/
+        # subdirectories are present and non-empty to avoid a needless build.
+        # (Checking the parent dirs is insufficient: liblxc/ always contains rootfs/
+        # which would make a partial restore appear complete.)
+        if [ -d /home/runner/go/bin/dqlite/include ] && [ -d /home/runner/go/bin/dqlite/libs ] && \
+           [ -d /home/runner/go/bin/liblxc/include ] && [ -d /home/runner/go/bin/liblxc/libs ] && \
+           [ -n "$(ls -A /home/runner/go/bin/dqlite/include)" ] && [ -n "$(ls -A /home/runner/go/bin/dqlite/libs)" ] && \
+           [ -n "$(ls -A /home/runner/go/bin/liblxc/include)" ] && [ -n "$(ls -A /home/runner/go/bin/liblxc/libs)" ]; then
+          echo "==> SKIP building as dqlite and liblxc deps were restored from fallback key"
+          echo "needed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install LXD build dependencies
+      if: ${{ steps.check-build.outputs.needed == 'true' }}
+      uses: ./.github/actions/install-lxd-builddeps
+
+    - name: Build LXD dependencies
+      if: ${{ steps.check-build.outputs.needed == 'true' }}
       shell: bash
       run: |
         set -eux
 
-        # It's possible to get here despite doing a cache-hit because when one
-        # of the restore-keys is used as fallback, the outputs.cache-hit is set
-        # to false. As such, check if the directories are present and if so,
-        # bail out early.
-        if [ -n "$(ls -A "/home/runner/go/bin/dqlite/")" ] && [ -n "$(ls -A "/home/runner/go/bin/liblxc/")" ]; then
-          echo "==> SKIP building as dqlite and liblxc deps were restored from fallback key"
-          exit 0
-        fi
+        # Build dqlite/liblxc and stage them into the cache dir. The Makefile owns
+        # the source/destination paths (see the deps-cache target), so this works
+        # from a plain workspace checkout in every job, including system-tests and
+        # snap-tests which do not run setup-go.
+        cd "${GITHUB_WORKSPACE}"
+        make deps-cache
 
-        # Build from unpacked dist tarball.
-        cd "${GITHUB_WORKSPACE}/../lxd-test"
-        make deps
-
-        # Include dqlite libs in dependencies for system tests.
-        mkdir -p /home/runner/go/bin/dqlite
-        mv "${GITHUB_WORKSPACE}/../lxd-test/vendor/dqlite/include" /home/runner/go/bin/dqlite/include
-        mv "${GITHUB_WORKSPACE}/../lxd-test/vendor/dqlite/.libs" /home/runner/go/bin/dqlite/libs
-
-        # Include liblxc libs in dependencies for system tests.
-        mkdir -p /home/runner/go/bin/liblxc
-        mv "${GITHUB_WORKSPACE}/../lxd-test/vendor/liblxc/include" /home/runner/go/bin/liblxc/include
-        mv "${GITHUB_WORKSPACE}/../lxd-test/vendor/liblxc/lib" /home/runner/go/bin/liblxc/libs
-
-        # liblxc requires a rootfs dir
-        mkdir -p /home/runner/go/bin/liblxc/rootfs
-
-    # Only save if there wasn't an exact cache hit, AND the code is running on the main repo (not an untrusted fork)
+    # Only save if deps were actually built (not restored), AND the code is running on the main repo (not an untrusted fork)
     - name: Save dqlite/liblxc deps
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: |
-        steps.cache-deps.outputs.cache-hit != 'true' &&
+        steps.check-build.outputs.needed == 'true' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       with:
         path: |

--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -39,8 +39,8 @@ runs:
       id: cache-deps
       with:
         path: |
-          /home/runner/go/bin/dqlite
-          /home/runner/go/bin/liblxc
+          /home/runner/go/deps/dqlite
+          /home/runner/go/deps/liblxc
         key: ${{ steps.deps-cache-key.outputs.KEY }}
         restore-keys: |
           ${{ steps.deps-cache-key.outputs.FALLBACK_KEY }}
@@ -51,14 +51,10 @@ runs:
       shell: bash
       run: |
         # When a restore-key fallback is used, cache-hit is false even though the
-        # directories were restored. Check that the specific include/ and libs/
-        # subdirectories are present and non-empty to avoid a needless build.
-        # (Checking the parent dirs is insufficient: liblxc/ always contains rootfs/
-        # which would make a partial restore appear complete.)
-        if [ -d /home/runner/go/bin/dqlite/include ] && [ -d /home/runner/go/bin/dqlite/libs ] && \
-           [ -d /home/runner/go/bin/liblxc/include ] && [ -d /home/runner/go/bin/liblxc/libs ] && \
-           [ -n "$(ls -A /home/runner/go/bin/dqlite/include)" ] && [ -n "$(ls -A /home/runner/go/bin/dqlite/libs)" ] && \
-           [ -n "$(ls -A /home/runner/go/bin/liblxc/include)" ] && [ -n "$(ls -A /home/runner/go/bin/liblxc/libs)" ]; then
+        # directories were restored. Check that the compiled libraries exist to
+        # avoid a needless build.
+        if [ -f /home/runner/go/deps/dqlite/.libs/libdqlite.so ] && \
+           [ -n "$(find /home/runner/go/deps/liblxc/lib -name liblxc.so 2>/dev/null)" ]; then
           echo "==> SKIP building as dqlite and liblxc deps were restored from fallback key"
           echo "needed=false" >> "$GITHUB_OUTPUT"
         else
@@ -75,12 +71,9 @@ runs:
       run: |
         set -eux
 
-        # Build dqlite/liblxc and stage them into the cache dir. The Makefile owns
-        # the source/destination paths (see the deps-cache target), so this works
-        # from a plain workspace checkout in every job, including system-tests and
-        # snap-tests which do not run setup-go.
+        # Build dqlite/liblxc in place.
         cd "${GITHUB_WORKSPACE}"
-        make deps-cache
+        make deps
 
     # Only save if deps were actually built (not restored), AND the code is running on the main repo (not an untrusted fork)
     - name: Save dqlite/liblxc deps
@@ -90,8 +83,8 @@ runs:
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       with:
         path: |
-          /home/runner/go/bin/dqlite
-          /home/runner/go/bin/liblxc
+          /home/runner/go/deps/dqlite
+          /home/runner/go/deps/liblxc
         key: ${{ steps.deps-cache-key.outputs.KEY }}
 
     # Export the liblxc arch-specific lib dir on top of the statically-known dqlite
@@ -105,9 +98,10 @@ runs:
       # none of which are attacker-controllable, so github-env injection is not a risk.
       run: | # zizmor: ignore[github-env]
         set -eux
-        LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
+        LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/deps/liblxc/lib/*-linux-gnu)"
 
-        echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
-        echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
-        echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"
+        echo "CGO_CFLAGS=-I/home/runner/go/deps/dqlite/include/ -I/home/runner/go/deps/liblxc/include/"    >> "${GITHUB_ENV}"
+        echo "CGO_LDFLAGS=${CGO_LDFLAGS:-} -L/home/runner/go/deps/dqlite/.libs/ -L${LIBLXC_ARCH_LIBS}"     >> "${GITHUB_ENV}"
+        echo "LD_LIBRARY_PATH=/home/runner/go/deps/dqlite/.libs/:${LIBLXC_ARCH_LIBS}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+        echo "LD_RUN_PATH=/home/runner/go/deps/dqlite/.libs/:${LIBLXC_ARCH_LIBS}:${LD_RUN_PATH:-}"         >> "${GITHUB_ENV}"
+        echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"                                               >> "${GITHUB_ENV}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,17 +102,8 @@ jobs:
       - name: Build or restore dqlite/liblxc dependencies
         if: matrix.language == 'go'
         uses: ./.github/actions/cache-dqlite-liblxc
-
-      - name: Update env variables for deps
-        if: matrix.language == 'go'
-        run: |
-          set -eux
-          LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
-
-          echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
-          echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
-          echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"
+        with:
+          export-env: true
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       - name: Autobuild

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,12 +97,8 @@ jobs:
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
-      # Create a symlink so the cache-dqlite-liblxc action can build from the checkout on a cache miss.
-      - name: Create deps build symlink
-        if: matrix.language == 'go'
-        run: ln -s "${GITHUB_WORKSPACE}" "${GITHUB_WORKSPACE}/../lxd-test"
-
-      # Build or restore dqlite/liblxc from the daily cache (Go only).
+      # Build or restore dqlite/liblxc from the daily cache (Go only). On a cache
+      # miss the action builds from the checked-out workspace.
       - name: Build or restore dqlite/liblxc dependencies
         if: matrix.language == 'go'
         uses: ./.github/actions/cache-dqlite-liblxc

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,10 +52,10 @@ jobs:
       contents: read
 
     env:
-      CGO_CFLAGS: "-I/home/runner/go/bin/dqlite/include/ -I/home/runner/go/bin/liblxc/include/"
-      CGO_LDFLAGS: "-L/home/runner/go/bin/dqlite/libs/"
-      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
-      LD_RUN_PATH: "/home/runner/go/bin/dqlite/libs/"
+      CGO_CFLAGS: "-I/home/runner/go/deps/dqlite/include/ -I/home/runner/go/deps/liblxc/include/"
+      CGO_LDFLAGS: "-L/home/runner/go/deps/dqlite/.libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/deps/dqlite/.libs/"
+      LD_RUN_PATH: "/home/runner/go/deps/dqlite/.libs/"
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
     strategy:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -58,16 +58,8 @@ jobs:
 
       - name: Build or restore dqlite/liblxc dependencies
         uses: ./.github/actions/cache-dqlite-liblxc
-
-      - name: Update env variables for deps
-        run: |
-          set -eux
-          LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
-
-          echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
-          echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
-          echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"
+        with:
+          export-env: true
 
       - name: Download go dependencies
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      CGO_CFLAGS: "-I/home/runner/go/bin/dqlite/include/ -I/home/runner/go/bin/liblxc/include/"
-      CGO_LDFLAGS: "-L/home/runner/go/bin/dqlite/libs/"
-      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
-      LD_RUN_PATH: "/home/runner/go/bin/dqlite/libs/"
+      CGO_CFLAGS: "-I/home/runner/go/deps/dqlite/include/ -I/home/runner/go/deps/liblxc/include/"
+      CGO_LDFLAGS: "-L/home/runner/go/deps/dqlite/.libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/deps/dqlite/.libs/"
+      LD_RUN_PATH: "/home/runner/go/deps/dqlite/.libs/"
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
     steps:
@@ -45,16 +45,6 @@ jobs:
 
       - name: Install build dependencies
         uses: ./.github/actions/install-lxd-builddeps
-
-      - name: Make LXD tarball and unpack it
-        env:
-          CUSTOM_VERSION: "test"
-        run: |
-          set -eux
-          make dist-dir
-
-          # Move the dist directory outside the workspace.
-          mv lxd-test ../
 
       - name: Build or restore dqlite/liblxc dependencies
         uses: ./.github/actions/cache-dqlite-liblxc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,16 +174,8 @@ jobs:
       # In code-tests, this action warms the cache for the system-tests job
       - name: Build or restore dqlite/liblxc dependencies
         uses: ./.github/actions/cache-dqlite-liblxc
-
-      - name: Update env variables for deps
-        run: |
-          set -eux
-          LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
-
-          echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
-          echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
-          echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"
+        with:
+          export-env: true
 
       - name: Build binaries
         run: |
@@ -872,6 +864,8 @@ jobs:
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
         uses: ./.github/actions/cache-dqlite-liblxc
+        with:
+          export-env: true
 
       - name: Download system test dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -879,17 +873,6 @@ jobs:
           name: system-test-deps
           merge-multiple: true
           path: /home/runner/go/bin
-
-      - name: Prepare for running LXD daemon
-        run: |
-          set -eux
-
-          # Update env variables for liblxc
-          LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
-          echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
-          echo "LD_RUN_PATH=${LD_RUN_PATH}:${LIBLXC_ARCH_LIBS}"         >> "${GITHUB_ENV}"
-          echo "PKG_CONFIG_PATH=${LIBLXC_ARCH_LIBS}/pkgconfig"          >> "${GITHUB_ENV}"
 
       - name: Install build dependencies
         uses: ./.github/actions/install-lxd-builddeps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,10 @@ jobs:
     outputs:
       fast-backend: ${{ steps.pick-fast-backend.outputs.fast-backend }}
     env:
-      CGO_CFLAGS: "-I/home/runner/go/bin/dqlite/include/ -I/home/runner/go/bin/liblxc/include/"
-      CGO_LDFLAGS: "-L/home/runner/go/bin/dqlite/libs/"
-      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
-      LD_RUN_PATH: "/home/runner/go/bin/dqlite/libs/"
+      CGO_CFLAGS: "-I/home/runner/go/deps/dqlite/include/ -I/home/runner/go/deps/liblxc/include/"
+      CGO_LDFLAGS: "-L/home/runner/go/deps/dqlite/.libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/deps/dqlite/.libs/"
+      LD_RUN_PATH: "/home/runner/go/deps/dqlite/.libs/"
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
       SUDO_PRESERVE_ENV: "CGO_CFLAGS,CGO_LDFLAGS,CGO_LDFLAGS_ALLOW,GOCOVERDIR,PKG_CONFIG_PATH,LD_LIBRARY_PATH,PATH"
     if: ${{ github.event_name != 'schedule' || github.repository_owner == 'canonical' }}
@@ -820,10 +820,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [client, system-tests, snap-tests, ui-e2e-tests]
     env:
-      CGO_CFLAGS: "-I/home/runner/go/bin/dqlite/include/ -I/home/runner/go/bin/liblxc/include/"
-      CGO_LDFLAGS: "-L/home/runner/go/bin/dqlite/libs/"
-      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
-      LD_RUN_PATH: "/home/runner/go/bin/dqlite/libs/"
+      CGO_CFLAGS: "-I/home/runner/go/deps/dqlite/include/ -I/home/runner/go/deps/liblxc/include/"
+      CGO_LDFLAGS: "-L/home/runner/go/deps/dqlite/.libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/deps/dqlite/.libs/"
+      LD_RUN_PATH: "/home/runner/go/deps/dqlite/.libs/"
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}
     steps:
@@ -1102,7 +1102,7 @@ jobs:
     needs: [code-tests, documentation]
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' ) && github.ref_name == 'main' && github.repository_owner == 'canonical' }}
     env:
-      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/deps/dqlite/.libs/"
       LXD_DIR: "/var/lib/lxd"
       LXD_OIDC_CLIENT_ID: "${{ secrets.LXD_UI_OIDC_TEST_CLIENT_ID }}"         # zizmor: ignore[secrets-outside-env]
       LXD_OIDC_CLIENT_SECRET: "${{ secrets.LXD_UI_OIDC_TEST_CLIENT_SECRET }}" # zizmor: ignore[secrets-outside-env]
@@ -1157,6 +1157,8 @@ jobs:
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
         uses: ./.github/actions/cache-dqlite-liblxc
+        with:
+          export-env: true
 
       - name: Download system test dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1170,14 +1172,6 @@ jobs:
 
       - name: Setup MicroOVN
         uses: ./.github/actions/setup-microovn
-
-      - name: Prepare for running LXD daemon
-        run: |
-          set -eux
-
-          # Update env variables for liblxc
-          LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBLXC_ARCH_LIBS}" >> "${GITHUB_ENV}"
 
       - name: Set exec perms on LXD binaries
         run: |

--- a/Makefile
+++ b/Makefile
@@ -136,10 +136,12 @@ dqlite:
 		git -C "$(DQLITE_PATH)" checkout -B "${DQLITE_BRANCH}" FETCH_HEAD; \
 	fi
 
-	cd "$(DQLITE_PATH)" && \
-		autoreconf -i && \
-		./configure --enable-build-raft && \
-		make -j
+	@if [ ! -f "$(DQLITE_PATH)/Makefile" ]; then \
+		cd "$(DQLITE_PATH)" && \
+			autoreconf -i && \
+			./configure --enable-build-raft; \
+	fi
+	cd "$(DQLITE_PATH)" && make -j
 
 ifneq ($(shell command -v ldd),)
 	# verify that libdqlite.so is linked against some critically important libs

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
 endif
 DQLITE_PATH=$(DEPS_PATH)/dqlite
 LIBLXC_PATH=$(DEPS_PATH)/liblxc
-LIBLXC_ROOTFS_MOUNT_PATH=$(GOPATH)/bin/liblxc/rootfs
+LIBLXC_ROOTFS_MOUNT_PATH=$(LIBLXC_PATH)/rootfs
 
 export CGO_CFLAGS ?= -I$(DQLITE_PATH)/include/ -I$(LIBLXC_PATH)/include/
 export CGO_LDFLAGS ?= -L$(DQLITE_PATH)/.libs/ -L$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/

--- a/Makefile
+++ b/Makefile
@@ -162,33 +162,32 @@ liblxc:
 		git -C "$(LIBLXC_PATH)" checkout -B "$(LIBLXC_BRANCH)" FETCH_HEAD; \
 	fi
 
-	# XXX: the rootfs-mount-path must not depend on LIBLXC_PATH to allow
-	# building in "vendor" mode but move the resulting binaries elsewhere for
-	# caching purposes
-	cd "$(LIBLXC_PATH)" && \
-		meson setup \
-			--buildtype=release \
-			-Dapparmor=true \
-			-Dcapabilities=true \
-			-Dcommands=false \
-			-Ddbus=false \
-			-Dexamples=false \
-			-Dinstall-init-files=false \
-			-Dinstall-state-dirs=false \
-			-Dlibdir="lib/$(ARCH)-linux-gnu" \
-			-Dman=false \
-			-Dmemfd-rexec=false \
-			-Dopenssl=false \
-			-Dprefix="$(LIBLXC_PATH)" \
-			-Drootfs-mount-path="$(LIBLXC_ROOTFS_MOUNT_PATH)" \
-			-Dseccomp=true \
-			-Dselinux=false \
-			-Dspecfile=false \
-			-Dtests=false \
-			-Dtools=false \
-			build && \
-		meson compile -C build && \
-		ninja -C build install
+	@mkdir -p "$(LIBLXC_ROOTFS_MOUNT_PATH)"
+	@if [ ! -d "$(LIBLXC_PATH)/build" ]; then \
+		cd "$(LIBLXC_PATH)" && \
+			meson setup \
+				--buildtype=release \
+				-Dapparmor=true \
+				-Dcapabilities=true \
+				-Dcommands=false \
+				-Ddbus=false \
+				-Dexamples=false \
+				-Dinstall-init-files=false \
+				-Dinstall-state-dirs=false \
+				-Dlibdir="lib/$(ARCH)-linux-gnu" \
+				-Dman=false \
+				-Dmemfd-rexec=false \
+				-Dopenssl=false \
+				-Dprefix="$(LIBLXC_PATH)" \
+				-Drootfs-mount-path="$(LIBLXC_ROOTFS_MOUNT_PATH)" \
+				-Dseccomp=true \
+				-Dselinux=false \
+				-Dspecfile=false \
+				-Dtests=false \
+				-Dtools=false \
+				build; \
+	fi
+	cd "$(LIBLXC_PATH)" && ninja -C build install
 
 ifneq ($(shell command -v ldd),)
 	# verify that liblxc.so is linked against some critically important libs


### PR DESCRIPTION
## Summary

This PR streamlines and hardens the build, storage, and caching logic for `dqlite` and `liblxc` CGO dependencies across GitHub Actions workflows and the `Makefile`.

## Key Changes

### Unified Dependency Storage Path (`~/go/deps`)
- Standardized the storage and caching location of `dqlite` and `liblxc` to `~/go/deps/` across all workflows.
- Replaced references pointing to `~/go/bin/` with `~/go/deps/`.

### Workspace Dependency Build on Cache Miss
- Updated `actions/cache-dqlite-liblxc` to build `dqlite` and `liblxc` directly in place from the checked-out workspace via `make deps` whenever a cache miss occurs.
- Removed reliance on external unpacked tarball paths (`../lxd-test`) and eliminated the temporary CodeQL symlink.

### Consolidated Environment Exports in Action
- Introduced an `export-env: true|false` input option in `actions/cache-dqlite-liblxc`.
- Replaced duplicated `Update env variables for deps` steps across workflow files with the action's centralized export step.

### Makefile Build & Configuration Optimizations
- Skipped redundant re-configuration steps in `Makefile`:
  - Skip `autoreconf` for `dqlite` if `$(DQLITE_PATH)/Makefile` exists.
  - Skip `meson setup` for `liblxc` if `$(LIBLXC_PATH)/build` exists.
- Updated `LIBLXC_ROOTFS_MOUNT_PATH` to be relative to `LIBLXC_PATH` (`$(LIBLXC_PATH)/rootfs`).