### PR TITLE
snap/edk2: stop exporting `LD_LIBRARY_PATH`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -462,9 +462,6 @@ parts:
       esac
       set -eux
 
-      # Ensure staged libraries are found (needed for qemu to generate secure boot vars)
-      export LD_LIBRARY_PATH="${CRAFT_STAGE}/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH):${CRAFT_STAGE}/lib:${LD_LIBRARY_PATH:-}"
-
       # Apply patches from Ubuntu sources.
       QUILT_PATCHES=debian/patches quilt push -a
 


### PR DESCRIPTION
QEMU is no longer used to generate SB variable files.
