### PR TITLE
lxd/cluster: Speed up cluster link creation

### DIFF
--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -1000,8 +1000,6 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		return response.InternalError(err)
 	}
 
-	activationErrs := make([]error, 0, len(trustToken.Addresses))
-
 	clusterLinksPost := api.ClusterLinksPost{
 		TrustToken:         trustToken.String(),
 		Type:               req.Type,
@@ -1011,26 +1009,27 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 		},
 	}
 
-	// Send POST to remote /1.0/cluster/links to activate pending cluster link using token.
-	for _, address := range trustToken.Addresses {
-		args := &lxd.ConnectionArgs{
-			TLSServerCert: clusterCert,
-			UserAgent:     version.UserAgent,
-		}
+	args := &lxd.ConnectionArgs{
+		TLSServerCert: clusterCert,
+		UserAgent:     version.UserAgent,
+	}
 
+	activationErrs := tryClusterLinkAddresses(trustToken.Addresses, func(address string) error {
 		clusterAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 		client, err := lxd.ConnectLXD("https://"+clusterAddress, args)
 		if err != nil {
-			activationErrs = append(activationErrs, fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err))
-			continue
+			return fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err)
 		}
 
 		err = client.CreateClusterLink(clusterLinksPost)
 		if err != nil {
-			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
-			continue
+			return fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err)
 		}
 
