### PR TITLE
test: Merge devlxd-container and devlxd-vm into devlxd to match lxd-c…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -544,8 +544,7 @@ jobs:
           - container-nesting
           - conversion
           - cpu-vm
-          - devlxd-container
-          - devlxd-vm
+          - devlxd
           - docker
           - efi-vm
           - lxd-installer


### PR DESCRIPTION
…i and stop failures

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

devlxd-container and devlxd-vm tests are currently failing at test start because the lxd-ci repo no longer contains those tests - this morning they were merged into a single devlxd test. This PR does the same thing in .githu/workflows/tests.yml to fix the failures.
see: https://github.com/canonical/lxd-ci/pull/843