### PR TITLE
test/cli: report monitor liveness under --verbose mode and use new liveness wait function to simplify testing

### DIFF
--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/logger"
 )
 
 type cmdMonitor struct {
@@ -212,6 +213,7 @@ func (c *cmdMonitor) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	logger.Info("Monitoring events", logger.Ctx{"remote": remote, "types": c.flagType})
 	go func() {
 		chError <- listener.Wait()
 	}()

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -434,6 +434,27 @@ cleanup_lxds() {
     umount_loops "$test_dir"
 }
 
+lxc_monitor_start() {
+    local output="${1}"; shift
+    local ready="${TEST_DIR}/monitor.$$.${RANDOM}.ready"
+
+    lxc monitor --verbose "$@" > "${output}" 2> "${ready}" &
+    LXC_MONITOR_PID=$!
+    for i in $(seq 200); do
+        if grep -qF "Monitoring events" "${ready}"; then
+            rm -f "${ready}"
+            return 0
+        fi
+
+        sleep 0.1
+    done
+    echo "lxc monitor $* (${LXC_MONITOR_PID}) failed liveness check"
+    cat "${ready}"
+    rm -f "${ready}"
+    kill_go_proc "${LXC_MONITOR_PID}"
+    return 1
+}
+
 lxd_shutdown_restart() {
     local scenario="${1}"
     local LXD_PID
@@ -443,11 +464,8 @@ lxd_shutdown_restart() {
 
     local logfile="${scenario}.log"
     echo "Starting LXD log capture in $logfile using lxc monitor..."
-    lxc monitor --pretty > "$logfile" 2>&1 &
-    local monitor_pid=$!
-
-    # Give monitor a moment to connect
-    sleep 0.1
+    lxd_monitor_start "$logfile" --pretty
+    local monitor_pid="${LXC_MONITOR_PID}"
     echo "Monitor PID: $monitor_pid"
     echo "LXD daemon PID: $LXD_PID"
     echo "Starting LXD shutdown sequence..."

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -464,7 +464,7 @@ lxd_shutdown_restart() {
 
     local logfile="${scenario}.log"
     echo "Starting LXD log capture in $logfile using lxc monitor..."
-    lxd_monitor_start "$logfile" --pretty
+    lxc_monitor_start "$logfile" --pretty
     local monitor_pid="${LXC_MONITOR_PID}"
     echo "Monitor PID: $monitor_pid"
     echo "LXD daemon PID: $LXD_PID"

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -521,9 +521,8 @@ events_filtering() {
 
   # Monitor as fine-grained identity with no permissions.
   lxc remote switch tls
-  lxc monitor --all-projects --format json > "${monfile}" &
-  monitor_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile}" --all-projects --format json
+  monitor_pid="${LXC_MONITOR_PID}"
   lxc remote switch local
 
   # Create an image via unix socket, then kill the monitor process.
@@ -539,9 +538,8 @@ events_filtering() {
   lxc auth group permission add test-group project default can_view
   lxc auth group permission add test-group project default can_view_events
   lxc remote switch tls
-  lxc monitor --all-projects --format json > "${monfile}" &
-  monitor_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile}" --all-projects --format json
+  monitor_pid="${LXC_MONITOR_PID}"
   lxc remote switch local
 
   # Create a profile via unix socket, then kill the monitor process.
@@ -558,9 +556,8 @@ events_filtering() {
   # Monitor as fine-grained identity that creates the profile with minimal permissions.
   lxc auth group permission add test-group project default can_create_profiles
   lxc remote switch tls
-  lxc monitor --all-projects --format json > "${monfile}" &
-  monitor_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile}" --all-projects --format json
+  monitor_pid="${LXC_MONITOR_PID}"
   lxc remote switch local
 
   # Create a profile via the fine-grained identity, without view permissions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4539,12 +4539,12 @@ test_clustering_events() {
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc list -f csv -c L c1)" = "node1" ]
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c2 --target=node2
 
-  LXD_DIR="${LXD_ONE_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node1.log" &
-  monitorNode1PID=$!
-  LXD_DIR="${LXD_TWO_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node2.log" &
-  monitorNode2PID=$!
-  LXD_DIR="${LXD_THREE_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node3.log" &
-  monitorNode3PID=$!
+  LXD_DIR="${LXD_ONE_DIR}" lxc_monitor_start "${TEST_DIR}/node1.log" --type=lifecycle
+  monitorNode1PID="${LXC_MONITOR_PID}"
+  LXD_DIR="${LXD_TWO_DIR}" lxc_monitor_start "${TEST_DIR}/node2.log" --type=lifecycle
+  monitorNode2PID="${LXC_MONITOR_PID}"
+  LXD_DIR="${LXD_THREE_DIR}" lxc_monitor_start "${TEST_DIR}/node3.log" --type=lifecycle
+  monitorNode3PID="${LXC_MONITOR_PID}"
 
   # Restart instance generating restart lifecycle event.
   LXD_DIR="${LXD_ONE_DIR}" lxc restart -f c1

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -148,8 +148,8 @@ EOF
   kill_go_proc "${client_websocket}"
   kill_go_proc "${client_stream}"
 
-  lxc monitor --type=lifecycle > "${TEST_DIR}/devlxd.log" &
-  monitorDevlxdPID=$!
+  lxc_monitor_start "${TEST_DIR}/devlxd.log" --type=lifecycle
+  monitorDevlxdPID="${LXC_MONITOR_PID}"
 
   # Test instance Ready state
   [ "$(lxc list -f csv -c s devlxd)" = "RUNNING" ]
@@ -178,8 +178,8 @@ EOF
   # volatile.last_state.ready should be unset during daemon init
   [ -z "$(lxc config get devlxd volatile.last_state.ready || echo fail)" ]
 
-  lxc monitor --type=lifecycle > "${TEST_DIR}/devlxd.log" &
-  monitorDevlxdPID=$!
+  lxc_monitor_start "${TEST_DIR}/devlxd.log" --type=lifecycle
+  monitorDevlxdPID="${LXC_MONITOR_PID}"
 
   lxc exec devlxd -- devlxd-client ready-state true
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "true" ]

--- a/test/suites/loki.sh
+++ b/test/suites/loki.sh
@@ -57,13 +57,8 @@ test_loki_security_types() {
 
   sub_test "Verify sys_monitor_disabled does not fire when security is removed from loki.types"
   local monfile="${TEST_DIR}/loki-monitor-disabled.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   # The Loki client stays up; sys_monitor_disabled is reserved for the
   # full enabled -> disabled transition.

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -207,17 +207,8 @@ test_security_events() {
   # No security events are emitted yet (emission sites are a later subtask),
   # so only the connection establishment is verified here.
   local monfile="${TEST_DIR}/security-events.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-
-  # The monitor process exits immediately on connection error. Retry kill -0
-  # for up to 10 seconds; once it succeeds we know the connection is live.
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   kill_go_proc "${mon_pid}" || true
   rm -f "${monfile}"
@@ -225,9 +216,8 @@ test_security_events() {
   sub_test "Verify existing lifecycle events are unaffected by the security event type"
   ensure_import_testimage
   local monfile_lifecycle="${TEST_DIR}/lifecycle-events.jsonl"
-  lxc monitor --type=lifecycle --format=json > "${monfile_lifecycle}" &
-  local mon_lifecycle_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile_lifecycle}" --type=lifecycle --format=json
+  local mon_lifecycle_pid="${LXC_MONITOR_PID}"
 
   lxc init --empty c-security-event-test
   lxc delete c-security-event-test --force
@@ -279,13 +269,8 @@ test_security_sys_events() {
   # is torn down. A pre-subscribed lxc monitor reliably captures it
   # because the WebSocket flushes pending frames before close.
   local monfile="${TEST_DIR}/security-sys-shutdown.jsonl"
-  LXD_DIR="${LXD_SYS_DIR}" lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  LXD_DIR="${LXD_SYS_DIR}" lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   shutdown_lxd "${LXD_SYS_DIR}"
 
@@ -303,22 +288,12 @@ test_security_user_events() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   local monfile="${TEST_DIR}/security-user-events.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   local lifecycle_monfile="${TEST_DIR}/security-user-events-lifecycle.jsonl"
-  lxc monitor --type=lifecycle --format=json > "${lifecycle_monfile}" &
-  local lifecycle_mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${lifecycle_mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${lifecycle_mon_pid}"
+  lxc_monitor_start "${lifecycle_monfile}" --type=lifecycle --format=json
+  local lifecycle_mon_pid="${LXC_MONITOR_PID}"
 
   sub_test "Verify user_created fires when a bearer identity is created"
   lxc auth identity create bearer/security-user-events-bearer
@@ -440,13 +415,8 @@ test_security_user_events_cluster_link() {
   LXD_DIR="${LXD_LINK_DIR}" lxc cluster enable security-user-events-node
 
   local monfile="${TEST_DIR}/security-cluster-link-user-events.jsonl"
-  LXD_DIR="${LXD_LINK_DIR}" lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  LXD_DIR="${LXD_LINK_DIR}" lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   sub_test "Verify user_created fires when a pending cluster link is created"
   LXD_DIR="${LXD_LINK_DIR}" lxc cluster link create security-user-events-link --quiet
@@ -481,13 +451,8 @@ test_security_user_events_cluster_link() {
 
   local activation_monfile="${TEST_DIR}/security-cluster-link-user-events-activation.jsonl"
   # Activation updates the pending identity on the token-issuing daemon.
-  LXD_DIR="${LXD_LINK_DIR}" lxc monitor --type=security --format=json > "${activation_monfile}" &
-  local activation_mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${activation_mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${activation_mon_pid}"
+  LXD_DIR="${LXD_LINK_DIR}" lxc_monitor_start "${activation_monfile}" --type=security --format=json
+  local activation_mon_pid="${LXC_MONITOR_PID}"
 
   local cluster_link_trust_token
   cluster_link_trust_token="$(LXD_DIR="${LXD_LINK_DIR}" lxc cluster link create security-user-events-link-remote --quiet)"
@@ -516,13 +481,8 @@ test_security_user_events_oidc() {
   lxc config set "oidc.issuer=http://127.0.0.1:$(< "${TEST_DIR}/oidc.port")/" "oidc.client.id=device"
 
   local monfile="${TEST_DIR}/security-oidc-user-events.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   sub_test "Verify user_created fires on OIDC first login"
   lxc remote add --accept-certificate oidc-security "${LXD_ADDR}" --auth-type oidc
@@ -594,13 +554,8 @@ test_security_events_bearer_authn() {
   # Subscribe to the security stream before any auth attempt so the revocation
   # path's authn_token_reuse event lands in the file.
   local monfile="${TEST_DIR}/security-events-bearer.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   sub_test "Verify a fresh bearer token authenticates successfully"
   curl --silent --insecure --header "Authorization: Bearer ${bearer_token}" "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.auth == "trusted"'
@@ -637,9 +592,8 @@ test_authn_events() {
 
   sub_test "Verify authn_login_fail does not fire on public unauthenticated endpoints"
   local monfile="${TEST_DIR}/authn-no-event.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   # GET /1.0 has AllowUntrusted=true so daemon.Authenticate is not reached
   # with a failing auth method.
@@ -657,9 +611,8 @@ test_authn_events() {
   gen_cert_and_key "authn-untrusted-cert"
 
   monfile="${TEST_DIR}/authn-login-fail-tls.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   curl --insecure --silent \
     --cert "${LXD_CONF}/authn-untrusted-cert.crt" \
@@ -677,9 +630,8 @@ test_authn_events() {
   bearer_id="$(lxc auth identity list bearer --format json | jq --raw-output --exit-status '.[] | select(.name == "authn-bearer-test") | .id')"
 
   monfile="${TEST_DIR}/authn-token-created.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   local issued_token
   issued_token="$(lxc auth identity token issue bearer/authn-bearer-test --quiet)"
@@ -697,9 +649,8 @@ test_authn_events() {
 
   sub_test "Verify authn_token_revoked fires when a bearer token is revoked"
   monfile="${TEST_DIR}/authn-token-revoked.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   lxc auth identity token revoke bearer/authn-bearer-test
 
@@ -721,9 +672,8 @@ test_authn_events() {
   gen_cert_and_key "authn-new-cert"
 
   monfile="${TEST_DIR}/authn-cert-change.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   lxc query --request PUT \
     --data "$(jq --null-input --exit-status \
@@ -754,9 +704,8 @@ test_authn_events() {
   gen_cert_and_key "authn-self-new-cert"
 
   monfile="${TEST_DIR}/authn-cert-selfchange.jsonl"
-  lxc monitor --type=security --format=json > "${monfile}" &
-  mon_pid=$!
-  sleep 0.2
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   CERTNAME="authn-self-cert" my_curl --request PUT \
     --data "$(jq --null-input --exit-status \
@@ -850,15 +799,8 @@ test_security_authz_events() {
   local monfile="${TEST_DIR}/authz-events.jsonl"
   rm -f "${monfile}"
 
-  lxc monitor --type=security --format=json > "${monfile}" &
-  local mon_pid=$!
-
-  # Wait until the monitor connection is live.
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
-  kill -0 "${mon_pid}"
+  lxc_monitor_start "${monfile}" --type=security --format=json
+  local mon_pid="${LXC_MONITOR_PID}"
 
   sub_test "authz_admin: group_create fires on auth group create"
   lxc auth group create authz-evt-g1
@@ -964,12 +906,8 @@ test_security_authz_events() {
   local old_mon_pid="${mon_pid}"
   kill_go_proc "${old_mon_pid}" || true
   wait "${old_mon_pid}" || true
-  lxc monitor --type=security --type=lifecycle --format=json > "${monfile}" &
-  mon_pid=$!
-  for _ in $(seq 10); do
-    kill -0 "${mon_pid}" && break
-    sleep 1
-  done
+  lxc_monitor_start "${monfile}" --type=security --type=lifecycle --format=json
+  mon_pid="${LXC_MONITOR_PID}"
 
   local coexist_lifecycle_jq='.type == "lifecycle" and .metadata.action == "auth-group-created" and .metadata.source == "/1.0/auth/groups/authz-evt-coexist"'
   local coexist_security_jq='.type == "security" and .metadata.name == "authz_admin:group_create:authz-evt-coexist"'

--- a/test/suites/syslog.sh
+++ b/test/suites/syslog.sh
@@ -1,9 +1,8 @@
 test_syslog_socket() {
   lxc config set core.syslog_socket=true
-  lxc monitor --type=ovn > "${TEST_DIR}/ovn.log" &
-  monitorOVNPID=$!
+  lxc_monitor_start "${TEST_DIR}/ovn.log" --type=ovn
+  monitorOVNPID="${LXC_MONITOR_PID}"
 
-  sleep 0.1
   echo "<29> ovs|ovn-controller|00017|rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected" | socat - unix-sendto:"${LXD_DIR}/syslog.socket"
   sleep 0.1
 

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -92,15 +92,13 @@ test_tls_restrictions() {
 
   # The restricted caller can listen for events on all projects, but the events are filtered to only those in the projects they have access to.
   monfile_root="${TEST_DIR}/mon-root.jsonl"
-  lxc monitor --all-projects --type lifecycle --format json > "${monfile_root}" &
-  mon_root_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile_root}" --all-projects --type lifecycle --format json
+  mon_root_pid="${LXC_MONITOR_PID}"
 
   monfile_restricted="${TEST_DIR}/mon-restricted.jsonl"
   lxc remote switch localhost
-  lxc monitor --all-projects --format json > "${monfile_restricted}" &
-  mon_restricted_pid=$!
-  sleep 0.1
+  lxc_monitor_start "${monfile_restricted}" --all-projects --format json
+  mon_restricted_pid="${LXC_MONITOR_PID}"
 
   lxc remote switch local
   lxc storage volume create "${pool_name}" vol1


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

This fixes a class of test failure I've seen several times over the last couple of days and (hopefully) also simplifies the code necessary to spawn and wait for an lxd monitor process to be ready.

The basic problem this PR is solving is: in a lot of places in the test system we're starting up 'lxc monitor' processes, then checking that operations we perform are logged by those processes or using those logs on the assumption that they either pick up everything we do after lxc monitor starts or something is wrong and the test should fail. But there is no guarantee that an lxc monitor process is prepared to consume and log the events to which it subscribes as soon as the shell command spawning it into the background completes - by that time, only the fork and not even the exec may have taken place. In many of these places in the test system we've added loops with sleeps and 'kill -0' on the 'lxc monitor' pid, but that too succeeds as soon as the spawn takes place, and in general we are relying on sleeps to leave enough time for lxc monitor to be ready.

This PR creates a new lxc_monitor_start function in test/includes/lxd.sh that starts an lxc monitor with the '--verbose' flag and waits for it to emit a readiness message to stderr, which it now does under that flag (the readiness message is a log with priority=INFO, so it gets emitted to stderr under verbose like other info log messages and is in agreement with some other unix utilities which emit readiness messages to stderr when they do not have the standard fork+parent-waits-for-child-readiness-on-pipe-and-exits-with-status pattern.

Test failures for reference:
https://github.com/jrtorsella/lxd/actions/runs/32752840225/job/97516446385