### PR TITLE
Listeners: Fix STARTTLS peek blocking the accept loop

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/lxd/metrics"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
@@ -69,7 +70,7 @@ func restServer(d *Daemon) *http.Server {
 		Handler:           &lxdHTTPServer{r: mux, d: d},
 		ConnContext:       request.SaveConnectionInContext,
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
+		ReadHeaderTimeout: util.HTTPServerReadTimeout,
 	}
 }
 
@@ -107,8 +108,8 @@ func metricsServer(d *Daemon) *http.Server {
 	return &http.Server{
 		Handler:           &lxdHTTPServer{r: mux, d: d},
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
-		ReadTimeout:       3 * time.Second,
+		ReadHeaderTimeout: util.HTTPServerReadTimeout,
+		ReadTimeout:       util.HTTPServerReadTimeout,
 		WriteTimeout:      30 * time.Second,
 	}
 }

--- a/lxd/api_devlxd.go
+++ b/lxd/api_devlxd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/ucred"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
@@ -29,8 +30,8 @@ func devLXDServer(d *Daemon) *http.Server {
 	return &http.Server{
 		Handler:           devLXDAPI(d, containerAuthenticator{}),
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
-		ReadTimeout:       3 * time.Second,
+		ReadHeaderTimeout: util.HTTPServerReadTimeout,
+		ReadTimeout:       util.HTTPServerReadTimeout,
 		ConnState:         pidMapper.ConnStateHandler,
 		ConnContext:       request.SaveConnectionInContext,
 	}

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -20,8 +20,8 @@ func vSockServer(d *Daemon) *http.Server {
 	return &http.Server{
 		Handler:           devLXDAPI(d, vSockAuthenticator{}),
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
-		ReadTimeout:       3 * time.Second,
+		ReadHeaderTimeout: util.HTTPServerReadTimeout,
+		ReadTimeout:       util.HTTPServerReadTimeout,
 	}
 }
 

--- a/lxd/endpoints/listeners/starttls.go
+++ b/lxd/endpoints/listeners/starttls.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/cancel"
 )
 
 // StarttlsListener is a variation of the standard tls.Listener that supports
@@ -18,32 +20,125 @@ type StarttlsListener struct {
 	net.Listener
 	mu     sync.RWMutex
 	config *tls.Config
+
+	accepted  chan acceptResult
+	canceller cancel.Canceller
+}
+
+// acceptResult carries the outcome of accepting a single connection.
+type acceptResult struct {
+	conn net.Conn
+	err  error
 }
 
 // NewSTARTTLSListener creates a new STARTTLS listener.
 func NewSTARTTLSListener(inner net.Listener, cert *shared.CertInfo) *StarttlsListener {
 	listener := &StarttlsListener{
-		Listener: inner,
+		Listener:  inner,
+		accepted:  make(chan acceptResult),
+		canceller: cancel.New(),
 	}
 
 	listener.Config(cert)
+
+	// Accept connections in the background.
+	go listener.acceptLoop()
+
 	return listener
 }
 
