### PR TITLE
lxd/operations: Return failed operation state from wait endpoint

### DIFF
--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -827,12 +827,9 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Wait for the operation.
-			err = op.Wait(ctx)
-			if err != nil {
-				_ = response.SmartError(err).Render(w, r)
-				return nil
-			}
+			_ = op.Wait(ctx)
 
+			// Render the current state, including operation failures and timeouts.
 			_, body := op.Render()
 			_ = response.SyncResponse(true, body).Render(w, r)
 			return nil

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -169,6 +169,7 @@ readonly test_group_standalone=(
     "filtering"
     "bulk_operation_children"
     "get_operations"
+    "operation_wait_failure"
     "operations_conflict_reference"
     "instances_selective_recursion"
     "kernel_limits"

--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -93,3 +93,29 @@ test_operations_conflict_reference() {
   lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}'
   ! lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}' || false
 }
+
+test_operation_wait_failure() {
+  network_name="opwait$$"
+
+  (
+    set -e
+
+    lxc network create "${network_name}" ipv4.address=none ipv6.address=none
+    trap 'lxc network delete "${network_name}"' EXIT
+
+    op_id=$(lxc query -X POST /1.0/networks -d '{"name": "'"${network_name}"'", "config": {"ipv4.address": "none", "ipv6.address": "none"}}' | jq --exit-status --raw-output '.id')
+    wait_response=$(lxc query "/1.0/operations/${op_id}/wait?timeout=60")
+
+    jq --exit-status '
+      .status == "Failure" and
+      .status_code == 400 and
+      .err == "The network already exists" and
+      .err_code == 400
+    ' <<< "${wait_response}"
+
+    if lxc network create "${network_name}" ipv4.address=none ipv6.address=none; then
+      echo "ERROR: Duplicate network creation succeeded"
+      exit 1
+    fi
+  )
+}


### PR DESCRIPTION
## Summary

- Render the current operation state after the wait call returns, including operation failures and timeouts.
- Add regression coverage for failed network operations and the CLI exit status.

## Root cause

The wait endpoint commits HTTP 200 before blocking on the operation. When `op.Wait` returned an operation error, the handler attempted to render a second HTTP error response instead of returning the operation state. Clients could therefore interpret failed asynchronous network operations as successful.

## Testing

- `make static-analysis`
- `make check-unit`
- `make`
- `sudo -E LXD_VM_TESTS=0 LXD_BACKENDS=dir ./test/main.sh operation_wait_failure`

Closes #18715
