### PR TITLE
Extract standby replica project write-guard into a shared helper

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1468,29 +1468,9 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Only replicator runs from the configured cluster link (or internal cluster
-		// notifications forwarded by the coordinator) can create instances in a standby
-		// replica project.
-		if targetProject.ReplicaMode == api.ReplicatorProjectModeStandby && !clusterNotification {
-			expectedCluster := targetProject.Config["replica.cluster"]
-
-			// Verify the request comes from the configured cluster link identity.
-			clusterLink, err := dbCluster.GetClusterLink(ctx, tx.Tx(), expectedCluster)
-			if err != nil {
-				if api.StatusErrorCheck(err, http.StatusNotFound) {
-					return api.StatusErrorf(http.StatusForbidden, "Cannot create instances in a standby replica project")
-				}
-
-				return fmt.Errorf("Failed loading cluster link %q: %w", expectedCluster, err)
-			}
-
-			// Only allow the expected cluster link identity to create instances in the standby replica project.
-			// We can check this using the requestor identity ID, since cluster links always communicate using a named
-			// TLS identity. We need to ensure the identity is not nil - since it can be nil for admin protocols.
-			// (Admins are not allowed to create instances in this project while it is in standby either).
-			if requestor.IdentityID == nil || *requestor.IdentityID != *clusterLink.IdentityID {
-				return api.StatusErrorf(http.StatusForbidden, "Cannot create instances in a standby replica project")
-			}
+		err = project.CheckStandbyReplica(ctx, tx, targetProject, requestor)
+		if err != nil {
+			return err
 		}
 
 		var allMembers []db.NodeInfo

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -2,11 +2,16 @@ package project
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/db"
+	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
@@ -34,6 +39,47 @@ func CheckRestrictedDevicesDiskPaths(projectConfig map[string]string, sourcePath
 	}
 
 	return false, ""
+}
+
+// CheckStandbyReplica returns a Forbidden error when the project is a standby replica and the
+// requestor is not the identity of the cluster link named by replica.cluster. It is a no-op for
+// cluster notifications and for projects that are not in standby mode.
+func CheckStandbyReplica(ctx context.Context, tx *db.ClusterTx, targetProject *api.Project, requestor *request.Requestor) error {
+	// Only replicator runs from the configured cluster link (or internal cluster
+	// notifications forwarded by the coordinator) can write to a standby replica
+	// project.
+	if targetProject.ReplicaMode != api.ReplicatorProjectModeStandby || requestor.IsClusterNotification() {
+		return nil
+	}
+
+	// A project can be force demoted to standby without replica.cluster set, which leaves no
+	// identity that is allowed to write to it.
+	expectedCluster := targetProject.Config["replica.cluster"]
+	if expectedCluster == "" {
+		return api.StatusErrorf(http.StatusForbidden, "Cannot write to a standby replica project")
+	}
+
+	// Verify the request comes from the configured cluster link identity.
+	clusterLink, err := cluster.GetClusterLink(ctx, tx.Tx(), expectedCluster)
+	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return api.StatusErrorf(http.StatusForbidden, "Cannot write to a standby replica project")
+		}
+
+		return fmt.Errorf("Failed loading cluster link %q: %w", expectedCluster, err)
+	}
+
+	// Only allow the expected cluster link identity to write to the standby replica project.
+	// We can check this using the requestor identity ID, since cluster links always communicate using a named
+	// TLS identity. We need to ensure the identity is not nil - since it can be nil for admin protocols.
+	// (Admins are not allowed to write to this project while it is in standby either).
+	// The cluster link identity can also be nil, for example a unidirectional link stored on the initiating
+	// side has no local identity, so treat that as forbidden rather than dereferencing a nil identity.
+	if requestor.IdentityID == nil || clusterLink.IdentityID == nil || *requestor.IdentityID != *clusterLink.IdentityID {
+		return api.StatusErrorf(http.StatusForbidden, "Cannot write to a standby replica project")
+	}
+
+	return nil
 }
 
 // FilterUsedBy filters a UsedBy list based on the entities that the requestor is able to view.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Description

Refactor. The standby replica project write-guard was inline in `instances_post.go`. Extract it into `checkStandbyReplicaProjectWriteGuard` in `api_replicators.go` so other create paths can reuse, it stays a no-op for cluster notifications and non-standby projects, and otherwise only the configured cluster link identity may create instances.

Split out of #18456 per review.