### PR TITLE
Enhance subprocess handling to prevent pid-reuse issues (stable-5.21)

### DIFF
--- a/lxd/subprocess/bgpm_test.go
+++ b/lxd/subprocess/bgpm_test.go
@@ -4,11 +4,15 @@ package subprocess
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"go.yaml.in/yaml/v2"
 )
 
 func TestSignalHandling(t *testing.T) {
@@ -186,5 +190,226 @@ func TestProcessStartWaitExit(t *testing.T) {
 	err = os.Remove("testscript/out.txt")
 	if err != nil {
 		t.Error("Could not delete file: ", err)
+	}
+}
+
+// startSleep starts a long-running process for identity tests and registers a
+// cleanup that kills it on test exit.
+func startSleep(t *testing.T) *Process {
+	t.Helper()
+
+	p, err := NewProcess("sleep", []string{"30"}, "", "")
+	if err != nil {
+		t.Fatal("Failed process creation: ", err)
+	}
+
+	err = p.Start(context.Background())
+	if err != nil {
+		t.Fatal("Failed starting process: ", err)
+	}
+
+	t.Cleanup(func() { _ = p.Stop() })
+
+	return p
+}
+
+// savePidFile saves p to a fresh pid file, applies mutate to the saved YAML,
+// and returns the file path.
+func savePidFile(t *testing.T, p *Process, mutate func(*Process)) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "proc.yaml")
+	err := p.Save(path)
+	if err != nil {
+		t.Fatal("Failed saving process: ", err)
+	}
+
+	if mutate == nil {
+		return path
+	}
+
+	dat, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal("Failed reading pid file: ", err)
+	}
+
+	saved := &Process{}
+	err = yaml.Unmarshal(dat, saved)
+	if err != nil {
+		t.Fatal("Failed parsing pid file: ", err)
+	}
+
+	mutate(saved)
+
+	dat, err = yaml.Marshal(saved)
+	if err != nil {
+		t.Fatal("Failed serializing pid file: ", err)
+	}
+
+	err = os.WriteFile(path, dat, 0600)
+	if err != nil {
+		t.Fatal("Failed writing pid file: ", err)
+	}
+
+	return path
+}
+
+// assertAlive fails the test if the monitored process exits within the grace
+// period. Detects a process that was wrongly signaled.
+func assertAlive(t *testing.T, p *Process, grace time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), grace)
+	defer cancel()
+
+	exitcode, err := p.Wait(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Process was killed but should have been left alone (exit code %d, err %v)", exitcode, err)
+	}
+}
+
+// TestImportRoundTripLive checks that a saved live process can
+// be imported, probed and stopped, and the stop lands on the correct process.
+func TestImportRoundTripLive(t *testing.T) {
+	p := startSleep(t)
+	path := savePidFile(t, p, nil)
+
+	imp, err := ImportProcess(path)
+	if err != nil {
+		t.Fatal("Failed importing process: ", err)
+	}
+
+	err = imp.Signal(0)
+	if err != nil {
+		t.Error("Imported process should be seen as running: ", err)
+	}
+
+	err = imp.Stop()
+	if err != nil {
+		t.Error("Failed stopping imported process: ", err)
+	}
+
+	// The kill must land on the process we saved: its monitor sees it exit.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = p.Wait(ctx)
+	if err == nil || errors.Is(err, context.DeadlineExceeded) {
+		t.Error("Original process did not exit after Stop of imported process: ", err)
+	}
+
+	// A second Stop reports the process as gone.
+	err = imp.Stop()
+	if !errors.Is(err, ErrNotRunning) {
+		t.Error("Second Stop should return ErrNotRunning, got: ", err)
+	}
+}
+
+// TestImportStalePidReuse checks that a pid file whose starttime does not match
+// the process currently holding the pid is recognized as not running and the imposter is
+// not signaled.
+func TestImportStalePidReuse(t *testing.T) {
+	victim := startSleep(t)
+	path := savePidFile(t, victim, func(saved *Process) {
+		if saved.StartTime == 0 {
+			t.Fatal("Saved pid file has no starttime; identity cannot be verified")
+		}
+
+		saved.StartTime += 12345
+	})
+
+	imp, err := ImportProcess(path)
+	if err != nil {
+		t.Fatal("Failed importing process: ", err)
+	}
+
+	err = imp.Stop()
+	if !errors.Is(err, ErrNotRunning) {
+		t.Error("Stop of a recycled pid should return ErrNotRunning, got: ", err)
+	}
+
+	assertAlive(t, victim, 150*time.Millisecond)
+}
+
+// TestImportStaleBootID checks that a pid file from a previous boot is never
+// acted on.
+func TestImportStaleBootID(t *testing.T) {
+	victim := startSleep(t)
+	path := savePidFile(t, victim, func(saved *Process) {
+		if saved.BootID == "" {
+			t.Fatal("Saved pid file has no boot ID; identity cannot be verified")
+		}
+
+		saved.BootID = "00000000-dead-beef-0000-000000000000"
+	})
+
+	imp, err := ImportProcess(path)
+	if err != nil {
+		t.Fatal("Failed importing process: ", err)
+	}
+
+	err = imp.Stop()
+	if !errors.Is(err, ErrNotRunning) {
+		t.Error("Stop after a reboot should return ErrNotRunning, got: ", err)
+	}
+
+	assertAlive(t, victim, 150*time.Millisecond)
+}
+
+// TestImportDeadProcess checks that importing a pid file for an exited
+// process yields ErrNotRunning rather than an import error. If the subprocess.ImportProcess() api
+// changes to return eg an ErrStale in the future, call sites would need to change;
+// this test encodes current caller expectations.
+func TestImportDeadProcess(t *testing.T) {
+	p, err := NewProcess("sleep", []string{"0"}, "", "")
+	if err != nil {
+		t.Fatal("Failed process creation: ", err)
+	}
+
+	err = p.Start(context.Background())
+	if err != nil {
+		t.Fatal("Failed starting process: ", err)
+	}
+
+	_, err = p.Wait(context.Background())
+	if err != nil {
+		t.Fatal("Failed waiting for process: ", err)
+	}
+
+	path := savePidFile(t, p, nil)
+
+	imp, err := ImportProcess(path)
+	if err != nil {
+		t.Fatal("Failed importing process: ", err)
+	}
+
+	err = imp.Stop()
+	if !errors.Is(err, ErrNotRunning) {
+		t.Error("Stop of an exited process should return ErrNotRunning, got: ", err)
+	}
+}
+
+// TestImportOldFormat checks that pid files written before the changes are handled
+// as they are currently. This is relevant for an lxd refresh on top of existing daemons.
+func TestImportOldFormat(t *testing.T) {
+	p := startSleep(t)
+	path := savePidFile(t, p, func(saved *Process) {
+		saved.StartTime = 0
+		saved.BootID = ""
+	})
+
+	imp, err := ImportProcess(path)
+	if err != nil {
+		t.Fatal("Failed importing process: ", err)
+	}
+
+	err = imp.Signal(0)
+	if err != nil {
+		t.Error("Old-format import of a live process should be seen as running: ", err)
+	}
+
+	err = imp.Stop()
+	if err != nil {
+		t.Error("Failed stopping process imported from old-format file: ", err)
 	}
 }

