### PR TITLE
Add promote/demote guards for replicated projects

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3664,3 +3664,9 @@ Public cluster links cannot be used by {ref}`replicators <exp-replicators>` or a
 Introduces new operation class for durable operations.
 Durable operations are restarted on the DQLite raft leader if the member that is running the operation fails to respond to heartbeats.
 If the leader was running the operation and goes offline, the operation is restarted on the newly elected leader.
+
+(extension-project-replica-mode-optional)=
+## `project_replica_mode_optional`
+
+The `replica_mode` field is now omitted from project responses when the project takes no part in replication, instead of being returned as an empty string.
+The field is still returned for projects in `leader` or `standby` mode.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3643,3 +3643,9 @@ For bearer tokens the expiry is recorded when a token is issued and cleared when
 The field is omitted for identities whose credential has no expiry, that have no credential yet (pending identities), or whose token has been revoked.
 
 Note that bearer identities created prior to this extension will have an omitted `expires_at` field until a new token is issued.
+
+(extension-project-replica-mode-optional)=
+## `project_replica_mode_optional`
+
+The `replica_mode` field is now omitted from project responses when the project takes no part in replication, instead of being returned as an empty string.
+The field is still returned for projects in `leader` or `standby` mode.

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -20,6 +20,8 @@ Replication is configured at the project level. Both clusters have a project wit
 
 Replica mode is managed via `lxc project promote-replica`, `lxc project demote-replica`, and `lxc project clear-replica` (which resets the replica mode back to empty). It is not a configuration key and cannot be set with `lxc project set`.
 
+Clearing the replica mode of a standby project requires `--force`, because it drops the record of which cluster was replicating into it, and the project could then be promoted under the weaker rules that apply to a project taking no part in replication.
+
 The {config:option}`project-replica:replica.cluster` configuration key identifies the cluster link that is allowed to push replication data into a standby project. It is required on the standby project, and it must also be set on the leader project if you intend to fail over and later return to the original replication direction: after a failover the original leader becomes a standby, and it can only be promoted back to leader once LXD can identify the cluster it was replicating with.
 
 A project can only be promoted or demoted if it takes part in a replication topology. Demoting requires the `replica.cluster` key, because a standby project cannot accept replication data without it. Promoting a project that has no replica mode set requires at least one replicator, and promoting a standby requires the `replica.cluster` key, which is what identifies the cluster whose project must have stepped down first. Use `--force` to override these checks.

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -20,7 +20,11 @@ Replication is configured at the project level. Both clusters have a project wit
 
 Replica mode is managed via `lxc project promote-replica`, `lxc project demote-replica`, and `lxc project clear-replica` (which resets the replica mode back to empty). It is not a configuration key and cannot be set with `lxc project set`.
 
-Only the standby project needs the {config:option}`project-replica:replica.cluster` configuration key, which identifies the cluster link that is allowed to push replication data into it. The leader project does not need this key because the replicator defines the target cluster.
+The {config:option}`project-replica:replica.cluster` configuration key identifies the cluster link that is allowed to push replication data into a standby project. It is required on the standby project, and it must also be set on the leader project if you intend to fail over and later return to the original replication direction: after a failover the original leader becomes a standby, and it can only be promoted back to leader once LXD can identify the cluster it was replicating with.
+
+A project can only be promoted or demoted if it takes part in a replication topology. Demoting requires the `replica.cluster` key, because a standby project cannot accept replication data without it. Promoting a project that has no replica mode set requires at least one replicator, and promoting a standby requires the `replica.cluster` key, which is what identifies the cluster whose project must have stepped down first. Use `--force` to override these checks.
+
+To swap the roles of two clusters in a planned switchover, demote the current leader first, then promote the standby. Demoting first is always safe: the topology is briefly left without a leader, which only pauses writes, whereas promoting first would leave two clusters accepting writes at the same time.
 
 The leader project pushes its instances to the standby project over the cluster link. The standby project mirrors the leader at the time of the last replicator run.
 
@@ -36,7 +40,7 @@ Replication can be triggered manually with `lxc replicator run`, or scheduled au
 (exp-replicators-failover)=
 ## Failover and recovery
 
-If the leader cluster fails, the standby project can be promoted with `lxc project promote-replica`. This makes the project writable and allows instances to be started. If the leader cluster is unreachable, validation against it is skipped automatically. Use `--force` to skip all validation without attempting to connect, which is useful when the leader is known to be down or during a planned takeover.
+If the leader cluster fails, the standby project can be promoted with `lxc project promote-replica`. This makes the project writable and allows instances to be started. If the leader cluster is unreachable, validation against it is skipped automatically. Use `--force` to skip all validation without attempting to connect, which is useful when the leader is known to be down. Do not use it for a planned switchover: demote the leader first, then promote the standby.
 
 When the original leader comes back online, it can be re-synced from the new leader by running the replicator in restore mode (`lxc replicator run --restore`), then returning both projects to their original roles with `lxc project demote-replica` and `lxc project promote-replica`. In restore mode, the remote leader's instance list is used as the authoritative source: instances that were created on the new leader after failover are also created on the recovering cluster, not just the instances that existed before the failure.
 

--- a/doc/explanation/replicators.md
+++ b/doc/explanation/replicators.md
@@ -20,7 +20,11 @@ Replication is configured at the project level. Both clusters have a project wit
 
 Replica mode is managed via `lxc project promote-replica`, `lxc project demote-replica`, and `lxc project clear-replica` (which resets the replica mode back to empty). It is not a configuration key and cannot be set with `lxc project set`.
 
-Only the standby project needs the {config:option}`project-replica:replica.cluster` configuration key, which identifies the cluster link that is allowed to push replication data into it. The leader project does not need this key because the replicator defines the target cluster.
+The {config:option}`project-replica:replica.cluster` configuration key identifies the cluster link that is allowed to push replication data into a standby project. It is required on the standby project, and it must also be set on the leader project if you intend to fail over and later return to the original replication direction: after a failover the original leader becomes a standby, and it can only be promoted back to leader once LXD can identify the cluster it was replicating with.
+
+A project can only be promoted or demoted if it takes part in a replication topology. Demoting requires the `replica.cluster` key, because a standby project cannot accept replication data without it. Promoting a project that has no replica mode set requires at least one replicator, and promoting a standby requires either the `replica.cluster` key or a replicator. Use `--force` to override these checks.
+
+To swap the roles of two clusters in a planned switchover, demote the current leader first, then promote the standby. Demoting first is always safe: the topology is briefly left without a leader, which only pauses writes, whereas promoting first would leave two clusters accepting writes at the same time.
 
 The leader project pushes its instances to the standby project over the cluster link. The standby project mirrors the leader at the time of the last replicator run.
 

