### PR TITLE
test: Export BROWSER=curl

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -57,6 +57,12 @@ if [ -n "${GOPATH:-}" ] && [[ "${PATH}" != *"${GOPATH}/bin"* ]]; then
 fi
 export PATH
 
+# The browser environment variable is used for opening a browser in OIDC tests.
+# `mini-oidc` just expects a curl request to the device authorization endpoint.
+# We never want to actually open a browser.
+export BROWSER="curl"
+
+
 # Don't translate lxc output for parsing in it in tests.
 export LC_ALL="C"
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -108,7 +108,7 @@ test_authorization() {
   lxc config set "oidc.issuer=${oidc_issuer}" "oidc.client.id=device"
 
   set_oidc test-user test-user@example.com
-  BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
+  lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
 
   ! lxc auth identity group add oidc/test-user@example.com not-found || false # Group not found
   [ "$(my_curl -X PUT -H 'Content-Type: application/json' --data '{"groups":["test-group","not-found1","not-found2"]}' "https://${LXD_ADDR}/1.0/auth/identities/oidc/test-user@example.com" | jq --exit-status --raw-output '.error')" = 'One or more groups were not found: "not-found1", "not-found2"' ] # Groups not found error (only contains the groups that were not found).

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -36,20 +36,20 @@ test_oidc() {
     jq --exit-status '.error_code == 400 and .error == "\"oidc.device.client.id\" cannot be set if \"oidc.client.id\" is unset"' # Can't remove client ID without removing device client ID first.
 
   # Expect this to fail. No user set.
-  ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
+  ! lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
 
   # Set a user with no email address
   set_oidc test-user
 
   # Expect this to fail. mini-oidc will issue a token but adding the remote will fail because no email address will be
   # returned from /userinfo
-  ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
+  ! lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
 
   # Set a user with an email address
   set_oidc test-user test-user@example.com
 
   # This should succeed.
-  BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
+  lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
 
   # The user should now be logged in and their email should show in the "auth_user_name" field.
   lxc query oidc:/1.0 | jq --exit-status '.auth == "trusted"'

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -525,7 +525,7 @@ test_security_user_events_oidc() {
   kill -0 "${mon_pid}"
 
   sub_test "Verify user_created fires on OIDC first login"
-  BROWSER=curl lxc remote add --accept-certificate oidc-security "${LXD_ADDR}" --auth-type oidc
+  lxc remote add --accept-certificate oidc-security "${LXD_ADDR}" --auth-type oidc
 
   lxc query oidc-security:/1.0 | jq --exit-status '.auth == "trusted"'
 
@@ -562,7 +562,7 @@ test_security_user_events_oidc() {
   local before_count
   before_count="$(jq --slurp --exit-status 'map(select(.type == "security" and (.metadata.name | startswith("user_created:oidc:")))) | length' "${monfile}")"
 
-  BROWSER=curl lxc query oidc-security:/1.0 | jq --exit-status '.auth == "trusted"'
+  lxc query oidc-security:/1.0 | jq --exit-status '.auth == "trusted"'
 
   # Allow a short window for any (unwanted) duplicate event to land.
   sleep 2


### PR DESCRIPTION
If the OIDC access token expires during a test run, subsequent commands using OIDC will fail, because the CLI won't be able to reauthenticate, because it can't open the URL. We need to globally set BROWSER=curl so that the URL displayed by the CLI is always curled by the CLI to get a new access token.

Forward port of https://github.com/canonical/lxd/pull/18882

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
