### PR TITLE
snap: call set-health during cluster refreshes

### DIFF
--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -110,7 +110,7 @@ func runUpdate() error {
 		return nil
 	}
 
-	shared.SnapSetHealth(context.Background(), "waiting", "Waiting for cluster snap refresh to complete")
+	shared.SnapSetHealth(context.Background(), shared.SnapHealthWaiting, "Waiting for cluster snap refresh to complete")
 	// Wait a random amount of seconds (up to 30) in order to avoid
 	// restarting all cluster members at the same time, and make the
 	// upgrade more graceful.
@@ -122,7 +122,7 @@ func runUpdate() error {
 	_, err := shared.RunCommand(context.TODO(), updateExecutable)
 	if err != nil {
 		logger.Error("Triggering cluster update failed", logger.Ctx{"err": err})
-		shared.SnapSetHealth(context.Background(), "error", "Cluster snap refresh failed")
+		shared.SnapSetHealth(context.Background(), shared.SnapHealthError, "Cluster snap refresh failed")
 		return err
 	}
 

--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -110,7 +110,8 @@ func runUpdate() error {
 		return nil
 	}
 
-	// Wait a random amout of seconds (up to 30) in order to avoid
+	shared.SnapSetHealth(context.Background(), "waiting", "Waiting for cluster snap refresh to complete")
+	// Wait a random amount of seconds (up to 30) in order to avoid
 	// restarting all cluster members at the same time, and make the
 	// upgrade more graceful.
 	wait := time.Duration(rand.Intn(30)) * time.Second
@@ -121,6 +122,7 @@ func runUpdate() error {
 	_, err := shared.RunCommand(context.TODO(), updateExecutable)
 	if err != nil {
 		logger.Error("Triggering cluster update failed", logger.Ctx{"err": err})
+		shared.SnapSetHealth(context.Background(), "error", "Cluster snap refresh failed")
 		return err
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1186,13 +1186,19 @@ func (d *Daemon) setupLoki(URL string, cert string, key string, caCert string, i
 	return nil
 }
 
-func (d *Daemon) init() error {
+func (d *Daemon) init() (err error) {
 	d.startStopLock.Lock()
 	defer d.startStopLock.Unlock()
 
-	var dbWarnings []dbCluster.Warning
+	defer func() {
+		if err != nil {
+			// Use context.Background() rather than d.shutdownCtx because a shutdown
+			// may be the reason init() failed, in which case d.shutdownCtx is already cancelled.
+			shared.SnapSetHealth(context.Background(), shared.SnapHealthError, "LXD daemon failed to start")
+		}
+	}()
 
-	var err error
+	var dbWarnings []dbCluster.Warning
 
 	// Set default authorizer.
 	d.authorizer, err = authDrivers.LoadAuthorizer(d.shutdownCtx, authDrivers.DriverTLS, logger.Log, authDrivers.WithSendSecurity(d.events.SendSecurity))
@@ -1609,6 +1615,7 @@ func (d *Daemon) init() error {
 			// now fine, and then retry
 			logger.Warn("Wait for other cluster members to align their versions, cluster not started yet")
 
+			shared.SnapSetHealth(d.shutdownCtx, shared.SnapHealthWaiting, "Waiting for cluster members to align their versions after snap refresh")
 			// The only thing we want to still do on this node is
 			// to run the heartbeat task, in case we are the raft
 			// leader.
@@ -2065,6 +2072,7 @@ func (d *Daemon) init() error {
 
 	logger.Info("Daemon started")
 
+	shared.SnapSetHealth(d.shutdownCtx, shared.SnapHealthOkay, "")
 	return nil
 }
 

--- a/shared/snap.go
+++ b/shared/snap.go
@@ -7,6 +7,14 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 )
 
+// Snap health status constants for use with SnapSetHealth.
+const (
+	SnapHealthOkay    = "okay"
+	SnapHealthWaiting = "waiting"
+	SnapHealthBlocked = "blocked"
+	SnapHealthError   = "error"
+)
+
 // SnapSetHealth calls snapctl set-health. No-op when not running inside the snap.
 // If ctx has no deadline, a 5s timeout is applied.
 func SnapSetHealth(ctx context.Context, status string, message string) {

--- a/shared/snap.go
+++ b/shared/snap.go
@@ -1,0 +1,33 @@
+package shared
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/lxd/shared/logger"
+)
+
+// SnapSetHealth calls snapctl set-health. No-op when not running inside the snap.
+// If ctx has no deadline, a 5s timeout is applied.
+func SnapSetHealth(ctx context.Context, status string, message string) {
+	if !InSnap() {
+		return
+	}
+
+	_, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+
+	args := []string{"set-health", status}
+	if message != "" {
+		args = append(args, message)
+	}
+
+	_, err := RunCommand(ctx, "snapctl", args...)
+	if err != nil {
+		logger.Warn("Failed setting snap health", logger.Ctx{"status": status, "message": message, "err": err})
+	}
+}


### PR DESCRIPTION
## Description
During a cluster-wide snap refresh, members that are waiting for the
rest of the cluster to align schema/API versions report a `waiting`
health state via `snapctl set-health`. Once the daemon has fully
initialised, the health is reset to `okay`.

A `SnapSetHealth` helper is added to `lxd/cluster` to encapsulate the
snapctl call; it is a no-op when LXD is not running inside the snap.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

Fixes #15721