### PR TITLE
Apply time limit to commands fetching data from external services

### DIFF
--- a/.github/actions/install-lxd-builddeps/action.yml
+++ b/.github/actions/install-lxd-builddeps/action.yml
@@ -8,9 +8,9 @@ runs:
       shell: bash
       run: |
         set -eux
-        sudo apt-get update
+        sudo timeout 10m apt-get update
 
-        sudo apt-get install --no-install-recommends -y \
+        sudo timeout 10m apt-get install --no-install-recommends -y \
           autoconf \
           automake \
           build-essential \

--- a/.github/actions/install-lxd-runtimedeps/action.yml
+++ b/.github/actions/install-lxd-runtimedeps/action.yml
@@ -16,7 +16,7 @@ runs:
         OPTIONAL: ${{ inputs.optional }}
       run: |
         set -eux
-        sudo apt-get update
+        sudo timeout 10m apt-get update
 
         if [ "${OPTIONAL}" != "false" ]; then
           echo "Installing optional runtime dependencies"
@@ -26,13 +26,13 @@ runs:
           . test/includes/setup.sh
           install_instance_drivers
 
-          sudo apt-get install --no-install-recommends -y \
+          sudo timeout 10m apt-get install --no-install-recommends -y \
             lvm2 \
             zfsutils-linux
         fi
 
         # XXX: storage driver tools (lvm2, zfsutils-linux, etc) are installed on-demand by `test/main.sh`.
-        sudo apt-get install --no-install-recommends -y \
+        sudo timeout 10m apt-get install --no-install-recommends -y \
           acl \
           attr \
           bind9-dnsutils \
@@ -68,16 +68,16 @@ runs:
           # shellcheck disable=SC1091
           . /etc/os-release
           if dpkg --compare-versions "${VERSION_ID}" ge 24.04; then
-              sudo apt-get install --no-install-recommends -y yq
+              sudo timeout 10m apt-get install --no-install-recommends -y yq
           else
-              sudo snap install yq
+              sudo timeout 10m snap install yq
           fi
         fi
 
         # unbuffer allows to simulate a TTY which is not available in GH action
         # runners but required by some tests
         if ! command -v unbuffer >/dev/null; then
-          sudo apt-get install --no-install-recommends -y expect
+          sudo timeout 10m apt-get install --no-install-recommends -y expect
         fi
 
         # reclaim some space

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -24,7 +24,7 @@ runs:
         GO_SNAP_CHANNEL: ${{ inputs.snap-channel }}
       run: |
         set -eux
-        sudo snap install go --classic --channel "${GO_SNAP_CHANNEL}"
+        sudo timeout 10m snap install go --classic --channel "${GO_SNAP_CHANNEL}"
         echo "/snap/bin" >> "${GITHUB_PATH}"
 
     - name: Verify Go snap

--- a/.github/actions/setup-microceph/setup-microceph.sh
+++ b/.github/actions/setup-microceph/setup-microceph.sh
@@ -12,7 +12,7 @@ install_microceph() {
       install_snap core24 latest/candidate
       install_snap microceph "${channel}"
   else
-    snap install microceph --channel="${channel}"
+    timeout 20m snap install microceph --channel="${channel}"
   fi
 }
 
@@ -133,8 +133,8 @@ configure_microceph() {
 
 # install_ceph_common: install ceph-common package for ceph CLI tools
 install_ceph_common() {
-  apt-get update
-  apt-get install --no-install-recommends -y ceph-common
+  timeout 10m apt-get update
+  timeout 20m apt-get install --no-install-recommends -y ceph-common
   # reclaim some space
   apt-get clean
 }

--- a/.github/actions/setup-microovn/action.yml
+++ b/.github/actions/setup-microovn/action.yml
@@ -39,7 +39,7 @@ runs:
               install_snap microovn \"${SNAP_CHANNEL}\"; \
             "
           else
-            sudo snap install microovn --channel "${SNAP_CHANNEL}"
+            sudo timeout 10m snap install microovn --channel "${SNAP_CHANNEL}"
           fi
 
     - name: Configure MicroOVN snap

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           SNAP_NAME: ${{ github.event.repository.name }}
         run: |
-          snap download "${SNAP_NAME}" --channel=${{ matrix.track }}/stable --cohort="+"
+          timeout 10m snap download "${SNAP_NAME}" --channel=${{ matrix.track }}/stable --cohort="+"
           unsquashfs ./${SNAP_NAME}*.snap
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,7 +217,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.unit-tests }}
         run: |
           set -eux
-          sudo apt-get install -y xdelta3 # Required for SimpleStreams client tests.
+          sudo timeout 10m apt-get install -y xdelta3 # Required for SimpleStreams client tests.
           chmod +x ~
           echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid
           make check-unit
@@ -888,7 +888,7 @@ jobs:
           # TiCS requires pylint to be installed on the system to run Python checks
           if ! command -v pylint; then
             # no need to `apt-get update` first as it was done in prior steps.
-            sudo apt-get install --no-install-recommends -y pylint
+            sudo timeout 10m apt-get install --no-install-recommends -y pylint
           fi
 
       - name: Convert coverage files
@@ -993,7 +993,7 @@ jobs:
           set -eux
           if [ "${{ runner.os }}" = "Linux" ]; then
             # Required for SimpleStreams client tests.
-            sudo apt-get install -y xdelta3
+            sudo timeout 10m apt-get install -y xdelta3
           fi
           [ -n "${COVER}" ] && COVER="${COVER} -test.gocoverdir=${GOCOVERDIR}"
           go test -mod=readonly -v ./client/... ${COVER}

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -115,7 +115,7 @@ install_packages() {
         exit 1
     fi
 
-    sudo apt-get install --no-install-recommends -y "$@"
+    sudo timeout 20m apt-get install --no-install-recommends -y "$@"
 }
 
 install_tools() {

--- a/test/includes/snap.sh
+++ b/test/includes/snap.sh
@@ -13,7 +13,7 @@ download_snap() {
         cd "${dir}"
         # Delete any revs older than 1 day
         find . -type f -mtime +1 \( -name "${name}_*.snap" -o -name "${name}_*.assert" \) -delete
-        exec snap download "${name}" --channel="${channel}" --cohort="+"
+        exec timeout 20m snap download "${name}" --channel="${channel}" --cohort="+"
     )
 }
 


### PR DESCRIPTION
This should avoid burning through the full CI time budget when an apt mirror or the snapstore is having a bad day.