### PR TITLE
Allow user specified uid/gid/mode on CDI GPU devices

### DIFF
--- a/lxd/device/gpu_cdi.go
+++ b/lxd/device/gpu_cdi.go
@@ -92,14 +92,14 @@ func startCDIDevices(d *deviceCommon, configDevices cdi.ConfigDevices, runConf *
 			return fmt.Errorf("Failed parsing minor number %q when starting CDI device: %w", conf["minor"], err)
 		}
 
-		uid := conf["uid"]
-		if uid != "" {
-			d.config["uid"] = uid
-		}
-
-		gid := conf["gid"]
-		if gid != "" {
-			d.config["gid"] = gid
+		// User-provided uid/gid/mode on the LXD device take priority over the values
+		// declared by the CDI spec. This lets unprivileged in-container runtimes (e.g.
+		// Anbox) request device node ownership matching their process uid/gid, while
+		// still falling back to the CDI spec's values when the user hasn't set any.
+		for _, field := range []string{"uid", "gid", "mode"} {
+			if d.config[field] != "" {
+				conf[field] = d.config[field]
+			}
 		}
 
 		// Here putting a `cdi.CDIUnixPrefix` prefix with 'd.name' as a device name will create an directory entry like:

--- a/test/suites/container_devices_gpu.sh
+++ b/test/suites/container_devices_gpu.sh
@@ -120,6 +120,12 @@ gpu_run_nvidia_tests() {
   lxc config device add "${ctName}" gpu-cdi-all gpu id=nvidia.com/gpu=all
   gpu_verify_nvidia_mounts "${ctName}"
   lxc config device remove "${ctName}" gpu-cdi-all
+
+  # Verify user-supplied uid/gid/mode are honored on NVIDIA CDI GPU devices.
+  lxc config device add "${ctName}" gpu-cdi-perms gpu id=nvidia.com/gpu=0 uid=1000 gid=1000 mode=0640
+  [ "$(lxc exec "${ctName}" -- stat -c '%u %g %a' /dev/nvidia0)" = "1000 1000 640" ]
+  [ "$(lxc exec "${ctName}" -- stat -c '%u %g %a' /dev/nvidiactl)" = "1000 1000 640" ]
+  lxc config device remove "${ctName}" gpu-cdi-perms
 }
 
 gpu_run_amd_tests() {
@@ -179,6 +185,12 @@ gpu_run_amd_tests() {
   lxc exec "${ctName}" -- mount | grep -wF "${amdDeviceName}"
 
   lxc config device remove "${ctName}" gpu-amd-all
+
+  # Verify user-supplied uid/gid/mode are honored on AMD CDI GPU devices.
+  lxc config device add "${ctName}" gpu-amd-perms gpu id=amd.com/gpu=0 uid=2000 gid=2000 mode=0640
+  [ "$(lxc exec "${ctName}" -- stat -c '%u %g %a' /dev/kfd)" = "2000 2000 640" ]
+  [ "$(lxc exec "${ctName}" -- stat -c '%u %g %a' /dev/dri/"${amdDeviceName}")" = "2000 2000 640" ]
+  lxc config device remove "${ctName}" gpu-amd-perms
 }
 
 test_container_devices_gpu() {


### PR DESCRIPTION
This PR fixes a bug where GPUs passed inside the LXD containers using CDI notation ignored the user-provided "uid", "gid", and "mode" values.

This should be merged together with https://github.com/canonical/lxd-ci/pull/840.
