### PR TITLE
doc: streamline the decommissioning guide

### DIFF
--- a/doc/howto/decommission.md
+++ b/doc/howto/decommission.md
@@ -7,109 +7,31 @@ myst:
 (howto-decommission)=
 # How to securely decommission a LXD deployment
 
-Follow these steps to securely decommission your LXD deployment on a standalone server, cluster member, or cluster.
-
 ```{important}
 This process will erase all data associated with your LXD deployment.
 Make copies of any data that you need to preserve before proceeding.
 Refer to {ref}`instances-backup` and {ref}`howto-storage-backup-volume` for relevant details.
 ```
 
-To decommission a standalone server, proceed directly to {ref}`howto-decommission-revoke-remote`.
-To decommission a single member of a cluster, proceed to {ref}`howto-decommission-remove-offline-member` or {ref}`howto-decommission-remove-online-member`, depending on the member's status.
-To decommission an entire cluster, first {ref}`delete replicators and cluster links <howto-decommission-delete-replicators-links>`.
+This guide walks you through the steps to decommission a LXD cluster. You can also follow this guide to decommission a standalone server, though the steps regarding cluster members will not apply in such cases.
 
-(howto-decommission-delete-replicators-links)=
-## Delete replicators and cluster links
+If you only need to decommission a single member of a cluster, first {ref}`remove that member from the cluster <cluster-manage-delete-members>`.
+After removing the member, {ref}`update the certificate <cluster-manage-update-certificate>` on the cluster remaining in production.
+Then, return to this guide, skip ahead to {ref}`howto-decommission-remove-lxd`, and follow the instructions in the sections that follow.
 
-```{note}
-Only delete replicators and cluster links if you are decommissioning an **entire** cluster.
-```
-
-Replicators are scoped by {ref}`project <projects>` and must be deleted by project.
-First, list all projects:
-
-```bash
-lxc project list
-```
-
-Next, list all replicators for each project, then delete each replicator:
-
-```bash
-lxc replicator list --project <project_name>
-lxc replicator delete <replicator_name> --project <project_name>
-```
-
-Finally, list cluster links, then delete each one:
-
-```bash
-lxc cluster link list
-lxc cluster link delete <cluster_link_name>
-```
+Unless otherwise noted, you can run the commands in this guide on any online cluster member.
 
 (howto-decommission-remove-offline-member)=
 ## Remove offline cluster members
 
-To decommission an entire cluster or a single offline member, {ref}`remove offline cluster members <cluster-manage-offline-members>` with the `--force` flag:
+Run this command with the `--force` flag to {ref}`remove any offline cluster members <cluster-manage-offline-members>` (you will remove online cluster members later in the process):
 
 ```bash
-lxc cluster remove --force <member_name>
+lxc cluster remove --force <offline_member_name>
 ```
-
-````{important}
-If you are only decommissioning the offline member, {ref}`update the cluster certificate <cluster-manage-update-certificate>` on the cluster.
-After removing the offline member, run this command on any member of the cluster remaining in production:
-
-```bash
-lxc cluster update-certificate <cert.crt> <cert.key>
-```
-````
-
-Then, to decommission the cluster member, proceed to {ref}`howto-decommission-remove-lxd`.
-To decommission the remaining cluster, proceed to {ref}`howto-decommission-revoke-remote` (you will remove online cluster members after you delete data).
-
-(howto-decommission-remove-online-member)=
-## Remove an online cluster member
-
-To decommission a single, online cluster member, first {ref}`evacuate instances <cluster-evacuate>` from the cluster member to other members:
-
-```bash
-lxc cluster evacuate <member_name>
-```
-
-Instances that are not suitable for migration may remain on the cluster member.
-Verify that no instances remain on the cluster member:
-
-```bash
-lxc list location=<member_name> --all-projects
-```
-
-If instances remain on the cluster member, {ref}`migrate those instances <howto-instances-migrate>` to another cluster member:
-
-```bash
-lxc move <instance_name> --target <target_member_name>
-```
-
-{ref}`Remove the member <cluster-manage-delete-members>` from the cluster:
-
-```bash
-lxc cluster remove <member_name>
-```
-
-Then, {ref}`update the cluster certificate <cluster-manage-update-certificate>` by running this command on any member of the cluster remaining in production:
-
-```bash
-lxc cluster update-certificate <cert.crt> <cert.key>
-```
-
-Now proceed to {ref}`howto-decommission-remove-lxd` to decommission the removed member.
 
 (howto-decommission-revoke-remote)=
 ## Revoke remote access
