### PR TITLE
lxc/auth: Show identity expiry when listing identities

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -1088,6 +1089,7 @@ func (c *cmdIdentityList) columns() []cli.ShorthandColumn[api.Identity] {
 		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
 		{Shorthand: 'i', Name: "IDENTIFIER", Data: c.identifierColumnData},
 		{Shorthand: 'g', Name: "GROUPS", Data: c.groupsColumnData},
+		{Shorthand: 'e', Name: "EXPIRY", Data: c.expiryColumnData},
 	}
 }
 
@@ -1167,6 +1169,11 @@ func (c *cmdIdentityList) groupsColumnData(identity api.Identity) string {
 	}
 
 	return strings.Join(identity.Groups, delimiter)
+}
+
+func (c *cmdIdentityList) expiryColumnData(identity api.Identity) string {
+	// Certificate not after times are typically displayed in UTC.
+	return formatTime(identity.ExpiresAt, time.UTC)
 }
 
 // Show.

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1088,6 +1088,7 @@ func (c *cmdIdentityList) columns() []cli.ShorthandColumn[api.Identity] {
 		{Shorthand: 'n', Name: "NAME", Data: c.nameColumnData},
 		{Shorthand: 'i', Name: "IDENTIFIER", Data: c.identifierColumnData},
 		{Shorthand: 'g', Name: "GROUPS", Data: c.groupsColumnData},
+		{Shorthand: 'e', Name: "EXPIRY", Data: c.expiryColumnData},
 	}
 }
 
@@ -1167,6 +1168,10 @@ func (c *cmdIdentityList) groupsColumnData(identity api.Identity) string {
 	}
 
 	return strings.Join(identity.Groups, delimiter)
+}
+
+func (c *cmdIdentityList) expiryColumnData(identity api.Identity) string {
+	return formatTime(identity.ExpiresAt)
 }
 
 // Show.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	yaml "go.yaml.in/yaml/v2"
@@ -1052,7 +1053,7 @@ func (c *cmdClusterListTokens) run(cmd *cobra.Command, args []string) error {
 		displayTokens = append(displayTokens, displayToken{
 			ServerName: joinToken.ServerName,
 			Token:      joinToken.String(),
-			ExpiresAt:  joinToken.ExpiresAt.Format("2006/01/02 15:04 MST"),
+			ExpiresAt:  formatTime(&joinToken.ExpiresAt, time.Local),
 		})
 	}
 

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1052,7 +1052,7 @@ func (c *cmdClusterListTokens) run(cmd *cobra.Command, args []string) error {
 		displayTokens = append(displayTokens, displayToken{
 			ServerName: joinToken.ServerName,
 			Token:      joinToken.String(),
-			ExpiresAt:  joinToken.ExpiresAt.Format("2006/01/02 15:04 MST"),
+			ExpiresAt:  formatTime(&joinToken.ExpiresAt),
 		})
 	}
 

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
@@ -415,14 +416,14 @@ func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		const layout = "Jan 2, 2006 at 3:04pm (MST)"
 		entries = append(entries, trustEntry{
 			certType:    cert.Type,
 			name:        cert.Name,
 			commonName:  tlsCert.Subject.CommonName,
 			fingerprint: fp,
-			issueDate:   tlsCert.NotBefore.Format(layout),
-			expiryDate:  tlsCert.NotAfter.Format(layout),
+			// Certificate not after/before times are typically displayed in UTC.
+			issueDate:  formatTime(&tlsCert.NotBefore, time.UTC),
+			expiryDate: formatTime(&tlsCert.NotAfter, time.UTC),
 		})
 	}
 
@@ -544,17 +545,10 @@ func (c *cmdConfigTrustListTokens) run(cmd *cobra.Command, args []string) error 
 			continue // Operation is not a valid certificate add token operation.
 		}
 
