### PR TITLE
Fix LXCFS clean up logic; Avoid generating new certs on running instances

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -363,7 +363,10 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 	}
 
 	// The connection uses mutual authentication, so use the LXD server's key & cert for client.
-	agentCert, _, clientCert, clientKey, err := d.generateAgentCert()
+	// Read the certificates rather than generating them: the instance is already
+	// running, so they exist, and generating here would write into a possibly
+	// unmounted instance directory (see readAgentCert).
+	agentCert, clientCert, clientKey, err := d.readAgentCert()
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +494,50 @@ func (d *qemu) unmount() error {
 	return nil
 }
 
+// readAgentCert reads the instance's existing agent certificates, without ever
+// creating them.
+//
+// It is meant for callers that run while the instance is already up, where the
+// certificates are expected to have been created at startup. Those callers must
+// not fall back to generating a fresh set.
+//
+// These live on the instance's config volume, which for a running instance is of
+// course mounted -- but not necessarily in the mount namespace of the daemon
+// asking. After a snap refresh the daemon restarts into a new namespace, where
+// the config volume is not mounted until RegisterDevices re-establishes it, and
+// getAgentClient is driven by QMP events that can fire before that happens.
+// Generating then writes a stray set into the *underlying* instance directory and
+// breaks the agent connection, which still trusts the original certificates. The
+// stray files get shadowed once the config volume is mounted over them, and
+// resurface at deletion time as "Failed removing ... directory not empty".
+func (d *qemu) readAgentCert() (agentCert string, clientCert string, clientKey string, err error) {
+	instancePath := d.Path()
+
+	for _, f := range []struct {
+		out  *string
+		name string
+	}{
+		{&agentCert, "agent.crt"},
+		{&clientCert, "agent-client.crt"},
+		{&clientKey, "agent-client.key"},
+	} {
+		contents, err := os.ReadFile(filepath.Join(instancePath, f.name))
+		if err != nil {
+			return "", "", "", fmt.Errorf("Failed reading agent TLS material %q (the instance's config volume may not be mounted in this mount namespace): %w", f.name, err)
+		}
+
+		*f.out = string(contents)
+	}
+
+	return agentCert, clientCert, clientKey, nil
+}
+
 // generateAgentCert creates the necessary server key and certificate if needed.
+//
+// This writes into the instance's directory, so it must only be called on paths
+// where the instance's volume is known to be mounted (e.g. instance startup).
+// Callers that merely need to read the certificates of a running instance must
+// use readAgentCert instead.
 func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCert string, clientKey string, err error) {
 	instancePath := d.Path()
 	agentCertFile := filepath.Join(instancePath, "agent.crt")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -557,8 +557,9 @@ func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCer
 		return "", "", "", "", err
 	}
 
-	// Read all the files
-	agentCertBytes, err := os.ReadFile(agentCertFile)
+	// Read back what was just created. Everything but the server key is shared
+	// with the read-only path.
+	agentCert, clientCert, clientKey, err = d.readAgentCert()
 	if err != nil {
 		return "", "", "", "", err
 	}
@@ -568,17 +569,7 @@ func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCer
 		return "", "", "", "", err
 	}
 
-	clientCertBytes, err := os.ReadFile(clientCertFile)
-	if err != nil {
-		return "", "", "", "", err
-	}
-
-	clientKeyBytes, err := os.ReadFile(clientKeyFile)
-	if err != nil {
-		return "", "", "", "", err
-	}
-
-	return string(agentCertBytes), string(agentKeyBytes), string(clientCertBytes), string(clientKeyBytes), nil
+	return agentCert, string(agentKeyBytes), clientCert, clientKey, nil
 }
 
 // Freeze freezes the instance.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -363,7 +363,10 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 	}
 
 	// The connection uses mutual authentication, so use the LXD server's key & cert for client.
-	agentCert, _, clientCert, clientKey, err := d.generateAgentCert()
+	// Read the certificates rather than generating them: the instance is already
+	// running, so they exist, and generating here would write into a possibly
+	// unmounted instance directory (see readAgentCert).
+	agentCert, clientCert, clientKey, err := d.readAgentCert()
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +494,48 @@ func (d *qemu) unmount() error {
 	return nil
 }
 
