### PR TITLE
auth: Add pending client and devlxd bearer identities

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3664,3 +3664,10 @@ Replication requires the remote cluster to authenticate the connection, so {ref}
 Introduces new operation class for durable operations.
 Durable operations are restarted on the DQLite raft leader if the member that is running the operation fails to respond to heartbeats.
 If the leader was running the operation and goes offline, the operation is restarted on the newly elected leader.
+
+(extension-access-management-bearer-pending)=
+## `access_management_bearer_pending`
+
+Adds three identity types, `Client token bearer (pending)`, `DevLXD token bearer (pending)` and `Initial UI token bearer (pending)`, that represent bearer identities for which no token is currently issued.
+
+A bearer identity is created in the pending state because no token has been issued for it yet. Issuing a token promotes the identity to its active type of `Client token bearer`, `DevLXD token bearer` or `Initial UI token bearer`, and revoking the token demotes it back to the pending type. A token that has expired but has not been revoked leaves the identity active.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3643,3 +3643,10 @@ For bearer tokens the expiry is recorded when a token is issued and cleared when
 The field is omitted for identities whose credential has no expiry, that have no credential yet (pending identities), or whose token has been revoked.
 
 Note that bearer identities created prior to this extension will have an omitted `expires_at` field until a new token is issued.
+
+(extension-access-management-bearer-pending)=
+## `access_management_bearer_pending`
+
+Adds two identity types, `Client token bearer (pending)` and `DevLXD token bearer (pending)`, that represent a bearer identity for which no token is currently issued.
+
+A client or DevLXD bearer identity is created in the pending state because no token has been issued for it yet. Issuing a token promotes the identity to its active type of `Client token bearer` or `DevLXD token bearer`, and revoking the token demotes it back to the pending type. A token that has expired but has not been revoked leaves the identity active.

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -291,6 +291,12 @@ LXD supports authenticating to the LXD API using bearer tokens. Bearer tokens pr
 
 Bearer tokens can be issued for identities of type `bearer`. The permissions associated with a token are derived from the identity it belongs to and are enforced through {ref}`fine-grained-authorization`.
 
+A bearer identity is created in a pending state, with the type `Client token bearer (pending)` or `DevLXD token bearer (pending)`.
+Issuing a bearer token activates the identity and its type changes to `Client token bearer` or `DevLXD token bearer`, respectively.
+Revoking the token removes it and returns the identity to the pending state.
+An expired token remains associated with the identity.
+Therefore, the identity remains active, even though its token can no longer be used for authentication.
+
 To authenticate an API request using a bearer token, include it in the `Authorization` header
 as `Authorization: Bearer <token>`, where `<token>` represents an actual token value.
 

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -291,6 +291,10 @@ LXD supports authenticating to the LXD API using bearer tokens. Bearer tokens pr
 
 Bearer tokens can be issued for identities of type `bearer`. The permissions associated with a token are derived from the identity it belongs to and are enforced through {ref}`fine-grained-authorization`.
 
+A bearer identity is created in a pending state, since no token has been issued for it yet.
+Its type is reported as `Client token bearer (pending)` or `DevLXD token bearer (pending)` for as long as it stays in that state.
+Issuing a token makes the identity active and revoking the token returns it to the pending state.
+
 To authenticate an API request using a bearer token, include it in the `Authorization` header
 as `Authorization: Bearer <token>`, where `<token>` represents an actual token value.
 

--- a/doc/howto/access_ui.md
+++ b/doc/howto/access_ui.md
@@ -71,6 +71,9 @@ For convenience, the `--ui-initial-access-link` flag can be used to non-interact
 lxd init --ui-initial-access-link
 ```
 
+The `ui-admin-initial` identity has the type `Initial UI token bearer` while a token is issued for it.
+Revoking the token changes its type to `Initial UI token bearer (pending)`, and issuing a new token changes it back.
+
 (access-ui-setup-certificate)=
 ### Permanent UI access using browser certificate
 

--- a/doc/howto/auth_bearer.md
+++ b/doc/howto/auth_bearer.md
@@ -9,7 +9,10 @@ To authenticate to the LXD API using a bearer token, first create an identity of
 lxc auth identity create bearer/<name> [[--group <group> ]]
 ```
 
-Next, issue a token for the identity:
+The new identity initially has type `Client token bearer (pending)`.
+A pending identity cannot authenticate but can be added to groups.
+
+Next, issue a token for the identity (this changes its type to `Client token bearer`):
 ```bash
 lxc auth identity token issue bearer/<name> [--expiry <expiry> ]
 ```
@@ -66,3 +69,22 @@ Case-sensitive units: years (`y`), months (`m`), weeks (`w`), days (`d`), hours 
 
 Note the distinction between months (`m`) and minutes (`M`): for example, `1m` means one month, while `1M` means one minute.
 ```
+
+Finally, a token that is no longer needed can be revoked:
+
+`````{tabs}
+````{group-tab} CLI
+```bash
+lxc auth identity token revoke bearer/<name>
+```
+````
+````{group-tab} API
+```bash
+lxc query --request DELETE /1.0/auth/identities/bearer/<name>/token
+```
+````
+`````
+
+Revoking the token invalidates it immediately and returns the identity to the pending state.
+The identity has type `Client token bearer (pending)` until a new token is issued for it.
+The identity remains in its assigned groups, so a newly issued token grants its bearer the same permissions as the revoked one.

--- a/doc/howto/auth_bearer.md
+++ b/doc/howto/auth_bearer.md
@@ -18,6 +18,9 @@ To authenticate to the LXD API using a bearer token, first create an identity of
 ```
 `````
 
+The new identity is reported with the type `Client token bearer (pending)`, which means that no token has been issued for it yet.
+Such an identity cannot authenticate, although it can already be added to groups.
+
 Next, issue a token for the identity:
 
 `````{tabs}
@@ -50,3 +53,17 @@ $ curl -k -H "Authorization: Bearer ${TOKEN}" https://<lxd_address>/1.0
   }
 }
 ```
+
+Finally, a token that is no longer needed can be revoked:
+
+`````{tabs}
+```{group-tab} CLI
+    lxc auth identity token revoke bearer/<name>
+```
+```{group-tab} API
+    lxc query --request DELETE /1.0/auth/identities/bearer/<name>/token
+```
+`````
+
+Revoking the token invalidates it immediately and returns the identity to the pending state, where it stays until a new token is issued for it.
+Any groups the identity belongs to are retained, so a newly issued token grants the same permissions as the revoked one.

--- a/doc/howto/devlxd_authenticate.md
+++ b/doc/howto/devlxd_authenticate.md
@@ -14,7 +14,10 @@ To authenticate over the DevLXD API, first create a `DevLXD token bearer` identi
 lxc auth identity create devlxd/<name> [[--group <group> ]]
 ```
 
-Next, issue a token for the identity:
+The new identity initially has type `DevLXD token bearer (pending)`.
+A pending identity cannot authenticate but can be added to groups.
+
+Next, issue a token for the identity (this changes its type to `DevLXD token bearer`):
 ```bash
 lxc auth identity token issue devlxd/<name> [--expiry <expiry> ]
 ```

--- a/doc/howto/devlxd_authenticate.md
+++ b/doc/howto/devlxd_authenticate.md
@@ -23,6 +23,8 @@ To authenticate over the DevLXD API, first create a `DevLXD token bearer` identi
 ```
 `````
 