-
-```{note}
-To decommission an entire cluster, run the commands in this section on any cluster member.
-```
 
 List all identities that have access to LXD, then delete each one:
 
@@ -120,28 +42,14 @@ lxc auth identity delete <type>/<name_or_identifier>
 
 To decommission a deployment {ref}`configured for single sign-on with OIDC <howto-oidc>`, remove the corresponding profile from your OIDC identity provider.
 
-(howto-decommission-delete-data)=
-## Delete data
+(howto-decommission-list-projects)=
+## List projects
 
-```{important}
-Data deleted by LXD physically remains on disks and can be recovered by users with access to the disks.
-To prevent unauthorized data recovery, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
-
-To decommission a single cluster member, run these commands **after** removing the member from the cluster.
-Do **not** run these commands on any member of a cluster that will remain in production.
-```
-
-```{note}
-To decommission an entire cluster, run the commands in this section on any cluster member.
-```
-
-### List projects
-
-Instances, profiles, custom volumes, and buckets are scoped by {ref}`project <projects>`.
+Replicators, instances, profiles, custom volumes, and buckets are scoped by {ref}`project <projects>`.
 For deployments with more than one project, you must repeat some steps for **each** project, using the `--project` flag.
 You do not need to use the `--project` flag to decommission deployments with only one project.
 
-View all projects:
+Run this command to get a list of all projects:
 
 ```bash
 lxc project list
@@ -155,6 +63,32 @@ lxc project delete <project_name> --force
 ```
 ````
 
+(howto-decommission-delete-replicators-links)=
+## Delete replicators and cluster links
+
+For each project, list all replicators, then delete each one:
+
+```bash
+lxc replicator list --project <project_name>
+lxc replicator delete <replicator_name> --project <project_name>
+```
+
+Likewise, list all cluster links, then delete each one (cluster links are not scoped by project, so you do not need to use the `--project` flag):
+
+```bash
+lxc cluster link list
+lxc cluster link delete <cluster_link_name>
+```
+
+(howto-decommission-delete-data)=
+## Delete data
+
+```{important}
+Data deleted by LXD physically remains on disks and can be recovered by users with access to the disks.
+To prevent unauthorized data recovery, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
+```
+
+(howto-decommission-delete-instances)=
 ### Stop and delete instances
 
 For each project, stop all instances:
@@ -163,47 +97,68 @@ For each project, stop all instances:
 lxc stop --all --project <project_name>
 ```
 
-Next, list the instances for each project, then delete each instance:
+Next, for each project, list all instances, then delete each one:
 
 ```bash
 lxc list --project <project_name>
 lxc delete <instance_name> --project <project_name>
 ```
 
-````{note}
 If you are unable to stop or delete an instance, use the `--force` flag:
 
 ```bash
 lxc stop --force <instance_name> --project <project_name>
 lxc delete --force <instance_name> --project <project_name>
 ```
-````
 
+(howto-decommission-delete-profiles)=
 ### Delete profiles
 
-For each project, list all profiles, then delete every profile but the `default` profile:
+For each project, list all profiles:
 
 ```bash
 lxc profile list --project <project_name>
+```
+
+Each project has a `default` profile that cannot be deleted. Delete all other profiles:
+
+```
 lxc profile delete <profile_name> --project <project_name>
 ```
 
-```{note}
-The `default` profile cannot be deleted.
+(howto-decommission-remove-disk-devices)=
+### Remove disk devices from `default` profiles
+
+You cannot delete a storage pool used by an instance, profile, or custom volume.
+You must, therefore, remove any disk devices used by `default` profiles in order to delete any storage pools or custom volumes referenced by those devices.
+
+At a minimum, the `default` profile of the `default` project has a disk device named `root` that references a storage pool.
+Remove this device with:
+
+```bash
+lxc profile device remove default root --project default
 ```
 
+To check for additional disk devices, view information about the `default` profile of each project:
+
+```bash
+lxc profile show default --project <project_name>
+```
+
+Remove any remaining disk devices that reference storage pools:
+
+```bash
+lxc profile device remove default <device_name> --project <project_name>
+```
+
+(howto-decommission-delete-volumes-buckets)=
 ### Delete custom volumes and buckets
 
 You must specify storage pools to delete {ref}`custom volumes <storage-volume-types>` or {ref}`buckets <storage-buckets>`.
