### PR TITLE
lxd/endpoints/listeners: Fix Accept cancellation race

### DIFF
--- a/lxd/endpoints/listeners/starttls.go
+++ b/lxd/endpoints/listeners/starttls.go
@@ -51,17 +51,20 @@ func NewSTARTTLSListener(inner net.Listener, cert *shared.CertInfo) *StarttlsLis
 // if the client began with a STARTTLS handshake. Once the listener is closed it
 // returns net.ErrClosed instead of blocking.
 func (l *StarttlsListener) Accept() (net.Conn, error) {
-	// Prioritise cancellation so a closed listener never hands out a connection,
-	// even if one raced into l.accepted just before Close.
-	if l.canceller.Err() != nil {
-		return nil, net.ErrClosed
-	}
-
 	select {
-	case res := <-l.accepted:
-		return res.conn, res.err
 	case <-l.canceller.Done():
 		return nil, net.ErrClosed
+	case res := <-l.accepted:
+		// Re-check: drop the connection rather than hand it out after the listener closed.
+		if l.canceller.Err() != nil {
+			if res.conn != nil {
+				_ = res.conn.Close()
+			}
+
+			return nil, net.ErrClosed
+		}
+
+		return res.conn, res.err
 	}
 }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.


Follow-up to #18819.

`Accept`'s pre-`select` cancellation check didn't give cancellation priority: if `Close` fired after the check, both `select` cases could be ready and the random selection could still hand out a connection after the listener closed. Move the check to after the receive so cancellation stays authoritative, dropping any connection that raced in.