--- a/doc/howto/replicators_create.md
+++ b/doc/howto/replicators_create.md
@@ -44,20 +44,24 @@ Then create the cluster links with that authentication group, as described in {r
 (howto-replicators-project-setup)=
 ## Configure projects for replication
 
-Both clusters need a project with the same name. Only the standby project requires the {config:option}`project-replica:replica.cluster` configuration key; the leader project does not need it because the replicator defines the target cluster.
+Both clusters need a project with the same name. The {config:option}`project-replica:replica.cluster` configuration key identifies the cluster link that is allowed to push replication data into a standby project. It is required on the standby project. Set it on the leader project as well, so that the leader can be promoted back to leader mode after a failover, when it has itself become a standby.
 
-1. On the leader cluster, create a project:
+1. On the leader cluster, create a project and point it at the standby cluster:
 
    `````{tabs}
    ````{group-tab} CLI
    ```bash
-   lxc project create <project_name>
+   lxc project create <project_name> -c replica.cluster=<standby_cluster_link_name>
    ```
    ````
    ````{group-tab} UI
    Expand the {guilabel}`Project` drop-down and select {guilabel}`+ Create project` at the bottom.
 
    Enter a name and optionally a description for the new project.
+
+   Go to the new project's configuration and select the {guilabel}`Replication` tab.
+
+   Under {guilabel}`Replica cluster`, select the cluster link established between the leader and the standby.
    ````
    `````
 
@@ -93,6 +97,8 @@ Both clusters need a project with the same name. Only the standby project requir
    ````
    `````
 
+1. On the leader cluster, {ref}`create a replicator <howto-replicators-create>` that targets the standby cluster. The replicator must exist before the project can be promoted, because it is what identifies the project as the source of a replication topology.
+
 1. On the leader cluster, promote the project to leader mode:
 
    `````{tabs}
@@ -111,15 +117,18 @@ Both clusters need a project with the same name. Only the standby project requir
 ```{admonition} Promote validation
 :class: note
 
-The `lxc project promote-replica` command validates that all target projects (on clusters referenced by the project's replicators) are in standby mode before allowing the promotion.
+The `lxc project promote-replica` command requires the project to have at least one replicator before it can be promoted from having no replica mode set.
+It then validates that all target projects (on clusters referenced by the project's replicators) are in standby mode before allowing the promotion.
 This ensures that new instances are not created on a standby cluster between replicator runs.
 If a target cluster is unreachable, promotion still proceeds to allow disaster recovery scenarios where the target may be offline.
+
+Use `--force` to skip these checks, for example when migrating a deployment that was set up before replicators were required for promotion.
 ```
 
 (howto-replicators-create)=
 ## Create a replicator
 
-After configuring the projects on both clusters, create a replicator on the leader cluster. The `cluster` configuration key is required and must be set to the name of an existing cluster link.
+Create a replicator on the leader cluster, before promoting the leader project as described in {ref}`howto-replicators-project-setup`. The `cluster` configuration key is required and must be set to the name of an existing cluster link.
 
 Each cluster link can be targeted by at most one replicator per project. Creating or updating a replicator to target a cluster link already used by another replicator in the same project fails with a conflict error.
 

--- a/doc/howto/replicators_dr.md
+++ b/doc/howto/replicators_dr.md
@@ -21,11 +21,13 @@ On the standby cluster, promote the replica project to become the leader:
 lxc project promote-replica <project_name>
 ```
 
-If the leader cluster is unreachable, promotion proceeds automatically without requiring validation. Use `--force` to skip validation when the leader cluster is still reachable but you want to promote anyway (for example, during a planned takeover before demoting the leader):
+If the leader cluster is unreachable, promotion proceeds automatically without requiring validation. Use `--force` only to promote while the leader cluster is still reachable and has not been demoted, which leaves both clusters writable:
 
 ```bash
 lxc project promote-replica <project_name> --force
 ```
+
+For a planned switchover rather than a failover, do not use `--force`: demote the leader first, then promote the standby, as described in {ref}`exp-replicators`.
 ````
 ````{group-tab} UI
 Select the project from the {guilabel}`Project` drop-down menu, then click {guilabel}`Configuration` in the navigation sidebar.
@@ -34,7 +36,7 @@ Select the {guilabel}`Replication` tab, then, under {guilabel}`Replica mode`, cl
 
 If the leader cluster is unreachable, promotion proceeds automatically without requiring validation. Click {guilabel}`Promote` in the confirmation modal.
 
-If the leader cluster is still reachable but you want to promote the replica project anyway (for example, during a planned takeover before demoting the leader), then check {guilabel}`Force` and click {guilabel}`Promote` to skip validation.
+If the leader cluster is still reachable and has not been demoted, checking {guilabel}`Force` before clicking {guilabel}`Promote` skips validation, but leaves both clusters writable. For a planned switchover, demote the leader first and then promote without {guilabel}`Force`.
 ````
 `````
 
@@ -87,7 +89,7 @@ Demote the project on the original leader cluster to standby mode:
 lxc project demote-replica <project_name>
 ```
 
-If the new leader cluster is unreachable, use `--force` to skip the validation:
+Demoting does not contact the new leader. It requires only that {config:option}`project-replica:replica.cluster` is set, so that the resulting standby knows which cluster is allowed to replicate into it. Use `--force` to demote without it:
 ```bash
 lxc project demote-replica <project_name> --force
 ```
@@ -97,8 +99,7 @@ Select the project from the {guilabel}`Project` drop-down menu, then click {guil
 
 Select the {guilabel}`Replication` tab, then, under {guilabel}`Replica mode`, click {guilabel}`Demote to standby`.
 
-If the new leader is reachable, click {guilabel}`Demote`.
-If the new leader is unreachable, check {guilabel}`Force` to skip the validation, then click {guilabel}`Demote`.
+Demoting does not contact the new leader. It requires only that {config:option}`project-replica:replica.cluster` is set, so that the resulting standby knows which cluster is allowed to replicate into it. If it is not set, check {guilabel}`Force` before clicking {guilabel}`Demote`.
 ````
 `````
 
@@ -143,7 +144,7 @@ Select the {guilabel}`Replication` tab, then, under {guilabel}`Replica mode`, cl
 ````
 `````
 
-Finally, promote the project on the original leader cluster back to leader mode:
+Finally, promote the project on the original leader cluster back to leader mode. The project is currently a standby, so LXD identifies the cluster it replicates with from the {config:option}`project-replica:replica.cluster` key and confirms that cluster has stepped down. If the project does not have the key set, set it to the cluster link pointing at the new leader before promoting:
 
 `````{tabs}
 ````{group-tab} CLI

--- a/doc/howto/replicators_dr.md
+++ b/doc/howto/replicators_dr.md
@@ -143,7 +143,7 @@ Select the {guilabel}`Replication` tab, then, under {guilabel}`Replica mode`, cl
 ````
 `````
 
-Finally, promote the project on the original leader cluster back to leader mode:
+Finally, promote the project on the original leader cluster back to leader mode. The project is currently a standby, so LXD identifies the cluster it replicates with either from the {config:option}`project-replica:replica.cluster` key or from the replicators the project kept when it was demoted, and confirms that cluster has stepped down. If the project has neither, set `replica.cluster` to the cluster link pointing at the new leader before promoting:
 
 `````{tabs}
 ````{group-tab} CLI

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4299,9 +4299,11 @@ This value is the maximum value for the sum of the individual {config:option}`in
 <!-- config group project-limits end -->
 <!-- config group project-replica start -->
 ```{config:option} replica.cluster project-replica
-:shortdesc: "Cluster link allowed to replicate to this standby project."
+:shortdesc: "Cluster link this project replicates with"
 :type: "string"
-This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.
+On a standby project, this identifies the cluster link that is allowed to replicate instances into it.
+
+Set it on the leader project as well: demoting to standby requires it, and it is what lets a project that has been demoted during a failover be promoted back to leader.
 ```
 
 <!-- config group project-replica end -->

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5688,10 +5688,13 @@ definitions:
                 x-go-name: Name
             replica_mode:
                 description: |-
-                    Replica mode for the project (leader, standby, or empty)
+                    Replica mode for the project (leader or standby)
                     This field is updated via PUT /1.0/projects/<name>/state
+                    It is omitted for projects that take no part in replication.
 
                     API extension: project_replica_mode
+
+                    API extension: project_replica_mode_optional
                 example: leader
                 readOnly: true
                 type: string
@@ -17895,7 +17898,7 @@ paths:
             description: Promotes or demotes the project for replication.
             operationId: project_state_put
             parameters:
-                - description: Skip validation of remote project states
+                - description: Skip the replication topology guards and the validation of remote project states, and allow clearing the replica mode of a standby project
                   example: false
                   in: query
                   name: force

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5526,10 +5526,13 @@ definitions:
                 x-go-name: Name
             replica_mode:
                 description: |-
-                    Replica mode for the project (leader, standby, or empty)
+                    Replica mode for the project (leader or standby)
                     This field is updated via PUT /1.0/projects/<name>/state
+                    It is omitted for projects that take no part in replication.
 
                     API extension: project_replica_mode
+
+                    API extension: project_replica_mode_optional
                 example: leader
                 readOnly: true
                 type: string

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -503,7 +503,6 @@ func (c *cmdProjectList) columns() []cli.ShorthandColumn[api.Project] {
 		{Shorthand: 'z', Name: "NETWORK ZONES", Data: c.networkZonesColumnData},
 		{Shorthand: 'd', Name: "DESCRIPTION", Data: c.descriptionColumnData},
 		{Shorthand: 'u', Name: "USED BY", Data: c.usedByColumnData},
-		{Shorthand: 'r', Name: "REPLICA MODE", Data: c.replicaModeColumnData},
 	}
 }
 
@@ -566,8 +565,14 @@ func (c *cmdProjectList) run(cmd *cobra.Command, args []string) error {
 
 	c.currentProject = info.Project
 
+	// Add non-default column that is available for user selection. REPLICA MODE is only
+	// meaningful for projects taking part in a replication topology, so it is opt-in.
+	cols := append(c.columns(),
+		cli.ShorthandColumn[api.Project]{Shorthand: 'r', Name: "REPLICA MODE", Data: c.replicaModeColumnData},
+	)
+
 	// Parse column flags.
-	columns, err := cli.ParseShorthandColumns(c.flagColumns, c.columns())
+	columns, err := cli.ParseShorthandColumns(c.flagColumns, cols)
 	if err != nil {
 		return err
 	}
@@ -1137,9 +1142,12 @@ func (c *cmdProjectPromote) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description",
 		`Promotes the project to leader mode for replication.
 
-This validates that all replicator targets are in standby mode unless --force is specified.`)
+The project must take part in a replication topology: one with no replica mode set requires at least
+one replicator, and one in standby mode requires the replica.cluster config key.
+This also validates that all replicator targets are in standby mode, and that the cluster the project
+replicates with is no longer in leader mode. Use --force to skip these checks.`)
 
