### PR TITLE
Use the instance entity URL for replicator instance operations

### DIFF
--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1135,13 +1135,10 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 			childArgs = append(childArgs, &operations.OperationArgs{
 				ProjectName: projectName,
-				EntityURL:   projectURL,
-				Type:        operationtype.ReplicatorRunInstance,
+				EntityURL:   entity.InstanceURL(projectName, inst.Name()),
+				Type:        operationtype.ReplicatorRunInstanceForward,
 				Class:       operationtype.OperationClassTask,
-				Metadata: map[string]any{
-					api.MetadataEntityURL: entity.InstanceURL(projectName, inst.Name()).String(),
-				},
-				RunHook: copyFunc,
+				RunHook:     copyFunc,
 			})
 		}
 
@@ -1389,10 +1386,13 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 			return nil
 		}
 
+		// The instance may exist only on the current leader cluster, in which case this operation creates it
+		// locally and there is nothing to name yet. The project is the primary entity here, and the instance
+		// URL reaches clients through the metadata.
 		childArgs = append(childArgs, &operations.OperationArgs{
 			ProjectName: projectName,
 			EntityURL:   projectURL,
-			Type:        operationtype.ReplicatorRunInstance,
+			Type:        operationtype.ReplicatorRunInstanceRestore,
 			Class:       operationtype.OperationClassTask,
 			Metadata: map[string]any{
 				api.MetadataEntityURL: entity.InstanceURL(projectName, instName).String(),

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -143,8 +143,9 @@ const (
 	NetworkZoneRecordUpdate
 	NetworkZoneRecordDelete
 	ReplicatorRun
-	ReplicatorRunInstance
+	ReplicatorRunInstanceForward
 	ProjectReplicaModeUpdate
+	ReplicatorRunInstanceRestore
 
 	// upperBound is used only to enforce consistency in the package on init.
 	// Make sure it's always the last item in this list.
@@ -392,8 +393,10 @@ func (t Type) Description() string {
 		return "Deleting network zone record"
 	case ReplicatorRun:
 		return "Running replicator"
-	case ReplicatorRunInstance:
+	case ReplicatorRunInstanceForward:
 		return "Replicating instance"
+	case ReplicatorRunInstanceRestore:
+		return "Restoring replicated instance"
 	case ProjectReplicaModeUpdate:
 		return "Updating project replica mode"
 
@@ -422,7 +425,7 @@ func (t Type) EntityType() entity.Type {
 	// (the entity being created is not yet referenceable).
 	case VolumeCreate, ProjectRename, InstanceCreate, ImageDownload, ImageUploadToken, CustomVolumeBackupRestore,
 		InstanceStateUpdateBulk, BackupRestore, ProjectDelete, NetworkCreate, NetworkACLCreate, StorageBucketCreate,
-		NetworkZoneCreate, ReplicatorRunInstance, ProjectReplicaModeUpdate:
+		NetworkZoneCreate, ProjectReplicaModeUpdate, ReplicatorRunInstanceRestore:
 		return entity.TypeProject
 
 	// Storage bucket operations.
@@ -440,7 +443,8 @@ func (t Type) EntityType() entity.Type {
 	// Instance operations.
 	case BackupCreate, ConsoleShow, InstanceFreeze, InstanceUpdate, InstanceUnfreeze,
 		InstanceStart, InstanceStop, InstanceRestart, InstanceRename, InstanceMigrate, InstanceLiveMigrate,
-		InstanceDelete, InstanceRebuild, SnapshotRestore, CommandExec, SnapshotCreate, InstanceCopy:
+		InstanceDelete, InstanceRebuild, SnapshotRestore, CommandExec, SnapshotCreate, InstanceCopy,
+		ReplicatorRunInstanceForward:
 		return entity.TypeInstance
 
 	// Instance backup operations.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6131,6 +6131,8 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq --exit-status '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 3 and .status == "Success" and ((.children // []) | length) == 2 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  # Each child operation names the instance it replicates.
+  jq --exit-status 'all(.children[]; .description == "Replicating instance") and ([.children[].metadata.entity_url] | sort == ["/1.0/instances/c1?project=replicator-project", "/1.0/instances/c2?project=replicator-project"])' <<< "${bulk_op}"
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
 
@@ -6206,6 +6208,10 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq --exit-status '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
   jq --exit-status '([., (.children? // [])[]] | length) == 4 and .status == "Success" and ((.children // []) | length) == 3 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  # Restore child operations name the project, because c3 was created on the current leader cluster
+  # during failover and is missing locally until the operation creates it. The instance each child
+  # restores is reported in the metadata.
+  jq --exit-status 'all(.children[]; .description == "Restoring replicated instance") and ([.children[].metadata.entity_url] | sort == ["/1.0/instances/c1?project=replicator-project", "/1.0/instances/c2?project=replicator-project", "/1.0/instances/c3?project=replicator-project"])' <<< "${bulk_op}"
   # c1 and c2 are restored from LXD_TWO's current state; c3 (created on LXD_TWO during failover) is created from scratch.
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

# Description

`ReplicatorRunInstance` child operations named the project as their primary entity and carried the instance URL only in the operation metadata. On the forward path the instance is the entity the operation acts on, so it should be named directly. A user watching the run can then click through to the instance being replicated.

Restore cannot do the same. It builds its child list from the current leader cluster, so it can include an instance the local database has never seen, such as one created on the leader after failover. Registration resolves the entity URL to an entity ID, and that lookup fails for an instance that does not exist locally yet.

An operation type carries a single entity type, so the two directions are now separate types. `ReplicatorRunInstanceForward` has entity type `instance`. `ReplicatorRunInstanceRestore` has entity type `project` and reports the instance it restores in the operation metadata, which is the current behaviour on main.

The new type is appended to the end of the operation type list so existing type codes in the database keep their values. The names follow #18869, which needs the same split to convert replicators to durable operations.

## Notes for review

- `ReplicatorRunVolume` is a follow-up on #18456. It needs the same split, plus a fix for the storage volume entity query, which matches on the volume's cluster member. The restore path does not know the local member for a volume it has not created yet.

Relates to #18456
