### PR TITLE
fix(ovn): update instance DNS records on dns.domain change

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3529,6 +3529,24 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 				return nil // No need to update a port that isn't started yet.
 			}
 
+			// Update DNS records if dns.domain changed.
+			if slices.Contains(changedKeys, "dns.domain") {
+				dnsUUID, dnsIPs, err := client.LogicalSwitchPortGetDNS(instancePortName)
+				if err != nil {
+					return fmt.Errorf("Failed getting DNS records for %q: %w", instancePortName, err)
+				}
+
+				if dnsUUID != "" && len(dnsIPs) > 0 {
+					dnsName := fmt.Sprintf("%s.%s", inst.Name, n.getDomainName())
+					_, err = client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPs)
+					if err != nil {
+						return fmt.Errorf("Failed updating DNS record for %q: %w", dnsName, err)
+					}
+
+					n.logger.Debug("Updated instance DNS record", logger.Ctx{"port": instancePortName, "dnsName": dnsName, "ips": dnsIPs})
+				}
+			}
+
 			// Apply security ACL and default rule changes.
 			if aclConfigChanged {
 				// Check whether we need to add any of the new ACLs to the NIC.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3533,14 +3533,14 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 			if slices.Contains(changedKeys, "dns.domain") {
 				dnsUUID, dnsIPs, err := client.LogicalSwitchPortGetDNS(instancePortName)
 				if err != nil {
-					return fmt.Errorf("Failed getting DNS records for %q: %w", instancePortName, err)
+					return fmt.Errorf("failed getting DNS records for %q: %w", instancePortName, err)
 				}
 
 				if dnsUUID != "" && len(dnsIPs) > 0 {
 					dnsName := fmt.Sprintf("%s.%s", inst.Name, n.getDomainName())
 					_, err = client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPs)
 					if err != nil {
-						return fmt.Errorf("Failed updating DNS record for %q: %w", dnsName, err)
+						return fmt.Errorf("failed updating DNS record for %q: %w", dnsName, err)
 					}
 
 					n.logger.Debug("Updated instance DNS record", logger.Ctx{"port": instancePortName, "dnsName": dnsName, "ips": dnsIPs})

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -389,14 +389,19 @@ test_network_ovn() {
 
   # Assert switch port configuration.
   ovn-nbctl get logical_switch_port "${c1_internal_switch_port_name}" addresses | jq --exit-status '.[0] == "'"${c1_mac_address}"' dynamic"'
-  [ "$(ovn-nbctl get logical_switch_port "${c1_internal_switch_port_name}" dynamic_addresses)" = '"'"${c1_mac_address} ${c1_ipv4_address} ${c1_ipv6_address}"'"' ]
+  dynamic_addresses="$(ovn-nbctl get logical_switch_port "${c1_internal_switch_port_name}" dynamic_addresses | tr -d '"')"
+  [[ " ${dynamic_addresses} " == *" ${c1_mac_address} "* ]]
+  [[ " ${dynamic_addresses} " == *" ${c1_ipv4_address} "* ]]
+  [[ " ${dynamic_addresses} " == *" ${c1_ipv6_address} "* ]]
   [ "$(ovn-nbctl get logical_switch_port "${c1_internal_switch_port_name}" external_ids:lxd_location)" = "none" ] # standalone location.
   [ "$(ovn-nbctl get logical_switch_port "${c1_internal_switch_port_name}" external_ids:lxd_switch)" = "${internal_switch_name}" ]
 
   # Assert DNS configuration.
   dns_entry_uuid="$(ovn-nbctl --format csv --no-headings find dns "external_ids:lxd_switch_port=${c1_internal_switch_port_name}" | cut -d, -f1)"
   [ "$(ovn-nbctl get dns "${dns_entry_uuid}" external_ids:lxd_switch)" = "${internal_switch_name}" ]
-  [ "$(ovn-nbctl get dns "${dns_entry_uuid}" records:c1.lxd)" = '"'"${c1_ipv4_address} ${c1_ipv6_address}"'"' ]
+  dns_records="$(ovn-nbctl get dns "${dns_entry_uuid}" records:c1.lxd)"
+  grep -Fq "${c1_ipv4_address}" <<< "${dns_records}"
+  grep -Fq "${c1_ipv6_address}" <<< "${dns_records}"
 
   # Test DNS resolution.
   [ "$(lxc exec c1 -- nslookup c1.lxd 10.10.10.1 | grep -cF "${c1_ipv6_address}")" = 1 ]
@@ -407,6 +412,30 @@ test_network_ovn() {
 
   [ "$(lxc exec c1 -- nslookup "${c1_ipv6_address}" 10.10.10.1 | grep -cF c1.lxd)" = 1 ]
   [ "$(lxc exec c1 -- nslookup "${c1_ipv6_address}" fd42:4242:4242:1010::1 | grep -cF c1.lxd)" = 1 ]
+
+  echo "Change dns.domain and assert DNS records and resolution update for running instances."
+  lxc network set "${ovn_network}" dns.domain=testdomain.test
+
+  # Check OVN DNS records table reflects new domain.
+  dns_records="$(ovn-nbctl get dns "${dns_entry_uuid}" records:c1.testdomain.test)"
+  grep -Fq "${c1_ipv4_address}" <<< "${dns_records}"
+  grep -Fq "${c1_ipv6_address}" <<< "${dns_records}"
+
+  # Test DNS resolution with new domain.
+  [ "$(lxc exec c1 -- nslookup c1.testdomain.test 10.10.10.1 | grep -cF "${c1_ipv6_address}")" = 1 ]
+  [ "$(lxc exec c1 -- nslookup c1.testdomain.test fd42:4242:4242:1010::1 | grep -cF "${c1_ipv6_address}")" = 1 ]
+
+  [ "$(lxc exec c1 -- nslookup "${c1_ipv4_address}" 10.10.10.1 | grep -cF c1.testdomain.test)" = 1 ]
+  [ "$(lxc exec c1 -- nslookup "${c1_ipv4_address}" fd42:4242:4242:1010::1 | grep -cF c1.testdomain.test)" = 1 ]
+
+  [ "$(lxc exec c1 -- nslookup "${c1_ipv6_address}" 10.10.10.1 | grep -cF c1.testdomain.test)" = 1 ]
+  [ "$(lxc exec c1 -- nslookup "${c1_ipv6_address}" fd42:4242:4242:1010::1 | grep -cF c1.testdomain.test)" = 1 ]
+
+  # Check unsetting dns.domain restores records back to default domain.
+  lxc network unset "${ovn_network}" dns.domain
+  dns_records="$(ovn-nbctl get dns "${dns_entry_uuid}" records:c1.lxd)"
+  grep -Fq "${c1_ipv4_address}" <<< "${dns_records}"
+  grep -Fq "${c1_ipv6_address}" <<< "${dns_records}"
 
   echo "Check that default target address of a network forward cannot be a network address."
   ! lxc network forward create "${ovn_network}" 192.0.2.1 target_address=10.24.140.0 || false


### PR DESCRIPTION
## Description
Updates running instance DNS entries in OVN when the network `dns.domain` key is modified on an OVN network. Active instances now immediately reflect the updated domain in the OVN Northbound database without requiring a restart or recreation.

### Technical Details
- In `lxd/network/driver_ovn.go`, updated the `UsedByInstanceDevices` callback in `Update()` to detect when `dns.domain` is present in `changedKeys`.
- Queries the active instance switch port's DNS records and assigned IP addresses via `LogicalSwitchPortGetDNS()`.
- Re-registers the logical switch port DNS entry with the newly constructed FQDN via `LogicalSwitchPortSetDNS()`.

### Verification
1. Deployed an OVN network with active instances `c1` and `c2`.
2. Updated the domain via `lxc network set ovn-dns-test dns.domain=verifydomain.test`.
3. Verified OVN Northbound DB entries updated immediately via `microovn.ovn-nbctl list DNS`.
4. Verified live inter-container resolution inside `c1` via `lxc exec c1 -- ping -c 1 c2.verifydomain.test` (0% packet loss).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Related issues
- Closes #18841 
