### PR TITLE
Fix stacked tmpfs shmounts; Moving devlxd to shmounts;  Migrate old devlxd path to new path;

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1930,6 +1930,11 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("Failed loading local instances: %w", err)
 		}
 
+		err = patchesApply(d, patchPostInstancesLoaded)
+		if err != nil {
+			return err
+		}
+
 		// Register devices on running instances to receive events and reconnect to VM monitor sockets.
 		// This should come after the event handler go routines have been started.
 		devicesRegister(instances)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1615,7 +1615,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 			_, err = files.Lstat(relativeTargetPath)
 			if err == nil {
-				err := d.removeMount(mount.TargetPath)
+				err := d.RemoveMount(mount.TargetPath)
 				if err != nil {
 					return fmt.Errorf("Error unmounting the device path inside container: %s", err)
 				}
@@ -4028,7 +4028,7 @@ func (d *lxc) Update(ctx context.Context, args db.InstanceArgs, actionType insta
 					reverter.Add(func() { _ = files.Close() })
 					_, err = files.Lstat("/dev/lxd")
 					if err == nil {
-						err = d.removeMount("/dev/lxd")
+						err = d.RemoveMount("/dev/lxd")
 						if err != nil {
 							return err
 						}
@@ -6647,7 +6647,10 @@ func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
 	return nil
 }
 
-func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+// MoveMount attaches source onto target inside the running container using
+// move_mount, without going through the /dev/.lxd-mounts staging area that
+// insertMountLXC and insertMountLXD rely on.
+func (d *lxc) MoveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {
@@ -6698,7 +6701,7 @@ func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType id
 	// Prefer open_tree()/move_mount() whenever the kernel supports it (which
 	// d.state.OS.IdmappedMounts establishes)
 	if d.state.OS.IdmappedMounts {
-		return d.moveMount(source, target, fstype, flags, idmapType)
+		return d.MoveMount(source, target, fstype, flags, idmapType)
 	}
 
 	if idmapType == idmap.IdmapStorageNone {
@@ -6708,7 +6711,8 @@ func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType id
 	return d.insertMountLXD(source, target, fstype, flags, -1, idmapType)
 }
 
-func (d *lxc) removeMount(mount string) error {
+// RemoveMount unmounts the given path inside the running container.
+func (d *lxc) RemoveMount(mount string) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1615,7 +1615,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 			_, err = files.Lstat(relativeTargetPath)
 			if err == nil {
-				err := d.removeMount(mount.TargetPath)
+				err := d.RemoveMount(mount.TargetPath)
 				if err != nil {
 					return fmt.Errorf("Error unmounting the device path inside container: %s", err)
 				}
@@ -4028,7 +4028,7 @@ func (d *lxc) Update(ctx context.Context, args db.InstanceArgs, actionType insta
 					reverter.Add(func() { _ = files.Close() })
 					_, err = files.Lstat("/dev/lxd")
 					if err == nil {
-						err = d.removeMount("/dev/lxd")
+						err = d.RemoveMount("/dev/lxd")
 						if err != nil {
 							return err
 						}
@@ -6639,7 +6639,10 @@ func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
 	return nil
 }
 
-func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+// MoveMount attaches source onto target inside the running container using
+// move_mount, without going through the /dev/.lxd-mounts staging area that
+// insertMountLXC and insertMountLXD rely on.
+func (d *lxc) MoveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {
@@ -6688,7 +6691,7 @@ func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idma
 
 func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
 	if d.state.OS.IdmappedMounts && idmapType == idmap.IdmapStorageIdmapped {
-		return d.moveMount(source, target, fstype, flags, idmapType)
+		return d.MoveMount(source, target, fstype, flags, idmapType)
 	}
 
 	if idmapType == idmap.IdmapStorageNone {
@@ -6698,7 +6701,8 @@ func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType id
 	return d.insertMountLXD(source, target, fstype, flags, -1, idmapType)
 }
 
-func (d *lxc) removeMount(mount string) error {
+// RemoveMount unmounts the given path inside the running container.
+func (d *lxc) RemoveMount(mount string) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -202,6 +202,8 @@ type Container interface {
 	FileSFTPNoLock() (*sftp.Client, error)
 	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 	StopForkFile(force bool)
+	MoveMount(source string, target string, fstype string, flags int, idmapType idmap.IdmapStorageType) error
+	RemoveMount(mount string) error
 }
 
 // VM interface is for VM specific functions.

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -28,6 +29,8 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/db/warningtype"
 	"github.com/canonical/lxd/lxd/device/filters"
+	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/lxd/instance"
 	instanceDrivers "github.com/canonical/lxd/lxd/instance/drivers"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/network"
@@ -36,6 +39,7 @@ import (
 	storagePools "github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	storageDrivers "github.com/canonical/lxd/lxd/storage/drivers"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -130,6 +134,7 @@ var patches = []patch{
 	{name: "storage_rename_nvme_mode", stage: patchPreLoadClusterConfig, run: patchStoragePoolConnectorNVMeMode},
 	{name: "replicators_remove_snapshot_config_key", stage: patchPreLoadClusterConfig, run: patchReplicatorsRemoveSnapshotConfigKey},
 	{name: "config_remove_legacy_nvidia_keys", stage: patchPreLoadClusterConfig, run: patchRemoveLegacyNvidiaConfigKeys},
+	{name: "instance_reattach_shared_devlxd_shmounts", stage: patchPostInstancesLoaded, run: patchReattachSharedDevLXDMounts},
 }
 
 type patch struct {
@@ -2490,6 +2495,144 @@ func patchRemoveLegacyNvidiaConfigKeys(_ string, d *Daemon) error {
 
 		return nil
 	})
+}
+
+// reattachSharedDevLXDMount re-establishes the devLXD bind-mount that the daemon
+// shares with a running container.
+//
+// /dev/lxd is a bind-mount, made in the container's mount namespace, of a tmpfs
+// that LXD mounts in its own. When LXD runs from the snap that per-snap namespace
+// is discarded on every refresh, so the incoming daemon can come up with a brand
+// new filesystem while a container that survived the refresh still holds a
+// bind-mount of the previous one. Such a container ends up with an empty /dev/lxd,
+// because the outgoing daemon unlinked the devLXD socket on its way down.
+//
+// This is a no-op whenever the container's mount and the daemon's current
+// filesystem are still backed by the same device ID — the common case once devlxd
+// persists across a refresh, or when the container was started by the currently
+// running daemon.  See issue #18194.
+// The caller is responsible for only passing containers that have devLXD enabled.
+func reattachSharedDevLXDMount(inst instance.Container) error {
+	pid := inst.InitPID()
+	if inst.IsSnapshot() || pid <= 0 {
+		return nil
+	}
+
+	source := shared.VarPath("devlxd")
+	expected, err := filesystem.StatDeviceID(source)
+	if err != nil {
+		logger.Warn("Skipped re-attaching devLXD mount, cannot stat the source", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "err": err})
+		return nil
+	}
+
+	// Look the mount up in the container's mount namespace rather than our own,
+	// which means reading the container's mountinfo and routing the path through
+	// /proc/<pid>/root so both describe the same mount tree.
+	const target = "/dev/lxd"
+	mountinfo := fmt.Sprintf("/proc/%d/mountinfo", pid)
+	fields, err := filesystem.GetMountinfo(mountinfo, fmt.Sprintf("/proc/%d/root%s", pid, target))
+	if err != nil {
+		// Either target does not exist in the container or its mountinfo could
+		// not be read or parsed: we don't know what is mounted there, so don't
+		// touch it.
+		logger.Warn("Skipped re-attaching devLXD mount, cannot look up the container's mount", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "mountinfo": mountinfo, "err": err})
+		return nil
+	}
+
+	if len(fields) < 5 {
+		logger.Warn("Skipped re-attaching devLXD mount, mountinfo entry too short", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "mountinfo": mountinfo, "fields": len(fields)})
+		return nil
+	}
+
+	// Field 2 is the device ID of the mount found and field 4 its mount point.
+	actual := fields[2]
+	if actual == expected {
+		return nil
+	}
+
+	// The lookup resolves to the mount target lives in, so a mount point other
+	// than target itself means nothing is mounted there and there is nothing
+	// stale to drop first.
+	stale := fields[4] == target
+
+	logCtx := logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "target": target, "expected": expected, "actual": actual}
+	logger.Info("Re-attaching devLXD mount", logCtx)
+
+	if stale {
+		// Drop the stale mount first so the new one doesn't end up stacked on it.
+		err = inst.RemoveMount(target)
+		if err != nil {
+			// Not fatal: the new mount shadows whatever is left underneath for
+			// path resolution (mountinfo's "last match wins"), and the container
+			// needs a working mount more than it needs a clean mount table.
+			logger.Warn("Failed dropping the stale devLXD mount; re-attaching over it", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "err": err})
+		}
+	}
+
+	// MoveMount is used rather than the insertMount paths because those hand the
+	// mount over to the container through /dev/.lxd-mounts, which the same
+	// refresh leaves stale and which this does not repair. move-mount needs no
+	// staging area.
+	err = inst.MoveMount(source, target, "none", unix.MS_BIND, idmap.IdmapStorageNone)
+	if err != nil {
+		return fmt.Errorf("Failed re-attaching %q onto %q: %w", source, target, err)
+	}
+
+	return nil
+}
+
+// patchReattachSharedDevLXDMounts re-establishes the devLXD bind-mount for any container that was
+// already running when the daemon started, so containers left holding a mount of a filesystem a
+// prior daemon owned (across a snap refresh, before the persistence fix from #18194) get repaired
+// once during the upgrade to this version.
+//
+// This is a soft patch: it never returns an error, so a failure to repair can't stop the daemon
+// from starting. The trade-off is that it still counts as applied, so anything left unrepaired
+// stays that way rather than being retried on the next start.
+func patchReattachSharedDevLXDMounts(name string, d *Daemon) error {
+	instances, err := instance.LoadNodeAll(d.State(), instancetype.Container)
+	if err != nil {
+		logger.Error("Failed loading instances, skipping devLXD mount re-attach", logger.Ctx{"name": name, "err": err})
+		return nil
+	}
+
+	var attempted int
+	var failedIDs []int
+
+	for _, inst := range instances {
+		if !inst.IsRunning() {
+			continue
+		}
+
+		c, isContainer := inst.(instance.Container)
+		if !isContainer {
+			continue
+		}
+
+		// Mirrors the condition under which the devLXD mount entry is added to
+		// the container's liblxc config.
+		if shared.IsTrueOrEmpty(c.ExpandedConfig()["security.devlxd"]) {
+			attempted++
+
+			// Best-effort: a failure here leaves this one instance no worse off
+			// than before this repair existed (it just keeps whatever mount it
+			// already had), and must not stop the other instances from being
+			// repaired.
+			err := reattachSharedDevLXDMount(c)
+			if err != nil {
+				failedIDs = append(failedIDs, inst.ID())
+				logger.Warn("Failed re-attaching devLXD mount", logger.Ctx{"id": inst.ID(), "project": inst.Project().Name, "instance": inst.Name(), "err": err})
+			}
+		}
+	}
+
+	if len(failedIDs) > 0 {
+		logger.Warn("Patch finished re-attaching devLXD mounts with failures", logger.Ctx{"name": name, "attempted": attempted, "failedInstanceIDs": failedIDs})
+	} else {
+		logger.Info("Patch finished re-attaching devLXD mounts", logger.Ctx{"name": name, "attempted": attempted})
+	}
+
+	return nil
 }
 
 // Patches end here

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -53,6 +53,7 @@ const (
 	patchPreDaemonStorage
 	patchPostDaemonStorage
 	patchPostNetworks
+	patchPostInstancesLoaded
 )
 
 /*

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -28,6 +29,8 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/db/warningtype"
 	"github.com/canonical/lxd/lxd/device/filters"
+	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/lxd/instance"
 	instanceDrivers "github.com/canonical/lxd/lxd/instance/drivers"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/network"
@@ -36,6 +39,7 @@ import (
 	storagePools "github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	storageDrivers "github.com/canonical/lxd/lxd/storage/drivers"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -130,6 +134,7 @@ var patches = []patch{
 	{name: "storage_rename_nvme_mode", stage: patchPreLoadClusterConfig, run: patchStoragePoolConnectorNVMeMode},
 	{name: "replicators_remove_snapshot_config_key", stage: patchPreLoadClusterConfig, run: patchReplicatorsRemoveSnapshotConfigKey},
 	{name: "config_remove_legacy_nvidia_keys", stage: patchPreLoadClusterConfig, run: patchRemoveLegacyNvidiaConfigKeys},
+	{name: "instance_reattach_shared_devlxd_shmounts", stage: patchPostInstancesLoaded, run: patchReattachSharedDevLXDMounts},
 }
 
 type patch struct {
@@ -2490,6 +2495,134 @@ func patchRemoveLegacyNvidiaConfigKeys(_ string, d *Daemon) error {
 
 		return nil
 	})
+}
+
+// reattachSharedDevLXDMount re-establishes the devLXD bind-mount that the daemon
+// shares with a running container.
+//
+// /dev/lxd is a bind-mount, made in the container's mount namespace, of a tmpfs
+// that LXD mounts in its own. When LXD runs from the snap that per-snap namespace
+// is discarded on every refresh, so the incoming daemon can come up with a brand
+// new filesystem while a container that survived the refresh still holds a
+// bind-mount of the previous one. Such a container ends up with an empty /dev/lxd,
+// because the outgoing daemon unlinked the devLXD socket on its way down.
+//
+// This is a no-op whenever the container's mount and the daemon's current
+// filesystem are still backed by the same device ID — the common case once devlxd
+// persists across a refresh, or when the container was started by the currently
+// running daemon.  See issue #18194.
+// The caller is responsible for only passing containers that have devLXD enabled.
+func reattachSharedDevLXDMount(inst instance.Container) error {
+	pid := inst.InitPID()
+	if inst.IsSnapshot() || pid <= 0 {
+		return nil
+	}
+
+	source := shared.VarPath("devlxd")
+	expected, err := filesystem.StatDeviceID(source)
+	if err != nil {
+		logger.Warn("Skipped re-attaching devLXD mount, cannot stat the source", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "err": err})
+		return nil
+	}
+
+	// Read the container's own mountinfo; stat'ing through /proc/<pid>/root
+	// would resolve paths the container itself controls.
+	mountinfo := fmt.Sprintf("/proc/%d/mountinfo", pid)
+	const target = "/dev/lxd"
+	actual, err := filesystem.GetDeviceIDFromMountInfo(mountinfo, target)
+	if err == nil && actual == expected {
+		return nil
+	}
+
+	if err != nil && !errors.Is(err, filesystem.ErrNoMountInfoEntry) {
+		// A real failure to read or parse the container's mountinfo, as opposed
+		// to "not currently mounted": we don't know whether target is stale, so
+		// don't touch it.
+		return fmt.Errorf("Failed checking %q: %w", target, err)
+	}
+
+	// A nil error above means target is mounted and stale (the device IDs did not
+	// match); ErrNoMountInfoEntry means nothing is mounted there to drop.
+	stale := err == nil
+
+	logCtx := logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "target": target, "expected": expected, "actual": actual}
+	logger.Info("Re-attaching devLXD mount", logCtx)
+
+	if stale {
+		// Drop the stale mount first so the new one doesn't end up stacked on it.
+		err = inst.RemoveMount(target)
+		if err != nil {
+			// Not fatal: the new mount shadows whatever is left underneath for
+			// path resolution (mountinfo's "last match wins"), and the container
+			// needs a working mount more than it needs a clean mount table.
+			logger.Warn("Failed dropping the stale devLXD mount; re-attaching over it", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "err": err})
+		}
+	}
+
+	// MoveMount is used rather than the insertMount paths because those hand the
+	// mount over to the container through /dev/.lxd-mounts, which the same
+	// refresh leaves stale and which this does not repair. move-mount needs no
+	// staging area.
+	err = inst.MoveMount(source, target, "none", unix.MS_BIND, idmap.IdmapStorageNone)
+	if err != nil {
+		return fmt.Errorf("Failed re-attaching %q onto %q: %w", source, target, err)
+	}
+
+	return nil
+}
+
+// patchReattachSharedDevLXDMounts re-establishes the devLXD bind-mount for any container that was
+// already running when the daemon started, so containers left holding a mount of a filesystem a
+// prior daemon owned (across a snap refresh, before the persistence fix from #18194) get repaired
+// once during the upgrade to this version.
+//
+// This is a soft patch: it never returns an error, so a failure to repair can't stop the daemon
+// from starting. The trade-off is that it still counts as applied, so anything left unrepaired
+// stays that way rather than being retried on the next start.
+func patchReattachSharedDevLXDMounts(name string, d *Daemon) error {
+	instances, err := instance.LoadNodeAll(d.State(), instancetype.Container)
+	if err != nil {
+		logger.Error("Failed loading instances, skipping devLXD mount re-attach", logger.Ctx{"name": name, "err": err})
+		return nil
+	}
+
+	var attempted int
+	var failedIDs []int
+
+	for _, inst := range instances {
+		if !inst.IsRunning() {
+			continue
+		}
+
+		c, isContainer := inst.(instance.Container)
+		if !isContainer {
+			continue
+		}
+
+		// Mirrors the condition under which the devLXD mount entry is added to
+		// the container's liblxc config.
+		if shared.IsTrueOrEmpty(c.ExpandedConfig()["security.devlxd"]) {
+			attempted++
+
+			// Best-effort: a failure here leaves this one instance no worse off
+			// than before this repair existed (it just keeps whatever mount it
+			// already had), and must not stop the other instances from being
+			// repaired.
+			err := reattachSharedDevLXDMount(c)
+			if err != nil {
+				failedIDs = append(failedIDs, inst.ID())
+				logger.Warn("Failed re-attaching devLXD mount", logger.Ctx{"id": inst.ID(), "project": inst.Project().Name, "instance": inst.Name(), "err": err})
+			}
+		}
+	}
+
+	if len(failedIDs) > 0 {
+		logger.Warn("Patch finished re-attaching devLXD mounts with failures", logger.Ctx{"name": name, "attempted": attempted, "failedInstanceIDs": failedIDs})
+	} else {
+		logger.Info("Patch finished re-attaching devLXD mounts", logger.Ctx{"name": name, "attempted": attempted})
+	}
+
+	return nil
 }
 
 // Patches end here

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -61,7 +61,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter 
 		}
 
 		// Get underlying btrfs mount options.
-		mountinfo, err := filesystem.GetMountinfo(volPath)
+		mountinfo, err := filesystem.GetMountinfo("/proc/self/mountinfo", volPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -225,15 +226,39 @@ func ResolveMountOptions(options []string) (uintptr, string) {
 	return mountFlags, strings.Join(mountOptions, ",")
 }
 
-// GetMountinfo tracks down the mount entry for the path and returns all MountInfo fields.
-func GetMountinfo(path string) ([]string, error) {
+// ErrNoMountInfoEntry is returned by GetMountinfo when the mountinfo file held no
+// entry for the path. Callers that need to tell this apart from a real failure to
+// read or parse the file should check for it with errors.Is rather than treating
+// every returned error the same way.
+var ErrNoMountInfoEntry = errors.New("No mountinfo entry found")
+
+// GetMountinfo tracks down the mount entry for the path in the given mountinfo
+// file and returns all MountInfo fields. Entries holding fewer than 5 fields are
+// never matched, so the slice returned always has at least the 5 fields up to and
+// including the mount point.
+//
+// The path is located by stat'ing it and matching the mount ID the kernel reports
+// against the first field of each entry, so both arguments have to describe the
+// same mount tree. Pass "/proc/self/mountinfo" to look a path up in the caller's
+// own mount namespace. To look one up in another process' mount namespace, pass
+// that process' "/proc/<pid>/mountinfo" together with a path routed through
+// "/proc/<pid>/root": a bare path would be resolved in the caller's namespace,
+// whose mount IDs do not appear in the other process' file.
+//
+// The entry returned is the mount the path lives in, which is not necessarily one
+// mounted at the path itself. To tell those apart, compare the returned mount
+// point (field 4) against the path as the mountinfo file spells it, which is not
+// always the path passed in: mount points are written relative to the root of the
+// namespace the file describes, so a path routed through "/proc/<pid>/root"
+// appears there with that prefix stripped.
+func GetMountinfo(mountinfoPath string, path string) ([]string, error) {
 	stat := &unix.Statx_t{}
 	err := unix.Statx(0, path, 0, 0, stat)
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := os.Open("/proc/self/mountinfo")
+	f, err := os.Open(mountinfoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -242,21 +267,25 @@ func GetMountinfo(path string) ([]string, error) {
 
 	statMountID := strconv.FormatUint(stat.Mnt_id, 10)
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
 
 		tokens := strings.Fields(line)
-		if len(tokens) < 5 {
-			continue
+		if len(tokens) >= 5 && tokens[0] == statMountID {
+			return tokens, nil
 		}
 
-		if tokens[0] == statMountID {
-			return tokens, nil
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, err
 		}
 	}
 
-	return nil, errors.New("No mountinfo entry found")
+	return nil, ErrNoMountInfoEntry
 }
 
 // MkdirAllOwner creates a directory named path, along with any necessary parents, in root.
@@ -314,4 +343,19 @@ func MkdirAllOwner(root *os.Root, path string, perm os.FileMode, uid int, gid in
 	}
 
 	return nil
+}
+
+// StatDeviceID stats path and returns the device ID (major:minor) of the
+// filesystem it lives on, in the same form as the third field of a mountinfo
+// entry. Other helpers that derive information from a path by stat'ing it should
+// follow the same StatXxx naming.
+func StatDeviceID(path string) (string, error) {
+	var st unix.Stat_t
+
+	err := unix.Stat(path, &st)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev))), nil
 }

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -258,3 +258,129 @@ func GetMountinfo(path string) ([]string, error) {
 
 	return nil, errors.New("No mountinfo entry found")
 }
+
+// StatDeviceID stats path and returns the device ID (major:minor) of the
+// filesystem it lives on, in the same form as the third field of a mountinfo
+// entry. Other helpers that derive information from a path by stat'ing it should
+// follow the same StatXxx naming.
+func StatDeviceID(path string) (string, error) {
+	var st unix.Stat_t
+
+	err := unix.Stat(path, &st)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev))), nil
+}
+
+// ErrNoMountInfoEntry is returned (possibly wrapped) by extractFromMountInfo and
+// GetDeviceIDFromMountInfo when no line matched. Callers that need to tell "not
+// mounted" apart from a real failure to read or parse the mountinfo file (e.g. to
+// avoid treating the latter as "not a mount any more") should check for it with
+// errors.Is rather than treating every returned error the same way.
+var ErrNoMountInfoEntry = errors.New("No matching mountinfo entry")
+
+// extractFromMountInfo scans a mountinfo file and, for every line with at least 5
+// whitespace-separated fields for which match returns true, records extract's
+// result. It returns the recording from the last matching line, which is what a
+// process in that mount namespace would actually see (later entries shadow
+// earlier ones mounted at the same point). It returns ErrNoMountInfoEntry if no
+// line matched.
+func extractFromMountInfo(mountinfoPath string, match func(fields []string) bool, extract func(fields []string) []string) ([]string, error) {
+	f, err := os.Open(mountinfoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = f.Close() }()
+
+	var found []string
+
+	scanner := bufio.NewScanner(f)
+
+	// bufio.Scanner's default 64 KiB max line length can be too small for a
+	// real mountinfo line: overlayfs mounts concatenate their lowerdir list
+	// into the superblock options field, which grows with the number of image
+	// layers and can exceed that easily. Without this, one such line anywhere
+	// in the file - even for an unrelated mount - would make Scan() stop and
+	// report ErrTooLong before ever reaching the line being looked for.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		// Fields are: mountID parentID major:minor root mountPoint ...
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+
+		if match(fields) {
+			found = extract(fields)
+		}
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	if found == nil {
+		return nil, ErrNoMountInfoEntry
+	}
+
+	return found, nil
+}
+
+// mountInfoEscaper replaces the characters the kernel octal-escapes in
+// mountinfo path fields (fs/proc_namespace.c's mangle(), the same convention
+// /etc/mtab uses): space, tab, newline and backslash become \040, \011, \012
+// and \134 respectively. Backslash must be replaced first, or the backslashes
+// introduced by the other replacements would themselves get escaped.
+var mountInfoEscaper = strings.NewReplacer(
+	`\`, `\134`,
+	" ", `\040`,
+	"\t", `\011`,
+	"\n", `\012`,
+)
+
+// escapeMountInfoField encodes path the way the kernel encodes mountinfo path
+// fields, so it can be compared against an already-escaped field like fields[4].
+func escapeMountInfoField(path string) string {
+	return mountInfoEscaper.Replace(path)
+}
+
+// GetDeviceIDFromMountInfo returns the device ID (major:minor) of the filesystem
+// mounted at mountPoint, as seen through the given mountinfo file.
+//
+// Unlike GetMountinfo, this matches by the mount point's path rather than by
+// stat'ing it and matching on mount ID, so it works against a mountinfo file
+// belonging to a different mount namespace than the caller's own (e.g.
+// /proc/<pid>/mountinfo for another process), where the path can't be stat'd
+// directly.
+func GetDeviceIDFromMountInfo(mountinfoPath string, mountPoint string) (string, error) {
+	// A mountinfo line looks like:
+	//
+	//   66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711
+	//
+	// Whitespace-split into fields, that's index 0: mount ID ("66"), 1: parent
+	// mount ID ("25"), 2: device ID ("0:58"), 3: root ("/"), 4: mount point
+	// ("/dev/lxd"), and more after that we don't care about here. So fields[2]
+	// below is the device ID and fields[4] is the mount point.
+	//
+	// The kernel escapes space/tab/newline/backslash in path fields (e.g. a
+	// mount point named "a b" appears as "a\040b"), so mountPoint needs the same
+	// encoding before comparing it against fields[4].
+	escapedMountPoint := escapeMountInfoField(mountPoint)
+	fields, err := extractFromMountInfo(mountinfoPath,
+		func(fields []string) bool { return fields[4] == escapedMountPoint },
+		func(fields []string) []string { return fields[2:3] })
+	if errors.Is(err, ErrNoMountInfoEntry) {
+		return "", fmt.Errorf("No %q mount entry in %q: %w", mountPoint, mountinfoPath, ErrNoMountInfoEntry)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return fields[0], nil
+}

--- a/lxd/storage/filesystem/fs_test.go
+++ b/lxd/storage/filesystem/fs_test.go
@@ -4,8 +4,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMkdirAllOwner(t *testing.T) {
@@ -173,4 +177,130 @@ func TestMkdirAllOwnerRootEscapeProtection(t *testing.T) {
 			t.Fatalf("Expected no outside directory at %q, got stat error: %v", outsidePaths[i], statErr)
 		}
 	}
+}
+
+func TestStatDeviceID(t *testing.T) {
+	dir := t.TempDir()
+
+	fileA := filepath.Join(dir, "a")
+	fileB := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(fileA, nil, 0600))
+	require.NoError(t, os.WriteFile(fileB, nil, 0600))
+
+	idA, err := StatDeviceID(fileA)
+	require.NoError(t, err)
+	assert.Regexp(t, `^\d+:\d+$`, idA)
+
+	// Two paths on the same filesystem report the same device ID.
+	idB, err := StatDeviceID(fileB)
+	require.NoError(t, err)
+	assert.Equal(t, idA, idB)
+
+	_, err = StatDeviceID(filepath.Join(dir, "does-not-exist"))
+	assert.Error(t, err)
+}
+
+func TestGetMountinfo(t *testing.T) {
+	dir := t.TempDir()
+
+	fields, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(fields), 5)
+
+	// dir is not itself a mount point, so the entry found is the mount it lives
+	// in and its mount point (field 4) is an ancestor of dir.
+	assert.True(t, strings.HasPrefix(dir, fields[4]), "mount point %q is not an ancestor of %q", fields[4], dir)
+
+	t.Run("path not in the given mountinfo file", func(t *testing.T) {
+		// A well-formed mountinfo file that simply holds no entry for dir's mount,
+		// which is what reading another mount namespace's file would look like if
+		// the path had been resolved in the caller's namespace instead.
+		path := filepath.Join(t.TempDir(), "mountinfo")
+		require.NoError(t, os.WriteFile(path, []byte("66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"), 0600))
+
+		_, err := GetMountinfo(path, dir)
+		assert.ErrorIs(t, err, ErrNoMountInfoEntry)
+	})
+
+	t.Run("missing mountinfo file", func(t *testing.T) {
+		// A real I/O error, as opposed to "no entry": callers need to be able to
+		// tell the two apart.
+		_, err := GetMountinfo(filepath.Join(t.TempDir(), "does-not-exist"), dir)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoMountInfoEntry)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		_, err := GetMountinfo("/proc/self/mountinfo", filepath.Join(dir, "does-not-exist"))
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestGetMountinfoLongLine(t *testing.T) {
+	dir := t.TempDir()
+
+	// Take the real mount ID for dir so the synthetic file below can hold an
+	// entry that the stat inside GetMountinfo will match.
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	// A real overlayfs mount concatenates one entry per lowerdir into its
+	// superblock options field, so its mountinfo line can be far longer than
+	// bufio.Scanner's default 64 KiB. An unrelated line that long, appearing
+	// before the line being looked for, must not stop the scan from reaching it.
+	// Deliberately past 1 MiB as well, so this stays a test of "no line length
+	// limit" rather than of some particular larger buffer size.
+	longOptions := "rw,lowerdir=" + strings.Repeat("/var/lib/lxd/storage-pools/default/images/deadbeef/rootfs:", 40000)
+	require.Greater(t, len(longOptions), 1024*1024)
+
+	// Appending a digit keeps this distinct from dir's own mount ID.
+	unrelatedID := mountID + "0"
+
+	mountinfo := "" +
+		unrelatedID + " 25 0:11 / /some/unrelated/overlay rw,relatime shared:1 - overlay overlay " + longOptions + "\n" +
+		mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
+}
+
+func TestGetMountinfoNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	// The matching entry is the last line and has no trailing newline, so it is
+	// only seen if the final short read is examined rather than discarded.
+	mountinfo := mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
+}
+
+func TestGetMountinfoMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	mountinfo := "" +
+		"garbage short line\n" +
+		"\n" +
+		mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
 }

--- a/lxd/storage/filesystem/fs_test.go
+++ b/lxd/storage/filesystem/fs_test.go
@@ -1,0 +1,240 @@
+package filesystem
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatDeviceID(t *testing.T) {
+	dir := t.TempDir()
+
+	fileA := filepath.Join(dir, "a")
+	fileB := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(fileA, nil, 0600))
+	require.NoError(t, os.WriteFile(fileB, nil, 0600))
+
+	idA, err := StatDeviceID(fileA)
+	require.NoError(t, err)
+	assert.Regexp(t, `^\d+:\d+$`, idA)
+
+	// Two paths on the same filesystem report the same device ID.
+	idB, err := StatDeviceID(fileB)
+	require.NoError(t, err)
+	assert.Equal(t, idA, idB)
+
+	_, err = StatDeviceID(filepath.Join(dir, "does-not-exist"))
+	assert.Error(t, err)
+}
+
+func TestExtractFromMountInfo(t *testing.T) {
+	mountinfo := "" +
+		"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n" +
+		"91 25 0:73 / /dev/.lxd-mounts rw,relatime shared:47 - tmpfs tmpfs rw,size=2048k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	// match/extract are generic over which field is being looked up and returned;
+	// exercise that with something other than GetDeviceIDFromMountInfo's own
+	// device-ID lookup, e.g. the fstype (field 8) for a match on mount ID.
+	fields, err := extractFromMountInfo(path,
+		func(fields []string) bool { return fields[0] == "91" },
+		func(fields []string) []string { return fields[8:9] })
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tmpfs"}, fields)
+
+	_, err = extractFromMountInfo(path,
+		func(fields []string) bool { return fields[0] == "does-not-exist" },
+		func(fields []string) []string { return fields })
+	assert.ErrorIs(t, err, ErrNoMountInfoEntry)
+
+	_, err = extractFromMountInfo(filepath.Join(t.TempDir(), "does-not-exist"),
+		func(fields []string) bool { return true },
+		func(fields []string) []string { return fields })
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoMountInfoEntry)
+}
+
+func TestExtractFromMountInfoLongLine(t *testing.T) {
+	// bufio.Scanner's default 64 KiB max line length is smaller than a real
+	// overlayfs mount can produce (its superblock options field concatenates
+	// one entry per lowerdir). An unrelated line this long, appearing before
+	// the line being looked for, must not stop the scan from reaching it.
+	longOptions := "rw,lowerdir=" + strings.Repeat("/var/lib/lxd/storage-pools/default/images/deadbeef/rootfs:", 2000)
+	require.Greater(t, len(longOptions), 64*1024)
+
+	mountinfo := "" +
+		"12 25 0:11 / /some/unrelated/overlay rw,relatime shared:1 - overlay overlay " + longOptions + "\n" +
+		"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := extractFromMountInfo(path,
+		func(fields []string) bool { return fields[4] == "/dev/lxd" },
+		func(fields []string) []string { return fields[2:3] })
+	require.NoError(t, err)
+	assert.Equal(t, []string{"0:58"}, fields)
+}
+
+func TestEscapeMountInfoField(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no special characters", in: "/dev/lxd", want: "/dev/lxd"},
+		{name: "space", in: "/mnt/my pool", want: `/mnt/my\040pool`},
+		{name: "tab", in: "/mnt/a\tb", want: `/mnt/a\011b`},
+		{name: "newline", in: "/mnt/a\nb", want: `/mnt/a\012b`},
+		{name: "backslash", in: `/mnt/a\b`, want: `/mnt/a\134b`},
+		{
+			name: "all of them together",
+			in:   "/mnt/a b\tc\nd\\e",
+			want: `/mnt/a\040b\011c\012d\134e`,
+		},
+		{
+			// A path whose literal bytes happen to spell out another field's
+			// escape sequence must not come out looking like that sequence:
+			// the backslash has to be escaped first, or this would collide
+			// with escapeMountInfoField("/mnt/ ") (a trailing space).
+			name: "literal backslash-zero-four-zero does not collide with an escaped space",
+			in:   `/mnt/\040`,
+			want: `/mnt/\134040`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeMountInfoField(tt.in))
+		})
+	}
+
+	// The two inputs distinguished by the case above must not escape to the
+	// same string.
+	assert.NotEqual(t, escapeMountInfoField(`/mnt/\040`), escapeMountInfoField("/mnt/ "))
+}
+
+func TestGetDeviceIDFromMountInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		mountinfo   string
+		mountPoint  string
+		want        string
+		wantErr     bool
+		wantNoEntry bool // asserted via errors.Is(err, ErrNoMountInfoEntry)
+	}{
+		{
+			name: "simple match",
+			mountinfo: "" +
+				"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n",
+			mountPoint: "/dev/lxd",
+			want:       "0:58",
+		},
+		{
+			name: "last match wins",
+			mountinfo: "" +
+				"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n" +
+				"91 25 0:73 / /dev/lxd rw,relatime shared:47 - tmpfs tmpfs rw,size=1024k,mode=711\n",
+			mountPoint: "/dev/lxd",
+			want:       "0:73",
+		},
+		{
+			name: "no match",
+			mountinfo: "" +
+				"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n",
+			mountPoint:  "/dev/.lxd-mounts",
+			wantErr:     true,
+			wantNoEntry: true,
+		},
+		{
+			name: "malformed lines are skipped, not matched",
+			mountinfo: "" +
+				"garbage short line\n" +
+				"66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n",
+			mountPoint: "/dev/lxd",
+			want:       "0:58",
+		},
+		{
+			name:        "empty file",
+			mountinfo:   "",
+			mountPoint:  "/dev/lxd",
+			wantErr:     true,
+			wantNoEntry: true,
+		},
+		{
+			// The kernel octal-escapes space/tab/newline/backslash in mountinfo
+			// path fields (fs/proc_namespace.c's mangle()); mountPoint is given
+			// as a normal, unescaped path, same as any other caller would pass.
+			name: "mount point containing a space",
+			mountinfo: "" +
+				`66 25 0:58 / /mnt/my\040pool rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711` + "\n",
+			mountPoint: "/mnt/my pool",
+			want:       "0:58",
+		},
+		{
+			name: "mount point containing a tab",
+			mountinfo: "" +
+				`66 25 0:58 / /mnt/a\011b rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711` + "\n",
+			mountPoint: "/mnt/a\tb",
+			want:       "0:58",
+		},
+		{
+			name: "mount point containing a newline",
+			mountinfo: "" +
+				`66 25 0:58 / /mnt/a\012b rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711` + "\n",
+			mountPoint: "/mnt/a\nb",
+			want:       "0:58",
+		},
+		{
+			name: "mount point containing a backslash",
+			mountinfo: "" +
+				`66 25 0:58 / /mnt/a\134b rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711` + "\n",
+			mountPoint: `/mnt/a\b`,
+			want:       "0:58",
+		},
+		{
+			// A mount point literally named "\040" (backslash, zero, four, zero
+			// as real characters) is a different path from one named " " (a
+			// single space); the kernel escapes the literal backslash too, so
+			// it appears as "\134040", not "\040". Looking up the space must
+			// not match the entry for the literal-backslash path.
+			name: "escaped mount point is not confused with an unrelated literal backslash sequence",
+			mountinfo: "" +
+				`66 25 0:58 / /mnt/\134040 rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711` + "\n",
+			mountPoint:  "/mnt/ ",
+			wantErr:     true,
+			wantNoEntry: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mountinfo")
+			require.NoError(t, os.WriteFile(path, []byte(tt.mountinfo), 0600))
+
+			got, err := GetDeviceIDFromMountInfo(path, tt.mountPoint)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantNoEntry, errors.Is(err, ErrNoMountInfoEntry))
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("missing mountinfo file", func(t *testing.T) {
+		// A real I/O error, as opposed to "not mounted": callers need to be able
+		// to tell the two apart, so this must not satisfy errors.Is(err,
+		// ErrNoMountInfoEntry).
+		_, err := GetDeviceIDFromMountInfo(filepath.Join(t.TempDir(), "does-not-exist"), "/dev/lxd")
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoMountInfoEntry)
+	})
+}

--- a/shmounts/setup-shmounts.c
+++ b/shmounts/setup-shmounts.c
@@ -207,6 +207,7 @@ int setup_ns() {
 int main() {
 	bool setup = true;
 	bool run_media = false;
+	const char *tmpmount;
 	int fd = -1;
 	int nsfd_current = -1, nsfd_old = -1, nsfd_host = -1, nsfd_shmounts = -1;
 	FILE *mounts;
@@ -267,30 +268,31 @@ int main() {
 		run_media = true;
 	}
 
+	// Pick the temporary mountpoint. This has to be a path that snapd
+	// exposes to the snap mntns with propagation from the host mntns, as
+	// the bind-mount we create below is made in the host mntns but has to
+	// be visible from the snap mntns so that it can be bind-mounted onto
+	// its final destination there. Both /media and /run/media qualify:
+	// /media is bind-mounted from the host and /run is a slave of the
+	// host's /run at the point where daemon.start calls us.
+	//
+	// The same path must be used on both sides. Using /run/media on one
+	// side and /media on the other made this fail with ENOENT on every
+	// host that has a /run/media directory (any host with udisks2
+	// installed), which silently disabled shmounts persistence and left a
+	// stacked bind-mount behind on every daemon start.
+	tmpmount = run_media ? "/run/media/.lxd-shmounts" : "/media/.lxd-shmounts";
+
 	// Create temporary mountpoint
-	if (run_media) {
-		if (mkdir("/run/media/.lxd-shmounts", 0700) < 0 && errno != EEXIST) {
-			fprintf(stderr, "Failed to create /run/media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
-	} else {
-		if (mkdir("/media/.lxd-shmounts", 0700) < 0 && errno != EEXIST) {
-			fprintf(stderr, "Failed to create /media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
+	if (mkdir(tmpmount, 0700) < 0 && errno != EEXIST) {
+		fprintf(stderr, "Failed to create %s: %s\n", tmpmount, strerror(errno));
+		return -1;
 	}
 
 	// Bind-mount onto temporary mountpoint
-	if (run_media) {
-		if (mount("/var/snap/lxd/common/shmounts", "/run/media/.lxd-shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-			fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to /run/media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
-	} else {
-		if (mount("/var/snap/lxd/common/shmounts", "/media/.lxd-shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-			fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to /media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
+	if (mount("/var/snap/lxd/common/shmounts", tmpmount, NULL, MS_BIND|MS_REC, NULL) < 0) {
+		fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to %s: %s\n", tmpmount, strerror(errno));
+		return -1;
 	}
 
 	// Attach to the snapd mntns
@@ -300,20 +302,20 @@ int main() {
 	}
 
 	// Bind-mount onto final destination
-	if (mount("/media/.lxd-shmounts", "/var/snap/lxd/common/shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-		fprintf(stderr, "Failed to bind-mount /media/.lxd-shmounts to /var/snap/lxd/common/shmounts: %s\n", strerror(errno));
+	if (mount(tmpmount, "/var/snap/lxd/common/shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
+		fprintf(stderr, "Failed to bind-mount %s to /var/snap/lxd/common/shmounts: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
 	// Mark temporary mountpoint private
-	if (mount("none", "/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL) < 0) {
-		fprintf(stderr, "Failed to mark /media/.lxd-shmounts as private: %s\n", strerror(errno));
+	if (mount("none", tmpmount, NULL, MS_REC|MS_PRIVATE, NULL) < 0) {
+		fprintf(stderr, "Failed to mark %s as private: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
 	// Get rid of the temporary mountpoint from snapd mntns
-	if (umount2("/media/.lxd-shmounts", MNT_DETACH) < 0) {
-		fprintf(stderr, "Failed to unmount /media/.lxd-shmounts: %s\n", strerror(errno));
+	if (umount2(tmpmount, MNT_DETACH) < 0) {
+		fprintf(stderr, "Failed to unmount %s: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
@@ -324,20 +326,11 @@ int main() {
 	}
 
 	// Attempt to cleanup mount there too (may be gone or may be there)
-	if (run_media) {
-		mount("none", "/run/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL);
-		umount2("/run/media/.lxd-shmounts", MNT_DETACH);
-	} else {
-		mount("none", "/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL);
-		umount2("/media/.lxd-shmounts", MNT_DETACH);
-	}
+	mount("none", tmpmount, NULL, MS_REC|MS_PRIVATE, NULL);
+	umount2(tmpmount, MNT_DETACH);
 
 	// Attempt to remove the temporary mountpoint
-	if (run_media) {
-		rmdir("/run/media/.lxd-shmounts");
-	} else {
-		rmdir("/media/.lxd-shmounts");
-	}
+	rmdir(tmpmount);
 
 	// Attempt to attach to previous LXD mntns
 	nsfd_old = open("/var/snap/lxd/common/ns/mntns", O_RDONLY);

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -174,6 +174,27 @@ if ! mountpoint -q "${SNAP_COMMON}/shmounts"; then
     fi
 fi
 
+# Make the devLXD socket directory live in the persistent shmounts path.
+#
+# Running containers get this directory bind-mounted onto /dev/lxd, so the
+# filesystem behind it has to outlive the daemon. LXD mounts a tmpfs there
+# itself when the path isn't already a mountpoint, but that tmpfs lives in the
+# per-snap mount namespace which snapd discards on refresh: the new daemon then
+# gets a brand new tmpfs and every already-running container is left holding a
+# bind-mount of the old, now empty, one.
+if ! mountpoint -q "${SNAP_COMMON}/lxd/devlxd"; then
+    echo "==> Making devLXD use the persistent shmounts path"
+    mkdir -p "${SNAP_COMMON}/shmounts/devlxd"
+    chmod 0755 "${SNAP_COMMON}/shmounts/devlxd"
+    mkdir -p "${SNAP_COMMON}/lxd/devlxd"
+    chmod 0755 "${SNAP_COMMON}/lxd/devlxd"
+    # A bind-mount is needed here instead of symlink because filesystem.IsMountPoint
+    # returns false for symlink which causes it to stack mount another tmpfs over it.
+    if ! mount -o bind "${SNAP_COMMON}/shmounts/devlxd" "${SNAP_COMMON}/lxd/devlxd"; then
+        echo "====> Failed to make devLXD persistent, continuing without"
+    fi
+fi
+
 # Fix lsmod/modprobe
 echo "==> Setting up kmod wrapper"
 mountpoint -q /bin/kmod && umount -l /bin/kmod

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -166,6 +166,27 @@ if ! mountpoint -q "${SNAP_COMMON}/shmounts"; then
     fi
 fi
 
+# Make the devLXD socket directory live in the persistent shmounts path.
+#
+# Running containers get this directory bind-mounted onto /dev/lxd, so the
+# filesystem behind it has to outlive the daemon. LXD mounts a tmpfs there
+# itself when the path isn't already a mountpoint, but that tmpfs lives in the
+# per-snap mount namespace which snapd discards on refresh: the new daemon then
+# gets a brand new tmpfs and every already-running container is left holding a
+# bind-mount of the old, now empty, one.
+if ! mountpoint -q "${SNAP_COMMON}/lxd/devlxd"; then
+    echo "==> Making devLXD use the persistent shmounts path"
+    mkdir -p "${SNAP_COMMON}/shmounts/devlxd"
+    chmod 0755 "${SNAP_COMMON}/shmounts/devlxd"
+    mkdir -p "${SNAP_COMMON}/lxd/devlxd"
+    chmod 0755 "${SNAP_COMMON}/lxd/devlxd"
+    # A bind-mount is needed here instead of symlink because filesystem.IsMountPoint
+    # returns false for symlink which causes it to stack mount another tmpfs over it.
+    if ! mount -o bind "${SNAP_COMMON}/shmounts/devlxd" "${SNAP_COMMON}/lxd/devlxd"; then
+        echo "====> Failed to make devLXD persistent, continuing without"
+    fi
+fi
+
 # Fix lsmod/modprobe
 echo "==> Setting up kmod wrapper"
 mountpoint -q /bin/kmod && umount -l /bin/kmod


### PR DESCRIPTION
…94).

Fixes: https://github.com/canonical/lxd/issues/18194

### TL;DR

- commit 1: `shmounts` in theory should survive `snap refresh`, but it didn't - it was stack mounted.  Fixed in `setup-shmounts.c`.
- commit 2: With that, moving devlxd to `shmounts`  would preserve the devlxd socket file.  With this, a patched daemon upgrading to another patched daemon will not suffer from the bug.  But an unpatched daemon upgrading to a patched daemon would still see the bug.
- commit 3: lxd/storage: Add StatDeviceID and GetDeviceIDFromMountInfo.  This is just to add some utils to prepare for the next fix.
- commit 4: Export `MoveMount` and `RemoveMount` from `Container` interface to prepare for the next one-time patch.
- commit 5: Add a `patchPostInstancesLoaded` patching stage with no registered patches in preparing for registering patch in the next commit.
- commit 6 (patch): This adds one-time patch to fix the unpatched -> patched daemon upgrade path.  (In the fullness of time, this patch can be removed once all existing running lxd daemons contain commit 1 and 2).

### Validation For the patched -> patched upgrade path

#### Before the fix

`nsenter --mount=/run/snapd/ns/lxd.mnt -- grep shmounts /proc/self/mountinfo` produces

```diff
-947 469 0:65 / /var/snap/lxd/common/shmounts rw,relatime - tmpfs tmpfs rw,size=1024k,mode=711,inode64
+1743 1325 0:91 / /var/snap/lxd/common/shmounts rw,relatime - tmpfs tmpfs rw,size=1024k,mode=711,inode64
```

Notice that `.../shmounts`'s instance counter changed from `65` to `91`.  It's a stack mounted tmpfs

#### After the fix

The same command produces

```diff
-494 640 0:55 / /var/snap/lxd/common/shmounts rw,relatime master:306 - tmpfs tmpfs rw,size=1024k,mode=711,inode64
+1784 1374 0:55 / /var/snap/lxd/common/shmounts rw,relatime master:306 - tmpfs tmpfs rw,size=1024k,mode=711,inode64
```

It's the same `shmounts` (`55`) that's preserved after `snap refresh`.


And also the `lxc exec snap-test -- ls -al /dev/lxd/` command output before and after the refresh also confirms that the `sock` file is preserved.

### Validation For the unpatched -> patched upgrade path

Unpatched
```
932 507 0:64 / /var/snap/lxd/common/shmounts rw,relatime - tmpfs tmpfs rw,size=1024k,mode=711,inode64
1343 1329 0:69 / /dev/lxd rw,relatime shared:344 - tmpfs tmpfs rw,size=100k,mode=755,inode64
```

Patched
```
1841 1471 0:62 / /var/snap/lxd/common/shmounts rw,relatime master:341 - tmpfs tmpfs rw,size=1024k,mode=711,inode64
451 1329 0:62 /devlxd /dev/lxd rw,relatime master:341 - tmpfs tmpfs rw,size=1024k,mode=711,inode64
```

We can see that `/dev/lxd` lives in on the same mount `0:62` as `shmounts` after upgrade confirming the self-heal fix (commit 3 and 4) moved the `/dev/lxd` to `shmounts` for existing containers.  `sock` file did not disappear under `/dev/lxd` after upgrade.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Resources

[repro-18194.sh](https://github.com/user-attachments/files/31280595/repro-18194.sh)

[build-patched-snap.sh](https://github.com/user-attachments/files/31242565/build-patched-snap.sh)


## Related

During investigation, it's found out that the `/dev/.lxd-mounts` also has similar stack mounting issue over a snap refresh that could cause device hot-plugging not functioning.  I'll open a separate issue and PR to track that, limiting the scope of this PR to devlxd issue.
