### PR TITLE
lxd/operations: Fix bulk operations with no children hanging forever

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -483,7 +483,8 @@ func (op *Operation) start() {
 
 	// If there's a run hook, we need to run it and get the final status from it.
 	// If there are child operations, we need to start and wait for them to finish before we can get the final status of the parent operation.
-	if op.onRun != nil || len(op.children) > 0 {
+	hasWork := op.onRun != nil || len(op.children) > 0
+	if hasWork {
 		// The operation context is the "running" context plus the requestor.
 		// The requestor is available directly on the operation, but we should still put it in the context.
 		// This is so that, if an operation queries another cluster member, the requestor information will be set
@@ -568,6 +569,39 @@ func (op *Operation) start() {
 	op.lock.Unlock()
 
 	op.logger.Debug("Started operation")
+	_, md := op.Render()
+
+	op.lock.Lock()
+	op.sendEvent(md)
+	op.lock.Unlock()
+
+	if !hasWork {
+		// There is no run hook and no children to wait on (e.g. a bulk operation that matched no
+		// resources), so there is nothing that would ever mark the operation as finished. Do so
+		// here, otherwise the operation would stay in the "Running" state forever and callers
+		// waiting on it (such as `lxc start --all` against a project with no instances) would hang.
+		op.finishNoWorkOperation()
+	}
+}
+
+// finishNoWorkOperation marks an operation with no run hook and no children as successful, unless
+// it was concurrently cancelled (e.g. deleted by the caller) between start() releasing the lock
+// above and this method re-acquiring it, in which case Cancel() has already finalized it and that
+// outcome must not be clobbered.
+func (op *Operation) finishNoWorkOperation() {
+	op.lock.Lock()
+
+	if op.running.Err() != nil {
+		op.lock.Unlock()
+		return
+	}
+
+	op.persistWithNewStatus(api.Success)
+	op.running.Cancel()
+	op.lock.Unlock()
+	op.done()
+
+	op.logger.Debug("Success for operation")
 	_, md := op.Render()
 
 	op.lock.Lock()

--- a/lxd/operations/operations_test.go
+++ b/lxd/operations/operations_test.go
@@ -147,3 +147,37 @@ func (s *operationsSuite) Test_deleteInternalParentWithChildren() {
 	s.False(op2.readonly)
 	s.NoError(op2.finished.Err())
 }
+
+// A parent operation with no run hook and no children (e.g. a bulk state change against a
+// project with no matching instances) has nothing that would ever mark it as finished, so
+// start() must finish it immediately instead of leaving it stuck in "Running" forever.
+func (s *operationsSuite) Test_startNoRunHookNoChildrenFinishesImmediately() {
+	op := newTestOp(s.Require())
+
+	op.start()
+
+	select {
+	case <-op.finished.Done():
+	case <-time.After(5 * time.Second):
+		s.Require().FailNow("operation never finished")
+	}
+
+	s.Equal(api.Success, op.status)
+	s.True(op.readonly)
+	s.ErrorIs(op.running.Err(), context.Canceled)
+}
+
+// If the operation is cancelled (e.g. deleted by the caller) in the window between start()
+// releasing the lock and finishNoWorkOperation() re-acquiring it, the latter must not clobber the
+// cancellation and report success instead.
+func (s *operationsSuite) Test_finishNoWorkOperationDoesNotClobberConcurrentCancel() {
+	op := newTestOp(s.Require())
+
+	err := op.Cancel()
+	s.Require().NoError(err)
+	s.Equal(api.Cancelled, op.status)
+
+	op.finishNoWorkOperation()
+
+	s.Equal(api.Cancelled, op.status)
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

Note: per this repo's `COMMITS.md` ("AI agents must not add a Signed-off-by line — it is a DCO certification that only the human submitter can make"), the commit intentionally omits a `Signed-off-by` trailer. The human submitter should add their own sign-off (and their cryptographic signature) before this is merged.

Fixes https://github.com/canonical/lxd/issues/18884

### Validation disclosure

This change could not be built or tested in the environment it was prepared in (no Linux C cross-toolchain / dqlite headers available, so `lxd/operations` — which pulls in `lxd/state` -> `lxd/storage/filesystem` and `lxd/db/query` — cannot compile there). This matches the dependency setup `.github/workflows/tests.yml` performs on its Ubuntu runners (building dqlite/liblxc from source) before running unit tests. The fix and its two new tests were verified by manual trace of the locking/cancellation logic and independently re-checked in two rounds of adversarial review, but not by actually executing `go test`. Please let the CI run confirm.

Fixes #18884