+The new identity is reported with the type `DevLXD token bearer (pending)` until a token is issued for it.
+
 Next, issue a token for the identity:
 
 `````{tabs}

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -759,6 +759,27 @@ func resolveIdentityTypeShorthand(identityArg string) (method string, identityTy
 	return "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
 }
 
+// identityTypeMatches reports whether the type reported by the server satisfies the requested type.
+// An active type also matches its pending counterpart, the same identity before it becomes usable.
+func identityTypeMatches(requestedType string, actualType string) bool {
+	if requestedType == "" || requestedType == actualType {
+		return true
+	}
+
+	switch requestedType {
+	case api.IdentityTypeBearerTokenClient:
+		return actualType == api.IdentityTypeBearerTokenClientPending
+	case api.IdentityTypeBearerTokenDevLXD:
+		return actualType == api.IdentityTypeBearerTokenDevLXDPending
+	case api.IdentityTypeCertificateClient:
+		return actualType == api.IdentityTypeCertificateClientPending
+	case api.IdentityTypeCertificateClusterLink:
+		return actualType == api.IdentityTypeCertificateClusterLinkPending
+	}
+
+	return false
+}
+
 // resolveIdentityTypeShorthand takes an identity argument of the form [<remote>:]<type>/<name> and returns the remote
 // name, an authentication method, an identity type, and a name (or an error).
 // If the shorthand <type> resolves to more than one identity type, it returns an empty string for the identity type.
@@ -1215,7 +1236,7 @@ func (c *cmdIdentityShow) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1350,7 +1371,7 @@ func (c *cmdIdentityEdit) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1463,7 +1484,7 @@ func (c *cmdIdentityDelete) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && id.Type != idType {
+	if !identityTypeMatches(idType, id.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, id.Type)
 	}
 
@@ -1531,7 +1552,7 @@ func (c *cmdIdentityGroupAdd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1582,7 +1603,7 @@ func (c *cmdIdentityGroupRemove) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1665,7 +1686,7 @@ func (c *cmdIdentityTokenIssue) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1723,7 +1744,7 @@ func (c *cmdIdentityTokenRevoke) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -759,6 +759,26 @@ func resolveIdentityTypeShorthand(identityArg string) (method string, identityTy
 	return "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
 }
 
+// identityTypeMatches reports whether the identity type reported by the server satisfies the type requested via an
+// identity argument shorthand. A shorthand names an active identity type, which also matches its pending counterpart,
+// since a pending identity is the same identity awaiting a token.
+func identityTypeMatches(requestedType string, actualType string) bool {
+	if requestedType == "" || requestedType == actualType {
+		return true
+	}
+
+	switch requestedType {
+	case api.IdentityTypeBearerTokenClient:
+		return actualType == api.IdentityTypeBearerTokenClientPending
+	case api.IdentityTypeBearerTokenDevLXD:
+		return actualType == api.IdentityTypeBearerTokenDevLXDPending
+	case api.IdentityTypeCertificateClusterLink:
+		return actualType == api.IdentityTypeCertificateClusterLinkPending
+	}
+
+	return false
+}
+
 // resolveIdentityTypeShorthand takes an identity argument of the form [<remote>:]<type>/<name> and returns the remote
 // name, an authentication method, an identity type, and a name (or an error).
 // If the shorthand <type> resolves to more than one identity type, it returns an empty string for the identity type.
@@ -1215,7 +1235,7 @@ func (c *cmdIdentityShow) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1350,7 +1370,7 @@ func (c *cmdIdentityEdit) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1463,7 +1483,7 @@ func (c *cmdIdentityDelete) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && id.Type != idType {
+	if !identityTypeMatches(idType, id.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, id.Type)
 	}
 
@@ -1531,7 +1551,7 @@ func (c *cmdIdentityGroupAdd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1582,7 +1602,7 @@ func (c *cmdIdentityGroupRemove) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1665,7 +1685,7 @@ func (c *cmdIdentityTokenIssue) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 
@@ -1723,7 +1743,7 @@ func (c *cmdIdentityTokenRevoke) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if idType != "" && identity.Type != idType {
+	if !identityTypeMatches(idType, identity.Type) {
 		return fmt.Errorf("Expected identity of type %q but found identity with type %q", idType, identity.Type)
 	}
 

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/identity"
-	"github.com/canonical/lxd/shared/api"
 )
 
 // entityTypeIdentity implements entityTypeDBInfo for an [IdentitiesRow].
@@ -18,7 +17,7 @@ type entityTypeIdentity struct {
 // identityTypes returns the list of identity type codes that are considered fine-grained.
 func (e entityTypeIdentity) identityTypes() (types []int64) {
 	for _, t := range identity.Types() {
-		if t.IsFineGrained() || t.Name() == api.IdentityTypeBearerTokenInitialUI {
+		if t.IsFineGrained() || identity.IsInitialUIBearer(t.Name()) {
 			types = append(types, t.Code())
 		}
 	}

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -320,36 +320,30 @@ func (i IdentitiesRow) BearerMetadata() (*BearerMetadata, error) {
 	return &metadata, nil
 }
 
-// SetBearerIdentityTokenExpiry records the expiry of the issued token for a bearer identity.
-func SetBearerIdentityTokenExpiry(ctx context.Context, tx *sql.Tx, identityID int64, expiry *time.Time) error {
+// SetBearerTokenExpiry sets the expiry of the issued token in the identity metadata. A nil expiry records
+// that the identity has no usable token. The [AuthMethod] of the [IdentitiesRow] must be
+// [api.AuthenticationMethodBearer]. The change is persisted by [query.UpdateByPrimaryKey].
+func (i *IdentitiesRow) SetBearerTokenExpiry(expiry *time.Time) error {
+	metadata, err := i.BearerMetadata()
+	if err != nil {
+		return err
+	}
+
 	// A non-nil expiry is signed into the token as a JWT NumericDate, which has second
 	// precision, so we truncate to second precision before storing it to ensure the expiry
 	// reported for a listed identity is identical to the one the token itself carries.
-	var value any
+	metadata.TokenExpiry = nil
 	if expiry != nil {
-		value = expiry.UTC().Truncate(time.Second).Format(time.RFC3339Nano)
+		truncated := expiry.UTC().Truncate(time.Second)
+		metadata.TokenExpiry = &truncated
 	}
 
-	// Update token_expiry in place so any other metadata fields are preserved.
-	// A nil expiry is stored as JSON null, which unmarshals back to a nil TokenExpiry,
-	// representing "no active token".
-	q := `
-UPDATE identities
-SET metadata = json_set(CASE WHEN metadata = '' THEN '{}' ELSE metadata END, '$.token_expiry', ?)
-WHERE id = ? AND auth_method = ?`
-	res, err := tx.ExecContext(ctx, q, value, identityID, AuthMethod(api.AuthenticationMethodBearer))
+	b, err := json.Marshal(metadata)
 	if err != nil {
-		return fmt.Errorf("Failed setting bearer identity token expiry: %w", err)
+		return fmt.Errorf("Failed marshaling bearer metadata: %w", err)
 	}
 
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("Failed checking bearer identity token expiry update: %w", err)
-	}
-
-	if rowsAffected != 1 {
-		return fmt.Errorf("Failed setting bearer identity token expiry: Expected to update 1 row, updated %d", rowsAffected)
-	}
+	i.Metadata = string(b)
 
 	return nil
 }

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -121,8 +121,30 @@ func (i IdentityType) ActiveType() (IdentityType, error) {
 		return api.IdentityTypeCertificateClient, nil
 	case api.IdentityTypeCertificateClusterLinkPending:
 		return api.IdentityTypeCertificateClusterLink, nil
+	case api.IdentityTypeBearerTokenClientPending:
+		return api.IdentityTypeBearerTokenClient, nil
+	case api.IdentityTypeBearerTokenDevLXDPending:
+		return api.IdentityTypeBearerTokenDevLXD, nil
+	case api.IdentityTypeBearerTokenInitialUIPending:
+		return api.IdentityTypeBearerTokenInitialUI, nil
 	default:
 		return "", fmt.Errorf("Identities of type %q cannot be activated", i)
+	}
+}
+
+// PendingType returns the pending version of an active bearer identity type.
+// A bearer identity is demoted to its pending type when its token is revoked and no signing key remains.
+// It returns an error for types that cannot be demoted to a pending variant.
+func (i IdentityType) PendingType() (IdentityType, error) {
+	switch i {
+	case api.IdentityTypeBearerTokenClient:
+		return api.IdentityTypeBearerTokenClientPending, nil
+	case api.IdentityTypeBearerTokenDevLXD:
+		return api.IdentityTypeBearerTokenDevLXDPending, nil
+	case api.IdentityTypeBearerTokenInitialUI:
+		return api.IdentityTypeBearerTokenInitialUIPending, nil
+	default:
+		return "", fmt.Errorf("Identities of type %q cannot be made pending", i)
 	}
 }
 
@@ -253,6 +275,12 @@ func (i IdentitiesRow) PendingTLSMetadata() (*PendingTLSMetadata, error) {
 
 	if !identityType.IsPending() {
 		return nil, api.StatusErrorf(http.StatusBadRequest, "Cannot extract pending %q TLS identity secret: Identity is not pending", i.Type)
+	}
+
+	// Pending identities of other authentication methods carry different metadata, so reject them rather than
+	// reporting an empty secret and expiry for them.
+	if identityType.AuthenticationMethod() != api.AuthenticationMethodTLS {
+		return nil, api.StatusErrorf(http.StatusBadRequest, "Cannot extract pending %q TLS identity secret: Identity does not authenticate with TLS", i.Type)
 	}
 
 	var metadata PendingTLSMetadata
@@ -461,9 +489,11 @@ func ActivateTLSIdentity(ctx context.Context, tx *sql.Tx, identifier uuid.UUID, 
 	return query.UpdateByPrimaryKey(ctx, tx, ident)
 }
 
-var pendingIdentityTypes = func() (result []int64) {
+// pendingTLSIdentityTypes returns the type codes of all pending identity types whose authentication method is TLS.
+// These are the only pending identities that carry a token secret in their metadata and can be activated with one.
+var pendingTLSIdentityTypes = func() (result []int64) {
 	for _, t := range identity.Types() {
-		if t.IsPending() {
+		if t.IsPending() && t.AuthenticationMethod() == api.AuthenticationMethodTLS {
 			result = append(result, t.Code())
 		}
 	}
@@ -475,7 +505,7 @@ var pendingIdentityTypes = func() (result []int64) {
 func GetPendingTLSIdentityByTokenSecret(ctx context.Context, tx *sql.Tx, secret string) (*IdentitiesRow, error) {
 	clause := fmt.Sprintf(`
 	WHERE identities.type IN %s
