### PR TITLE
doc: backport to implement sphinx-llm to generate llms.txt (stable-5.21)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,7 +19,7 @@ CONFIRM_SUDO    ?= N
 VALE_CONFIG     = $(SPHINXDIR)/vale.ini
 VALEDIR         = $(VENVDIR)/lib/python*/site-packages/vale
 VOCAB_CANONICAL = $(SPHINXDIR)/styles/config/vocabularies/Canonical
-VALE_GLOB       := --glob='!{.sphinx/**,reference/manpages/**}'
+VALE_GLOB       := --glob='!{.sphinx/**,reference/manpages/**,_build/**}'
 SPHINX_HOST     ?= 127.0.0.1
 SPHINX_PORT     ?= 8000
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,7 @@ SPHINXBUILD     ?= $(VENVDIR)/bin/sphinx-build
 SOURCEDIR       = .
 BUILDDIR        = _build
 MANPAGEDIR      = reference/manpages
+SPHINX_AUTOBUILD_OPTS ?= -D=llms_txt_enabled=0
 VENVDIR         = $(SPHINXDIR)/venv
 PA11Y           = $(SPHINXDIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINXDIR)/pa11y.json
 VENV            = $(VENVDIR)/bin/activate
@@ -82,7 +83,7 @@ client:
 install: $(VENVDIR) client
 
 run: install
-	export LOCAL_SPHINX_BUILD=True && . $(VENV) && sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(SOURCEDIR)" "$(BUILDDIR)" --ignore '$(SPHINXDIR)/deps/manpages/*' $(SPHINXOPTS)
+	export LOCAL_SPHINX_BUILD=True && . $(VENV) && sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(SOURCEDIR)" "$(BUILDDIR)" --ignore '$(SPHINXDIR)/deps/manpages/*' $(SPHINXOPTS) $(SPHINX_AUTOBUILD_OPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 # If the target is html-rtd, uses LOCAL_SPHINX_BUILD=False; True otherwise (for target html)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import yaml
+import textwrap
 
 ############################
 # LXD custom initializations #
@@ -156,6 +157,21 @@ templates_path = ['_templates']
 # NOTE: The above line is commented out because LXD imports redirects from redirects.py
 # instead of setting it here
 
+############################
+# sphinx-llm configuration #
+############################
+
+# This description is included in llms.txt to provide some initial context for your
+# product docs.
+llms_txt_description = textwrap.dedent(
+    """\
+    This is the documentation for LXD, a system container and virtual machine manager.
+    """
+)
+
+# The base URL for references built by sphinx-markdown-builder.
+if os.environ.get("READTHEDOCS"):
+    markdown_http_base = html_baseurl
 
 ###########################
 # Link checker exceptions #
@@ -224,6 +240,7 @@ extensions = [
     'sphinxcontrib.jquery',
     'sphinxext.opengraph',
     'sphinx_config_options',
+    'sphinx_llm.txt',
     'sphinx_related_links',
     'sphinx_roles',
     'sphinx_terminal',

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -25,6 +25,7 @@ packaging==26.0
 sphinxcontrib-svg2pdfconverter[CairoSVG]==2.0.0
 sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
+sphinx-llm~=0.4
 
 ## Vale dependencies 
 vale==3.13.0


### PR DESCRIPTION
Backports PR #18272 to implement a Sphinx extension to auto-generate llms.txt and llms-full.txt files from the documentation. These files make it easier for LLMs to work with the docs. Documentation for this extension can be found at https://sphinx-llms-txt.readthedocs.io/en/latest/.

This backport does not include a commit from the original PR that updated a doc cheatsheet removed from the docs in #18310.