### PR TITLE
github: init CodeQL after `dqlite`/`liblxc` are made available

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,18 +85,6 @@ jobs:
         if: matrix.language == 'go'
         uses: ./.github/actions/install-lxd-builddeps
 
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
       # Build or restore dqlite/liblxc from the daily cache (Go only). On a cache
       # miss the action builds from the checked-out workspace.
       - name: Build or restore dqlite/liblxc dependencies
@@ -104,6 +92,19 @@ jobs:
         uses: ./.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.language == 'go' && 'manual' || 'none' }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       - name: Autobuild


### PR DESCRIPTION
Also, explicitly configure `build-mode: ${{ matrix.language == 'go' && 'manual' || 'none' }}` on `github/codeql-action/init` so that CodeQL waits for the subsequent manual `make all` compilation step to trace Go and CGO builds.