-First, list all storage pools:
+First, list all storage pools across projects:
 
 ```bash
 lxc storage list
-```
-
-```{note}
-You do not need to specify a project.
-This command lists all storage pools across projects.
 ```
 
 Next, list the custom volumes on each storage pool.
@@ -213,7 +168,7 @@ Use the `--all-projects` flag to view all custom volumes across projects:
 lxc storage volume list <pool_name> type=custom --all-projects
 ```
 
-Then, for {ref}`Ceph Object <storage-cephobject>` pools only, list the buckets:
+Then, for {ref}`Ceph Object <storage-cephobject>` pools only, list all buckets:
 
 ```bash
 lxc storage bucket list <pool_name> --all-projects
@@ -221,34 +176,24 @@ lxc storage bucket list <pool_name> --all-projects
 
 Use the `PROJECT` column in the output to identify the project associated with each custom volume or bucket.
 
-Finally, delete all custom volumes and buckets, specifying the storage pool and project:
+Finally, delete all custom volumes and buckets, specifying both the storage pool and the project:
 
 ```bash
 lxc storage volume delete <pool_name> <volume_name> --project <project_name>
 lxc storage bucket delete <pool_name> <bucket_name> --project <project_name>
 ```
 
+(howto-delete-storage-pools)=
 ### Delete storage pools
 
-Storage pools cannot be deleted if they are used by an instance, profile, custom volume, or bucket.
-The `default` profile cannot be deleted; therefore, the storage pool used by the `default` profile cannot be deleted.
-To identify this storage pool, view information about the `default` profile and find the pool listed under `devices` > `root` > `pool`:
-
-```bash
-lxc profile show default
-```
-
-Next, list all storage pools, then delete every pool but the one used by the `default` profile.
+List all storage pools, then delete each one (storage pools are not scoped by project, so you do not need to use the `--project` flag):
 
 ```bash
 lxc storage list
 lxc storage delete <pool_name>
 ```
 
