### PR TITLE
lxd/operations: Return failed operation state from wait endpoint

### DIFF
--- a/lxd-agent/operations.go
+++ b/lxd-agent/operations.go
@@ -183,10 +183,13 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(err)
 	}
 
-	err = op.Wait(ctx)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	// We intentionally ignore the error from op.Wait() here because we want
+	// to fetch and render the actual final state of the operation (which
+	// contains the Failure payload) rather than sending a secondary HTTP error.
+	_ = op.Wait(ctx)
+
+	_, opAPI := op.Render()
+	return response.SyncResponse(true, opAPI)
 
 	_, opAPI := op.Render()
 	return response.SyncResponse(true, opAPI)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -836,10 +836,6 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			_, body := op.Render()
 			_ = response.SyncResponse(true, body).Render(w, r)
 			return nil
-
-			_, body := op.Render()
-			_ = response.SyncResponse(true, body).Render(w, r)
-			return nil
 		}
 
 		return response.ManualResponse(waitResponse)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -827,11 +827,15 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Wait for the operation.
-			err = op.Wait(ctx)
-			if err != nil {
-				_ = response.SmartError(err).Render(w, r)
-				return nil
-			}
+			// We intentionally ignore the error from op.Wait() here because we want
+			// to fetch and render the actual final state of the operation (which
+			// contains the Failure payload) rather than sending a secondary HTTP error.
+			_ = op.Wait(ctx)
+
+			// Render the current state, including operation failures and timeouts.
+			_, body := op.Render()
+			_ = response.SyncResponse(true, body).Render(w, r)
+			return nil
 
 			_, body := op.Render()
 			_ = response.SyncResponse(true, body).Render(w, r)

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -173,6 +173,7 @@ readonly test_group_standalone=(
     "filtering"
     "bulk_operation_children"
     "get_operations"
+    "operation_wait_failure"
     "operations_conflict_reference"
     "instances_selective_recursion"
     "kernel_limits"

--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -93,3 +93,28 @@ test_operations_conflict_reference() {
   lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}'
   ! lxc query -X POST '/internal/testing/operation-wait' -d '{"duration": "5s", "op_class": 1, "op_type": 75, "conflict_reference": "'"${conflictRef}"'"}' || false
 }
+
+test_operation_wait_failure() {
+  network_name="opwait$$"
+
+  # Create the network initially
+  lxc network create "${network_name}" ipv4.address=none ipv6.address=none
+
+  # Using lxc query to create the network a second time so that we can extract the operation ID
+  op_id=$(lxc query -X POST /1.0/networks -d '{"name": "'"${network_name}"'", "config": {"ipv4.address": "none", "ipv6.address": "none"}}' | jq --exit-status --raw-output '.id')
+  wait_response=$(lxc query "/1.0/operations/${op_id}/wait?timeout=60")
+
+  # Verify the operation wait endpoint returns the actual failure payload
+  jq --exit-status '
+    .status == "Failure" and
+    .status_code == 400 and
+    .err == "The network already exists" and
+    .err_code == 400
+  ' <<< "${wait_response}"
+
+  # Verify that using the standard CLI command also fails correctly
+  if lxc network create "${network_name}" ipv4.address=none ipv6.address=none; then
+    echo "ERROR: Duplicate network creation succeeded"
+    exit 1
+  fi
+}


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

### Root Cause
The wait endpoint commits to an HTTP 200 OK before blocking on the operation. When `op.Wait` returned an operation error, the handler attempted to render a second HTTP error response instead of returning the operation state. As a result, clients (like `lxc network`) interpreted failed asynchronous operations as successful because they received a 200 OK without the failure payload.

### The Fix
Instead of checking the error from `op.Wait(ctx)`, we now call `op.Render()` after the wait returns to fetch the actual final state of the operation (which includes failures and timeouts) and return it to the client via a `SyncResponse`. 

*Note: Per Mark's review on the previous PR, the Bash test has been cleaned up (subshell/trap removed, comments added, EOF newline fixed) and the changes have been cleanly separated into a Code commit and a Test commit.*

Fixes #18715