### PR TITLE
Allow `lxc <action> --all` on empty projects

### DIFF
--- a/lxd/operations/args.go
+++ b/lxd/operations/args.go
@@ -117,7 +117,9 @@ func (a OperationArgs) validate(isChild bool) error {
 		return errors.New("Bulk operations cannot have nested bulk operations")
 	}
 
-	if isBulkOperation && len(a.Children) == 0 {
+	// If it is a bulk operation, the children slice must be initialized but a zero length slice is allowed.
+	// This allows e.g. `lxc start --all` for an empty project.
+	if isBulkOperation && a.Children == nil {
 		return errors.New("Bulk operations must have children")
 	}
 
@@ -132,7 +134,7 @@ func (a OperationArgs) validate(isChild bool) error {
 	switch a.Class {
 	case operationtype.OperationClassTask:
 		// If this is a single task operation without children, it must have a run hook.
-		if len(a.Children) == 0 && a.RunHook == nil {
+		if !isBulkOperation && a.RunHook == nil {
 			return errors.New("Task operations must have a Run hook")
 		}
 

--- a/lxd/operations/args_test.go
+++ b/lxd/operations/args_test.go
@@ -257,6 +257,18 @@ func (s *argsSuite) TestValidate() {
 			errMsg:    "Bulk operations must have children",
 		},
 		{
+			name: "bulk operation with zero children (but with initialized slice)",
+			args: func() OperationArgs {
+				args := validTaskOperationArgs()
+				args.Type = operationtype.InstanceStateUpdateBulk
+				args.Children = []*OperationArgs{}
+				args.RunHook = nil
+				return args
+			}(),
+			isChild:   false,
+			expectErr: false,
+		},
+		{
 			name: "bulk operation with a run hook",
 			args: func() OperationArgs {
 				args := validTaskOperationArgs()

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -613,7 +613,7 @@ func runBulkOperation(op *Operation) error {
 	var firstChildError error
 
 	// Function to run or cancel a child operation.
-	runChildOp := func(op *Operation) {
+	handleChildOp := func(op *Operation) {
 		// Start if there are no previous errors.
 		if firstChildError == nil {
 			op.start()
@@ -633,7 +633,7 @@ func runBulkOperation(op *Operation) error {
 	// Process each batch.
 	for _, batch := range batches {
 		for _, childOp := range batch {
-			runChildOp(childOp)
+			handleChildOp(childOp)
 		}
 
 		// Wait on any operations that have been started or cancelled in this batch.

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -333,18 +333,21 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 		return nil, err
 	}
 
-	// Create the child operations, if any.
-	op.children = make([]*Operation, 0, len(args.Children))
-	for _, childArgs := range args.Children {
-		// Child operations inherit the requestor from the parent operation.
-		// metricsCallback is set only on the parent operation, so that it's called only once for the whole bulk operation.
-		childArgs.requestor = args.requestor
-		childOp, err := initOperation(s, *childArgs)
-		if err != nil {
-			return nil, fmt.Errorf("Failed creating child operation: %w", err)
-		}
+	// Create the child operations, if any. Note that we only initialize Operation.children if args.Children is non-nil.
+	// This differentiates a non-bulk operation from a bulk operations with zero children.
+	if args.Children != nil {
+		op.children = make([]*Operation, 0, len(args.Children))
+		for _, childArgs := range args.Children {
+			// Child operations inherit the requestor from the parent operation.
+			// metricsCallback is set only on the parent operation, so that it's called only once for the whole bulk operation.
+			childArgs.requestor = args.requestor
+			childOp, err := initOperation(s, *childArgs)
+			if err != nil {
+				return nil, fmt.Errorf("Failed creating child operation: %w", err)
+			}
 
-		op.addChild(childOp)
+			op.addChild(childOp)
+		}
 	}
 
 	shutdownCtx := context.TODO()
@@ -483,7 +486,7 @@ func (op *Operation) start() {
 
 	// If there's a run hook, we need to run it and get the final status from it.
 	// If there are child operations, we need to start and wait for them to finish before we can get the final status of the parent operation.
-	if op.onRun != nil || len(op.children) > 0 {
+	if op.onRun != nil || op.children != nil {
 		// The operation context is the "running" context plus the requestor.
 		// The requestor is available directly on the operation, but we should still put it in the context.
 		// This is so that, if an operation queries another cluster member, the requestor information will be set
@@ -495,7 +498,7 @@ func (op *Operation) start() {
 
 		go func(ctx context.Context, op *Operation) {
 			var err error
-			if op.parent == nil && len(op.children) > 0 {
+			if op.parent == nil && op.children != nil {
 				err = runBulkOperation(op)
 			} else if op.onRun != nil {
 				// Single-task operation: just run the hook.

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -668,6 +668,11 @@ test_basic_usage() {
   lxc list | grep c1 | grep RUNNING
   lxc list | grep c2 | grep RUNNING
 
+  # Test --all flag on project with no instances
+  lxc project create p1
+  lxc start --all --project p1
+  lxc project delete p1
+
   # Find the respective operation
   bulk_op="$(lxc query -X GET '/1.0/operations?recursion=2' | jq --exit-status '.. | objects | select(.description == "Updating the state of multiple instances")')"
 


### PR DESCRIPTION
This was previously allowed and a regression occurred after adding operation argument validation. We now allow a bulk operation to have zero children as long as the slice is initialized. Added unit tests for validation changes and system tests for `lxc start --all` in an empty project.

Closes #18884

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