-	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of remote project states")
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of the replication topology and remote project states")
 
 	cmd.RunE = c.run
 

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -1272,6 +1272,8 @@ func (c *cmdProjectDemote) run(cmd *cobra.Command, args []string) error {
 type cmdProjectClearReplica struct {
 	global  *cmdGlobal
 	project *cmdProject
+
+	flagForce bool
 }
 
 func (c *cmdProjectClearReplica) command() *cobra.Command {
@@ -1279,7 +1281,12 @@ func (c *cmdProjectClearReplica) command() *cobra.Command {
 	cmd.Use = usage("clear-replica", "[<remote>:]<project>")
 	cmd.Short = "Clear the replica mode of a project"
 	cmd.Long = cli.FormatSection("Description",
-		`Clears the replica mode of a project, removing it from any replication setup.`)
+		`Clears the replica mode of a project, removing it from any replication setup.
+
+Clearing the replica mode of a standby project requires --force, because it drops the record of
+which cluster was replicating into it.`)
+
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Allow clearing the replica mode of a standby project")
 
 	cmd.RunE = c.run
 
@@ -1314,7 +1321,7 @@ func (c *cmdProjectClearReplica) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Clear the project's replica mode
-	op, err := resource.server.UpdateProjectState(resource.name, api.ProjectStatePut{ReplicaMode: api.ReplicatorProjectModeNone}, false)
+	op, err := resource.server.UpdateProjectState(resource.name, api.ProjectStatePut{ReplicaMode: api.ReplicatorProjectModeNone}, c.flagForce)
 	if err != nil {
 		return err
 	}

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -514,8 +514,12 @@ func (c *cmdProjectList) command() *cobra.Command {
 	cmd.Short = "List projects"
 	cmd.Long = cli.FormatSection("Description", cmd.Short)
 
+	// 'r' (REPLICA MODE) is only meaningful for projects taking part in a replication topology,
+	// so it is opt-in via --columns rather than shown by default.
+	defaultColumns := strings.ReplaceAll(cli.DefaultColumnString(c.columns()), "r", "")
+
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", cli.FormatStringFlagLabel("Format (csv|json|table|yaml|compact)"))
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", cli.DefaultColumnString(c.columns()), cli.FormatStringFlagLabel("Columns"))
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultColumns, cli.FormatStringFlagLabel("Columns"))
 
 	cmd.RunE = c.run
 
@@ -1137,9 +1141,12 @@ func (c *cmdProjectPromote) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description",
 		`Promotes the project to leader mode for replication.
 
-This validates that all replicator targets are in standby mode unless --force is specified.`)
+The project must take part in a replication topology: one with no replica mode set requires at least
+one replicator, and one in standby mode requires either the replica.cluster config key or a replicator.
+This also validates that all replicator targets are in standby mode, and that the cluster the project
+replicates with is no longer in leader mode. Use --force to skip these checks.`)
 
-	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of remote project states")
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Skip validation of the replication topology and remote project states")
 
 	cmd.RunE = c.run
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1483,7 +1483,7 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 //	parameters:
 //	  - in: query
 //	    name: force
-//	    description: Skip validation of remote project states
+//	    description: Skip the replication topology guards and the validation of remote project states, and allow clearing the replica mode of a standby project
 //	    type: boolean
 //	    example: false
 //	  - in: body
@@ -1530,7 +1530,7 @@ func projectStatePut(d *Daemon, r *http.Request) response.Response {
 
 	case api.ReplicatorProjectModeNone:
 		run = func(ctx context.Context, op *operations.Operation) error {
-			return projectClearReplicaMode(ctx, s, name)
+			return projectClearReplicaMode(ctx, s, name, force)
 		}
 
 	default:
@@ -1723,7 +1723,7 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 }
 
 // projectClearReplicaMode clears the project's replica mode, removing it from any replication setup.
-func projectClearReplicaMode(ctx context.Context, s *state.State, projectName string) error {
+func projectClearReplicaMode(ctx context.Context, s *state.State, projectName string, force bool) error {
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
@@ -1732,6 +1732,13 @@ func projectClearReplicaMode(ctx context.Context, s *state.State, projectName st
 
 		if dbProject.ReplicaMode == dbCluster.ProjectReplicaMode(api.ReplicatorProjectModeNone) {
 			return fmt.Errorf("Project %q is not in a replica mode", projectName)
+		}
+
+		// Clearing a standby's replica mode drops the record of which cluster was replicating
+		// into it, which would let the project be promoted under the weaker rules that apply
+		// to a project with no replica mode while the old leader is still running.
+		if !force && dbProject.ReplicaMode == dbCluster.ProjectReplicaMode(api.ReplicatorProjectModeStandby) {
+			return fmt.Errorf("Project %q is a standby replica, use --force to clear its replica mode", projectName)
 		}
 
 		// Clear the replica mode.

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -2162,10 +2162,12 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 		"restricted.snapshots": isEitherAllowOrBlock,
 
 		// lxdmeta:generate(entities=project; group=replica; key=replica.cluster)
-		// This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.
+		// On a standby project, this identifies the cluster link that is allowed to replicate instances into it.
+		//
+		// Set it on the leader project as well: demoting to standby requires it, and it is what lets a project that has been demoted during a failover be promoted back to leader.
 		// ---
 		//  type: string
-		//  shortdesc: Cluster link allowed to replicate to this standby project.
+		//  shortdesc: Cluster link this project replicates with
 		"replica.cluster": validate.Optional(func(value string) error {
 			err := s.DB.Cluster.Transaction(ctx, func(dbCtx context.Context, tx *db.ClusterTx) error {
 				clusterLink, err := dbCluster.GetClusterLink(dbCtx, tx.Tx(), value)

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -1551,31 +1550,46 @@ func projectStatePut(d *Daemon, r *http.Request) response.Response {
 	return response.OperationResponse(op)
 }
 
+// getProjectAndReplicatorLinks loads a project along with the names of the cluster links targeted by
+// its replicators.
+func getProjectAndReplicatorLinks(ctx context.Context, s *state.State, projectName string) (*api.Project, []string, error) {
+	var project *api.Project
+	var clusterLinkNames []string
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		clusterLinkNames, err = replicatorClusterLinkNames(ctx, tx, projectName)
+		return err
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return project, clusterLinkNames, nil
+}
+
 // validateProjectPromote validates that a project is ready to be promoted to leader mode.
 // It checks that the source cluster's project is no longer in leader mode, and that all
 // replicator target clusters have their project in standby mode.
-func validateProjectPromote(ctx context.Context, s *state.State, projectName string, project *api.Project, replicators []dbCluster.Replicator, allConfigs map[int64]map[string]string) error {
-	clusterCert := s.Endpoints.NetworkCert()
+func validateProjectPromote(ctx context.Context, s *state.State, projectName string, project *api.Project, clusterLinkNames []string) error {
+	sourceClusterLinkName := project.Config["replica.cluster"]
 
 	// Check the old leader (identified by replica.cluster config) is unreachable or already demoted.
-	sourceClusterLinkName := project.Config["replica.cluster"]
 	if sourceClusterLinkName != "" {
-		var clusterLink *api.ClusterLink
-		var targetCert *x509.Certificate
-		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			var err error
-			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), sourceClusterLinkName)
-			return err
-		})
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link %q: %w", sourceClusterLinkName, err)
-		}
-
-		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
-		sourceClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
-		if err != nil {
+		sourceClient, err := cluster.ConnectClusterLinkByName(ctx, s, sourceClusterLinkName)
+		if errors.Is(err, cluster.ErrClusterLinkUnreachable) {
 			// Source cluster is unreachable, allow failover promotion.
 			logger.Warn("Failed connecting to source cluster, allowing failover promotion", logger.Ctx{"clusterLink": sourceClusterLinkName, "err": err})
+		} else if err != nil {
+			return err
 		} else {
 			defer sourceClient.Disconnect()
 
@@ -1591,30 +1605,14 @@ func validateProjectPromote(ctx context.Context, s *state.State, projectName str
 	}
 
 	// Check all replicator targets are in standby mode.
-	for _, replicator := range replicators {
-		config := allConfigs[replicator.Row.ID]
-		clusterLinkName := config["cluster"]
-		if clusterLinkName == "" {
-			continue
-		}
-
-		var clusterLink *api.ClusterLink
-		var targetCert *x509.Certificate
-		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			var err error
-			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
-			return err
-		})
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link %q: %w", clusterLinkName, err)
-		}
-
-		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
-		targetClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
-		if err != nil {
+	for _, clusterLinkName := range clusterLinkNames {
+		targetClient, err := cluster.ConnectClusterLinkByName(ctx, s, clusterLinkName)
+		if errors.Is(err, cluster.ErrClusterLinkUnreachable) {
 			// Skip unreachable clusters to allow for disaster recovery failover.
 			logger.Warn("Failed connecting to target cluster, skipping validation", logger.Ctx{"clusterLink": clusterLinkName, "err": err})
 			continue
+		} else if err != nil {
+			return err
 		}
 
 		targetProject, _, err := targetClient.GetProject(projectName)
@@ -1636,39 +1634,7 @@ func validateProjectPromote(ctx context.Context, s *state.State, projectName str
 
 // projectPromote promotes the project to leader mode for replication.
 func projectPromote(ctx context.Context, s *state.State, projectName string, force bool) error {
-	var project *api.Project
-	var replicators []dbCluster.Replicator
-	var allConfigs map[int64]map[string]string
-
-	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
-		if err != nil {
-			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
-		}
-
-		project, err = dbProject.ToAPI(ctx, tx.Tx())
-		if err != nil {
-			return err
-		}
-
-		// Load all replicators for this project.
-		replicators, _, err = dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, func(_ dbCluster.Replicator) bool { return true })
-		if err != nil {
-			return fmt.Errorf("Failed loading replicators for project %q: %w", projectName, err)
-		}
-
-		replicatorIDList := make([]int64, 0, len(replicators))
-		for _, r := range replicators {
-			replicatorIDList = append(replicatorIDList, r.Row.ID)
-		}
-
-		allConfigs, err = dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), replicatorIDList...)
-		if err != nil {
-			return fmt.Errorf("Failed loading replicator configs: %w", err)
-		}
-
-		return nil
-	})
+	project, clusterLinkNames, err := getProjectAndReplicatorLinks(ctx, s, projectName)
 	if err != nil {
 		return err
 	}
@@ -1678,7 +1644,7 @@ func projectPromote(ctx context.Context, s *state.State, projectName string, for
 	}
 
 	if !force {
-		err = validateProjectPromote(ctx, s, projectName, project, replicators, allConfigs)
+		err = validateProjectPromote(ctx, s, projectName, project, clusterLinkNames)
 		if err != nil {
 			return err
 		}
@@ -1700,7 +1666,6 @@ func projectPromote(ctx context.Context, s *state.State, projectName string, for
 // projectDemote demotes the project to standby mode for replication.
 func projectDemote(ctx context.Context, s *state.State, projectName string, force bool) error {
 	var project *api.Project
-
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
@@ -1708,11 +1673,7 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 		}
 
 		project, err = dbProject.ToAPI(ctx, tx.Tx())
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	})
 	if err != nil {
 		return err

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1577,10 +1577,27 @@ func getProjectAndReplicatorLinks(ctx context.Context, s *state.State, projectNa
 }
 
 // validateProjectPromote validates that a project is ready to be promoted to leader mode.
-// It checks that the source cluster's project is no longer in leader mode, and that all
-// replicator target clusters have their project in standby mode.
+// It checks that the project takes part in a replication topology, that the source cluster's
+// project is no longer in leader mode, and that all replicator target clusters have their project
+// in standby mode.
 func validateProjectPromote(ctx context.Context, s *state.State, projectName string, project *api.Project, clusterLinkNames []string) error {
 	sourceClusterLinkName := project.Config["replica.cluster"]
+
+	switch project.ReplicaMode {
+	case api.ReplicatorProjectModeStandby:
+		// replica.cluster names the cluster this project replicates with. Without it there is
+		// nothing to check that the old leader has stepped down against, and a replicator
+		// target is not necessarily that leader.
+		if sourceClusterLinkName == "" {
+			return fmt.Errorf("Project %q must have replica.cluster config set before promoting to leader mode", projectName)
+		}
+
+	case api.ReplicatorProjectModeNone:
+		// Require proof that the project takes part in a replication topology.
+		if len(clusterLinkNames) == 0 {
+			return fmt.Errorf("Project %q has no replicators, create a replicator before promoting to leader mode", projectName)
+		}
+	}
 
 	// Check the old leader (identified by replica.cluster config) is unreachable or already demoted.
 	if sourceClusterLinkName != "" {
@@ -1683,7 +1700,11 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 		return fmt.Errorf("Project %q is already in standby mode", projectName)
 	}
 
-	// Require replica.cluster config to be set so the standby knows which cluster can write to it.
+	// A standby project only accepts replication data from the cluster link named by
+	// replica.cluster, so it must be set before the project can enter standby mode.
+	// Demoting a leader is never blocked on the standby having taken over first: leaving the
+	// topology briefly without a leader is recoverable, whereas promoting before the leader
+	// steps down would give it two.
 	if !force && project.Config["replica.cluster"] == "" {
 		return fmt.Errorf("Project %q must have replica.cluster config set before demoting to standby mode", projectName)
 	}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -1551,31 +1550,73 @@ func projectStatePut(d *Daemon, r *http.Request) response.Response {
 	return response.OperationResponse(op)
 }
 
+// replicatorClusterLinks returns the names of the cluster links targeted by the given replicators.
+// Replicators without a cluster config key are skipped.
+func replicatorClusterLinks(replicators []dbCluster.Replicator, allConfigs map[int64]map[string]string) []string {
+	clusterLinkNames := make([]string, 0, len(replicators))
+	for _, replicator := range replicators {
+		clusterLinkName := allConfigs[replicator.Row.ID]["cluster"]
+		if clusterLinkName == "" {
+			continue
+		}
+
+		clusterLinkNames = append(clusterLinkNames, clusterLinkName)
+	}
+
+	return clusterLinkNames
+}
+
+// getProjectAndReplicators loads a project along with its replicators and their configs.
+func getProjectAndReplicators(ctx context.Context, s *state.State, projectName string) (project *api.Project, replicators []dbCluster.Replicator, allConfigs map[int64]map[string]string, err error) {
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		// Load all replicators for this project.
+		replicators, _, err = dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, nil)
+		if err != nil {
+			return fmt.Errorf("Failed loading replicators for project %q: %w", projectName, err)
+		}
+
+		replicatorIDList := make([]int64, 0, len(replicators))
+		for _, r := range replicators {
+			replicatorIDList = append(replicatorIDList, r.Row.ID)
+		}
+
+		allConfigs, err = dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), replicatorIDList...)
+		if err != nil {
+			return fmt.Errorf("Failed loading replicator configs: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return project, replicators, allConfigs, nil
+}
+
 // validateProjectPromote validates that a project is ready to be promoted to leader mode.
 // It checks that the source cluster's project is no longer in leader mode, and that all
 // replicator target clusters have their project in standby mode.
 func validateProjectPromote(ctx context.Context, s *state.State, projectName string, project *api.Project, replicators []dbCluster.Replicator, allConfigs map[int64]map[string]string) error {
-	clusterCert := s.Endpoints.NetworkCert()
-
 	// Check the old leader (identified by replica.cluster config) is unreachable or already demoted.
 	sourceClusterLinkName := project.Config["replica.cluster"]
 	if sourceClusterLinkName != "" {
-		var clusterLink *api.ClusterLink
-		var targetCert *x509.Certificate
-		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			var err error
-			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), sourceClusterLinkName)
-			return err
-		})
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link %q: %w", sourceClusterLinkName, err)
-		}
-
-		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
-		sourceClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
-		if err != nil {
+		sourceClient, err := cluster.ConnectClusterLinkByName(ctx, s, sourceClusterLinkName)
+		if errors.Is(err, cluster.ErrClusterLinkUnreachable) {
 			// Source cluster is unreachable, allow failover promotion.
 			logger.Warn("Failed connecting to source cluster, allowing failover promotion", logger.Ctx{"clusterLink": sourceClusterLinkName, "err": err})
+		} else if err != nil {
+			return err
 		} else {
 			defer sourceClient.Disconnect()
 
@@ -1591,30 +1632,14 @@ func validateProjectPromote(ctx context.Context, s *state.State, projectName str
 	}
 
 	// Check all replicator targets are in standby mode.
-	for _, replicator := range replicators {
-		config := allConfigs[replicator.Row.ID]
-		clusterLinkName := config["cluster"]
-		if clusterLinkName == "" {
-			continue
-		}
-
-		var clusterLink *api.ClusterLink
-		var targetCert *x509.Certificate
-		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			var err error
-			_, clusterLink, targetCert, err = cluster.LoadClusterLinkAndCert(ctx, tx.Tx(), clusterLinkName)
-			return err
-		})
-		if err != nil {
-			return fmt.Errorf("Failed loading cluster link %q: %w", clusterLinkName, err)
-		}
-
-		args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
-		targetClient, err := cluster.ConnectCluster(ctx, *clusterLink, args)
-		if err != nil {
+	for _, clusterLinkName := range replicatorClusterLinks(replicators, allConfigs) {
+		targetClient, err := cluster.ConnectClusterLinkByName(ctx, s, clusterLinkName)
+		if errors.Is(err, cluster.ErrClusterLinkUnreachable) {
 			// Skip unreachable clusters to allow for disaster recovery failover.
 			logger.Warn("Failed connecting to target cluster, skipping validation", logger.Ctx{"clusterLink": clusterLinkName, "err": err})
 			continue
+		} else if err != nil {
+			return err
 		}
 
 		targetProject, _, err := targetClient.GetProject(projectName)
@@ -1636,39 +1661,7 @@ func validateProjectPromote(ctx context.Context, s *state.State, projectName str
 
 // projectPromote promotes the project to leader mode for replication.
 func projectPromote(ctx context.Context, s *state.State, projectName string, force bool) error {
-	var project *api.Project
-	var replicators []dbCluster.Replicator
-	var allConfigs map[int64]map[string]string
-
-	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
-		if err != nil {
-			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
-		}
-
-		project, err = dbProject.ToAPI(ctx, tx.Tx())
-		if err != nil {
-			return err
-		}
-
-		// Load all replicators for this project.
-		replicators, _, err = dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, func(_ dbCluster.Replicator) bool { return true })
-		if err != nil {
-			return fmt.Errorf("Failed loading replicators for project %q: %w", projectName, err)
-		}
-
-		replicatorIDList := make([]int64, 0, len(replicators))
-		for _, r := range replicators {
-			replicatorIDList = append(replicatorIDList, r.Row.ID)
-		}
-
-		allConfigs, err = dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), replicatorIDList...)
-		if err != nil {
-			return fmt.Errorf("Failed loading replicator configs: %w", err)
-		}
-
-		return nil
-	})
+	project, replicators, allConfigs, err := getProjectAndReplicators(ctx, s, projectName)
 	if err != nil {
 		return err
 	}
@@ -1678,6 +1671,22 @@ func projectPromote(ctx context.Context, s *state.State, projectName string, for
 	}
 
 	if !force {
+		switch project.ReplicaMode {
+		case api.ReplicatorProjectModeStandby:
+			// The old leader is identified either by replica.cluster or by the replicators the
+			// project kept when it was demoted. Without one of them validateProjectPromote has
+			// nothing to check that the old leader has stepped down against.
+			if project.Config["replica.cluster"] == "" && len(replicatorClusterLinks(replicators, allConfigs)) == 0 {
+				return fmt.Errorf("Project %q must have replica.cluster config set or at least one replicator before promoting to leader mode", projectName)
+			}
+
+		case api.ReplicatorProjectModeNone:
+			// Require proof that the project takes part in a replication topology.
+			if len(replicatorClusterLinks(replicators, allConfigs)) == 0 {
+				return fmt.Errorf("Project %q has no replicators, create a replicator before promoting to leader mode", projectName)
+			}
+		}
+
 		err = validateProjectPromote(ctx, s, projectName, project, replicators, allConfigs)
 		if err != nil {
 			return err
@@ -1700,7 +1709,6 @@ func projectPromote(ctx context.Context, s *state.State, projectName string, for
 // projectDemote demotes the project to standby mode for replication.
 func projectDemote(ctx context.Context, s *state.State, projectName string, force bool) error {
 	var project *api.Project
-
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
@@ -1708,11 +1716,7 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 		}
 
 		project, err = dbProject.ToAPI(ctx, tx.Tx())
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	})
 	if err != nil {
 		return err
@@ -1722,9 +1726,15 @@ func projectDemote(ctx context.Context, s *state.State, projectName string, forc
 		return fmt.Errorf("Project %q is already in standby mode", projectName)
 	}
 
-	// Require replica.cluster config to be set so the standby knows which cluster can write to it.
-	if !force && project.Config["replica.cluster"] == "" {
-		return fmt.Errorf("Project %q must have replica.cluster config set before demoting to standby mode", projectName)
+	if !force {
+		// A standby project only accepts replication data from the cluster link named by
+		// replica.cluster, so it must be set before the project can enter standby mode.
+		// Demoting a leader is never blocked on the standby having taken over first: leaving the
+		// topology briefly without a leader is recoverable, whereas promoting before the leader
+		// steps down would give it two.
+		if project.Config["replica.cluster"] == "" {
+			return fmt.Errorf("Project %q must have replica.cluster config set before demoting to standby mode", projectName)
+		}
 	}
 
 	// Update the replica mode to standby.

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -408,13 +408,12 @@ func replicatorValidateConfig(ctx context.Context, s *state.State, config map[st
 	return nil
 }
 
-// replicatorCheckClusterLinkUnique returns an error if another replicator in the given project
-// already targets the given cluster link. excludeID should be the ID of the replicator being
-// updated, or 0 when creating a new replicator.
-func replicatorCheckClusterLinkUnique(ctx context.Context, tx *db.ClusterTx, projectName string, clusterLinkName string, excludeID int64) error {
+// replicatorsAndConfigs returns the replicators in the given project along with their configs,
+// keyed by replicator ID.
+func replicatorsAndConfigs(ctx context.Context, tx *db.ClusterTx, projectName string) ([]dbCluster.Replicator, map[int64]map[string]string, error) {
 	replicators, _, err := dbCluster.GetReplicatorsAndURLs(ctx, tx.Tx(), &projectName, nil)
 	if err != nil {
-		return err
+		return nil, nil, fmt.Errorf("Failed loading replicators for project %q: %w", projectName, err)
 	}
 
 	ids := make([]int64, 0, len(replicators))
@@ -424,7 +423,40 @@ func replicatorCheckClusterLinkUnique(ctx context.Context, tx *db.ClusterTx, pro
 
 	allConfigs, err := dbCluster.ReplicatorsConfigStore().GetByEntityIDs(ctx, tx.Tx(), ids...)
 	if err != nil {
-		return fmt.Errorf("Failed loading replicator configs: %w", err)
+		return nil, nil, fmt.Errorf("Failed loading replicator configs: %w", err)
+	}
+
+	return replicators, allConfigs, nil
+}
+
+// replicatorClusterLinkNames returns the names of the cluster links targeted by the replicators in
+// the given project. Replicators without a cluster config key are skipped.
+func replicatorClusterLinkNames(ctx context.Context, tx *db.ClusterTx, projectName string) ([]string, error) {
+	replicators, allConfigs, err := replicatorsAndConfigs(ctx, tx, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterLinkNames := make([]string, 0, len(replicators))
+	for _, replicator := range replicators {
+		clusterLinkName := allConfigs[replicator.Row.ID]["cluster"]
+		if clusterLinkName == "" {
+			continue
+		}
+
+		clusterLinkNames = append(clusterLinkNames, clusterLinkName)
+	}
+
+	return clusterLinkNames, nil
+}
+
+// replicatorCheckClusterLinkUnique returns an error if another replicator in the given project
+// already targets the given cluster link. excludeID should be the ID of the replicator being
+// updated, or 0 when creating a new replicator.
+func replicatorCheckClusterLinkUnique(ctx context.Context, tx *db.ClusterTx, projectName string, clusterLinkName string, excludeID int64) error {
+	replicators, allConfigs, err := replicatorsAndConfigs(ctx, tx, projectName)
+	if err != nil {
+		return err
 	}
 
 	for _, replicator := range replicators {

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -2,11 +2,13 @@ package cluster
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
@@ -215,7 +217,14 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 
 // ConnectCluster connects to a linked cluster using the provided connection args, trying each address until one succeeds.
 func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.ConnectionArgs) (lxd.InstanceServer, error) {
-	addresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, false)
+	// Pending or otherwise incomplete cluster links have no bootstrap addresses yet. Report that
+	// distinctly rather than as ErrClusterLinkUnreachable, so callers that tolerate an offline
+	// linked cluster do not silently accept a misconfigured link as one that has gone away.
+	addresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, true)
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("Cluster link %q has no known addresses", clusterLink.Name)
+	}
+
 	var errs []error
 	for _, address := range addresses {
 		client, err := lxd.ConnectLXD("https://"+address, args)
@@ -227,7 +236,71 @@ func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.
 		return client, nil
 	}
 
-	return nil, fmt.Errorf("Failed connecting to any address of cluster link %q: %w", clusterLink.Name, errors.Join(errs...))
+	// Only report the cluster as unreachable when every address failed for a reachability reason.
+	// If any address answered and rejected us, the cluster is up and the caller must not treat it
+	// as having gone away.
+	joined := errors.Join(errs...)
+	for _, e := range errs {
+		if !isUnreachableError(e) {
+			return nil, fmt.Errorf("Failed connecting to any address of cluster link %q: %w", clusterLink.Name, joined)
+		}
+	}
+
+	return nil, fmt.Errorf("%w: Failed connecting to any address of cluster link %q: %w", ErrClusterLinkUnreachable, clusterLink.Name, joined)
+}
+
+// isUnreachableError reports whether err means the cluster could not be contacted at all, as
+// opposed to one that answered and rejected us. ConnectLXD requests GET /1.0 before returning, so
+// its errors cover the whole exchange rather than just the dial.
+//
+// It is deliberately conservative: only recognised dial-level failures qualify, so an unrecognised
+// error fails a promotion rather than silently allowing one against a cluster that is still
+// running as leader.
+func isUnreachableError(err error) bool {
+	// Check certificate failures first. A TLS error arrives wrapped in *url.Error, which itself
+	// satisfies net.Error, so a looser check would misclassify a cluster that answered with a bad
+	// certificate as unreachable.
+	var certErr *tls.CertificateVerificationError
+	var hostErr x509.HostnameError
+	var authErr x509.UnknownAuthorityError
+	var invalidErr x509.CertificateInvalidError
+	if errors.As(err, &certErr) || errors.As(err, &hostErr) || errors.As(err, &authErr) || errors.As(err, &invalidErr) {
+		return false
+	}
+
+	var opErr *net.OpError
+	var dnsErr *net.DNSError
+	return errors.As(err, &opErr) || errors.As(err, &dnsErr) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// ErrClusterLinkUnreachable is returned by [ConnectCluster] when none of the cluster link's
+// addresses could be reached. Callers that tolerate offline clusters (such as disaster recovery
+// paths) can check for it with [errors.Is].
+var ErrClusterLinkUnreachable = errors.New("Cluster link is unreachable")
+
+// ConnectClusterLinkByName loads the cluster link with the given name and connects to it.
+// If the link cannot be loaded the returned error describes the failure; if the link is loaded but
+// no address responds, the returned error wraps [ErrClusterLinkUnreachable].
+func ConnectClusterLinkByName(ctx context.Context, s *state.State, name string) (lxd.InstanceServer, error) {
+	var clusterLink *api.ClusterLink
+	var targetCert *x509.Certificate
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		_, clusterLink, targetCert, err = LoadClusterLinkAndCert(ctx, tx.Tx(), name)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading cluster link %q: %w", name, err)
+	}
+
+	var args *lxd.ConnectionArgs
+	if clusterLink.Type == api.ClusterLinkTypePublic {
+		args = GetPublicClusterLinkConnectionArgs(targetCert)
+	} else {
+		args = GetClusterLinkConnectionArgs(s.Endpoints.NetworkCert(), targetCert)
+	}
+
+	return ConnectCluster(ctx, *clusterLink, args)
 }
 
 // RefreshClusterLinkVolatileAddresses refreshes the volatile addresses of a cluster link.

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -180,6 +180,34 @@ func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.
 	return nil, fmt.Errorf("Failed connecting to any address of cluster link %q: %w", clusterLink.Name, errors.Join(errs...))
 }
 
+// ErrClusterLinkUnreachable is returned by [ConnectClusterLinkByName] when the cluster link was
+// loaded successfully but none of its addresses could be reached. Callers that tolerate offline
+// clusters (such as disaster recovery paths) can check for it with [errors.Is].
+var ErrClusterLinkUnreachable = errors.New("Cluster link is unreachable")
+
+// ConnectClusterLinkByName loads the cluster link with the given name and connects to it.
+// If the link cannot be loaded the returned error describes the failure; if the link is loaded but
+// no address responds, the returned error wraps [ErrClusterLinkUnreachable].
+func ConnectClusterLinkByName(ctx context.Context, s *state.State, name string) (lxd.InstanceServer, error) {
+	var clusterLink *api.ClusterLink
+	var targetCert *x509.Certificate
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		_, clusterLink, targetCert, err = LoadClusterLinkAndCert(ctx, tx.Tx(), name)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading cluster link %q: %w", name, err)
+	}
+
+	client, err := ConnectCluster(ctx, *clusterLink, GetClusterLinkConnectionArgs(s.Endpoints.NetworkCert(), targetCert))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrClusterLinkUnreachable, err)
+	}
+
+	return client, nil
+}
+
 // RefreshClusterLinkVolatileAddresses refreshes the volatile addresses of a cluster link.
 // It connects to the linked cluster and retrieves its current cluster members. If the addresses
 // have changed, [CheckClusterLinkCertificate] is called to ensure the cluster certificate remains valid.

--- a/lxd/cluster/cluster_link_test.go
+++ b/lxd/cluster/cluster_link_test.go
@@ -1,9 +1,19 @@
 package cluster
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/canonical/lxd/shared/api"
 )
 
 func TestAddressSetChanged(t *testing.T) {
@@ -72,6 +82,86 @@ func TestAddressSetChanged(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := addressSetChanged(tc.current, tc.updated)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsUnreachableError(t *testing.T) {
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+	dnsErr := &net.DNSError{Err: "no such host", Name: "cluster.example.net", IsNotFound: true}
+	certErr := &tls.CertificateVerificationError{Err: x509.UnknownAuthorityError{}}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "connection refused",
+			err:  dialErr,
+			want: true,
+		},
+		{
+			name: "dns failure",
+			err:  dnsErr,
+			want: true,
+		},
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "wrapped dial failure is still unreachable",
+			err:  fmt.Errorf("Failed connecting to %q: %w", "10.0.0.1:8443", dialErr),
+			want: true,
+		},
+		{
+			name: "joined dial failures are still unreachable",
+			err:  errors.Join(dialErr, dnsErr),
+			want: true,
+		},
+		{
+			name: "certificate verification failure means the cluster answered",
+			err:  certErr,
+			want: false,
+		},
+		{
+			name: "wrapped certificate failure means the cluster answered",
+			err:  fmt.Errorf("Failed connecting to %q: %w", "10.0.0.1:8443", certErr),
+			want: false,
+		},
+		{
+			name: "hostname mismatch means the cluster answered",
+			err:  x509.HostnameError{Host: "10.0.0.1"},
+			want: false,
+		},
+		{
+			name: "unknown authority means the cluster answered",
+			err:  x509.UnknownAuthorityError{},
+			want: false,
+		},
+		{
+			name: "expired certificate means the cluster answered",
+			err:  x509.CertificateInvalidError{Reason: x509.Expired},
+			want: false,
+		},
+		{
+			name: "http rejection means the cluster answered",
+			err:  api.NewStatusError(http.StatusForbidden, "not authorized"),
+			want: false,
+		},
+		{
+			name: "unrecognised errors are not treated as unreachable",
+			err:  errors.New("something else went wrong"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isUnreachableError(tc.err)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4821,8 +4821,8 @@
 				"keys": [
 					{
 						"replica.cluster": {
-							"longdesc": "This setting is used on standby projects to identify which cluster link is allowed to replicate instances to this project.",
-							"shortdesc": "Cluster link allowed to replicate to this standby project.",
+							"longdesc": "On a standby project, this identifies the cluster link that is allowed to replicate instances into it.\n\nSet it on the leader project as well: demoting to standby requires it, and it is what lets a project that has been demoted during a failover be promoted back to leader.",
+							"shortdesc": "Cluster link this project replicates with",
 							"type": "string"
 						}
 					}

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -76,13 +76,16 @@ type Project struct {
 	// Example: ["/1.0/images/0e60015346f06627f10580d56ac7fffd9ea775f6d4f25987217d5eed94910a20", "/1.0/instances/c1", "/1.0/networks/lxdbr0", "/1.0/profiles/default", "/1.0/storage-pools/default/volumes/custom/blah"]
 	UsedBy []string `json:"used_by" yaml:"used_by"`
 
-	// Replica mode for the project (leader, standby, or empty)
+	// Replica mode for the project (leader or standby)
 	// Read only: true
 	// This field is updated via PUT /1.0/projects/<name>/state
+	// It is omitted for projects that take no part in replication.
 	// Example: leader
 	//
 	// API extension: project_replica_mode
-	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
+	//
+	// API extension: project_replica_mode_optional
+	ReplicaMode string `json:"replica_mode,omitempty" yaml:"replica_mode,omitempty"`
 }
 
 // Writable converts a full Project struct into a ProjectPut struct (filters read-only fields)
@@ -141,5 +144,5 @@ type ProjectStateResource struct {
 type ProjectStatePut struct {
 	// Replica mode to set: "leader", "standby", or "" to clear the replica mode
 	// Example: leader
-	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
+	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"` // No omitempty: unlike the read-only field on Project, "" is a meaningful request that clears the replica mode.
 }

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -76,13 +76,16 @@ type Project struct {
 	// Example: ["/1.0/images/0e60015346f06627f10580d56ac7fffd9ea775f6d4f25987217d5eed94910a20", "/1.0/instances/c1", "/1.0/networks/lxdbr0", "/1.0/profiles/default", "/1.0/storage-pools/default/volumes/custom/blah"]
 	UsedBy []string `json:"used_by" yaml:"used_by"`
 
-	// Replica mode for the project (leader, standby, or empty)
+	// Replica mode for the project (leader or standby)
 	// Read only: true
 	// This field is updated via PUT /1.0/projects/<name>/state
+	// It is omitted for projects that take no part in replication.
 	// Example: leader
 	//
 	// API extension: project_replica_mode
-	ReplicaMode string `json:"replica_mode" yaml:"replica_mode"`
+	//
+	// API extension: project_replica_mode_optional
+	ReplicaMode string `json:"replica_mode,omitempty" yaml:"replica_mode,omitempty"`
 }
 
 // Writable converts a full Project struct into a ProjectPut struct (filters read-only fields)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -502,6 +502,7 @@ var APIExtensions = []string{
 	"access_management_expiry",
 	"cluster_links_public",
 	"durable_operations",
