### PR TITLE
Fix cluster link docs

### DIFF
--- a/doc/howto/cluster_links_manage.md
+++ b/doc/howto/cluster_links_manage.md
@@ -79,10 +79,10 @@ Alternatively, for bidirectional links you can specify an authentication group w
 lxc cluster link create <cluster-link-name> --auth-group <group name>
 ```
 
-For unidirectional links, `--auth-group` is not supported on the initiating cluster (Cluster A has no identity for B). Specify the auth group on the target cluster (Cluster B) when issuing the identity token:
+For unidirectional links, `--auth-group` is not supported on the initiating cluster (Cluster A has no identity for B) when running `lxc cluster link create`. Instead, specify the authentication group on the target cluster (Cluster B) with `--group` when issuing the identity token with `lxc auth identity create`:
 
 ```bash
-lxc auth identity create cluster-link/<name-for-cluster-a> --auth-group <group name>
+lxc auth identity create cluster-link/<name-for-cluster-a> --group <group name>
 ```
 
 (howto-cluster-links-configure)=


### PR DESCRIPTION
The docs give a broken example here:

```
root@latest-edge:~# lxc auth identity create cluster-link/linky --auth-group admins
Error: unknown flag: --auth-group
```

Instead for identity creation the argument is named `group` without the `auth` prefix:

```
root@latest-edge:~# lxc auth identity create cluster-link/linky --group admins
Cluster link "linky" (945f665b-b6f3-46ec-acf5-0314702b2a42) pending identity token:
...
```

I would like the arguments to be the same, that would be much more learnable for a user.