### PR TITLE
doc/redirects.py: add redirect for 6.9

### DIFF
--- a/doc/redirects.py
+++ b/doc/redirects.py
@@ -11,4 +11,5 @@ redirects = {
     'reference/release-notes/release-notes-6.7': '../6/release-notes-6.7',
     'reference/release-notes/release-notes-6.8': '../6/release-notes-6.8',
     'reference/release-notes/release-notes-6.9': '../6/release-notes-6.9',
+    'reference/release-notes/6-feature/release-notes-6.9': '../../6/release-notes-6.9',
 }


### PR DESCRIPTION
When the release notes were reorganized (see
https://github.com/canonical/lxd/issues/18574), LXD 6 release notes were briefly placed in a `6-feature` directory, before the notes were reorganized into a `6` directory. Analytics show that, since the reorganization, some users are using the `6-feature` URL for the LXD 6.9 release notes and landing on 404 pages. This commit adds a redirect to the active `6` path.