-	AND json_extract(identities.metadata, '$.secret') = ?`, query.IntParams(pendingIdentityTypes()...))
+	AND json_extract(identities.metadata, '$.secret') = ?`, query.IntParams(pendingTLSIdentityTypes()...))
 
 	ident, err := query.SelectOne[IdentitiesRow](ctx, tx, clause, secret)
 	if err != nil {

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -121,8 +121,26 @@ func (i IdentityType) ActiveType() (IdentityType, error) {
 		return api.IdentityTypeCertificateClient, nil
 	case api.IdentityTypeCertificateClusterLinkPending:
 		return api.IdentityTypeCertificateClusterLink, nil
+	case api.IdentityTypeBearerTokenClientPending:
+		return api.IdentityTypeBearerTokenClient, nil
+	case api.IdentityTypeBearerTokenDevLXDPending:
+		return api.IdentityTypeBearerTokenDevLXD, nil
 	default:
 		return "", fmt.Errorf("Identities of type %q cannot be activated", i)
+	}
+}
+
+// PendingType returns the pending version of an active bearer identity type.
+// A bearer identity is demoted to its pending type when it has no usable token.
+// It returns an error for types that cannot be demoted to a pending variant.
+func (i IdentityType) PendingType() (IdentityType, error) {
+	switch i {
+	case api.IdentityTypeBearerTokenClient:
+		return api.IdentityTypeBearerTokenClientPending, nil
+	case api.IdentityTypeBearerTokenDevLXD:
+		return api.IdentityTypeBearerTokenDevLXDPending, nil
+	default:
+		return "", fmt.Errorf("Identities of type %q cannot be made pending", i)
 	}
 }
 
@@ -255,6 +273,12 @@ func (i IdentitiesRow) PendingTLSMetadata() (*PendingTLSMetadata, error) {
 		return nil, api.StatusErrorf(http.StatusBadRequest, "Cannot extract pending %q TLS identity secret: Identity is not pending", i.Type)
 	}
 