+// readAgentCert reads the instance's existing agent certificates, without ever
+// creating them.
+//
+// It is meant for callers that run while the instance is already up, where the
+// certificates are expected to have been created at startup. Those callers must
+// not fall back to generating a fresh set: getAgentClient is driven by QMP
+// events, so it can fire during daemon startup before the volume of an
+// already-running instance has been mounted, and the certificates live on that
+// volume. Generating there would write a stray set into the *underlying*
+// instance directory and break the agent connection, which still trusts the
+// original certificates. The stray files then get shadowed once the real volume
+// is mounted over them, and resurface at deletion time as
+// "Failed removing ... directory not empty".
+// See https://github.com/canonical/lxd/issues/18470.
+func (d *qemu) readAgentCert() (agentCert string, clientCert string, clientKey string, err error) {
+	instancePath := d.Path()
+
+	for _, f := range []struct {
+		out  *string
+		name string
+	}{
+		{&agentCert, "agent.crt"},
+		{&clientCert, "agent-client.crt"},
+		{&clientKey, "agent-client.key"},
+	} {
+		contents, err := os.ReadFile(filepath.Join(instancePath, f.name))
+		if err != nil {
+			return "", "", "", fmt.Errorf("Failed reading agent TLS material %q (the instance's volume may not be mounted): %w", f.name, err)
+		}
+
+		*f.out = string(contents)
+	}
+
+	return agentCert, clientCert, clientKey, nil
+}
+
 // generateAgentCert creates the necessary server key and certificate if needed.
+//
+// This writes into the instance's directory, so it must only be called on paths
+// where the instance's volume is known to be mounted (e.g. instance startup).
+// Callers that merely need to read the certificates of a running instance must
+// use readAgentCert instead.
 func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCert string, clientKey string, err error) {
 	instancePath := d.Path()
 	agentCertFile := filepath.Join(instancePath, "agent.crt")

--- a/lxd/instance/drivers/driver_qemu_agent_cert_test.go
+++ b/lxd/instance/drivers/driver_qemu_agent_cert_test.go
@@ -1,0 +1,90 @@
+package drivers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// newAgentCertTestInstance returns a qemu instance whose Path() resolves to a fresh
+// temporary directory, along with that path.
+func newAgentCertTestInstance(t *testing.T) (*qemu, string) {
+	t.Helper()
+
+	t.Setenv("LXD_DIR", t.TempDir())
+
+	d := &qemu{
+		common: common{
+			dbType:  instancetype.VM,
+			name:    "v1",
+			project: api.Project{Name: api.ProjectDefaultName},
+		},
+	}
+
+	instancePath := d.Path()
+	require.NoError(t, os.MkdirAll(instancePath, 0700))
+
+	return d, instancePath
+}
+
+// TestReadAgentCertReturnsExistingMaterial checks that the certificates are returned
+// verbatim and that the server key is not among them.
+func TestReadAgentCertReturnsExistingMaterial(t *testing.T) {
+	d, instancePath := newAgentCertTestInstance(t)
+
+	for name, contents := range map[string]string{
+		"agent.crt":        "AGENT CERT",
+		"agent.key":        "AGENT KEY",
+		"agent-client.crt": "CLIENT CERT",
+		"agent-client.key": "CLIENT KEY",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(instancePath, name), []byte(contents), 0600))
+	}
+
+	agentCert, clientCert, clientKey, err := d.readAgentCert()
+	require.NoError(t, err)
+	assert.Equal(t, "AGENT CERT", agentCert)
+	assert.Equal(t, "CLIENT CERT", clientCert)
+	assert.Equal(t, "CLIENT KEY", clientKey)
+}
+
+// TestReadAgentCertNeverGeneratesMaterial checks that an empty instance directory
+// yields an error and that nothing is created.
+func TestReadAgentCertNeverGeneratesMaterial(t *testing.T) {
+	d, instancePath := newAgentCertTestInstance(t)
+
+	_, _, _, err := d.readAgentCert()
+	assert.Error(t, err)
+
+	entries, readErr := os.ReadDir(instancePath)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "readAgentCert must not create anything in the instance directory")
+}
+
+// TestReadAgentCertReportsMissingFile checks that the error names the file that could
+// not be read.
+func TestReadAgentCertReportsMissingFile(t *testing.T) {
+	for _, missing := range []string{"agent.crt", "agent-client.crt", "agent-client.key"} {
+		t.Run(missing, func(t *testing.T) {
+			d, instancePath := newAgentCertTestInstance(t)
+
+			for _, name := range []string{"agent.crt", "agent-client.crt", "agent-client.key"} {
+				if name == missing {
+					continue
+				}
+
+				require.NoError(t, os.WriteFile(filepath.Join(instancePath, name), []byte("x"), 0600))
+			}
+
+			_, _, _, err := d.readAgentCert()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), missing)
+		})
+	}
+}

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -606,6 +606,33 @@ else
     ln -s /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
 fi
 
