### PR TITLE
lxd/idmap: fix double-close in shift_linux.go

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,6 @@ on:
 
 env:
   GOTOOLCHAIN: "local"  # Never download a different Go toolchain
-  LXD_SKIP_TESTS: "concurrent"  # concurrent is too unreliable/racy
   LXD_REQUIRED_TESTS: "network_ovn"
   GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' ) || ( github.event_name == 'pull_request' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed

--- a/lxd/idmap/shift_linux.go
+++ b/lxd/idmap/shift_linux.go
@@ -394,7 +394,6 @@ static int create_detached_idmapped_mount(const char *path, const char *fstype)
 	if (ret < 0)
 		return -errno;
 
-	close(fd_userns);
 	return 0;
 }
 */


### PR DESCRIPTION
fd_userns was given an `__attribute__((__cleanup__(...` with a closer using __do_close, but it was also manually closed prior to return and the fd was not reset to -EBADF. This resulted in a double-close. If a concurrently running daemon thread opened a file after the first close but before the second and it was assigned the same file descriptor, this would result in the new file being inadvertently closed. This issue was responsible for the flakiness in test_concurrent and certain failures in standalone_storage which occurred when multiple instances were started concurrently. 

I've reverted the disablement of test_concurrent. I was able to reproduce the issue rarely with a modified version of the test that was pretty much just doing lxc start i1 i2, but I've left concurrent in its original form since it is known to reproduce the issue anyway and is wider than the reproducer I settled on.

Closes #15955 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