+	// Pending identities of other authentication methods carry different metadata, so reject them rather than
+	// reporting an empty secret and expiry for them.
+	if identityType.AuthenticationMethod() != api.AuthenticationMethodTLS {
+		return nil, api.StatusErrorf(http.StatusBadRequest, "Cannot extract pending %q TLS identity secret: Identity does not authenticate with TLS", i.Type)
+	}
+
 	var metadata PendingTLSMetadata
 	err = json.Unmarshal([]byte(i.Metadata), &metadata)
 	if err != nil {
@@ -321,6 +345,27 @@ WHERE id = ? AND auth_method = ?`
 
 	if rowsAffected != 1 {
 		return fmt.Errorf("Failed setting bearer identity token expiry: Expected to update 1 row, updated %d", rowsAffected)
+	}
+
+	return nil
+}
+
+// SetIdentityType updates only the type of the identity with the given ID. It is used to promote a bearer identity
+// to its active type when a token is issued, and to demote it to its pending type when the token is revoked. Only the
+// type column is written so that other metadata (such as a token expiry set in the same transaction) is preserved.
+func SetIdentityType(ctx context.Context, tx *sql.Tx, identityID int64, identityType IdentityType) error {
+	res, err := tx.ExecContext(ctx, `UPDATE identities SET type = ? WHERE id = ?`, identityType, identityID)
+	if err != nil {
+		return fmt.Errorf("Failed setting identity type: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed checking identity type update: %w", err)
+	}
+
+	if rowsAffected != 1 {
+		return fmt.Errorf("Failed setting identity type: Expected to update 1 row, updated %d", rowsAffected)
 	}
 
 	return nil
@@ -461,9 +506,11 @@ func ActivateTLSIdentity(ctx context.Context, tx *sql.Tx, identifier uuid.UUID, 
 	return query.UpdateByPrimaryKey(ctx, tx, ident)
 }
 
-var pendingIdentityTypes = func() (result []int64) {
+// pendingTLSIdentityTypes returns the type codes of all pending identity types whose authentication method is TLS.
+// These are the only pending identities that carry a token secret in their metadata and can be activated with one.
+var pendingTLSIdentityTypes = func() (result []int64) {
 	for _, t := range identity.Types() {
-		if t.IsPending() {
+		if t.IsPending() && t.AuthenticationMethod() == api.AuthenticationMethodTLS {
 			result = append(result, t.Code())
 		}
 	}
@@ -475,7 +522,7 @@ var pendingIdentityTypes = func() (result []int64) {
 func GetPendingTLSIdentityByTokenSecret(ctx context.Context, tx *sql.Tx, secret string) (*IdentitiesRow, error) {
 	clause := fmt.Sprintf(`
 	WHERE identities.type IN %s
-	AND json_extract(identities.metadata, '$.secret') = ?`, query.IntParams(pendingIdentityTypes()...))
+	AND json_extract(identities.metadata, '$.secret') = ?`, query.IntParams(pendingTLSIdentityTypes()...))
 
 	ident, err := query.SelectOne[IdentitiesRow](ctx, tx, clause, secret)
 	if err != nil {

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -826,5 +826,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (88, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (89, strftime("%s"))
 `

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -113,7 +113,7 @@ CREATE TABLE identities_projects (
     FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
     UNIQUE (identity_id, project_id)
 );
-CREATE UNIQUE INDEX identities_type_initial_ui ON identities (type) WHERE type = 11;
+CREATE UNIQUE INDEX identities_type_initial_ui ON identities ((1)) WHERE type = 11 OR type = 16;
 CREATE INDEX identity_name_auth_method ON identities (auth_method,
     name);
 CREATE TABLE identity_provider_groups (
@@ -837,5 +837,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (89, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (90, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -132,6 +132,50 @@ var updates = map[int]schema.Update{
 	86: updateFromV85,
 	87: updateFromV86,
 	88: updateFromV87,
+	89: updateFromV88,
+}
+
+// updateFromV88 converts bearer identities that have no signing key to their pending type.
+//
+// A bearer identity has no usable token when it has no signing key and this is now reflected by
+// a distinct pending identity type. Identities that still hold a signing key keep their active type,
+// even if the issued token has already expired.
+func updateFromV88(ctx context.Context, tx *sql.Tx) error {
+	// Identity type codes:
+	// 9:  DevLXD token bearer
+	// 10: Client token bearer
+	// 11: Initial UI token bearer, which has no pending variant.
+	// 14: Client token bearer (pending)
+	// 15: DevLXD token bearer (pending)
+	//
+	// Entity type codes:
+	// 24: Identity entities
+	//
+	// Secret type codes:
+	// 2:  Bearer signing keys
+	_, err := tx.ExecContext(ctx, `
+UPDATE identities
+SET type = 15
+WHERE type = 9
+	AND NOT EXISTS (
+		SELECT 1 FROM secrets
+		WHERE secrets.entity_type = 24
+			AND secrets.entity_id = identities.id
+			AND secrets.type = 2
+	);
+
+UPDATE identities
+SET type = 14
+WHERE type = 10
+	AND NOT EXISTS (
+		SELECT 1 FROM secrets
+		WHERE secrets.entity_type = 24
+			AND secrets.entity_id = identities.id
+			AND secrets.type = 2
+	);
+`)
+
+	return err
 }
 
 func updateFromV87(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -133,6 +133,74 @@ var updates = map[int]schema.Update{
 	87: updateFromV86,
 	88: updateFromV87,
 	89: updateFromV88,
+	90: updateFromV89,
+}
+
+// updateFromV89 converts bearer identities that have no signing key to their pending type.
+//
+// A bearer identity has no usable token when it has no signing key and this is now reflected by
+// a distinct pending identity type. Identities that still hold a signing key keep their active type,
+// even if the issued token has already expired.
+func updateFromV89(ctx context.Context, tx *sql.Tx) error {
+	// Identity type codes:
+	// 9:  DevLXD token bearer
+	// 10: Client token bearer
+	// 11: Initial UI token bearer
+	// 14: Client token bearer (pending)
+	// 15: DevLXD token bearer (pending)
+	// 16: Initial UI token bearer (pending)
+	//
+	// Entity type codes:
+	// 24: Identity entities
+	//
+	// Secret type codes:
+	// 2:  Bearer signing keys
+	//
+	// There can only ever be one initial UI identity. The replacement index holds that invariant across both of its
+	// type codes by indexing a constant rather than the type, so that every covered row has the same key and a second
+	// one collides with the first whether or not the two share a type.
+	_, err := tx.ExecContext(ctx, `
+-- Replace the initial UI index with one that also covers the pending initial UI type.
+DROP INDEX identities_type_initial_ui;
+
+-- Index the same constant for both pending and non-pending initial UI identity to ensure only one exists.
+CREATE UNIQUE INDEX identities_type_initial_ui ON identities ((1)) WHERE type = 11 OR type = 16;
+
+-- Convert DevLXD bearer identities without a signing key to the pending type.
+UPDATE identities
+SET type = 15
+WHERE type = 9
+	AND NOT EXISTS (
+		SELECT 1 FROM secrets
+		WHERE secrets.entity_type = 24
+			AND secrets.entity_id = identities.id
+			AND secrets.type = 2
+	);
+
+-- Convert client bearer identities without a signing key to the pending type.
+UPDATE identities
+SET type = 14
+WHERE type = 10
+	AND NOT EXISTS (
+		SELECT 1 FROM secrets
+		WHERE secrets.entity_type = 24
+			AND secrets.entity_id = identities.id
+			AND secrets.type = 2
+	);
+
+-- Convert the initial UI bearer identity without a signing key to the pending type.
+UPDATE identities
+SET type = 16
+WHERE type = 11
+	AND NOT EXISTS (
+		SELECT 1 FROM secrets
+		WHERE secrets.entity_type = 24
+			AND secrets.entity_id = identities.id
+			AND secrets.type = 2
+	);
+`)
+
+	return err
 }
 
 func updateFromV88(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -900,7 +900,7 @@ INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('
 	require.NoError(t, err)
 
 	baseQ := `SELECT certificates.fingerprint, certificates.certificate, identities.identifier, identities.metadata
-FROM identities 
+FROM identities
     JOIN identities_certificates ON identities.id = identities_certificates.identity_id
 	JOIN certificates ON identities_certificates.certificate_id = certificates.id `
 	row := db.QueryRowContext(t.Context(), baseQ+"WHERE identities.name = ?", "unrestricted")
@@ -950,4 +950,57 @@ FROM identities
 	err = json.Unmarshal([]byte(metadata), &gotPendingTLSMetadata)
 	require.NoError(t, err)
 	require.Equal(t, pendingTLSMetadata, gotPendingTLSMetadata)
+}
+
+func TestUpdateFromV88(t *testing.T) {
+	// Identity type codes:
+	// 9:  DevLXD token bearer
+	// 10: Client token bearer
+	// 11: Initial UI token bearer, which has no pending variant.
+	//
+	// Entity type codes:
+	// 24: Identity entities
+	//
+	// Secret type codes:
+	// 2:  Bearer signing keys
+	schema := Schema()
+	db, err := schema.ExerciseUpdate(89, func(db *sql.DB) {
+		_, err := db.Exec(`
+-- Client bearer identity without a signing key (should become pending).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000001', 3, 10, 'client-no-token', '');
+-- Client bearer identity with a signing key (should stay active).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000002', 3, 10, 'client-with-token', '{"token_expiry":"2035-01-01T00:00:00Z"}');
+-- DevLXD bearer identity without a signing key (should become pending).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000003', 3, 9, 'devlxd-no-token', '');
+-- DevLXD bearer identity with a signing key (should stay active).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000004', 3, 9, 'devlxd-with-token', '{"token_expiry":"2035-01-01T00:00:00Z"}');
+-- Initial UI identity without a signing key (has no pending variant, should stay unchanged).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000005', 3, 11, 'initial-ui', '');
+
+-- Add signing keys for the two identities that have an issued token.
+INSERT INTO secrets (entity_type, entity_id, type, value) SELECT 24, id, 2, 'client-signing-key' FROM identities WHERE identifier = '019d6c4f-bf62-7bb8-a1d2-000000000002';
+INSERT INTO secrets (entity_type, entity_id, type, value) SELECT 24, id, 2, 'devlxd-signing-key' FROM identities WHERE identifier = '019d6c4f-bf62-7bb8-a1d2-000000000004';
+`)
+		require.NoError(t, err)
+	})
+	require.NoError(t, err)
+
+	assertType := func(identifier string, expected string) {
+		t.Helper()
+		var identityType IdentityType
+		err := db.QueryRowContext(t.Context(), `SELECT type FROM identities WHERE identifier = ?`, identifier).Scan(&identityType)
+		require.NoError(t, err)
+		require.Equal(t, IdentityType(expected), identityType)
+	}
+
+	// Tokenless client and DevLXD identities are demoted to their pending type.
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000001", api.IdentityTypeBearerTokenClientPending)
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000003", api.IdentityTypeBearerTokenDevLXDPending)
+
+	// Identities that still hold a signing key keep their active type.
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000002", api.IdentityTypeBearerTokenClient)
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000004", api.IdentityTypeBearerTokenDevLXD)
+
+	// The initial UI identity has no pending variant and is left untouched.
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000005", api.IdentityTypeBearerTokenInitialUI)
 }

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -900,7 +900,7 @@ INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('
 	require.NoError(t, err)
 
 	baseQ := `SELECT certificates.fingerprint, certificates.certificate, identities.identifier, identities.metadata
-FROM identities 
+FROM identities
     JOIN identities_certificates ON identities.id = identities_certificates.identity_id
 	JOIN certificates ON identities_certificates.certificate_id = certificates.id `
 	row := db.QueryRowContext(t.Context(), baseQ+"WHERE identities.name = ?", "unrestricted")

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -951,3 +951,83 @@ FROM identities
 	require.NoError(t, err)
 	require.Equal(t, pendingTLSMetadata, gotPendingTLSMetadata)
 }
+
+func TestUpdateFromV89(t *testing.T) {
+	// Identity type codes:
+	// 9:  DevLXD token bearer
+	// 10: Client token bearer
+	// 11: Initial UI token bearer
+	//
+	// Entity type codes:
+	// 24: Identity entities
+	//
+	// Secret type codes:
+	// 2:  Bearer signing keys
+	schema := Schema()
+	db, err := schema.ExerciseUpdate(90, func(db *sql.DB) {
+		_, err := db.Exec(`
+-- Client bearer identity without a signing key (should become pending).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000001', 3, 10, 'client-no-token', '');
+ -- Client bearer identity with a signing key and an expired token (should stay active).
+ INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000002', 3, 10, 'client-with-token', '{"token_expiry":"2020-01-01T00:00:00Z"}');
+-- DevLXD bearer identity without a signing key (should become pending).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000003', 3, 9, 'devlxd-no-token', '');
+-- DevLXD bearer identity with a signing key (should stay active).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000004', 3, 9, 'devlxd-with-token', '{"token_expiry":"2035-01-01T00:00:00Z"}');
+-- Initial UI identity without a signing key (should become pending).
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000005', 3, 11, 'initial-ui', '');
+
+-- Add signing keys for the two identities that have an issued token.
+INSERT INTO secrets (entity_type, entity_id, type, value) SELECT 24, id, 2, 'client-signing-key' FROM identities WHERE identifier = '019d6c4f-bf62-7bb8-a1d2-000000000002';
+INSERT INTO secrets (entity_type, entity_id, type, value) SELECT 24, id, 2, 'devlxd-signing-key' FROM identities WHERE identifier = '019d6c4f-bf62-7bb8-a1d2-000000000004';
+`)
+		require.NoError(t, err)
+	})
+	require.NoError(t, err)
+
+	assertType := func(identifier string, expected string) {
+		t.Helper()
+		var identityType IdentityType
+		err := db.QueryRowContext(t.Context(), `SELECT type FROM identities WHERE identifier = ?`, identifier).Scan(&identityType)
+		require.NoError(t, err)
+		require.Equal(t, IdentityType(expected), identityType)
+	}
+
+	// Tokenless client and DevLXD identities are demoted to their pending type.
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000001", api.IdentityTypeBearerTokenClientPending)
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000003", api.IdentityTypeBearerTokenDevLXDPending)
+
+	// Identities that still hold a signing key keep their active type.
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000002", api.IdentityTypeBearerTokenClient)
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000004", api.IdentityTypeBearerTokenDevLXD)
+
+	assertType("019d6c4f-bf62-7bb8-a1d2-000000000005", api.IdentityTypeBearerTokenInitialUIPending)
+
+	// There is only ever one initial UI identity, whether it is active or pending, so a second one of either type
+	// must collide with the pending one that is already present.
+	_, err = db.ExecContext(t.Context(), `INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000006', 3, 11, 'initial-ui-active', '')`)
+	require.ErrorContains(t, err, "UNIQUE constraint failed")
+
+	_, err = db.ExecContext(t.Context(), `INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000007', 3, 16, 'initial-ui-pending', '')`)
+	require.ErrorContains(t, err, "UNIQUE constraint failed")
+}
+
+func TestUpdateFromV89InitialUIWithSigningKey(t *testing.T) {
+	// The initial UI identity is subject to the same rule as the other bearer identities, it keeps its active type
+	// while it holds a signing key. It gets its own test because the index that predates this update permits only
+	// one initial UI identity in the fixture.
+	schema := Schema()
+	db, err := schema.ExerciseUpdate(90, func(db *sql.DB) {
+		_, err := db.Exec(`
+INSERT INTO identities (identifier, auth_method, type, name, metadata) VALUES ('019d6c4f-bf62-7bb8-a1d2-000000000008', 3, 11, 'initial-ui', '{"token_expiry":"2035-01-01T00:00:00Z"}');
+INSERT INTO secrets (entity_type, entity_id, type, value) SELECT 24, id, 2, 'initial-ui-signing-key' FROM identities WHERE identifier = '019d6c4f-bf62-7bb8-a1d2-000000000008';
+`)
+		require.NoError(t, err)
+	})
+	require.NoError(t, err)
+
+	var identityType IdentityType
+	err = db.QueryRowContext(t.Context(), `SELECT type FROM identities WHERE identifier = ?`, "019d6c4f-bf62-7bb8-a1d2-000000000008").Scan(&identityType)
+	require.NoError(t, err)
+	require.Equal(t, IdentityType(api.IdentityTypeBearerTokenInitialUI), identityType)
+}

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -416,12 +416,19 @@ func identitiesBearerPost(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(errors.New("Initial UI identities may only be created via unix socket"))
 	}
 
+	// A bearer identity is created in pending state as no token has been issued for it yet.
+	// It is promoted to its active type when a token is first issued.
+	identityType, err := dbCluster.IdentityType(req.Type).PendingType()
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Identity type %q cannot be created: %w", req.Type, err))
+	}
+
 	newIdentityID := uuid.New()
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Create the identity.
 		id, err := query.Create(ctx, tx.Tx(), dbCluster.IdentitiesRow{
 			AuthMethod: api.AuthenticationMethodBearer,
-			Type:       dbCluster.IdentityType(req.Type),
+			Type:       identityType,
 			Identifier: newIdentityID.String(),
 			Name:       req.Name,
 		})