-		var expiresAt string
-
-		// Only show the expiry date if available, otherwise show an empty string.
-		if joinToken.ExpiresAt.Unix() > 0 {
-			expiresAt = joinToken.ExpiresAt.Format("2006/01/02 15:04 MST")
-		}
-
 		displayTokens = append(displayTokens, displayToken{
 			ClientName: joinToken.ClientName,
 			Token:      joinToken.String(),
-			ExpiresAt:  expiresAt,
+			ExpiresAt:  formatTime(&joinToken.ExpiresAt, time.Local),
 		})
 	}
 

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -415,14 +415,13 @@ func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		const layout = "Jan 2, 2006 at 3:04pm (MST)"
 		entries = append(entries, trustEntry{
 			certType:    cert.Type,
 			name:        cert.Name,
 			commonName:  tlsCert.Subject.CommonName,
 			fingerprint: fp,
-			issueDate:   tlsCert.NotBefore.Format(layout),
-			expiryDate:  tlsCert.NotAfter.Format(layout),
+			issueDate:   formatTime(&tlsCert.NotBefore),
+			expiryDate:  formatTime(&tlsCert.NotAfter),
 		})
 	}
 
@@ -544,17 +543,10 @@ func (c *cmdConfigTrustListTokens) run(cmd *cobra.Command, args []string) error 
 			continue // Operation is not a valid certificate add token operation.
 		}
 
-		var expiresAt string
-
-		// Only show the expiry date if available, otherwise show an empty string.
-		if joinToken.ExpiresAt.Unix() > 0 {
-			expiresAt = joinToken.ExpiresAt.Format("2006/01/02 15:04 MST")
-		}
-
 		displayTokens = append(displayTokens, displayToken{
 			ClientName: joinToken.ClientName,
 			Token:      joinToken.String(),
-			ExpiresAt:  expiresAt,
+			ExpiresAt:  formatTime(&joinToken.ExpiresAt),
 		})
 	}
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
@@ -1026,24 +1027,11 @@ func (c *cmdImageInfo) run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Public: %s\n", public)
 	fmt.Print("Timestamps:\n")
 
-	const layout = "2006/01/02 15:04 UTC"
-	if shared.TimeIsSet(info.CreatedAt) {
-		fmt.Printf("    Created: %s\n", info.CreatedAt.UTC().Format(layout))
-	}
-
-	fmt.Printf("    Uploaded: %s\n", info.UploadedAt.UTC().Format(layout))
-
-	if shared.TimeIsSet(info.ExpiresAt) {
-		fmt.Printf("    Expires: %s\n", info.ExpiresAt.UTC().Format(layout))
-	} else {
-		fmt.Print("    Expires: never\n")
-	}
-
-	if shared.TimeIsSet(info.LastUsedAt) {
-		fmt.Printf("    Last used: %s\n", info.LastUsedAt.UTC().Format(layout))
-	} else {
-		fmt.Print("    Last used: never\n")
-	}
+	timeFallback := "never"
+	printTimeIfSet(os.Stdout, "    Created:", &info.CreatedAt, nil, time.Local)
+	printTimeIfSet(os.Stdout, "    Uploaded:", &info.UploadedAt, nil, time.Local)
+	printTimeIfSet(os.Stdout, "    Expires:", &info.ExpiresAt, &timeFallback, time.Local)
+	printTimeIfSet(os.Stdout, "    Last used:", &info.LastUsedAt, &timeFallback, time.Local)
 
 	fmt.Println("Properties:")
 	for key, value := range info.Properties {
@@ -1216,7 +1204,7 @@ func (c *cmdImageList) typeColumnData(image api.Image) string {
 }
 
 func (c *cmdImageList) uploadDateColumnData(image api.Image) string {
-	return image.UploadedAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&image.UploadedAt, time.Local)
 }
 
 func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -983,21 +983,20 @@ func (c *cmdImageInfo) run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Public: %s\n", public)
 	fmt.Print("Timestamps:\n")
 
-	const layout = "2006/01/02 15:04 UTC"
 	if shared.TimeIsSet(info.CreatedAt) {
-		fmt.Printf("    Created: %s\n", info.CreatedAt.UTC().Format(layout))
+		fmt.Printf("    Created: %s\n", formatTime(&info.CreatedAt))
 	}
 
-	fmt.Printf("    Uploaded: %s\n", info.UploadedAt.UTC().Format(layout))
+	fmt.Printf("    Uploaded: %s\n", formatTime(&info.UploadedAt))
 
 	if shared.TimeIsSet(info.ExpiresAt) {
-		fmt.Printf("    Expires: %s\n", info.ExpiresAt.UTC().Format(layout))
+		fmt.Printf("    Expires: %s\n", formatTime(&info.ExpiresAt))
 	} else {
 		fmt.Print("    Expires: never\n")
 	}
 
 	if shared.TimeIsSet(info.LastUsedAt) {
-		fmt.Printf("    Last used: %s\n", info.LastUsedAt.UTC().Format(layout))
+		fmt.Printf("    Last used: %s\n", formatTime(&info.LastUsedAt))
 	} else {
 		fmt.Print("    Last used: never\n")
 	}