+# Remember the LXCFS that was running before this start, if any.
+#
+# On a snap refresh daemon.stop only stops LXD, leaving LXCFS running on
+# purpose so containers keep their /proc overlays. That surviving LXCFS keeps
+# the *previous* revision's mount namespace alive, along with everything that
+# was mounted in it -- including instance storage volumes. Those have to be
+# unmounted from that namespace further down, otherwise the kernel keeps a
+# reference on the underlying dataset and deleting the instance later fails
+# with e.g. "cannot destroy '<pool>/virtual-machines/<name>': dataset is busy"
+#
+# The LXCFS section below may spawn a replacement LXCFS, which overwrites
+# lxcfs.pid with its own pid, so capture the old pid here while it is still
+# the previous revision's one.
+PREV_LXCFS_PID=""
+if [ -e "${SNAP_COMMON}/lxcfs.pid" ]; then
+    read -r PREV_LXCFS_PID < "${SNAP_COMMON}/lxcfs.pid" || true
+
+    # The pidfile is only removed on a clean stop, so it can outlive an unclean
+    # shutdown and name a PID that has since been reused. Confirm it is still
+    # LXCFS before its namespace gets entered further down. /proc/<pid>/comm is
+    # used rather than the exe path because the latter becomes unresolvable once
+    # snapd garbage-collects the revision the process was started from.
+    if [ "$(cat "/proc/${PREV_LXCFS_PID}/comm" 2>/dev/null)" != "lxcfs" ]; then
+        PREV_LXCFS_PID=""
+    fi
+fi
+
 # LXCFS
 if [ -e "${SNAP_COMMON}/var/lib/lxcfs/cgroup" ]; then
     echo "=> Re-using existing LXCFS"
@@ -678,9 +705,22 @@ else
     )
 fi
 