-// Accept waits for and returns the next incoming TLS connection then use the
-// current TLS configuration to handle it.
+// Accept waits for and returns the next incoming connection, upgrading it to TLS
+// if the client began with a STARTTLS handshake. Once the listener is closed it
+// returns net.ErrClosed instead of blocking.
 func (l *StarttlsListener) Accept() (net.Conn, error) {
-	c, err := l.Listener.Accept()
+	// Prioritise cancellation so a closed listener never hands out a connection,
+	// even if one raced into l.accepted just before Close.
+	if l.canceller.Err() != nil {
+		return nil, net.ErrClosed
+	}
+
+	select {
+	case res := <-l.accepted:
+		return res.conn, res.err
+	case <-l.canceller.Done():
+		return nil, net.ErrClosed
+	}
+}
+
+// Close closes the underlying listener and unblocks in-flight handle goroutines.
+func (l *StarttlsListener) Close() error {
+	if l.canceller.Err() != nil {
+		return nil
+	}
+
+	l.canceller.Cancel()
+	return l.Listener.Close()
+}
+
+// acceptLoop accepts raw connections and handles each concurrently, stopping only
+// once the listener is closed.
+func (l *StarttlsListener) acceptLoop() {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			// Closed: stop. Accept reports the closure via the canceller.
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+
+			// Transient error: forward it for the serve loop's backoff, then keep
+			// accepting so the listener recovers. The canceller guard prevents
+			// leaking this goroutine if Close races the send.
+			select {
+			case l.accepted <- acceptResult{err: err}:
+			case <-l.canceller.Done():
+				return
+			}
+
+			continue
+		}
+
+		go l.handle(conn)
+	}
+}
+
+// handle classifies a single connection and delivers it to Accept. A failure
+// only closes that connection; it is never forwarded as an Accept error, which
+// would tear down the serve loop.
+func (l *StarttlsListener) handle(rawConn net.Conn) {
+	conn, err := l.classify(rawConn)
+	if err != nil {
+		_ = rawConn.Close()
+		return
+	}
+
+	select {
+	case l.accepted <- acceptResult{conn: conn}:
+	case <-l.canceller.Done():
+		// Closed mid-detection; drop rather than block on a stopped serve loop.
+		_ = conn.Close()
+	}
+}
+
+// classify peeks for the STARTTLS header and returns a TLS server connection if
+// present, otherwise the buffered connection with its peeked bytes intact.
+func (l *StarttlsListener) classify(rawConn net.Conn) (net.Conn, error) {
+	// Bound the peek so an idle client cannot hold the connection open forever.
+	// The deadline is cleared before returning, since the HTTP server manages its
+	// own timeouts once it takes over the connection.
+	_ = rawConn.SetReadDeadline(time.Now().Add(util.HTTPServerReadTimeout))
+	defer func() { _ = rawConn.SetReadDeadline(time.Time{}) }()
+
+	// Setup buffered connection.
+	bufConn := BufferedUnixConn{bufio.NewReader(rawConn), rawConn.(*net.UnixConn)}
+
+	// Peek to see if STARTTLS.
+	header, err := bufConn.Peek(8)
 	if err != nil {
 		return nil, err
 	}
 
-	// Setup bufferred connection.
-	bufConn := BufferedUnixConn{bufio.NewReader(c), c.(*net.UnixConn)}
-
-	// Peak to see if STARTTLS.
-	header, err := bufConn.Peek(8)
-	if err == nil && string(header) == "STARTTLS" {
+	if string(header) == "STARTTLS" {
 		discarded, err := bufConn.Discard(9)
 		if err != nil {
 			return nil, err

--- a/lxd/endpoints/listeners/starttls_test.go
+++ b/lxd/endpoints/listeners/starttls_test.go
@@ -1,0 +1,257 @@
+package listeners
+
+import (
+	"bufio"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared"
+)
+
+// newRawUnixListener returns a plain unix listener on a temporary socket.
+func newRawUnixListener(t *testing.T) *net.UnixListener {
+	t.Helper()
+
+	file, err := os.CreateTemp("", "lxd-starttls-test")
+	require.NoError(t, err)
+
+	path := file.Name()
+	require.NoError(t, file.Close())
+	require.NoError(t, os.Remove(path))
+
+	addr, err := net.ResolveUnixAddr("unix", path)
+	require.NoError(t, err)
+
+	inner, err := net.ListenUnix("unix", addr)
+	require.NoError(t, err)
+
+	return inner
+}
+
+// newTestUnixListener returns a StarttlsListener on a temporary unix socket.
+func newTestUnixListener(t *testing.T) *StarttlsListener {
+	t.Helper()
+
+	listener := NewSTARTTLSListener(newRawUnixListener(t), shared.TestingKeyPair())
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return listener
+}
+
+// An idle connection that sends no bytes must not block acceptance of others
+// (issue #18705).
+func TestStarttlsListener_IdleConnectionDoesNotBlockAccept(t *testing.T) {
+	listener := newTestUnixListener(t)
+	sockPath := listener.Addr().String()
+
+	// Connect but send nothing.
+	idle, err := net.Dial("unix", sockPath)
+	require.NoError(t, err)
+	defer func() { _ = idle.Close() }()
+
+	// A second client that sends immediately.
+	active, err := net.Dial("unix", sockPath)
+	require.NoError(t, err)
+	defer func() { _ = active.Close() }()
+
+	_, err = active.Write([]byte("GET / HTTP/1.1\r\n\r\n"))
+	require.NoError(t, err)
+
+	// Accept must return the active connection despite the idle one.
+	type acceptOut struct {
+		conn net.Conn
+		err  error
+	}
+
+	done := make(chan acceptOut, 1)
+	go func() {
+		conn, err := listener.Accept()
+		done <- acceptOut{conn: conn, err: err}
+	}()
+
+	select {
+	case out := <-done:
+		require.NoError(t, out.err)
+		require.NotNil(t, out.conn)
+
+		// The accepted connection is the active one.
+		header, err := bufio.NewReader(out.conn).Peek(3)
+		require.NoError(t, err)
+		assert.Equal(t, "GET", string(header))
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("Accept blocked on the idle connection")
+	}
+}
+
+// A plain connection is returned as a BufferedUnixConn so SO_PEERCRED keeps
+// working.
+func TestStarttlsListener_PlainConnectionPassthrough(t *testing.T) {
+	listener := newTestUnixListener(t)
+	sockPath := listener.Addr().String()
+
+	client, err := net.Dial("unix", sockPath)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	_, err = client.Write([]byte("PING/1.0 hello"))
+	require.NoError(t, err)
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+
+	bufConn, ok := conn.(BufferedUnixConn)
+	require.True(t, ok, "plain connection should be a BufferedUnixConn")
+	require.NotNil(t, bufConn.Unix(), "underlying UnixConn must be reachable for SO_PEERCRED")
+
+	buf := make([]byte, 4)
+	_, err = conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "PING", string(buf))
+}
+
+// A client that sends the STARTTLS header is upgraded to a TLS connection over
+// which application data flows.
+func TestStarttlsListener_STARTTLSUpgrade(t *testing.T) {
+	listener := newTestUnixListener(t)
+	sockPath := listener.Addr().String()
+
+	clientErr := make(chan error, 1)
+	go func() {
+		clientErr <- func() error {
+			raw, err := net.Dial("unix", sockPath)
+			if err != nil {
+				return err
+			}
+
+			defer func() { _ = raw.Close() }()
+
+			// Send the STARTTLS header, then perform the TLS handshake.
+			_, err = raw.Write([]byte("STARTTLS\n"))
+			if err != nil {
+				return err
+			}
+
+			client := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
+			err = client.Handshake()
+			if err != nil {
+				return err
+			}
+
+			_, err = client.Write([]byte("ping"))
+			return err
+		}()
+	}()
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+
+	server, ok := conn.(*tls.Conn)
+	require.True(t, ok, "STARTTLS connection should upgrade to *tls.Conn")
+
+	// Reading drives the server-side handshake and returns the client's data.
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(server, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(buf))
+
+	require.NoError(t, <-clientErr)
+}
+
+// Closing the listener must unblock a pending Accept with an error, so the HTTP
+// server's serve loop terminates on shutdown.
+func TestStarttlsListener_CloseUnblocksAccept(t *testing.T) {
+	listener := newTestUnixListener(t)
+
+	accepted := make(chan error, 1)
+	go func() {
+		_, err := listener.Accept()
+		accepted <- err
+	}()
+
+	require.NoError(t, listener.Close())
+
+	select {
+	case err := <-accepted:
+		require.Error(t, err, "Accept must return an error after Close")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Accept did not return after Close")
+	}
+}
+
+// flakyListener fails Accept a fixed number of times before delegating.
+type flakyListener struct {
+	net.Listener
+	failuresLeft atomic.Int64
+}
+
+func (f *flakyListener) Accept() (net.Conn, error) {
+	if f.failuresLeft.Add(-1) >= 0 {
+		return nil, errors.New("transient accept error")
+	}
+
+	return f.Listener.Accept()
+}
+
+// A transient Accept error must not tear down the accept loop.
+func TestStarttlsListener_AcceptLoopSurvivesTransientError(t *testing.T) {
+	flaky := &flakyListener{Listener: newRawUnixListener(t)}
+	flaky.failuresLeft.Store(1)
+
+	listener := NewSTARTTLSListener(flaky, shared.TestingKeyPair())
+	t.Cleanup(func() { _ = listener.Close() })
+
+	// The transient error surfaces to the serve loop.
+	_, err := listener.Accept()
+	require.Error(t, err)
+
+	// Loop survived: a later connection is still accepted.
+	client, err := net.Dial("unix", listener.Addr().String())
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	_, err = client.Write([]byte("PING/1.0 hello"))
+	require.NoError(t, err)
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+}
+
+// Close must be idempotent: the http.Server serve loop also closes the listener.
+func TestStarttlsListener_CloseIsIdempotent(t *testing.T) {
+	listener := newTestUnixListener(t)
+
+	require.NoError(t, listener.Close())
+	require.NoError(t, listener.Close())
+}
+
+// Accept called after Close, with no receiver waiting when Close happened, must
+// return net.ErrClosed rather than block forever.
+func TestStarttlsListener_AcceptAfterCloseReturnsError(t *testing.T) {
+	listener := newTestUnixListener(t)
+
+	require.NoError(t, listener.Close())
+
+	accepted := make(chan error, 1)
+	go func() {
+		_, err := listener.Accept()
+		accepted <- err
+	}()
+
+	select {
+	case err := <-accepted:
+		require.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Accept blocked after Close")
+	}
+}

--- a/lxd/endpoints/pprof.go
+++ b/lxd/endpoints/pprof.go
@@ -21,8 +21,8 @@ func pprofCreateServer() *http.Server {
 	srv := &http.Server{
 		Handler:           pprofMux,
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
-		ReadTimeout:       3 * time.Second,
+		ReadHeaderTimeout: util.HTTPServerReadTimeout,
+		ReadTimeout:       util.HTTPServerReadTimeout,
 	}
 
 	return srv

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -8,10 +8,17 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
 )
+
+// HTTPServerReadTimeout bounds how long LXD's HTTP servers wait to read request
+// headers, and, on servers that set ReadTimeout, the full request. It also bounds
+// the STARTTLS peek on the local unix socket. Legitimate clients send their first
+// bytes immediately.
+const HTTPServerReadTimeout = 3 * time.Second
 
 // CanonicalNetworkAddress parses the given network address and returns a string of the form "host:port",
 // possibly filling it with the default port if it's missing. It will also wrap a bare IPv6 address with square


### PR DESCRIPTION
This PR fixes https://github.com/canonical/lxd/issues/18705 by demultiplexing the peek off the accept path:
- A background `acceptLoop` goroutine does the fast raw `Accept` and hands each connection to its own `handle` goroutine for STARTTLS detection.
- Ready connections are delivered back to `Accept()` over a channel; per-connection failures close only that connection and are never surfaced as a fatal accept error.
- A read deadline (`util.HTTPServerReadTimeout`) bounds the peek, so an idle client is dropped rather than leaking a goroutine and fd.
- Shutdown uses `cancel.Canceller`, so `Accept()` returns `net.ErrClosed` after `Close()`; `Close()` is idempotent since `http.Server.Serve` also closes the listener on exit.

#### Testing

- New regression test `TestStarttlsListener_IdleConnectionDoesNotBlockAccept` fails against the old blocking code and passes with this change.
- Further tests cover plain passthrough (SO_PEERCRED), STARTTLS upgrade, and `Close()`/`Accept()` shutdown semantics.
- `go test ./lxd/endpoints/listeners/ ./lxd/endpoints/ -race` passes.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.