### PR TITLE
github: Remove old reference to unused key LXD_PRIVATE_DEPLOY_KEY (release-6.9)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1379,14 +1379,6 @@ jobs:
         with:
           ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}" # zizmor: ignore[secrets-outside-env]
 
-      - name: Setup lxd-private SSH access
-        env:
-          INPUTS_SSH_KEY: ${{ secrets.LXD_PRIVATE_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
-        run: |
-          set -eu # let's not use -x here to avoid leaking the SSH key in the logs
-          ssh-add - <<< "${INPUTS_SSH_KEY}"
-          unset INPUTS_SSH_KEY
-
       - name: Trigger Launchpad snap build
         run: |
           set -eux


### PR DESCRIPTION
Needed to trigger rebuild of 6.9.