### PR TITLE
Remove sleep from `test_clustering_edit_configuration`

### DIFF
--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -388,6 +388,26 @@ wait_for_cluster_leader() {
   return 1
 }
 
+wait_all_members_online() {
+  local lxdDir="${1}"
+  local i members
+
+  for i in $(seq "${MAX_WAIT_SECONDS:-120}"); do
+    members="$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${lxdDir}" lxc cluster list --format json 2>/dev/null || true)"
+    if [ -n "${members}" ] && jq --exit-status 'all(.status == "Online")' <<< "${members}" > /dev/null; then
+      return 0
+    fi
+
+    sleep 1
+  done
+
+  echo "One or more cluster members did not come back online after ${i}s"
+
+  # Dump all members for debugging purposes.
+  echo "${members}"
+  return 1
+}
+
 is_uuid_v4() {
   # Case insensitive match for a v4 UUID. The third group must start with 4, and the fourth group must start with 8, 9,
   # a, or b. This accounts for the version and variant. See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4043,8 +4043,8 @@ test_clustering_edit_configuration() {
   # shellcheck disable=SC2154
   LXD_NETNS="${ns6}" respawn_lxd "${LXD_SIX_DIR}" true
 
-  # Let the heartbeats catch up
-  sleep 11
+  # Wait for all members to be back online.
+  wait_all_members_online "${LXD_SIX_DIR}"
 
   # Sanity check of the automated backup
   # We can't check that the backup has the same files as even LXD_ONE_DIR, because
@@ -4068,7 +4068,6 @@ test_clustering_edit_configuration() {
   LXD_DIR="${LXD_FOUR_DIR}"  lxc info --target node1 | grep -F "server_name: node1"
   LXD_DIR="${LXD_FIVE_DIR}"  lxc info --target node1 | grep -F "server_name: node1"
   LXD_DIR="${LXD_SIX_DIR}"   lxc info --target node1 | grep -F "server_name: node1"
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -F "No heartbeat" || false
 
   # Clean up
   shutdown_lxd "${LXD_ONE_DIR}"


### PR DESCRIPTION
Using sleeps to wait for certain conditions to be met is flaky. I think this particular sleep was causing flakiness in the `clustering_edit_configuration` test, where some cluster members were not fully online before connectivity tests were started. This PR adds a util for checking if all members are online and uses it in that test.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