@@ -1167,7 +1166,7 @@ func (c *cmdImageList) typeColumnData(image api.Image) string {
 }
 
 func (c *cmdImageList) uploadDateColumnData(image api.Image) string {
-	return image.UploadedAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&image.UploadedAt)
 }
 
 func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
@@ -465,8 +467,6 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", inst.Name)
 
 	fmt.Printf("Status: %s\n", strings.ToUpper(inst.Status))
@@ -491,13 +491,8 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 		fmt.Printf("PID: %d\n", inst.State.Pid)
 	}
 
-	if shared.TimeIsSet(inst.CreatedAt) {
-		fmt.Printf("Created: %s\n", inst.CreatedAt.Local().Format(layout))
-	}
-
-	if shared.TimeIsSet(inst.LastUsedAt) {
-		fmt.Printf("Last Used: %s\n", inst.LastUsedAt.Local().Format(layout))
-	}
+	printTimeIfSet(os.Stdout, "Created:", &inst.CreatedAt, nil, time.Local)
+	printTimeIfSet(os.Stdout, "Last used:", &inst.LastUsedAt, nil, time.Local)
 
 	if inst.State.Pid != 0 {
 		fmt.Println("\nResources:")
@@ -626,19 +621,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 			var row []string
 
 			fields := strings.Split(snap.Name, shared.SnapshotDelimiter)
-			row = append(row, fields[len(fields)-1])
-
-			if shared.TimeIsSet(snap.CreatedAt) {
-				row = append(row, snap.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(snap.ExpiresAt) {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, fields[len(fields)-1], formatTime(&snap.CreatedAt, time.Local), formatTime(&snap.ExpiresAt, time.Local))
 
 			if snap.Stateful {
 				row = append(row, "YES")
@@ -722,19 +705,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 			}
 
 			var row []string
-			row = append(row, backup.Name)
-
-			if shared.TimeIsSet(backup.CreatedAt) {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(backup.ExpiresAt) {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, backup.Name, formatTime(&backup.CreatedAt, time.Local), formatTime(&backup.ExpiresAt, time.Local))
 
 			if backup.InstanceOnly {
 				row = append(row, "YES")

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -465,8 +465,6 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", inst.Name)
 
 	fmt.Printf("Status: %s\n", strings.ToUpper(inst.Status))
@@ -492,11 +490,11 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 	}
 
 	if shared.TimeIsSet(inst.CreatedAt) {
-		fmt.Printf("Created: %s\n", inst.CreatedAt.Local().Format(layout))
+		fmt.Printf("Created: %s\n", formatTime(&inst.CreatedAt))
 	}
 
 	if shared.TimeIsSet(inst.LastUsedAt) {
-		fmt.Printf("Last Used: %s\n", inst.LastUsedAt.Local().Format(layout))
+		fmt.Printf("Last Used: %s\n", formatTime(&inst.LastUsedAt))
 	}
 
 	if inst.State.Pid != 0 {
@@ -626,19 +624,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 			var row []string
 
 			fields := strings.Split(snap.Name, shared.SnapshotDelimiter)
-			row = append(row, fields[len(fields)-1])
-
-			if shared.TimeIsSet(snap.CreatedAt) {
-				row = append(row, snap.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(snap.ExpiresAt) {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, fields[len(fields)-1], formatTime(&snap.CreatedAt), formatTime(&snap.ExpiresAt))
 
 			if snap.Stateful {
 				row = append(row, "YES")
@@ -722,19 +708,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 			}
 
 			var row []string
-			row = append(row, backup.Name)
-
-			if shared.TimeIsSet(backup.CreatedAt) {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(backup.ExpiresAt) {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, backup.Name, formatTime(&backup.CreatedAt), formatTime(&backup.ExpiresAt))
 
 			if backup.InstanceOnly {
 				row = append(row, "YES")

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -10,12 +10,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/units"
@@ -930,23 +930,11 @@ func (c *cmdList) profilesColumnData(cInfo api.InstanceFull) string {
 }
 
 func (c *cmdList) createdColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
-	if shared.TimeIsSet(cInfo.CreatedAt) {
-		return cInfo.CreatedAt.UTC().Format(layout)
-	}
-
-	return ""
+	return formatTime(&cInfo.CreatedAt, time.Local)
 }
 
 func (c *cmdList) lastUsedColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
-	if !cInfo.LastUsedAt.IsZero() && shared.TimeIsSet(cInfo.LastUsedAt) {
-		return cInfo.LastUsedAt.UTC().Format(layout)
-	}
-
-	return ""
+	return formatTime(&cInfo.LastUsedAt, time.Local)
 }
 
 func (c *cmdList) numberOfProcessesColumnData(cInfo api.InstanceFull) string {

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/units"
@@ -930,23 +929,11 @@ func (c *cmdList) profilesColumnData(cInfo api.InstanceFull) string {
 }
 
 func (c *cmdList) createdColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
-	if shared.TimeIsSet(cInfo.CreatedAt) {
-		return cInfo.CreatedAt.UTC().Format(layout)
-	}
-
-	return ""
+	return formatTime(&cInfo.CreatedAt)
 }
 
 func (c *cmdList) lastUsedColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
-	if !cInfo.LastUsedAt.IsZero() && shared.TimeIsSet(cInfo.LastUsedAt) {
-		return cInfo.LastUsedAt.UTC().Format(layout)
-	}
-
-	return ""
+	return formatTime(&cInfo.LastUsedAt)
 }
 
 func (c *cmdList) numberOfProcessesColumnData(cInfo api.InstanceFull) string {

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v2"
@@ -218,7 +219,7 @@ func (c *cmdOperationList) cancelableColumnData(op api.Operation) string {
 }
 
 func (c *cmdOperationList) createdColumnData(op api.Operation) string {
-	return op.CreatedAt.UTC().Format("2006/01/02 15:04 UTC")
+	return formatTime(&op.CreatedAt, time.Local)
 }
 
 func (c *cmdOperationList) locationColumnData(op api.Operation) string {

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -218,7 +218,7 @@ func (c *cmdOperationList) cancelableColumnData(op api.Operation) string {
 }
 
 func (c *cmdOperationList) createdColumnData(op api.Operation) string {
-	return op.CreatedAt.UTC().Format("2006/01/02 15:04 UTC")
+	return formatTime(&op.CreatedAt)
 }
 
 func (c *cmdOperationList) locationColumnData(op api.Operation) string {

--- a/lxc/replicator.go
+++ b/lxc/replicator.go
@@ -356,20 +356,13 @@ func (c *cmdReplicatorList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	data := [][]string{}
 	for _, replicator := range replicators {
 		details := []string{
 			replicator.Name,
 			replicator.Description,
 			replicator.Config["cluster"],
-		}
-
-		if shared.TimeIsSet(replicator.LastRunAt) {
-			details = append(details, replicator.LastRunAt.Local().Format(layout))
-		} else {
-			details = append(details, "")
+			formatTime(&replicator.LastRunAt, time.Local),
 		}
 
 		data = append(data, details)
@@ -849,8 +842,6 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 
 	sort.Strings(instanceNames)
 
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", replicator.Name)
 	if replicator.Description != "" {
 		fmt.Printf("Description: %s\n", replicator.Description)
@@ -865,7 +856,7 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if shared.TimeIsSet(replicator.LastRunAt) {
-		fmt.Printf("Last run: %s\n", replicator.LastRunAt.Local().Format(layout))
+		fmt.Printf("Last run: %s\n", formatTime(&replicator.LastRunAt, time.Local))
 	}
 
 	if schedule != "" {
@@ -883,9 +874,7 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if !nextRun.IsZero() {
-			fmt.Printf("Next run: %s\n", nextRun.Local().Format(layout))
-		}
+		printTimeIfSet(os.Stdout, "Next run:", &nextRun, nil, time.Local)
 	}
 
 	// Render instances as a table.

--- a/lxc/replicator.go
+++ b/lxc/replicator.go
@@ -356,20 +356,13 @@ func (c *cmdReplicatorList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	data := [][]string{}
 	for _, replicator := range replicators {
 		details := []string{
 			replicator.Name,
 			replicator.Description,
 			replicator.Config["cluster"],
-		}
-
-		if shared.TimeIsSet(replicator.LastRunAt) {
-			details = append(details, replicator.LastRunAt.Local().Format(layout))
-		} else {
-			details = append(details, "")
+			formatTime(&replicator.LastRunAt),
 		}
 
 		data = append(data, details)
@@ -849,8 +842,6 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 
 	sort.Strings(instanceNames)
 
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", replicator.Name)
 	if replicator.Description != "" {
 		fmt.Printf("Description: %s\n", replicator.Description)
@@ -865,7 +856,7 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if shared.TimeIsSet(replicator.LastRunAt) {
-		fmt.Printf("Last run: %s\n", replicator.LastRunAt.Local().Format(layout))
+		fmt.Printf("Last run: %s\n", formatTime(&replicator.LastRunAt))
 	}
 
 	if schedule != "" {
@@ -884,7 +875,7 @@ func (c *cmdReplicatorInfo) run(cmd *cobra.Command, args []string) error {
 		}
 
 		if !nextRun.IsZero() {
-			fmt.Printf("Next run: %s\n", nextRun.Local().Format(layout))
+			fmt.Printf("Next run: %s\n", formatTime(&replicator.LastRunAt))
 		}
 	}
 

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1469,8 +1469,6 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the overview.
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", vol.Name)
 	if vol.Description != "" {
 		fmt.Printf("Description: %s\n", vol.Description)
@@ -1503,7 +1501,7 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if shared.TimeIsSet(vol.CreatedAt) {
-		fmt.Printf("Created: %s\n", vol.CreatedAt.Local().Format(layout))
+		fmt.Printf("Created: %s\n", formatTime(&vol.CreatedAt, time.Local))
 	}
 
 	// List snapshots
@@ -1516,16 +1514,8 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 				fmt.Println("\nSnapshots:")
 			}
 
-			var row []string
-
 			fields := strings.Split(snap.Name, shared.SnapshotDelimiter)
-			row = append(row, fields[len(fields)-1], snap.Description)
-
-			if snap.ExpiresAt != nil {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row := []string{fields[len(fields)-1], snap.Description, formatTime(snap.ExpiresAt, time.Local)}
 
 			firstSnapshot = false
 			snapData = append(snapData, row)
@@ -1552,19 +1542,7 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 			}
 
 			var row []string
-			row = append(row, backup.Name)
-
-			if shared.TimeIsSet(backup.CreatedAt) {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(backup.ExpiresAt) {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, backup.Name, formatTime(&backup.CreatedAt, time.Local), formatTime(&backup.ExpiresAt, time.Local))
 
 			if backup.VolumeOnly {
 				row = append(row, "YES")

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1469,8 +1469,6 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the overview.
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf("Name: %s\n", vol.Name)
 	if vol.Description != "" {
 		fmt.Printf("Description: %s\n", vol.Description)
@@ -1503,7 +1501,7 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if shared.TimeIsSet(vol.CreatedAt) {
-		fmt.Printf("Created: %s\n", vol.CreatedAt.Local().Format(layout))
+		fmt.Printf("Created: %s\n", formatTime(&vol.CreatedAt))
 	}
 
 	// List snapshots
@@ -1516,16 +1514,8 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 				fmt.Println("\nSnapshots:")
 			}
 
-			var row []string
-
 			fields := strings.Split(snap.Name, shared.SnapshotDelimiter)
-			row = append(row, fields[len(fields)-1], snap.Description)
-
-			if snap.ExpiresAt != nil {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row := []string{fields[len(fields)-1], snap.Description, formatTime(snap.ExpiresAt)}
 
 			firstSnapshot = false
 			snapData = append(snapData, row)
@@ -1552,19 +1542,7 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 			}
 
 			var row []string
-			row = append(row, backup.Name)
-
-			if shared.TimeIsSet(backup.CreatedAt) {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
-
-			if shared.TimeIsSet(backup.ExpiresAt) {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
-			} else {
-				row = append(row, " ")
-			}
+			row = append(row, backup.Name, formatTime(&backup.CreatedAt), formatTime(&backup.ExpiresAt))
 
 			if backup.VolumeOnly {
 				row = append(row, "YES")

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -13,12 +13,19 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/termios"
+)
+
+const (
+	// timeLayout is the layout for all [time.Time] values displayed by the CLI when using the table output or other
+	// custom outputs that are not raw JSON/Yaml.
+	timeLayout = "2006/01/02 15:04 MST"
 )
 
 // Batch operations.
@@ -601,4 +608,39 @@ func entityNameFromURL(urlStr string) (string, error) {
 	}
 
 	return name, nil
+}
+
+// printTimeIfSet writes the given time to the given writer with the given location. If no time is set, the fallback will
+// be written (if set). The prefix is space separated from the time and a newline is appended.
+func printTimeIfSet(writer io.Writer, prefix string, t *time.Time, fallback *string, location *time.Location) {
+	tStr := formatTime(t, location)
+	if tStr == "" {
+		if fallback == nil {
+			return
+		}
+
+		tStr = *fallback
+	}
+
+	// Space separate time from prefix if set.
+	if prefix != "" {
+		prefix += " "
+	}
+
+	_, _ = writer.Write([]byte(prefix + tStr + "\n"))
+}
+
+// formatTime returns the given time formatted such that displayed times are consistent across the CLI.
+func formatTime(t *time.Time, location *time.Location) string {
+	// Times are only displayed if available and set.
+	if t == nil || !shared.TimeIsSet(*t) {
+		return ""
+	}
+
+	// (time.Time).In panics if a nil location is given. Default to UTC.
+	if location == nil {
+		location = time.UTC
+	}
+
+	return t.In(location).Format(timeLayout)
 }

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -13,12 +13,19 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/termios"
+)
+
+const (
+	// timeLayout is the layout for all [time.Time] values displayed by the CLI when using the table output or other
+	// custom outputs that are not raw JSON/Yaml.
+	timeLayout = "2006/01/02 15:04 MST"
 )
 
 // Batch operations.
@@ -566,4 +573,15 @@ func entityNameFromURL(urlStr string) (string, error) {
 	}
 
 	return name, nil
+}
+
+// formatTime returns the given time formatted such that displayed times are consistent across the CLI.
+func formatTime(t *time.Time) string {
+	// Times are only displayed if available and set.
+	if t == nil || !shared.TimeIsSet(*t) {
+		return " "
+	}
+
+	// Always use the local time.
+	return t.Local().Format(timeLayout)
 }

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -179,6 +181,188 @@ func (s *utilsTestSuite) TestResolveRegistryImageSource() {
 			s.Equal(tc.wantFingerprint, imgInfo.Fingerprint)
 			s.Equal(tc.wantProject, imgInfo.Project)
 			s.Equal(tc.wantRegistry, registryName)
+		})
+	}
+}
+
+func (s *utilsTestSuite) TestFormatTime() {
+	// Create a fixed time for testing: 2026-08-10 12:30:45 UTC.
+	fixedTime := time.Date(2026, 8, 10, 12, 30, 45, 0, time.UTC)
+
+	// Create timezone locations.
+	estLocation, err := time.LoadLocation("America/New_York")
+	s.NoError(err)
+
+	pstLocation, err := time.LoadLocation("America/Los_Angeles")
+	s.NoError(err)
+
+	// Create a zero time (Unix timestamp 0).
+	zeroTime := time.Unix(0, 0)
+
+	// Create an unset time (negative Unix timestamp).
+	unsetTime := time.Unix(-1, 0)
+
+	tests := []struct {
+		name     string
+		t        *time.Time
+		location *time.Location
+		want     string
+	}{
+		{
+			name:     "Nil time pointer",
+			t:        nil,
+			location: time.UTC,
+			want:     "",
+		},
+		{
+			name:     "Zero time",
+			t:        &zeroTime,
+			location: time.UTC,
+			want:     "",
+		},
+		{
+			name:     "Unset time (negative Unix timestamp)",
+			t:        &unsetTime,
+			location: time.UTC,
+			want:     "",
+		},
+		{
+			name:     "Valid time in UTC with nil location defaults to UTC",
+			t:        &fixedTime,
+			location: nil,
+			want:     "2026/08/10 12:30 UTC",
+		},
+		{
+			name:     "Valid time in UTC",
+			t:        &fixedTime,
+			location: time.UTC,
+			want:     "2026/08/10 12:30 UTC",
+		},
+		{
+			name:     "Valid time in EST",
+			t:        &fixedTime,
+			location: estLocation,
+			want:     "2026/08/10 08:30 EDT",
+		},
+		{
+			name:     "Valid time in PST",
+			t:        &fixedTime,
+			location: pstLocation,
+			want:     "2026/08/10 05:30 PDT",
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			got := formatTime(tc.t, tc.location)
+			s.Equal(tc.want, got)
+		})
+	}
+}
+
+func (s *utilsTestSuite) TestPrintTimeIfSet() {
+	// Create a fixed time for testing: 2026-08-10 12:30:45 UTC.
+	fixedTime := time.Date(2026, 8, 10, 12, 30, 45, 0, time.UTC)
+
+	// Create a zero time (Unix timestamp 0).
+	zeroTime := time.Unix(0, 0)
+
+	// Create timezone locations.
+	estLocation, err := time.LoadLocation("America/New_York")
+	s.NoError(err)
+
+	// Helper to create string pointers.
+	strPtr := func(s string) *string {
+		return &s
+	}
+
+	tests := []struct {
+		name     string
+		prefix   string
+		t        *time.Time
+		fallback *string
+		location *time.Location
+		want     string
+	}{
+		{
+			name:     "Valid time with prefix",
+			prefix:   "Created:",
+			t:        &fixedTime,
+			fallback: nil,
+			location: time.UTC,
+			want:     "Created: 2026/08/10 12:30 UTC\n",
+		},
+		{
+			name:     "Valid time in EST timezone",
+			prefix:   "Modified:",
+			t:        &fixedTime,
+			fallback: nil,
+			location: estLocation,
+			want:     "Modified: 2026/08/10 08:30 EDT\n",
+		},
+		{
+			name:     "Nil time with no fallback returns empty",
+			prefix:   "Created:",
+			t:        nil,
+			fallback: nil,
+			location: time.UTC,
+			want:     "",
+		},
+		{
+			name:     "Zero time with no fallback returns empty",
+			prefix:   "Created:",
+			t:        &zeroTime,
+			fallback: nil,
+			location: time.UTC,
+			want:     "",
+		},
+		{
+			name:     "Nil time with fallback uses fallback",
+			prefix:   "Created:",
+			t:        nil,
+			fallback: strPtr("MISSING"),
+			location: time.UTC,
+			want:     "Created: MISSING\n",
+		},
+		{
+			name:     "Zero time with fallback uses fallback",
+			prefix:   "Created:",
+			t:        &zeroTime,
+			fallback: strPtr("never"),
+			location: time.UTC,
+			want:     "Created: never\n",
+		},
+		{
+			name:     "Valid time ignores fallback",
+			prefix:   "Updated:",
+			t:        &fixedTime,
+			fallback: strPtr("FALLBACK_IGNORED"),
+			location: time.UTC,
+			want:     "Updated: 2026/08/10 12:30 UTC\n",
+		},
+		{
+			name:     "Empty prefix with valid time",
+			prefix:   "",
+			t:        &fixedTime,
+			fallback: nil,
+			location: time.UTC,
+			want:     "2026/08/10 12:30 UTC\n",
+		},
+		{
+			name:     "Nil location defaults to UTC",
+			prefix:   "Timestamp:",
+			t:        &fixedTime,
+			fallback: nil,
+			location: nil,
+			want:     "Timestamp: 2026/08/10 12:30 UTC\n",
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			buf := &bytes.Buffer{}
+			printTimeIfSet(buf, tc.prefix, tc.t, tc.fallback, tc.location)
+			s.Equal(tc.want, buf.String())
 		})
 	}
 }

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	yaml "go.yaml.in/yaml/v2"
@@ -198,11 +199,11 @@ func (c *cmdWarningList) countColumnData(warning api.Warning) string {
 }
 
 func (c *cmdWarningList) firstSeenColumnData(warning api.Warning) string {
-	return warning.FirstSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&warning.FirstSeenAt, time.Local)
 }
 
 func (c *cmdWarningList) lastSeenColumnData(warning api.Warning) string {
-	return warning.LastSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&warning.LastSeenAt, time.Local)
 }
 
 func (c *cmdWarningList) locationColumnData(warning api.Warning) string {

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -198,11 +198,11 @@ func (c *cmdWarningList) countColumnData(warning api.Warning) string {
 }
 
 func (c *cmdWarningList) firstSeenColumnData(warning api.Warning) string {
-	return warning.FirstSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&warning.FirstSeenAt)
 }
 
 func (c *cmdWarningList) lastSeenColumnData(warning api.Warning) string {
-	return warning.LastSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return formatTime(&warning.LastSeenAt)
 }
 
 func (c *cmdWarningList) locationColumnData(warning api.Warning) string {


### PR DESCRIPTION
Follow up to https://github.com/canonical/lxd/pull/18791 to include identity expiry in the table view for identities.

This also standardises how times are displayed in the CLI more generally by adding some utils with unit tests.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