@@ -517,7 +524,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if id.Type == api.IdentityTypeBearerTokenInitialUI {
+	if identity.IsInitialUIBearer(string(id.Type)) {
 		if requestor.Protocol != request.ProtocolUnix {
 			return response.Forbidden(errors.New("Initial UI identity tokens may only be issued via unix socket"))
 		}
@@ -543,13 +550,37 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 
 	var secret []byte
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		updated, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), id.ID)
+		if err != nil {
+			return err
+		}
+
+		idType, err := identity.New(string(updated.Type))
+		if err != nil {
+			return err
+		}
+
 		secret, err = dbCluster.RotateBearerIdentitySigningKey(ctx, tx.Tx(), id.ID)
 		if err != nil {
 			return err
 		}
 
 		// Record the expiry alongside the new signing key so that it can be reported when the identity is listed.
-		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, &expiresAt)
+		err = updated.SetBearerTokenExpiry(&expiresAt)
+		if err != nil {
+			return err
+		}
+
+		// Promote a pending identity to its active type now that it has a usable token.
+		// Re-issuing a token for an already active identity leaves the type unchanged.
+		if idType.IsPending() {
+			updated.Type, err = updated.Type.ActiveType()
+			if err != nil {
+				return err
+			}
+		}
+
+		return query.UpdateByPrimaryKey(ctx, tx.Tx(), *updated)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -557,7 +588,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 
 	var token string
 	switch id.Type {
-	case api.IdentityTypeBearerTokenClient, api.IdentityTypeBearerTokenInitialUI:
+	case api.IdentityTypeBearerTokenClient, api.IdentityTypeBearerTokenClientPending, api.IdentityTypeBearerTokenInitialUI, api.IdentityTypeBearerTokenInitialUIPending:
 		var serverCertFingerprint string
 
 		// When creating LXD bearer tokens, include the server certificate fingerprint.
@@ -567,7 +598,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		token, err = encryption.GetClientBearerToken(secret, id.Identifier, s.GlobalConfig.ClusterUUID(), expiresAt, serverCertFingerprint)
-	case api.IdentityTypeBearerTokenDevLXD:
+	case api.IdentityTypeBearerTokenDevLXD, api.IdentityTypeBearerTokenDevLXDPending:
 		token, err = encryption.GetDevLXDBearerToken(secret, id.Identifier, s.GlobalConfig.ClusterUUID(), expiresAt)
 	default:
 		err = api.StatusErrorf(http.StatusBadRequest, "Token cannot be issued for identity of type %q", id.Type)
@@ -624,13 +655,31 @@ func identityBearerTokenDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		err := dbCluster.DeleteBearerIdentitySigningKey(ctx, tx.Tx(), id.ID)
+		// The access handler read its copy of the identity in an earlier transaction and the update below
+		// writes every column, so reload the row here and derive the type transition from committed state.
+		updated, err := dbCluster.GetIdentityByID(ctx, tx.Tx(), id.ID)
+		if err != nil {
+			return err
+		}
+
+		err = dbCluster.DeleteBearerIdentitySigningKey(ctx, tx.Tx(), id.ID)
 		if err != nil {
 			return fmt.Errorf("Failed revoking token: %w", err)
 		}
 
 		// Clear the recorded expiry so that the revoked token is no longer reported when the identity is listed.
-		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, nil)
+		err = updated.SetBearerTokenExpiry(nil)
+		if err != nil {
+			return err
+		}
+
+		// Demote the identity to its pending type now that it has no usable token.
+		updated.Type, err = updated.Type.PendingType()
+		if err != nil {
+			return err
+		}
+
+		return query.UpdateByPrimaryKey(ctx, tx.Tx(), *updated)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -2311,7 +2360,7 @@ func identityDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if !identityType.IsFineGrained() && identityType.Name() != api.IdentityTypeBearerTokenInitialUI {
+	if !identityType.IsFineGrained() && !identity.IsInitialUIBearer(identityType.Name()) {
 		return response.NotImplemented(fmt.Errorf("Identities of type %q cannot be modified via this API", id.Type))
 	}
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -2579,7 +2579,7 @@ func updateIdentityCache(d *Daemon) {
 		} else if identityType.AuthenticationMethod() == api.AuthenticationMethodBearer {
 			secret, ok := bearerIdentitySecrets[id.ID]
 			if !ok {
-				// No need to add bearer identities with no secret to the cache, they cannot authenticate.
+				logger.Warn("Missing signing key for active bearer identity", logger.Ctx{"identity_identifier": id.Identifier})
 				continue
 			}
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -412,8 +412,21 @@ func identitiesBearerPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Identities of type %q cannot be created via the bearer API", req.Type))
 	}
 
+	if idType.IsPending() {
+		return response.BadRequest(fmt.Errorf("Identity type %q cannot be created: Type is assigned to bearer identities with no issued token", req.Type))
+	}
+
 	if req.Type == api.IdentityTypeBearerTokenInitialUI && requestor.Protocol != request.ProtocolUnix {
 		return response.Forbidden(errors.New("Initial UI identities may only be created via unix socket"))
+	}
+
+	// Client and DevLXD bearer identities begin life pending, as no token has been issued for them yet. They are
+	// promoted to their active type when a token is first issued. The initial UI identity has no pending variant and
+	// is stored with the requested type.
+	identityType := dbCluster.IdentityType(req.Type)
+	pendingType, err := identityType.PendingType()
+	if err == nil {
+		identityType = pendingType
 	}
 
 	newIdentityID := uuid.New()
@@ -421,7 +434,7 @@ func identitiesBearerPost(d *Daemon, r *http.Request) response.Response {
 		// Create the identity.
 		id, err := query.Create(ctx, tx.Tx(), dbCluster.IdentitiesRow{
 			AuthMethod: api.AuthenticationMethodBearer,
-			Type:       dbCluster.IdentityType(req.Type),
+			Type:       identityType,
 			Identifier: newIdentityID.String(),
 			Name:       req.Name,
 		})
@@ -521,6 +534,11 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	idType, err := identity.New(string(id.Type))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	s := d.State()
 
 	var secret []byte
@@ -531,7 +549,23 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Record the expiry alongside the new signing key so that it can be reported when the identity is listed.
-		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, &expiresAt)
+		err = dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, &expiresAt)
+		if err != nil {
+			return err
+		}
+
+		// Promote a pending identity to its active type now that it has a usable token. Re-issuing a token for an
+		// already active identity leaves the type unchanged.
+		if idType.IsPending() {
+			activeType, err := id.Type.ActiveType()
+			if err != nil {
+				return err
+			}
+
+			return dbCluster.SetIdentityType(ctx, tx.Tx(), id.ID, activeType)
+		}
+
+		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -539,7 +573,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 
 	var token string
 	switch id.Type {
-	case api.IdentityTypeBearerTokenClient, api.IdentityTypeBearerTokenInitialUI:
+	case api.IdentityTypeBearerTokenClient, api.IdentityTypeBearerTokenClientPending, api.IdentityTypeBearerTokenInitialUI:
 		var serverCertFingerprint string
 
 		// When creating LXD bearer tokens, include the server certificate fingerprint.
@@ -549,7 +583,7 @@ func identityBearerTokenPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		token, err = encryption.GetClientBearerToken(secret, id.Identifier, s.GlobalConfig.ClusterUUID(), expiresAt, serverCertFingerprint)
-	case api.IdentityTypeBearerTokenDevLXD:
+	case api.IdentityTypeBearerTokenDevLXD, api.IdentityTypeBearerTokenDevLXDPending:
 		token, err = encryption.GetDevLXDBearerToken(secret, id.Identifier, s.GlobalConfig.ClusterUUID(), expiresAt)
 	default:
 		err = api.StatusErrorf(http.StatusBadRequest, "Token cannot be issued for identity of type %q", id.Type)
@@ -612,7 +646,19 @@ func identityBearerTokenDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Clear the recorded expiry so that the revoked token is no longer reported when the identity is listed.
-		return dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, nil)
+		err = dbCluster.SetBearerIdentityTokenExpiry(ctx, tx.Tx(), id.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		// Demote the identity to its pending type now that it has no usable token. The initial UI identity has no
+		// pending variant and keeps its type.
+		pendingType, err := id.Type.PendingType()
+		if err == nil {
+			return dbCluster.SetIdentityType(ctx, tx.Tx(), id.ID, pendingType)
+		}
+
+		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/identity/token_bearer_client.go
+++ b/lxd/identity/token_bearer_client.go
@@ -36,3 +36,36 @@ func (TokenBearerClient) IsFineGrained() bool {
 func (TokenBearerClient) IsCacheable() bool {
 	return true
 }
+
+// TokenBearerClientPending represents a client token bearer identity for which no token is currently issued.
+// An identity is pending before its first token is issued and again after its most recent token is revoked.
+// It supports fine-grained permissions (so it can be added to groups while pending, allowing the eventual token
+// holder to assume the correct permissions) but is not cacheable, as a pending identity cannot authenticate.
+type TokenBearerClientPending struct {
+	typeInfoCommon
+}
+
+// Name returns the name of the TokenBearerClientPending identity type.
+func (TokenBearerClientPending) Name() string {
+	return api.IdentityTypeBearerTokenClientPending
+}
+
+// Code returns the database code for TokenBearerClientPending.
+func (TokenBearerClientPending) Code() int64 {
+	return identityTypeBearerClientPending
+}
+
+// AuthenticationMethod indicates that identities of this type authenticate via bearer token.
+func (TokenBearerClientPending) AuthenticationMethod() string {
+	return api.AuthenticationMethodBearer
+}
+
+// IsFineGrained indicates that this identity uses fine-grained permissions.
+func (TokenBearerClientPending) IsFineGrained() bool {
+	return true
+}
+
+// IsPending indicates that this identity is pending.
+func (TokenBearerClientPending) IsPending() bool {
+	return true
+}

--- a/lxd/identity/token_bearer_devlxd.go
+++ b/lxd/identity/token_bearer_devlxd.go
@@ -36,3 +36,36 @@ func (TokenBearerDevLXD) IsFineGrained() bool {
 func (TokenBearerDevLXD) IsCacheable() bool {
 	return true
 }
+
+// TokenBearerDevLXDPending represents a DevLXD token bearer identity for which no token is currently issued.
+// An identity is pending before its first token is issued and again after its most recent token is revoked.
+// It supports fine-grained permissions (so it can be added to groups while pending, allowing the eventual token
+// holder to assume the correct permissions) but is not cacheable, as a pending identity cannot authenticate.
+type TokenBearerDevLXDPending struct {
+	typeInfoCommon
+}
+
+// Name returns the name of the TokenBearerDevLXDPending identity type.
+func (TokenBearerDevLXDPending) Name() string {
+	return api.IdentityTypeBearerTokenDevLXDPending
+}
+
+// Code returns the database code for TokenBearerDevLXDPending.
+func (TokenBearerDevLXDPending) Code() int64 {
+	return identityTypeBearerDevLXDPending
+}
+
+// AuthenticationMethod indicates that identities of this type authenticate via bearer token.
+func (TokenBearerDevLXDPending) AuthenticationMethod() string {
+	return api.AuthenticationMethodBearer
+}
+
+// IsFineGrained indicates that this identity uses fine-grained permissions.
+func (TokenBearerDevLXDPending) IsFineGrained() bool {
+	return true
+}
+
+// IsPending indicates that this identity is pending.
+func (TokenBearerDevLXDPending) IsPending() bool {
+	return true
+}

--- a/lxd/identity/token_bearer_initial_ui.go
+++ b/lxd/identity/token_bearer_initial_ui.go
@@ -40,3 +40,31 @@ func (TokenBearerInitialUI) IsAdmin() bool {
 func (TokenBearerInitialUI) IsCacheable() bool {
 	return true
 }
+
+// TokenBearerInitialUIPending represents an initial UI token bearer identity for which no token is currently issued.
+// An identity is pending before its first token is issued and again after its most recent token is revoked.
+// It is neither an administrator nor cacheable, as a pending identity cannot authenticate.
+// As with [TokenBearerInitialUI], there can only ever be one initial UI identity, whether active or pending.
+type TokenBearerInitialUIPending struct {
+	typeInfoCommon
+}
+
+// Name returns the name of the TokenBearerInitialUIPending identity type.
+func (TokenBearerInitialUIPending) Name() string {
+	return api.IdentityTypeBearerTokenInitialUIPending
+}
+
+// Code returns the database code for TokenBearerInitialUIPending.
+func (TokenBearerInitialUIPending) Code() int64 {
+	return identityTypeBearerInitialUIPending
+}
+
+// AuthenticationMethod indicates that identities of this type authenticate via bearer token.
+func (TokenBearerInitialUIPending) AuthenticationMethod() string {
+	return api.AuthenticationMethodBearer
+}
+
+// IsPending indicates that this identity is pending.
+func (TokenBearerInitialUIPending) IsPending() bool {
+	return true
+}

--- a/lxd/identity/type_interface.go
+++ b/lxd/identity/type_interface.go
@@ -83,6 +83,12 @@ const (
 
 	// identityTypeCertificateClusterLinkPending represents cluster links for which a token has been issued but who have not yet authenticated with a linked LXD cluster.
 	identityTypeCertificateClusterLinkPending int64 = 13
+
+	// identityTypeBearerClientPending is the code for [api.IdentityTypeBearerTokenClientPending].
+	identityTypeBearerClientPending int64 = 14
+
+	// identityTypeBearerDevLXDPending is the code for [api.IdentityTypeBearerTokenDevLXDPending].
+	identityTypeBearerDevLXDPending int64 = 15
 )
 
 // types is a slice of all identity types that implement the [Type] interface.
@@ -98,7 +104,9 @@ var types = []Type{
 	CertificateMetricsUnrestricted{},
 	CertificateServer{},
 	TokenBearerDevLXD{},
+	TokenBearerDevLXDPending{},
 	TokenBearerClient{},
+	TokenBearerClientPending{},
 	TokenBearerInitialUI{},
 }
 

--- a/lxd/identity/type_interface.go
+++ b/lxd/identity/type_interface.go
@@ -83,6 +83,15 @@ const (
 
 	// identityTypeCertificateClusterLinkPending represents cluster links for which a token has been issued but who have not yet authenticated with a linked LXD cluster.
 	identityTypeCertificateClusterLinkPending int64 = 13
+
+	// identityTypeBearerClientPending is the code for [api.IdentityTypeBearerTokenClientPending].
+	identityTypeBearerClientPending int64 = 14
+
+	// identityTypeBearerDevLXDPending is the code for [api.IdentityTypeBearerTokenDevLXDPending].
+	identityTypeBearerDevLXDPending int64 = 15
+
+	// identityTypeBearerInitialUIPending is the code for [api.IdentityTypeBearerTokenInitialUIPending].
+	identityTypeBearerInitialUIPending int64 = 16
 )
 
 // types is a slice of all identity types that implement the [Type] interface.
@@ -98,8 +107,11 @@ var types = []Type{
 	CertificateMetricsUnrestricted{},
 	CertificateServer{},
 	TokenBearerDevLXD{},
+	TokenBearerDevLXDPending{},
 	TokenBearerClient{},
+	TokenBearerClientPending{},
 	TokenBearerInitialUI{},
+	TokenBearerInitialUIPending{},
 }
 
 var nameToType = make(map[string]Type, len(types))

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -16,3 +16,9 @@ func ValidateAuthenticationMethod(authenticationMethod string) error {
 
 	return nil
 }
+
+// IsInitialUIBearer returns true if the given identity type name represents an initial UI token
+// bearer, active or pending.
+func IsInitialUIBearer(identityTypeName string) bool {
+	return identityTypeName == api.IdentityTypeBearerTokenInitialUI || identityTypeName == api.IdentityTypeBearerTokenInitialUIPending
+}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/identity"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -320,7 +321,7 @@ func (c *cmdInit) createUIInitialAccessLink(d lxd.InstanceServer) error {
 		if err != nil {
 			return fmt.Errorf("Failed creating initial UI identity: %w", err)
 		}
-	} else if uiAdminIdentity.Type != api.IdentityTypeBearerTokenInitialUI {
+	} else if !identity.IsInitialUIBearer(uiAdminIdentity.Type) {
 		return fmt.Errorf("A bearer identity with name %q already exists but is not of type %q", uiAdminIdentityName, api.IdentityTypeBearerTokenInitialUI)
 	}
 

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/task"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -47,7 +48,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 
 	var expiredPendingTLSIdentities []cluster.IdentitiesRow
 	if leaderInfo != nil && leaderInfo.Leader {
-		expiredPendingTLSIdentities, err = getExpiredPendingIdentities(ctx, s)
+		expiredPendingTLSIdentities, err = getExpiredPendingTLSIdentities(ctx, s)
 		if err != nil {
 			// Log warning but don't return here so that any local token operations are pruned.
 			logger.Warn("Failed retrieving expired pending TLS identities during removal of expired tokens task", logger.Ctx{"err": err})
@@ -108,19 +109,21 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 	logger.Debug("Done removing expired tokens")
 }
 
-func getExpiredPendingIdentities(ctx context.Context, s *state.State) ([]cluster.IdentitiesRow, error) {
-	// Get a list of pending identity types.
+func getExpiredPendingTLSIdentities(ctx context.Context, s *state.State) ([]cluster.IdentitiesRow, error) {
+	// Get a list of pending TLS identity types. Only a pending TLS identity holds a token secret whose expiry is
+	// recorded in its metadata, so only it can expire and be removed. A pending bearer identity is never removed
+	// automatically, as it holds no token and becomes active again as soon as a token is issued for it.
 	types := identity.Types()
 	args := make([]any, 0, len(types))
 	for _, t := range types {
-		if !t.IsPending() {
+		if !t.IsPending() || t.AuthenticationMethod() != api.AuthenticationMethodTLS {
 			continue
 		}
 
 		args = append(args, cluster.IdentityType(t.Name()))
 	}
 
-	// Query only for pending identities.
+	// Query only for pending TLS identities.
 	var pendingIdentities []cluster.IdentitiesRow
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/task"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -109,18 +110,20 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 }
 
 func getExpiredPendingIdentities(ctx context.Context, s *state.State) ([]cluster.IdentitiesRow, error) {
-	// Get a list of pending identity types.
+	// Get a list of pending TLS identity types. Only a pending TLS identity holds a token secret whose expiry is
+	// recorded in its metadata, so only it can expire and be removed. A pending bearer identity is never removed
+	// automatically, as it holds no token and becomes active again as soon as a token is issued for it.
 	types := identity.Types()
 	args := make([]any, 0, len(types))
 	for _, t := range types {
-		if !t.IsPending() {
+		if !t.IsPending() || t.AuthenticationMethod() != api.AuthenticationMethodTLS {
 			continue
 		}
 
 		args = append(args, cluster.IdentityType(t.Name()))
 	}
 
-	// Query only for pending identities.
+	// Query only for pending TLS identities.
 	var pendingIdentities []cluster.IdentitiesRow
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -48,8 +48,14 @@ const (
 	// IdentityTypeBearerTokenDevLXD represents an identity that bears a LXD token that can be used to interact with the DevLXD API.
 	IdentityTypeBearerTokenDevLXD = "DevLXD token bearer"
 
+	// IdentityTypeBearerTokenDevLXDPending represents a DevLXD token bearer identity for which no token is currently issued, because none has been issued yet or the most recent one was revoked.
+	IdentityTypeBearerTokenDevLXDPending = "DevLXD token bearer (pending)"
+
 	// IdentityTypeBearerTokenClient represents an identity that bears a LXD token that can be used to interact with the LXD API.
 	IdentityTypeBearerTokenClient = "Client token bearer"
+
+	// IdentityTypeBearerTokenClientPending represents a client token bearer identity for which no token is currently issued, because none has been issued yet or the most recent one was revoked.
+	IdentityTypeBearerTokenClientPending = "Client token bearer (pending)"
 
 	// IdentityTypeBearerTokenInitialUI is the identity type used for initial connection to LXD via the UI when conventional authentication is not yet configured.
 	IdentityTypeBearerTokenInitialUI = "Initial UI token bearer"

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -48,11 +48,20 @@ const (
 	// IdentityTypeBearerTokenDevLXD represents an identity that bears a LXD token that can be used to interact with the DevLXD API.
 	IdentityTypeBearerTokenDevLXD = "DevLXD token bearer"
 
+	// IdentityTypeBearerTokenDevLXDPending represents a DevLXD token bearer identity for which no token is currently issued, because none has been issued yet or the most recent one was revoked.
+	IdentityTypeBearerTokenDevLXDPending = "DevLXD token bearer (pending)"
+
 	// IdentityTypeBearerTokenClient represents an identity that bears a LXD token that can be used to interact with the LXD API.
 	IdentityTypeBearerTokenClient = "Client token bearer"
 
+	// IdentityTypeBearerTokenClientPending represents a client token bearer identity for which no token is currently issued, because none has been issued yet or the most recent one was revoked.
+	IdentityTypeBearerTokenClientPending = "Client token bearer (pending)"
+
 	// IdentityTypeBearerTokenInitialUI is the identity type used for initial connection to LXD via the UI when conventional authentication is not yet configured.
 	IdentityTypeBearerTokenInitialUI = "Initial UI token bearer"
+
+	// IdentityTypeBearerTokenInitialUIPending represents an initial UI token bearer identity for which no token is currently issued, because none has been issued yet or the most recent one was revoked.
+	IdentityTypeBearerTokenInitialUIPending = "Initial UI token bearer (pending)"
 
 	// IdentityTypeCertificateClusterLink represents cluster links that authenticate using TLS and whose permissions are managed via group ownership.
 	IdentityTypeCertificateClusterLink = "Cluster link certificate"

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -500,6 +500,7 @@ var APIExtensions = []string{
 	"operation_child_count",
 	"storage_driver_powerstore_nvme",
 	"access_management_expiry",
+	"access_management_bearer_pending",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -502,6 +502,7 @@ var APIExtensions = []string{
 	"access_management_expiry",
 	"cluster_links_public",
 	"durable_operations",
+	"access_management_bearer_pending",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -261,6 +261,8 @@ fine_grained: true"
   lxc auth identity delete tls/tmp
 
   lxc auth identity create devlxd/tmp
+  # A newly created DevLXD bearer identity is pending until a token is issued.
+  [ "$(lxc auth identity show devlxd/tmp | sed -n 's/^type: //p')" = "DevLXD token bearer (pending)" ]
   devlxd_identity_id="$(lxc auth identity list --format csv | grep -F 'DevLXD token bearer' | cut -d, -f4)"
   ! lxc auth group permission add test-group identity "${devlxd_identity_id}" can_view || false # Missing authentication method
   lxc auth group permission add test-group identity "devlxd/${devlxd_identity_id}" can_view # Valid
@@ -281,10 +283,19 @@ fine_grained: true"
   lxc auth identity create bearer/tmp
   tmp_bearer_identity_id="$(lxc auth identity show bearer/tmp | grep "^id:" | cut -d' ' -f2)"
 
-  # A bearer identity with no issued token has no expiry to report.
+  # A bearer identity with no issued token is pending and has no expiry to report.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
   lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
 
+  # Pruning expired tokens must not remove a pending bearer identity, which holds no token and is waiting for one
+  # to be issued, unlike a pending TLS identity whose token secret expires.
+  lxc query --request POST /internal/testing/prune-tokens
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
+
   tmp_bearer_identity_token="$(lxc auth identity token issue bearer/tmp --quiet)"
+
+  # Issuing a token promotes the identity from pending to its active type.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer" ]
 
   # Once a token is issued, the identity reports its expiry when shown, not only via the current identity endpoint.
   # The reported expiry must match the "exp" claim of the issued token exactly, so that the identity and the token
@@ -306,14 +317,22 @@ fine_grained: true"
   lxc auth identity token revoke bearer/tmp
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.error_code == 403'
 
-  # Revoking the token clears the reported expiry, so that a revoked token is not advertised as still valid.
+  # Revoking the token demotes the identity back to its pending type and clears the reported expiry, so that a
+  # revoked token is not advertised as still valid.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
   lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
+
+  # An identity that was demoted to pending by a revocation must also survive token pruning.
+  lxc query --request POST /internal/testing/prune-tokens
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
 
   lxc auth identity delete bearer/tmp
 
   # Ensure DevLXD token cannot be to authenticate with main LXD API.
   lxc auth identity create devlxd/tmp
   devlxd_identity_token="$(lxc auth identity token issue devlxd/tmp --quiet)"
+  # Issuing a token promotes the DevLXD identity to its active type.
+  [ "$(lxc auth identity show devlxd/tmp | sed -n 's/^type: //p')" = "DevLXD token bearer" ]
   curl -s -k -H "Authorization: Bearer ${devlxd_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.error_code == 403'
   lxc auth identity delete devlxd/tmp
 
@@ -473,9 +492,9 @@ fine_grained: true"
 
   # As an admin
   ! lxc query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}" || false
-  [ "$("${_LXC}" query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer"' ]
+  [ "$("${_LXC}" query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer (pending)"' ]
   ! lxc query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" || false
-  [ "$("${_LXC}" query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" 2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer"' ]
+  [ "$("${_LXC}" query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" 2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer (pending)"' ]
   ! lxc query -X PUT /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}" || false
   [ "$("${_LXC}" query -X PUT /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "OIDC client"' ]
   ! lxc query -X PATCH /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\"}" || false

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -319,7 +319,9 @@ fine_grained: true"
   lxc auth identity delete tls/tmp
 
   lxc auth identity create devlxd/tmp
-  devlxd_identity_id="$(lxc auth identity list --format csv | grep -F 'DevLXD token bearer' | cut -d, -f4)"
+  # A newly created DevLXD bearer identity is pending until a token is issued.
+  [ "$(lxc auth identity show devlxd/tmp | sed -n 's/^type: //p')" = "DevLXD token bearer (pending)" ]
+  devlxd_identity_id="$(lxc auth identity show devlxd/tmp | grep "^id:" | cut -d' ' -f2)"
   ! lxc auth group permission add test-group identity "${devlxd_identity_id}" can_view || false # Missing authentication method
   lxc auth group permission add test-group identity "devlxd/${devlxd_identity_id}" can_view # Valid
   lxc auth group permission remove test-group identity "devlxd/${devlxd_identity_id}" can_view
@@ -339,10 +341,19 @@ fine_grained: true"
   lxc auth identity create bearer/tmp
   tmp_bearer_identity_id="$(lxc auth identity show bearer/tmp | grep "^id:" | cut -d' ' -f2)"
 
-  # A bearer identity with no issued token has no expiry to report.
+  # A bearer identity with no issued token is pending and has no expiry to report.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
   lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
 
+  # Pruning expired tokens must not remove a pending bearer identity, which holds no token and is waiting for one
+  # to be issued, unlike a pending TLS identity whose token secret expires.
+  lxc query --request POST /internal/testing/prune-tokens
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
+
   tmp_bearer_identity_token="$(lxc auth identity token issue bearer/tmp --quiet)"
+
+  # Issuing a token promotes the identity from pending to its active type.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer" ]
 
   # Once a token is issued, the identity reports its expiry when shown, not only via the current identity endpoint.
   # The reported expiry must match the "exp" claim of the issued token exactly, so that the identity and the token
@@ -364,14 +375,22 @@ fine_grained: true"
   lxc auth identity token revoke bearer/tmp
   curl -s -k -H "Authorization: Bearer ${tmp_bearer_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.error_code == 403'
 
-  # Revoking the token clears the reported expiry, so that a revoked token is not advertised as still valid.
+  # Revoking the token demotes the identity back to its pending type and clears the reported expiry, so that a
+  # revoked token is not advertised as still valid.
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
   lxc query "/1.0/auth/identities/bearer/${tmp_bearer_identity_id}" | jq --exit-status '.expires_at == null'
+
+  # An identity that was demoted to pending by a revocation must also survive token pruning.
+  lxc query --request POST /internal/testing/prune-tokens
+  [ "$(lxc auth identity show bearer/tmp | sed -n 's/^type: //p')" = "Client token bearer (pending)" ]
 
   lxc auth identity delete bearer/tmp
 
   # Ensure DevLXD token cannot be to authenticate with main LXD API.
   lxc auth identity create devlxd/tmp
   devlxd_identity_token="$(lxc auth identity token issue devlxd/tmp --quiet)"
+  # Issuing a token promotes the DevLXD identity to its active type.
+  [ "$(lxc auth identity show devlxd/tmp | sed -n 's/^type: //p')" = "DevLXD token bearer" ]
   curl -s -k -H "Authorization: Bearer ${devlxd_identity_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.error_code == 403'
   lxc auth identity delete devlxd/tmp
 
@@ -531,9 +550,9 @@ fine_grained: true"
 
   # As an admin
   ! lxc query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}" || false
-  [ "$("${_LXC}" query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer"' ]
+  [ "$("${_LXC}" query -X PUT /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer (pending)"' ]
   ! lxc query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" || false
-  [ "$("${_LXC}" query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" 2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer"' ]
+  [ "$("${_LXC}" query -X PATCH /1.0/auth/identities/bearer/test-bearer -d "{\"tls_certificate\":\"${user6_cert}\"}" 2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "DevLXD token bearer (pending)"' ]
   ! lxc query -X PUT /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}" || false
   [ "$("${_LXC}" query -X PUT /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\",\"name\":\" \",\"identifier\":\"test-user@example.com\"}"  2>&1 >/dev/null)" = 'Error: Cannot update certificate for identities of type "OIDC client"' ]
   ! lxc query -X PATCH /1.0/auth/identities/oidc/test-user@example.com -d "{\"tls_certificate\":\"${user6_cert}\"}" || false
@@ -1978,6 +1997,9 @@ test_ui_initial_access_link() {
   echo "==> Test initial UI access link"
   lxd init --ui-initial-access-link
 
+  # Issuing the initial UI token promotes the identity from pending to its active type.
+  [ "$(lxc auth identity show bearer/ui-admin-initial | sed -n 's/^type: //p')" = "Initial UI token bearer" ]
+
   # Regenerate while identity already exists.
   lxd init --ui-initial-access-link
 
@@ -2081,6 +2103,10 @@ test_ui_initial_access_link() {
 
   echo "==> Testing revoked token access"
   lxc auth identity token revoke bearer/ui-admin-initial
+
+  # Revoking the token demotes the identity back to its pending type.
+  [ "$(lxc auth identity show bearer/ui-admin-initial | sed -n 's/^type: //p')" = "Initial UI token bearer (pending)" ]
+
   loginOutput=$(curl -s -k -i -H "User-Agent: Mozilla" "${url}")
 
   if grep -q "token_bearer_session=" <<< "${loginOutput}"; then
@@ -2096,6 +2122,10 @@ test_ui_initial_access_link() {
 
   # Ensure access is forbidden when using the revoked token.
   curl -s -k -H "User-Agent: Mozilla" -H "Cookie: token_bearer_session=${cookie}" "https://${LXD_ADDR}/1.0/auth/identities/current" | jq --exit-status '.error_code == 403'
+
+  # Regenerate while the identity is pending, which is the state a revoked token leaves it in.
+  lxd init --ui-initial-access-link
+  [ "$(lxc auth identity show bearer/ui-admin-initial | sed -n 's/^type: //p')" = "Initial UI token bearer" ]
 
   # Cleanup.
   lxc auth identity delete bearer/ui-admin-initial


### PR DESCRIPTION
Bearer identities (client, DevLXD, and initial UI) currently look identical whether or not a token has actually been issued for them. This adds three new identity types, `Client token bearer (pending)`, `DevLXD token bearer (pending)`, and `Initial UI bearer (pending)` so that a bearer identity without a currently issued token is distinguishable from an active one.

The driver is to allow LXD UI to figure out when a bearer identity has a token associated with it and provide issue/revoke actions accordingly.

The reason for using pending identity type is consistency with pending TLS identities, which can not be used to authenticate, but can have auth groups associated with them.

Behaviour:
- A bearer identity is created in the pending state, since no token exists for it yet.
- Issuing a token promotes it to the active type. Revoking the token demotes it back to pending.
- **An expired (but not revoked) token leaves the identity active.**
- Pending bearer types are fine-grained, so they can be added to groups while pending. Similarly, they retain all settings when demoted from an active to pending.
- Automatic pruning of expired pending identities applies only to TLS identities. Pending bearer identities have no token to expire and are never pruned.

A cluster DB patch converts existing bearer identities with no signing key to their pending type. Identities that still hold a signing key remain active. 

API extension `access_management_bearer_pending`.