### PR TITLE
Security fix release notes updates

### DIFF
--- a/doc/reference/release-notes/4.0/index.md
+++ b/doc/reference/release-notes/4.0/index.md
@@ -16,6 +16,7 @@ This page lists recent release notes for LXD 4.0 LTS.
 :titlesonly:
 :maxdepth: 1
 
+LXD 4.0.12 LTS <release-notes-4.0.12>
 LXD 4.0.11 LTS <release-notes-4.0.11>
 ```
 

--- a/doc/reference/release-notes/4.0/release-notes-4.0.12.md
+++ b/doc/reference/release-notes/4.0/release-notes-4.0.12.md
@@ -1,0 +1,63 @@
+---
+myst:
+  html_meta:
+    description: Release notes for LXD 4.0.12, including highlights about new features, bugfixes, and other updates from the LXD project.
+---
+
+(ref-release-notes-4.0.12)=
+# LXD 4.0.12 release notes
+
+This is a {ref}`LTS release <ref-releases-lts>` and is recommended for production use.
+
+```{admonition} Release notes content
+:class: note
+These release notes cover updates in the [core LXD repository](https://github.com/canonical/lxd) and the [LXD snap package](https://snapcraft.io/lxd).
+```
+
+This is a maintenance release for the 4.0 LTS series. It focuses on security hardening, stricter input validation, and bug fixes backported from the main development branch.
+
+(ref-release-notes-4.0.12-highlights)=
+## Highlights
+
+This section highlights notable improvements in this release.
+
+### Security hardening for image and backup handling
+
+Several hardening fixes were backported to reduce archive and template-related attack surface:
+
+- Reject non-regular metadata files after unpack.
+- Reject unconfined backup metadata.
+- Prevent instance templates from escaping the templates directory.
+- Validate backup instance and volume names during import.
+
+### NVIDIA configuration validation improvements
+
+Validation for NVIDIA-related instance configuration was tightened and applied consistently at set time and start time. This includes stricter validation for `nvidia.driver.capabilities`, `nvidia.require.cuda`, and `nvidia.require.driver`.
+
+(ref-release-notes-4.0.12-bugfixes)=
+## Bug fixes
+
+The following bug fixes are included in this release.
+
+- [{spellexception}`Arbitrary file read and write via image metadata.yaml symlink (GHSA-j825-cg34-5fr5)`](https://github.com/canonical/lxd/security/advisories/GHSA-j825-cg34-5fr5)
+- [{spellexception}`NVIDIA configuration validation bypass for nvidia.require.* and nvidia.driver.capabilities (GHSA-vfh7-q59q-54v2)`](https://github.com/canonical/lxd/security/advisories/GHSA-vfh7-q59q-54v2)
+- [{spellexception}`Restricted project bypass for security.idmap.isolated defaults (GHSA-7vp9-3vmp-c5jm)`](https://github.com/canonical/lxd/security/advisories/GHSA-7vp9-3vmp-c5jm)
+- [{spellexception}`Unconfined backup.yaml accepted after unpack in crafted backups (GHSA-fv82-v4fj-mm4m)`](https://github.com/canonical/lxd/security/advisories/GHSA-fv82-v4fj-mm4m)
+- [{spellexception}`Prevent image metadata templates from escaping the instance directory (GHSA-9hcm-hxh5-7xxh)`](https://github.com/canonical/lxd/security/advisories/GHSA-9hcm-hxh5-7xxh)
+- [{spellexception}`Validate backup import names to prevent path traversal during restore (GHSA-m857-c7gc-c984)`](https://github.com/canonical/lxd/security/advisories/GHSA-m857-c7gc-c984)
+
+(ref-release-notes-4.0.12-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/lxd/compare/lxd-4.0.11...lxd-4.0.12).
+
+(ref-release-notes-4.0.12-downloads)=
+## Downloads
+
+The source tarballs and binary clients can be found on our [download page](https://github.com/canonical/lxd/releases/tag/lxd-4.0.12).
+
+Binary packages are also available for:
+
+- **Linux:** `snap install lxd --channel=4.0/stable`
+- **MacOS client:** `brew install lxc`
+- **Windows client:** `choco install lxc`

--- a/doc/reference/release-notes/5.0/release-notes-5.0.8.md
+++ b/doc/reference/release-notes/5.0/release-notes-5.0.8.md
@@ -55,6 +55,21 @@ If you are building LXD from source instead of using a package manager, the mini
 - Dropped the now unused `qemu-ovmf-secureboot` part and the standalone `nasm` part (and its patch).
 - Dropped unused EDK2 patches.
 
+(ref-release-notes-5.0.8-bugfixes)=
+## Bug fixes
+
+The following bug fixes are included in this release.
+
+- [{spellexception}`Arbitrary file read and write via image metadata.yaml symlink (GHSA-j825-cg34-5fr5)`](https://github.com/canonical/lxd/security/advisories/GHSA-j825-cg34-5fr5)
+- [{spellexception}`Root command execution via image backup.yaml symlink (GHSA-fv82-v4fj-mm4m)`](https://github.com/canonical/lxd/security/advisories/GHSA-fv82-v4fj-mm4m)
+- [{spellexception}`NVIDIA configuration validation bypass for nvidia.driver.capabilities (GHSA-vfh7-q59q-54v2)`](https://github.com/canonical/lxd/security/advisories/GHSA-vfh7-q59q-54v2)
+- [{spellexception}`Restricted project bypass for security.idmap.isolated defaults (GHSA-7vp9-3vmp-c5jm)`](https://github.com/canonical/lxd/security/advisories/GHSA-7vp9-3vmp-c5jm)
+- [{spellexception}`Project restriction bypass via instance migration config override (GHSA-gcr9-5q6r-w625)`](https://github.com/canonical/lxd/security/advisories/GHSA-gcr9-5q6r-w625)
+- [{spellexception}`Cross-project instance copy bypass via config merge timing (GHSA-v989-qw7w-xvg4)`](https://github.com/canonical/lxd/security/advisories/GHSA-v989-qw7w-xvg4)
+- [{spellexception}`Storage volume cross-project move and restore bypass project disk limits (GHSA-5h78-p252-989h)`](https://github.com/canonical/lxd/security/advisories/GHSA-5h78-p252-989h)
+- [{spellexception}`Cross-project cluster migration bypasses project restrictions (GHSA-v9wr-9r7q-fh4g)`](https://github.com/canonical/lxd/security/advisories/GHSA-v9wr-9r7q-fh4g)
+- [{spellexception}`Cross-project instance move bypasses project restrictions (GHSA-5g5r-wh97-qcq2)`](https://github.com/canonical/lxd/security/advisories/GHSA-5g5r-wh97-qcq2)
+
 (ref-release-notes-5.0.8-changelog)=
 ## Change log
 

--- a/doc/reference/release-notes/5.21/release-notes-5.21.6.md
+++ b/doc/reference/release-notes/5.21/release-notes-5.21.6.md
@@ -38,6 +38,15 @@ A new lightweight ACME test server (`mini-acme`) has been added to the integrati
 
 The following bug fixes are included in this release.
 
+- [{spellexception}`Arbitrary file read and write via image metadata.yaml symlink (GHSA-j825-cg34-5fr5)`](https://github.com/canonical/lxd/security/advisories/GHSA-j825-cg34-5fr5)
+- [{spellexception}`Root command execution via image backup.yaml symlink (GHSA-fv82-v4fj-mm4m)`](https://github.com/canonical/lxd/security/advisories/GHSA-fv82-v4fj-mm4m)
+- [{spellexception}`NVIDIA configuration validation bypass for nvidia.driver.capabilities (GHSA-vfh7-q59q-54v2)`](https://github.com/canonical/lxd/security/advisories/GHSA-vfh7-q59q-54v2)
+- [{spellexception}`Restricted project bypass for security.idmap.isolated defaults (GHSA-7vp9-3vmp-c5jm)`](https://github.com/canonical/lxd/security/advisories/GHSA-7vp9-3vmp-c5jm)
+- [{spellexception}`Project restriction bypass via instance migration config override (GHSA-gcr9-5q6r-w625)`](https://github.com/canonical/lxd/security/advisories/GHSA-gcr9-5q6r-w625)
+- [{spellexception}`Cross-project instance copy bypass via config merge timing (GHSA-v989-qw7w-xvg4)`](https://github.com/canonical/lxd/security/advisories/GHSA-v989-qw7w-xvg4)
+- [{spellexception}`Storage volume cross-project move and restore bypass project disk limits (GHSA-5h78-p252-989h)`](https://github.com/canonical/lxd/security/advisories/GHSA-5h78-p252-989h)
+- [{spellexception}`Cross-project cluster migration bypasses project restrictions (GHSA-v9wr-9r7q-fh4g)`](https://github.com/canonical/lxd/security/advisories/GHSA-v9wr-9r7q-fh4g)
+- [{spellexception}`Cross-project instance move bypasses project restrictions (GHSA-5g5r-wh97-qcq2)`](https://github.com/canonical/lxd/security/advisories/GHSA-5g5r-wh97-qcq2)
 - [{spellexception}`Fix listing images with --all-projects and shared fingerprints`](https://github.com/canonical/lxd/pull/18668)
 - [{spellexception}`Fix bcache device detection in resources`](https://github.com/canonical/lxd/pull/18704)
 - [{spellexception}`Fix nil http.Request handling on updateClusterCertificate`](https://github.com/canonical/lxd/pull/18697)

--- a/doc/reference/release-notes/6/release-notes-6.9.md
+++ b/doc/reference/release-notes/6/release-notes-6.9.md
@@ -227,6 +227,19 @@ The following bug fixes are included in this release.
 - [{spellexception}`Work with modern LVM`](https://github.com/canonical/lxd/pull/18463)
 - [{spellexception}`Add missing content types for storage volume POST`](https://github.com/canonical/lxd/pull/18457)
 
+### Security fixes in interim snap release `6.9-ab8fad2`
+
+The following security issues were fixed in the interim snap release `6.9-ab8fad2`:
+
+- [{spellexception}`Arbitrary file read and write via image metadata.yaml symlink (GHSA-j825-cg34-5fr5)`](https://github.com/canonical/lxd/security/advisories/GHSA-j825-cg34-5fr5)
+- [{spellexception}`Root command execution via image backup.yaml symlink (GHSA-fv82-v4fj-mm4m)`](https://github.com/canonical/lxd/security/advisories/GHSA-fv82-v4fj-mm4m)
+- [{spellexception}`NVIDIA configuration validation bypass for nvidia.driver.capabilities (GHSA-vfh7-q59q-54v2)`](https://github.com/canonical/lxd/security/advisories/GHSA-vfh7-q59q-54v2)
+- [{spellexception}`Restricted project bypass for security.idmap.isolated defaults (GHSA-7vp9-3vmp-c5jm)`](https://github.com/canonical/lxd/security/advisories/GHSA-7vp9-3vmp-c5jm)
+- [{spellexception}`Project restriction bypass via instance migration config override (GHSA-gcr9-5q6r-w625)`](https://github.com/canonical/lxd/security/advisories/GHSA-gcr9-5q6r-w625)
+- [{spellexception}`Storage volume cross-project move and restore bypass project disk limits (GHSA-5h78-p252-989h)`](https://github.com/canonical/lxd/security/advisories/GHSA-5h78-p252-989h)
+- [{spellexception}`Cross-project cluster migration bypasses project restrictions (GHSA-v9wr-9r7q-fh4g)`](https://github.com/canonical/lxd/security/advisories/GHSA-v9wr-9r7q-fh4g)
+- [{spellexception}`Cross-project instance move bypasses project restrictions (GHSA-5g5r-wh97-qcq2)`](https://github.com/canonical/lxd/security/advisories/GHSA-5g5r-wh97-qcq2)
+
 (ref-release-notes-6.9-incompatible)=
 ## Backwards-incompatible changes
 

--- a/doc/reference/release-notes/6/release-notes-6.9.md
+++ b/doc/reference/release-notes/6/release-notes-6.9.md
@@ -188,7 +188,7 @@ The following bug fixes are included in this release.
 - [{spellexception}`Project restriction bypass in instance copy across projects (CVE-2026-55622)`](https://github.com/canonical/lxd/security/advisories/GHSA-qx75-2p3r-pwm5)
 - [{spellexception}`Project restriction bypass for custom volume copy across projects (CVE-2026-55621)`](https://github.com/canonical/lxd/security/advisories/GHSA-7mr3-28h5-m5vx)
 - [{spellexception}`Restricted project bypass leading to arbitrary command execution (CVE-2026-48751)`](https://github.com/canonical/lxd/security/advisories/GHSA-47w9-6r3f-938g)
-- [{spellexception}`Arbitrary file write on host via `exec-output` symlink in crafted image (CVE-2026-48750)`](https://github.com/canonical/lxd/security/advisories/GHSA-9j25-mm2h-2f76)
+- [{spellexception}`Arbitrary file write on host via exec-output symlink in crafted image (CVE-2026-48750)`](https://github.com/canonical/lxd/security/advisories/GHSA-9j25-mm2h-2f76)
 - [{spellexception}`Arbitrary file read+write on host via templates/ symlink in malicious image (CVE-2026-48752)`](https://github.com/canonical/lxd/security/advisories/GHSA-jpf8-86f3-wp38)
 - [{spellexception}`Arbitrary file read+write on host via rootfs/ symlink in malicious image (CVE-2026-48749)`](https://github.com/canonical/lxd/security/advisories/GHSA-vghh-5rfx-xhq8)
 - [{spellexception}`Argument injection in backup compression algorithm leading to AFW and ACE (CVE-2026-48755)`](https://github.com/canonical/lxd/security/advisories/GHSA-fmc8-p6q7-75cc)


### PR DESCRIPTION
Includes 4.0.12 release notes.

From https://discourse.ubuntu.com/t/security-advisory-multiple-vulnerabilities-found-in-canonical-lxd/85253