+	"project_replica_mode_optional",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -500,6 +500,7 @@ var APIExtensions = []string{
 	"operation_child_count",
 	"storage_driver_powerstore_nvme",
 	"access_management_expiry",
+	"project_replica_mode_optional",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6797,10 +6797,13 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
-  # clear-replica resets the replica mode back to empty from standby mode.
+  # clear-replica resets the replica mode back to empty from standby mode, but only with --force:
+  # clearing a standby drops the record of which cluster was replicating into it, which would
+  # otherwise let the project be promoted under the weaker no-replica-mode rules.
   LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "standby"'
-  LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is a standby replica, use --force to clear its replica mode' ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project delete replica-state-project

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5834,10 +5834,20 @@ test_clustering_replicator_basic() {
 
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
+  sub_test "Verify promote and demote are rejected for projects outside a replication topology"
+
+  # A project that takes no part in a replication topology cannot be promoted without --force.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" has no replicators, create a replicator before promoting to leader mode' ]
+
+  # Demoting without replica.cluster would produce a standby that cannot identify the cluster
+  # allowed to push into it, so every subsequent replicator run would be rejected.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" must have replica.cluster config set before demoting to standby mode' ]
+
   sub_test "Verify promote fails before target is in standby mode"
 
-  # Set replica.cluster on standby side only (leader doesn't need it since replicator defines targets).
+  # Both sides set replica.cluster so the replication direction can be reversed during a failover.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
 
   # Create replicator on LXD_ONE first (defines target cluster).
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
@@ -5846,6 +5856,36 @@ test_clustering_replicator_basic() {
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Target project "replicator-project" on cluster "lxd_two" is not in standby mode' ]
 
   # Demote standby side, then promote leader side.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
+
+  sub_test "Verify a leader with replicators cannot be demoted without replica.cluster"
+
+  # Demoting a leader without replica.cluster would leave a standby that cannot identify the cluster
+  # allowed to push into it, so every subsequent replicator run would be rejected.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project unset replicator-project replica.cluster
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" must have replica.cluster config set before demoting to standby mode' ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
+
+  sub_test "Verify a force-demoted standby cannot be promoted without replica.cluster"
+
+  # A replicator target is not necessarily the old leader, so it cannot stand in for
+  # replica.cluster when checking that the old leader has stepped down.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project unset replicator-project replica.cluster
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" must have replica.cluster config set before promoting to leader mode' ]
+
+  # Restore the original direction.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
+
+  sub_test "Verify a planned switchover needs no --force in either direction"
+
+  # The leader steps down first so the topology never has two leaders, then the standby takes over.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project promote-replica replicator-project
+
+  # Switch back to the original direction the same way.
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
@@ -6023,8 +6063,10 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6112,8 +6154,10 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6200,7 +6244,8 @@ test_clustering_replicator_dr() {
 
   sub_test "Verify --restore is rejected when local instances are running"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  # No --force needed: replica.cluster is set on this side, so the leader may step down.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected with a clear error.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 
@@ -6275,8 +6320,10 @@ test_clustering_replicator_snapshot() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6358,8 +6405,10 @@ test_clustering_replicator_multi_member() {
   LXD_DIR="${LXD_THREE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
   LXD_DIR="${LXD_THREE_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6503,8 +6552,10 @@ test_clustering_replicator_evacuated_member() {
   LXD_DIR="${LXD_FOUR_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_FOUR_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
   LXD_DIR="${LXD_FOUR_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6649,8 +6700,10 @@ test_clustering_replicator_vm() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create vm-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6738,7 +6791,8 @@ test_clustering_replicator_unclustered() {
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is not in a replica mode' ]
 
   # clear-replica resets the replica mode back to empty from leader mode.
-  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project
+  # --force is required: the project has no replicators, so it is not part of a replication topology.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "leader"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
@@ -6763,8 +6817,10 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project: LXD_ONE is leader, LXD_TWO is standby.
+  # Configure replica project: LXD_ONE is leader, LXD_TWO is standby. Both sides set
+  # replica.cluster so the direction can be reversed during a failover.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6832,7 +6888,8 @@ test_clustering_replicator_unclustered() {
 
   sub_test "Verify --restore is rejected when local instances are running"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  # No --force needed: replica.cluster is set on this side, so the leader may step down.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6785,7 +6785,7 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project create replica-state-project
 
   # New projects have no replica mode set.
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   # clear-replica is rejected when the project has no replica mode set.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is not in a replica mode' ]
@@ -6795,13 +6795,13 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "leader"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   # clear-replica resets the replica mode back to empty from standby mode.
   LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "standby"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project delete replica-state-project
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5832,10 +5832,20 @@ test_clustering_replicator_basic() {
 
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
+  sub_test "Verify promote and demote are rejected for projects outside a replication topology"
+
+  # A project that takes no part in a replication topology cannot be promoted without --force.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" has no replicators, create a replicator before promoting to leader mode' ]
+
+  # Demoting without replica.cluster would produce a standby that cannot identify the cluster
+  # allowed to push into it, so every subsequent replicator run would be rejected.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" must have replica.cluster config set before demoting to standby mode' ]
+
   sub_test "Verify promote fails before target is in standby mode"
 
-  # Set replica.cluster on standby side only (leader doesn't need it since replicator defines targets).
+  # Both sides set replica.cluster so the replication direction can be reversed during a failover.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
 
   # Create replicator on LXD_ONE first (defines target cluster).
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
@@ -5844,6 +5854,24 @@ test_clustering_replicator_basic() {
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project 2>&1)" = 'Error: Target project "replicator-project" on cluster "lxd_two" is not in standby mode' ]
 
   # Demote standby side, then promote leader side.
+  LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
+
+  sub_test "Verify a leader with replicators cannot be demoted without replica.cluster"
+
+  # Demoting a leader without replica.cluster would leave a standby that cannot identify the cluster
+  # allowed to push into it, so every subsequent replicator run would be rejected.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project unset replicator-project replica.cluster
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project 2>&1)" = 'Error: Project "replicator-project" must have replica.cluster config set before demoting to standby mode' ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
+
+  sub_test "Verify a planned switchover needs no --force in either direction"
+
+  # The leader steps down first so the topology never has two leaders, then the standby takes over.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc project promote-replica replicator-project
+
+  # Switch back to the original direction the same way.
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
 
@@ -6021,8 +6049,10 @@ test_clustering_replicator_scheduled() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6110,8 +6140,10 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6194,7 +6226,8 @@ test_clustering_replicator_dr() {
 
   sub_test "Verify --restore is rejected when local instances are running"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  # No --force needed: replica.cluster is set on this side, so the leader may step down.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected with a clear error.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 
@@ -6263,8 +6296,10 @@ test_clustering_replicator_snapshot() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create snap-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6346,8 +6381,10 @@ test_clustering_replicator_multi_member() {
   LXD_DIR="${LXD_THREE_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_THREE_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
   LXD_DIR="${LXD_THREE_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6491,8 +6528,10 @@ test_clustering_replicator_evacuated_member() {
   LXD_DIR="${LXD_FOUR_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_FOUR_DIR}" lxc cluster link create lxd_a --token "${LXD_B_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_FOUR_DIR}" lxc project set replicator-project replica.cluster=lxd_a
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_b
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_b --project replicator-project
   LXD_DIR="${LXD_FOUR_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6637,8 +6676,10 @@ test_clustering_replicator_vm() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project settings: standby sets replica.cluster, leader creates replicator.
+  # Configure replica project settings: both sides set replica.cluster so the direction can be
+  # reversed during a failover, and the leader creates the replicator.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create vm-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6726,7 +6767,8 @@ test_clustering_replicator_unclustered() {
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is not in a replica mode' ]
 
   # clear-replica resets the replica mode back to empty from leader mode.
-  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project
+  # --force is required: the project has no replicators, so it is not part of a replication topology.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "leader"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
@@ -6751,8 +6793,10 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_TWO_DIR}" lxc auth group permission add replicator-group project replicator-project can_edit
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create lxd_one --token "${LXD_ONE_TRUST_TOKEN}" --auth-group replicator-group
 
-  # Configure replica project: LXD_ONE is leader, LXD_TWO is standby.
+  # Configure replica project: LXD_ONE is leader, LXD_TWO is standby. Both sides set
+  # replica.cluster so the direction can be reversed during a failover.
   LXD_DIR="${LXD_TWO_DIR}" lxc project set replicator-project replica.cluster=lxd_one
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set replicator-project replica.cluster=lxd_two
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator create my-replicator cluster=lxd_two --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc project demote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
@@ -6820,7 +6864,8 @@ test_clustering_replicator_unclustered() {
 
   sub_test "Verify --restore is rejected when local instances are running"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
+  # No --force needed: replica.cluster is set on this side, so the leader may step down.
+  LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6761,7 +6761,7 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project create replica-state-project
 
   # New projects have no replica mode set.
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   # clear-replica is rejected when the project has no replica mode set.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project 2>&1)" = 'Error: Project "replica-state-project" is not in a replica mode' ]
@@ -6771,13 +6771,13 @@ test_clustering_replicator_unclustered() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "leader"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   # clear-replica resets the replica mode back to empty from standby mode.
   LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replica-state-project --force
   LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status '.replica_mode == "standby"'
   LXD_DIR="${LXD_ONE_DIR}" lxc project clear-replica replica-state-project
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --raw-output --exit-status '.replica_mode' || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/projects/replica-state-project | jq --exit-status 'has("replica_mode") | not'
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project delete replica-state-project
 


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/18642.

`promote-replica` could run on any project, and a standby could promote without checking whether the old leader had stepped down, leaving two clusters writing to the same project. Promoting now requires the project to be part of a replication topology, and `--force` skips the checks:

| Project is | Promoting requires |
| --- | --- |
| not replicated | at least one replicator |
| standby | `replica.cluster` |

A replicator is not accepted for a standby: it names a cluster the project pushes to, not necessarily the one that was leading it. Clearing the replica mode of a standby now also needs `--force`, since it otherwise launders the project into "not replicated" and past the guard above.

Behaviour changes:
- Replicators must exist before `promote-replica`. Use `--force` to migrate existing deployments.
- `replica.cluster` is now needed on the leader too, so it can be demoted and later promoted back. A planned switchover is demote-then-promote, needing `--force` on neither side.
- `replica_mode` is omitted for projects outside a replication topology (API extension `project_replica_mode_optional`), and `lxc project list` hides `REPLICA MODE` by default (`--columns r` shows it).