-```{note}
-You do not need to specify a project when running these commands.
-```
-
+(howto-delete-monitoring-data)=
 ### Delete monitoring data
 
 Delete data from any external systems that you used to {ref}`monitor events <howto-security-events>` or {ref}`monitor metrics <metrics>`, such as [Loki](https://grafana.com/oss/loki/), [Prometheus](https://prometheus.io/), or [Grafana](https://grafana.com/).
@@ -257,18 +202,12 @@ Refer to the documentation for those systems for details.
 (howto-decommission-remove-remaining-members)=
 ## Remove remaining cluster members
 
-To decommission an entire cluster, list all cluster members, then remove each one:
+After deleting data, you can remove the online cluster members from the cluster.
+List all cluster members, then remove each one:
 
 ```bash
 lxc cluster list
 lxc cluster remove <member_name>
-```
-
-```{note}
-Iterate over every cluster member name except the name of the member on which you are running the commands.
-
-Offline cluster members should have been removed before revoking remote access.
-See {ref}`howto-decommission-remove-offline-member`.
 ```
 
 (howto-decommission-remove-lxd)=
@@ -310,6 +249,7 @@ To prevent unauthorized recovery, you must physically overwrite the data.
 Follow your data destruction policy to securely erase and destroy disks used by LXD, as well as disks on machines used to monitor LXD events or metrics.
 Consult storage providers for details about how to securely sanitize data on {ref}`remote storage <storage-drivers-remote>`.
 For deployments {ref}`configured for single sign-on with OIDC <howto-oidc>`, consult your OIDC identity provider for the steps to remove any associated data.
+Likewise, if you used {ref}`ACME services to issue server certificates <authentication-server-certificate>`, refer to the service provider for the steps to remove any associated data.
 
 ```{important}
 Sanitized data is irreversibly destroyed and cannot be recovered.

--- a/doc/howto/decommission.md
+++ b/doc/howto/decommission.md
@@ -7,141 +7,51 @@ myst:
 (howto-decommission)=
 # How to securely decommission a LXD deployment
 
-Follow these steps to securely decommission your LXD deployment on a standalone server, cluster member, or cluster.
-
 ```{important}
 This process will erase all data associated with your LXD deployment.
 Make copies of any data that you need to preserve before proceeding.
 Refer to {ref}`instances-backup` and {ref}`howto-storage-backup-volume` for relevant details.
 ```
 
-To decommission a standalone server, proceed directly to {ref}`howto-decommission-revoke-remote`.
-To decommission a single member of a cluster, proceed to {ref}`howto-decommission-remove-offline-member` or {ref}`howto-decommission-remove-online-member`, depending on the member's status.
-To decommission an entire cluster, first {ref}`delete replicators and cluster links <howto-decommission-delete-replicators-links>`.
+This guide walks you through the steps to decommission a LXD cluster. You can also follow this guide to decommission a standalone server, though the steps regarding cluster members will not apply in such cases.
 
-(howto-decommission-delete-replicators-links)=
-## Delete replicators and cluster links
+If you only need to decommission a single member of a cluster, first {ref}`remove that member from the cluster <cluster-manage-delete-members>`.
+After removing the member, {ref}`update the certificate <cluster-manage-update-certificate>` on the cluster remaining in production.
+Then, return to this guide, skip ahead to {ref}`howto-decommission-remove-lxd`, and follow the instructions in the sections that follow.
 
-```{note}
-Only delete replicators and cluster links if you are decommissioning an **entire** cluster.
-```
-
-Replicators are scoped by {ref}`project <projects>` and must be deleted by project.
-First, list all projects:
-
-```bash
-lxc project list
-```
-
-Next, list all replicators for each project, then delete each replicator:
-
-```bash
-lxc replicator list --project <project_name>
-lxc replicator delete <replicator_name> --project <project_name>
-```
-
-Finally, list cluster links, then delete each one:
-
-```bash
-lxc cluster link list
-lxc cluster link delete <cluster_link_name>
-```
+Unless otherwise noted, you can run the commands in this guide on any online cluster member.
 
 (howto-decommission-remove-offline-member)=
 ## Remove offline cluster members
 
-To decommission an entire cluster or a single offline member, {ref}`remove offline cluster members <cluster-manage-offline-members>` with the `--force` flag:
+Run this command with the `--force` flag to {ref}`remove any offline cluster members <cluster-manage-offline-members>` (you will remove online cluster members later in the process):
 
 ```bash
-lxc cluster remove --force <member_name>
+lxc cluster remove --force <offline_member_name>
 ```
-
-````{important}
-If you are only decommissioning the offline member, {ref}`update the cluster certificate <cluster-manage-update-certificate>` on the cluster.
-After removing the offline member, run this command on any member of the cluster remaining in production:
-
-```bash
-lxc cluster update-certificate <cert.crt> <cert.key>
-```
-````
-
-Then, to decommission the cluster member, proceed to {ref}`howto-decommission-remove-lxd`.
-To decommission the remaining cluster, proceed to {ref}`howto-decommission-revoke-remote` (you will remove online cluster members after you delete data).
-
-(howto-decommission-remove-online-member)=
-## Remove an online cluster member
-
-To decommission a single, online cluster member, first {ref}`evacuate instances <cluster-evacuate>` from the cluster member to other members:
-
-```bash
-lxc cluster evacuate <member_name>
-```
-
-Instances that are not suitable for migration may remain on the cluster member.
-Verify that no instances remain on the cluster member:
-
-```bash
-lxc list location=<member_name> --all-projects
-```
-
-If instances remain on the cluster member, {ref}`migrate those instances <howto-instances-migrate>` to another cluster member:
-
-```bash
-lxc move <instance_name> --target <target_member_name>
-```
-
-{ref}`Remove the member <cluster-manage-delete-members>` from the cluster:
-
-```bash
-lxc cluster remove <member_name>
-```
-
-Then, {ref}`update the cluster certificate <cluster-manage-update-certificate>` by running this command on any member of the cluster remaining in production:
-
-```bash
-lxc cluster update-certificate <cert.crt> <cert.key>
-```
-
-Now proceed to {ref}`howto-decommission-remove-lxd` to decommission the removed member.
 
 (howto-decommission-revoke-remote)=
 ## Revoke remote access
-
-```{note}
-To decommission an entire cluster, run the commands in this section on any cluster member.
-```
 
 List all identities that have access to LXD, then delete each one:
 
 ```bash
 lxc auth identity list
-lxc auth identity delete <type>/<name_or_identifier>
+lxc auth identity delete <authentication_method>/<name_or_identifier>
 ```
 
 To decommission a deployment {ref}`configured for single sign-on with OIDC <howto-oidc>`, remove the corresponding profile from your OIDC identity provider.
 
-(howto-decommission-delete-data)=
-## Delete data
+(howto-decommission-list-projects)=
+## List projects
 
-```{important}
-Data deleted by LXD physically remains on disks and can be recovered by users with access to the disks.
-To prevent unauthorized data recovery, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
+Replicators, instances, profiles, custom volumes, and buckets are scoped by {ref}`project <projects>`.
+By default, LXD commands only affect project-scoped entities on the currently active project; you can specify a different project by using the `--project` flag.
 
-To decommission a single cluster member, run these commands **after** removing the member from the cluster.
-Do **not** run these commands on any member of a cluster that will remain in production.
-```
+If your deployment has more than one project, this means that you must repeat project-scoped commands with the `--project` flag to delete entities across projects.
+Note that you do not need to use the `--project` flag to delete entities on the currently active project (for example, `default`).
 
-```{note}
-To decommission an entire cluster, run the commands in this section on any cluster member.
-```
-
-### List projects
-
-Instances, profiles, custom volumes, and buckets are scoped by {ref}`project <projects>`.
-For deployments with more than one project, you must repeat some steps for **each** project, using the `--project` flag.
-You do not need to use the `--project` flag to decommission deployments with only one project.
-
-View all projects:
+Run this command to get a list of all projects:
 
 ```bash
 lxc project list
@@ -155,6 +65,40 @@ lxc project delete <project_name> --force
 ```
 ````
 
+(howto-decommission-delete-replicators-links)=
+## Delete replicators and cluster links
+
+For each project, list all replicators, then delete each one:
+
+```bash
+lxc replicator list --project <project_name>
+lxc replicator delete <replicator_name> --project <project_name>
+```
+
+```{important}
+Deleting a replicator does not delete the replica project on the remote cluster.
+To prevent unauthorized data recovery, you must decommission both clusters.
+```
+
+Likewise, list all cluster links, then delete each one (cluster links are not scoped by project, so you do not need to use the `--project` flag):
+
+```bash
+lxc cluster link list
+lxc cluster link delete <cluster_link_name>
+```
+
+To fully revoke the trust relationship established by cluster links, delete any corresponding cluster links or identities on the other clusters.
+See the {ref}`guide to deleting cluster links <howto-cluster-links-delete>` for details.
+
+(howto-decommission-delete-data)=
+## Delete data
+
+```{important}
+Data deleted by LXD physically remains on disks and can be recovered by users with access to the disks.
+To prevent unauthorized data recovery, you must {ref}`destroy and sanitize your data <howto-decommission-destroy-data>`.
+```
+
+(howto-decommission-delete-instances)=
 ### Stop and delete instances
 
 For each project, stop all instances:
@@ -163,47 +107,69 @@ For each project, stop all instances:
 lxc stop --all --project <project_name>
 ```
 
-Next, list the instances for each project, then delete each instance:
+Next, for each project, list all instances, then delete each one:
 
 ```bash
 lxc list --project <project_name>
 lxc delete <instance_name> --project <project_name>
 ```
 
-````{note}
 If you are unable to stop or delete an instance, use the `--force` flag:
 
 ```bash
 lxc stop --force <instance_name> --project <project_name>
 lxc delete --force <instance_name> --project <project_name>
 ```
-````
 
+(howto-decommission-delete-profiles)=
 ### Delete profiles
 
-For each project, list all profiles, then delete every profile but the `default` profile:
+For each project, list all profiles:
 
 ```bash
 lxc profile list --project <project_name>
+```
+
+Each project has a `default` profile that cannot be deleted. Delete all other profiles:
+
+```
 lxc profile delete <profile_name> --project <project_name>
 ```
 
-```{note}
-The `default` profile cannot be deleted.
+(howto-decommission-remove-disk-devices)=
+### Remove disk devices from `default` profiles
+
+You cannot delete a storage pool used by an instance, profile, or custom volume.
+You must, therefore, remove any disk devices used by `default` profiles in order to delete any storage pools or custom volumes referenced by those devices.
+
+For example, if you configured a new storage pool during the {ref}`interactive initialization process <initialize>` with `lxd init`, then the `default` profile of the `default` project will have a disk device named `root` that references a storage pool.
+
+Remove this device with:
+
+```bash
+lxc profile device remove default root --project default
 ```
 
+To check for additional disk devices, view information about the `default` profile of each project:
+
+```bash
+lxc profile show default --project <project_name>
+```
+
+Remove any remaining disk devices that reference storage pools:
+
+```bash
+lxc profile device remove default <device_name> --project <project_name>
+```
+
+(howto-decommission-delete-volumes-buckets)=
 ### Delete custom volumes and buckets
 
 You must specify storage pools to delete {ref}`custom volumes <storage-volume-types>` or {ref}`buckets <storage-buckets>`.
-First, list all storage pools:
+First, list all storage pools across projects:
 
 ```bash
 lxc storage list
-```
-
-```{note}
-You do not need to specify a project.
-This command lists all storage pools across projects.
 ```
 
 Next, list the custom volumes on each storage pool.
@@ -213,7 +179,7 @@ Use the `--all-projects` flag to view all custom volumes across projects:
 lxc storage volume list <pool_name> type=custom --all-projects
 ```
 
-Then, for {ref}`Ceph Object <storage-cephobject>` pools only, list the buckets:
+Then, for {ref}`Ceph Object <storage-cephobject>` pools only, list all buckets:
 
 ```bash
 lxc storage bucket list <pool_name> --all-projects
@@ -221,34 +187,24 @@ lxc storage bucket list <pool_name> --all-projects
 
 Use the `PROJECT` column in the output to identify the project associated with each custom volume or bucket.
 
-Finally, delete all custom volumes and buckets, specifying the storage pool and project:
+Finally, delete all custom volumes and buckets, specifying both the storage pool and the project:
 
 ```bash
 lxc storage volume delete <pool_name> <volume_name> --project <project_name>
 lxc storage bucket delete <pool_name> <bucket_name> --project <project_name>
 ```
 
+(howto-delete-storage-pools)=
 ### Delete storage pools
 
-Storage pools cannot be deleted if they are used by an instance, profile, custom volume, or bucket.
-The `default` profile cannot be deleted; therefore, the storage pool used by the `default` profile cannot be deleted.
-To identify this storage pool, view information about the `default` profile and find the pool listed under `devices` > `root` > `pool`:
-
-```bash
-lxc profile show default
-```
-
-Next, list all storage pools, then delete every pool but the one used by the `default` profile.
+List all storage pools, then delete each one (storage pools are not scoped by project, so you do not need to use the `--project` flag):
 
 ```bash
 lxc storage list
 lxc storage delete <pool_name>
 ```
 
-```{note}
-You do not need to specify a project when running these commands.
-```
-
+(howto-delete-monitoring-data)=
 ### Delete monitoring data
 
 Delete data from any external systems that you used to {ref}`monitor events <howto-security-events>` or {ref}`monitor metrics <metrics>`, such as [Loki](https://grafana.com/oss/loki/), [Prometheus](https://prometheus.io/), or [Grafana](https://grafana.com/).
@@ -257,18 +213,12 @@ Refer to the documentation for those systems for details.
 (howto-decommission-remove-remaining-members)=
 ## Remove remaining cluster members
 
-To decommission an entire cluster, list all cluster members, then remove each one:
+After deleting data, you can remove the online cluster members from the cluster.
+List all cluster members, then remove each one:
 
 ```bash
 lxc cluster list
 lxc cluster remove <member_name>
-```
-
-```{note}
-Iterate over every cluster member name except the name of the member on which you are running the commands.
-
-Offline cluster members should have been removed before revoking remote access.
-See {ref}`howto-decommission-remove-offline-member`.
 ```
 
 (howto-decommission-remove-lxd)=
@@ -310,6 +260,7 @@ To prevent unauthorized recovery, you must physically overwrite the data.
 Follow your data destruction policy to securely erase and destroy disks used by LXD, as well as disks on machines used to monitor LXD events or metrics.
 Consult storage providers for details about how to securely sanitize data on {ref}`remote storage <storage-drivers-remote>`.
 For deployments {ref}`configured for single sign-on with OIDC <howto-oidc>`, consult your OIDC identity provider for the steps to remove any associated data.
+Likewise, if you used {ref}`ACME services to issue server certificates <authentication-server-certificate>`, refer to the service provider for the steps to remove any associated data.
 
 ```{important}
 Sanitized data is irreversibly destroyed and cannot be recovered.


### PR DESCRIPTION
Aligns the LXD decommissioning guide with the MicroCloud approach to the guide:

- Focuses the guide on the cluster scenario, rather than providing separate "tracks" for full clusters, single members, or standalone servers.
- Removes extensive directions for removing an online cluster member, and instead directs users to the relevant how-to guide (avoids duplication of content across pages).
- Restructures the steps, to provide information and instructions regarding projects near the top of the guide, *before* the section on replicators, to avoid repeating info about projects.
- Removes excessive `note` admonitions, and instead includes some of that content in the body of the guide.
- Adds details about how to remove disk devices from `default` profiles in order to delete the associated storage pool.
- Adds labels to all headings.
- Adds note about ACME services.