--- a/lxd/subprocess/errors.go
+++ b/lxd/subprocess/errors.go
@@ -8,3 +8,6 @@ import (
 
 // ErrNotRunning is returned when performing an action against a stopped process.
 var ErrNotRunning = errors.New("The process isn't running")
+
+// ErrBadPID is returned when an import file contains a facially incorrect/dangerous PID <= 0.
+var ErrBadPID = errors.New("Invalid PID")

--- a/lxd/subprocess/manager.go
+++ b/lxd/subprocess/manager.go
@@ -67,6 +67,32 @@ func ImportProcess(path string) (*Process, error) {
 		return nil, fmt.Errorf("Unable to parse YAML in PID file %q: %w", path, err)
 	}
 
-	proc.proc, _ = os.FindProcess(int(proc.PID))
+	if proc.PID <= 0 {
+		return nil, fmt.Errorf("%w %d in PID file %q", ErrBadPID, proc.PID, path)
+	}
+
+	if proc.BootID != "" {
+		bootID, err := currentBootID()
+		if err == nil {
+			if bootID != proc.BootID {
+				return &proc, nil
+			}
+		}
+	}
+
+	// On unix, FindProcess always returns successfully (with a 'done' process if pidfd_open
+	// returned with ESRCH).
+	proc.proc, _ = os.FindProcess(proc.PID)
+	if proc.StartTime != 0 {
+		starttime, err := processStartTime(proc.PID)
+		if err == nil {
+			if proc.StartTime != starttime {
+				_ = proc.proc.Release()
+				proc.proc = nil
+				return &proc, nil
+			}
+		}
+	}
+
 	return &proc, nil
 }