-PID=""
-[ -e "${SNAP_COMMON}/lxcfs.pid" ] && read -r PID < "${SNAP_COMMON}/lxcfs.pid"
-if [ -n "${PID}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "$(readlink "/proc/${PID}/ns/mnt")" ]; then
+# Use the pid captured before the LXCFS section above: by this point
+# lxcfs.pid may already have been replaced by a freshly spawned LXCFS living
+# in *our* namespace, in which case the comparison below would never match
+# and the previous revision's namespace would be leaked (issue #18470).
+PID="${PREV_LXCFS_PID}"
+
+# Resolving the namespace doubles as the liveness check: an empty result means
+# the old LXCFS is already gone and there is nothing left to clean up. It can
+# also exit at any point after this, so the rest of the block tolerates its
+# /proc entries disappearing rather than aborting daemon.start (set -e).
+PREV_MNT_NS=""
+if [ -n "${PID}" ]; then
+    PREV_MNT_NS="$(readlink "/proc/${PID}/ns/mnt" 2>/dev/null || true)"
+fi
+
+if [ -n "${PREV_MNT_NS}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "${PREV_MNT_NS}" ]; then
     echo "==> Cleaning up existing LXCFS namespace"
 
     # Read mountinfo directly, extracting the mount point (5th column)
@@ -693,7 +733,7 @@ if [ -n "${PID}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "$(readlink "/proc/
             *)
                 ;;
         esac
-    done < "/proc/${PID}/mountinfo"
+    done < "/proc/${PID}/mountinfo" || true
 fi
 
 # LXD

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -603,6 +603,25 @@ else
     ln -s /var/lib/snapd/hostfs/run/openvswitch /run/openvswitch
 fi
 
+# Remember the LXCFS that was running before this start, if any.
+#
+# On a snap refresh daemon.stop only stops LXD, leaving LXCFS running on
+# purpose so containers keep their /proc overlays. That surviving LXCFS keeps
+# the *previous* revision's mount namespace alive, along with everything that
+# was mounted in it -- including instance storage volumes. Those have to be
+# unmounted from that namespace further down, otherwise the kernel keeps a
+# reference on the underlying dataset and deleting the instance later fails
+# with e.g. "cannot destroy '<pool>/virtual-machines/<name>': dataset is busy"
+# (https://github.com/canonical/lxd/issues/18470).
+#
+# The LXCFS section below may spawn a replacement LXCFS, which overwrites
+# lxcfs.pid with its own pid, so capture the old pid here while it is still
+# the previous revision's one.
+PREV_LXCFS_PID=""
+if [ -e "${SNAP_COMMON}/lxcfs.pid" ]; then
+    read -r PREV_LXCFS_PID < "${SNAP_COMMON}/lxcfs.pid" || true
+fi
+
 # LXCFS
 if [ -e "${SNAP_COMMON}/var/lib/lxcfs/cgroup" ]; then
     echo "=> Re-using existing LXCFS"
@@ -675,9 +694,22 @@ else
     )
 fi
 
-PID=""
-[ -e "${SNAP_COMMON}/lxcfs.pid" ] && read -r PID < "${SNAP_COMMON}/lxcfs.pid"
-if [ -n "${PID}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "$(readlink "/proc/${PID}/ns/mnt")" ]; then
+# Use the pid captured before the LXCFS section above: by this point
+# lxcfs.pid may already have been replaced by a freshly spawned LXCFS living
+# in *our* namespace, in which case the comparison below would never match
+# and the previous revision's namespace would be leaked (issue #18470).
+PID="${PREV_LXCFS_PID}"
+
+# Resolving the namespace doubles as the liveness check: an empty result means
+# the old LXCFS is already gone and there is nothing left to clean up. It can
+# also exit at any point after this, so the rest of the block tolerates its
+# /proc entries disappearing rather than aborting daemon.start (set -e).
+PREV_MNT_NS=""
+if [ -n "${PID}" ]; then
+    PREV_MNT_NS="$(readlink "/proc/${PID}/ns/mnt" 2>/dev/null || true)"
+fi
+
+if [ -n "${PREV_MNT_NS}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "${PREV_MNT_NS}" ]; then
     echo "==> Cleaning up existing LXCFS namespace"
 
     # Read mountinfo directly, extracting the mount point (5th column)
@@ -690,7 +722,7 @@ if [ -n "${PID}" ] && [ "$(readlink "/proc/self/ns/mnt")" != "$(readlink "/proc/
             *)
                 ;;
         esac
-    done < "/proc/${PID}/mountinfo"
+    done < "/proc/${PID}/mountinfo" || true
 fi
 
 # LXD


### PR DESCRIPTION
This PR fixes issue https://github.com/canonical/lxd/issues/18470

## Root causes

Two defects exist.

**Defect 1**: On a snap refresh daemon.stop stops only LXD and deliberately leaves LXCFS running, so the previous revision's mount namespace stays alive with the instance's volume still mounted in it, holding a kernel reference on the dataset and making `zfs destroy` fail with dataset is busy — invisible to the new daemon. `daemon.start` already had a block meant to unmount those stale mounts, but it never ran , so the else branch removes lxcfs.pid and the **replacement LXCFS writes its own pid there, leaving the cleanup to read that new pid, find it in its own namespace, and skip**. 

**Defect 2**: `getAgentClient()` is driven by QMP events and can fire during daemon startup **before the config volume containing the TLS materials is mounted into the daemon's new namespace** and it called `generateAgentCert()`, which wrote a fresh certificate set into the underlying instance directory — breaking the agent connection with x509: certificate signed by unknown authority and leaving stray files that resurface at deletion as directory not empty.  A longer explanation of the race condition can be found [in this comment](https://github.com/canonical/lxd/pull/18894#issuecomment-5418685015)


## Fixes 

**Fix 1**: Capture the LXCFS pid before the LXCFS section can replace it, so the existing stale-namespace cleanup actually runs on refresh. (Commit 1) 

**Fix 2**: Add a read-only readAgentCert() and use it from getAgentClient(), so paths running against an already-started instance never create certificates.
  - commit 2: add `readAgentCert()` with UT
  - commit 3: simplify `generateAgentCert` using `readAgentCert()`

## Repro and validation

[repro_18470.sh](https://github.com/user-attachments/files/31284205/repro_18470.sh)


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