+		return nil
+	})
+
+	if activationErrs == nil {
 		// Send cluster link lifecycle event.
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
 
@@ -1595,33 +1594,33 @@ func clusterLinkCreateUnidirectional(s *state.State, r *http.Request, req api.Cl
 	// Call B to activate B's pending identity for A using the identity API.
 	// Present A's cluster certificate as a TLS client cert so B can extract it
 	// from the TLS handshake and associate it with the activated identity.
-	activationErrs := make([]error, 0, len(trustToken.Addresses))
-
 	identityReq := api.IdentitiesTLSPost{
 		TrustToken: trustToken.String(),
 	}
 
-	for _, address := range trustToken.Addresses {
-		args := &lxd.ConnectionArgs{
-			TLSServerCert: remotePEM,
-			TLSClientCert: string(networkCert.PublicKey()),
-			TLSClientKey:  string(networkCert.PrivateKey()),
-			UserAgent:     version.UserAgent,
-		}
+	args := &lxd.ConnectionArgs{
+		TLSServerCert: remotePEM,
+		TLSClientCert: string(networkCert.PublicKey()),
+		TLSClientKey:  string(networkCert.PrivateKey()),
+		UserAgent:     version.UserAgent,
+	}
 
+	activationErrs := tryClusterLinkAddresses(trustToken.Addresses, func(address string) error {
 		clusterAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 		client, err := lxd.ConnectLXD("https://"+clusterAddress, args)
 		if err != nil {
-			activationErrs = append(activationErrs, fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err))
-			continue
+			return fmt.Errorf("Failed connecting to remote cluster address %q: %w", clusterAddress, err)
 		}
 
 		err = client.CreateIdentityTLS(identityReq)
 		if err != nil {
-			activationErrs = append(activationErrs, fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err))
-			continue
+			return fmt.Errorf("Remote cluster address %q: %w", clusterAddress, err)
 		}
 
+		return nil
+	})
+
+	if activationErrs == nil {
 		s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
 
 		err = cluster.RefreshClusterLinkVolatileAddresses(r.Context(), s, req.Name)
@@ -1655,4 +1654,30 @@ func clusterLinkCreateUnidirectional(s *state.State, r *http.Request, req api.Cl
 	}
 
 	return response.SmartError(api.StatusErrorf(http.StatusBadGateway, "Failed activating unidirectional cluster link %q: %s", req.Name, strings.Join(errStrings, "; ")))
+}
+
+// tryClusterLinkAddresses tries all addresses in parallel and returns nil on the first successful attempt.
+func tryClusterLinkAddresses(addresses []string, attempt func(address string) error) []error {
+	type result struct {
+		err error
+	}
+
+	results := make(chan result, len(addresses))
+	for _, address := range addresses {
+		go func(addr string) {
+			results <- result{err: attempt(addr)}
+		}(address)
+	}
+
+	errs := make([]error, 0, len(addresses))
+	for range len(addresses) {
+		result := <-results
+		if result.err == nil {
+			return nil
+		}
+
+		errs = append(errs, result.err)
+	}
+
+	return errs
 }

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -28,7 +28,7 @@ import (
 // If a valid, consistent cluster certificate is found, it is returned with the first address at which it was found. Unreachable addresses are tolerated
 // so long as at least one address is reachable and no reachable address presents a different certificate.
 func CheckClusterLinkCertificate(ctx context.Context, addresses []string, fingerprint string, userAgent string) (*x509.Certificate, string, error) {
-	type result struct {
+	type certificateResult struct {
 		cert    *x509.Certificate
 		address string
 	}
@@ -40,17 +40,21 @@ func CheckClusterLinkCertificate(ctx context.Context, addresses []string, finger
 	_, ok := ctx.Deadline()
 	if !ok {
 		// Set default timeout of 30s if no deadline context provided.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(30*time.Second))
-		defer cancel()
+		var timeoutCancel context.CancelFunc
+		ctx, timeoutCancel = context.WithTimeout(ctx, 30*time.Second)
+		defer timeoutCancel()
 	}
+
+	// Allow early cancellation once a valid certificate has been found.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// Pass context to the goroutines.
 	g, ctx := errgroup.WithContext(ctx)
 
 	var mu sync.Mutex
 	var once sync.Once
-	var firstResult result
+	var firstResult certificateResult
 	var errs []error
 	for _, address := range addresses {
 		networkAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
@@ -84,7 +88,8 @@ func CheckClusterLinkCertificate(ctx context.Context, addresses []string, finger
 			}
 
 			once.Do(func() {
-				firstResult = result{cert: cert, address: address}
+				firstResult = certificateResult{cert: cert, address: address}
+				cancel() // Short-circuit: abort remaining certificate checks.
 			})
 			return nil
 		})
@@ -163,18 +168,42 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 	return dbLink.ID, clusterLink, cert, nil
 }
 
-// ConnectCluster connects to a linked cluster using the provided connection args, trying each address until one succeeds.
+// ConnectCluster connects to a linked cluster using the provided connection args, trying all addresses in parallel and returning the first successful connection.
 func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.ConnectionArgs) (lxd.InstanceServer, error) {
 	addresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, false)
-	var errs []error
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("Failed connecting to any address of cluster link %q: no addresses available", clusterLink.Name)
+	}
+
+	type connectionResult struct {
+		client lxd.InstanceServer
+		err    error
+	}
+
+	// Start a connection attempt to every address concurrently.
+	resultCh := make(chan connectionResult, len(addresses))
 	for _, address := range addresses {
-		client, err := lxd.ConnectLXD("https://"+address, args)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("Failed connecting to %q: %w", address, err))
-			continue
+		go func(addr string) {
+			client, err := lxd.ConnectLXD("https://"+addr, args)
+			if err != nil {
+				resultCh <- connectionResult{err: fmt.Errorf("Failed connecting to %q: %w", addr, err)}
+				return
+			}
+
+			resultCh <- connectionResult{client: client}
+		}(address)
+	}
+
+	// Return the first successful connection. Remaining goroutines write to the
+	// buffered channel and terminate without blocking even if we return early.
+	var errs []error
+	for range len(addresses) {
+		r := <-resultCh
+		if r.err == nil {
+			return r.client, nil
 		}
 
-		return client, nil
+		errs = append(errs, r.err)
 	}
 
 	return nil, fmt.Errorf("Failed connecting to any address of cluster link %q: %w", clusterLink.Name, errors.Join(errs...))


### PR DESCRIPTION
Try cluster link addresses in parallel and cancel the certificate pre-check as soon as one valid address responds.

Fixes https://github.com/canonical/lxd/issues/18848

# QA

- Compile this changeset and run it locally, maybe on port 8445
- On your host LXD, create a token: `lxc cluster link create a-link --auth-group admins`
- Decode the token with a tool such as https://www.base64decode.org/
- Edit the addresses in the token JSON, such as inserting an invalid address `"10.168.2.55:8440",` at the beginning of the addresses list.
- Encode the modified token JSON with a tool such as https://www.base64encode.org/
- Use the modified token on the compiled changeset `LXD_DIR=/var/lib/lxd lxc cluster link create a-link --auth-group admins --token`
- See, the link now gets created immediately.
- Without the changes, the link creation blocks for > 10 seconds as it gets stalled on the first address.