--- a/lxd/subprocess/manager.go
+++ b/lxd/subprocess/manager.go
@@ -67,5 +67,6 @@ func ImportProcess(path string) (*Process, error) {
 		return nil, fmt.Errorf("Unable to parse YAML in PID file %q: %w", path, err)
 	}
 
+	proc.proc, _ = os.FindProcess(int(proc.PID))
 	return &proc, nil
 }

--- a/lxd/subprocess/proc.go
+++ b/lxd/subprocess/proc.go
@@ -24,6 +24,7 @@ type Process struct {
 	chExit     chan struct{}
 	hasMonitor bool
 	closeFds   bool
+	proc       *os.Process
 
 	Name     string   `yaml:"name"`
 	Args     []string `yaml:"args,flow"`
@@ -57,29 +58,6 @@ func (p *Process) hasApparmor() bool {
 	return true
 }
 
-// GetPid returns the pid for the given process object.
-func (p *Process) GetPid() (int64, error) {
-	pr, err := os.FindProcess(int(p.PID))
-	if err != nil {
-		if err == os.ErrProcessDone {
-			return 0, ErrNotRunning
-		}
-
-		return 0, err
-	}
-
-	err = pr.Signal(syscall.Signal(0))
-	if err != nil {
-		if err == os.ErrProcessDone {
-			return 0, ErrNotRunning
-		}
-
-		return 0, err
-	}
-
-	return p.PID, nil
-}
-
 // SetApparmor allows setting the AppArmor profile.
 func (p *Process) SetApparmor(profile string) {
 	p.Apparmor = profile
@@ -91,39 +69,39 @@ func (p *Process) SetCreds(uid uint32, gid uint32) {
 	p.GID = gid
 }
 
+func (p *Process) release() {
+	if p.proc == nil {
+		return
+	}
+
+	_ = p.proc.Release()
+	p.proc = nil
+}
+
+func (p *Process) finish() {
+	if p.hasMonitor {
+		<-p.chExit
+		return
+	}
+
+	p.release()
+}
+
 // Stop will stop the given process object.
 func (p *Process) Stop() error {
-	pr, err := os.FindProcess(int(p.PID))
-	if err != nil {
-		if err == os.ErrProcessDone {
-			if p.hasMonitor {
-				<-p.chExit
-			}
-
-			return ErrNotRunning
-		}
-
-		return err
+	if p.proc == nil {
+		return ErrNotRunning
 	}
 
-	// Check if process exists.
-	err = pr.Signal(syscall.Signal(0))
+	err := p.proc.Signal(syscall.SIGKILL)
 	if err == nil {
-		err = pr.Kill()
-		if err == nil {
-			if p.hasMonitor {
-				<-p.chExit
-			}
+		p.finish()
 
-			return nil // Killed successfully.
-		}
+		return nil
 	}
 
-	// Check if either the existence check or the kill resulted in an already finished error.
-	if err == os.ErrProcessDone {
-		if p.hasMonitor {
-			<-p.chExit
-		}
+	if errors.Is(err, os.ErrProcessDone) {
+		p.finish()
 
 		return ErrNotRunning
 	}
@@ -184,6 +162,7 @@ func (p *Process) start(ctx context.Context, fds []*os.File) error {
 		return fmt.Errorf("Unable to start process: %w", err)
 	}
 
+	p.proc = cmd.Process
 	p.PID = int64(cmd.Process.Pid)
 
 	// Reset exitCode/exitErr
@@ -235,29 +214,21 @@ func (p *Process) Restart(ctx context.Context) error {
 
 // Reload sends the SIGHUP signal to the given process object.
 func (p *Process) Reload() error {
-	pr, err := os.FindProcess(int(p.PID))
+	if p.proc == nil {
+		return ErrNotRunning
+	}
+
+	err := p.proc.Signal(syscall.SIGHUP)
 	if err != nil {
-		if err == os.ErrProcessDone {
+		if errors.Is(err, os.ErrProcessDone) {
+			p.finish()
 			return ErrNotRunning
 		}
 
 		return fmt.Errorf("Could not reload process: %w", err)
 	}
 
-	err = pr.Signal(syscall.Signal(0))
-	switch err {
-	case nil:
-		err = pr.Signal(syscall.SIGHUP)
-		if err != nil {
-			return fmt.Errorf("Could not reload process: %w", err)
-		}
-
-		return nil
-	case os.ErrProcessDone:
-		return ErrNotRunning
-	}
-
-	return fmt.Errorf("Could not reload process: %w", err)
+	return nil
 }
 
 // Save will save the given process object to a YAML file. Can be imported at a later point.
@@ -277,29 +248,21 @@ func (p *Process) Save(path string) error {
 
 // Signal will send a signal to the given process object given a signal value.
 func (p *Process) Signal(signal int64) error {
-	pr, err := os.FindProcess(int(p.PID))
-	if err != nil {
-		if err == os.ErrProcessDone {
-			return ErrNotRunning
-		}
-
-		return err
-	}
-
-	err = pr.Signal(syscall.Signal(0))
-	switch err {
-	case nil:
-		err = pr.Signal(syscall.Signal(signal))
-		if err != nil {
-			return fmt.Errorf("Could not signal process: %w", err)
-		}
-
-		return nil
-	case os.ErrProcessDone:
+	if p.proc == nil {
 		return ErrNotRunning
 	}
 
-	return fmt.Errorf("Could not signal process: %w", err)
+	err := p.proc.Signal(syscall.Signal(signal))
+	if err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			p.finish()
+			return ErrNotRunning
+		}
+
+		return fmt.Errorf("Could not signal process: %w", err)
+	}
+
+	return nil
 }
 
 // Wait will wait for the given process object exit code.

--- a/lxd/subprocess/proc.go
+++ b/lxd/subprocess/proc.go
@@ -29,7 +29,8 @@ type Process struct {
 	Name     string   `yaml:"name"`
 	Args     []string `yaml:"args,flow"`
 	Apparmor string   `yaml:"apparmor"`
-	PID      int64    `yaml:"pid"`
+	PID      int      `yaml:"pid"`
+	BootID   string   `yaml:"boot_id"`
 	stdin    io.ReadCloser
 	stdout   io.WriteCloser
 	stderr   io.WriteCloser
@@ -37,6 +38,7 @@ type Process struct {
 	UID       uint32 `yaml:"uid"`
 	GID       uint32 `yaml:"gid"`
 	SetGroups bool   `yaml:"set_groups"`
+	StartTime int64  `yaml:"start_time"`
 
 	SysProcAttr *syscall.SysProcAttr
 }
@@ -162,9 +164,20 @@ func (p *Process) start(ctx context.Context, fds []*os.File) error {
 		return fmt.Errorf("Unable to start process: %w", err)
 	}
 
+	p.BootID = ""
+	p.StartTime = 0
 	p.proc = cmd.Process
-	p.PID = int64(cmd.Process.Pid)
+	p.PID = cmd.Process.Pid
 
+	starttime, err := processStartTime(p.PID)
+	if err == nil {
+		p.StartTime = starttime
+	}
+
+	bootID, err := currentBootID()
+	if err == nil {
+		p.BootID = bootID
+	}
 	// Reset exitCode/exitErr
 	p.exitCode = 0
 	p.exitErr = nil

--- a/lxd/subprocess/procfs_linux.go
+++ b/lxd/subprocess/procfs_linux.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-var bootID func() (string, error) = sync.OnceValues(func() (string, error) {
+var bootID = sync.OnceValues(func() (string, error) {
 	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
 	if err != nil {
 		return "", err

--- a/lxd/subprocess/procfs_linux.go
+++ b/lxd/subprocess/procfs_linux.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package subprocess
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var bootID func() (string, error) = sync.OnceValues(func() (string, error) {
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(data)), nil
+})
+
+func currentBootID() (string, error) {
+	return bootID()
+}
+
+func processStartTime(pid int) (int64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+
+	i := bytes.LastIndexByte(data, ')')
+	if i < 0 {
+		return 0, fmt.Errorf("Malformed /proc/%d/stat", pid)
+	}
+
+	fields := strings.Fields(string(data[i+1:]))
+	if len(fields) < 20 {
+		return 0, fmt.Errorf("Malformed /proc/%d/stat", pid)
+	}
+
+	return strconv.ParseInt(fields[19], 10, 64)
+}

--- a/lxd/subprocess/procfs_other.go
+++ b/lxd/subprocess/procfs_other.go
@@ -1,0 +1,15 @@
+//go:build !linux && !windows
+
+package subprocess
+
+import (
+	"errors"
+)
+
+func currentBootID() (string, error) {
+	return "", errors.New("Procfs is only supported on Linux")
+}
+
+func processStartTime(pid int) (int64, error) {
+	return 0, errors.New("Procfs is only supported on Linux")
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

This backports https://github.com/canonical/lxd/pull/18872 to stable-5.21. I included the follow-up linter/convention fix.