### PR TITLE
Storage: Remove unused CreateCustomVolumeFromISO (stable-5.0)

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1730,22 +1730,6 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 	}
 }
 
-// isoFiller returns a function that can be used as a filler function with CreateVolume().
-// The function returned will copy the ISO content into the specified mount path
-// provided.
-func (b *lxdBackend) isoFiller(data io.Reader) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
-	return func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
-		f, err := os.OpenFile(rootBlockPath, os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return -1, err
-		}
-
-		defer func() { _ = f.Close() }()
-
-		return io.Copy(f, data)
-	}
-}
-
 // CreateInstanceFromImage creates a new volume for an instance populated with the image requested.
 // On failure caller is expected to call DeleteInstance() to clean up.
 func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
@@ -5897,80 +5881,6 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 		return err
 	}
 
-	return nil
-}
-
-// CreateCustomVolumeFromISO creates a custom volume from ISO.
-func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
-	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName})
-	l.Debug("CreateCustomVolumeFromISO started")
-	defer l.Debug("CreateCustomVolumeFromISO finished")
-
-	// Check whether we are allowed to create volumes.
-	req := api.StorageVolumesPost{
-		Name: volName,
-		StorageVolumePut: api.StorageVolumePut{
-			Config: map[string]string{
-				"size": fmt.Sprintf("%d", size),
-			},
-		},
-	}
-
-	err := b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
-		return project.AllowVolumeCreation(tx, projectName, req)
-	})
-	if err != nil {
-		return fmt.Errorf("Failed checking volume creation allowed: %w", err)
-	}
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	// Get the volume name on storage.
-	volStorageName := project.StorageVolume(projectName, volName)
-
-	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentTypeISO, volStorageName, req.Config)
-
-	volExists, err := b.driver.HasVolume(vol)
-	if err != nil {
-		return err
-	}
-
-	if volExists {
-		return fmt.Errorf("Cannot create volume, already exists on target storage")
-	}
-
-	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, projectName, volName, "", vol.Type(), false, vol.Config(), time.Time{}, vol.ContentType(), true, true)
-	if err != nil {
-		return fmt.Errorf("Failed creating database entry for custom volume: %w", err)
-	}
-
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
-
-	_, err = srcData.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
-
-	volFiller := drivers.VolumeFiller{
-		Fill: b.isoFiller(srcData),
-	}
-
-	// Unpack the ISO into the new storage volume(s).
-	err = b.driver.CreateVolume(vol, &volFiller, op)
-	if err != nil {
-		return fmt.Errorf("Failed creating volume: %w", err)
-	}
-
-	eventCtx := logger.Ctx{"type": vol.Type()}
-	if !b.Driver().Info().Remote {
-		eventCtx["location"] = b.state.ServerName
-	}
-
-	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, eventCtx))
-
-	revert.Success()
 	return nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -314,7 +314,3 @@ func (b *mockBackend) BackupCustomVolume(projectName string, volName string, tar
 func (b *mockBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
 	return nil
 }
-
-func (b *mockBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
-	return nil
-}

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -106,7 +106,6 @@ type Pool interface {
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
 	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
-	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 
 	// Custom volume snapshots.
 	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error


### PR DESCRIPTION
This PR removes the unused `CreateCustomVolumeFromISO()` function from the storage `Pool` interface and its implementation.

This function was originally backported to 5.0 in the https://github.com/canonical/lxd/pull/12319 PR (commit https://github.com/canonical/lxd/commit/b420fabf45772d1527deb79e7f82343de12fe597) but since then have not been used. It is never called and is essentially dead code.