### PR TITLE
lxd/idmap: fix double-close in shift_linux.go (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,6 @@ on:
     - cron: '0 0 * * *'  # Test TICS daily
 
 env:
-  LXD_SKIP_TESTS: "concurrent"  # concurrent is too unreliable/racy
   LXD_REQUIRED_TESTS: "storage_buckets network_ovn"
   GOCOVERAGE: ${{ (( github.event_name == 'workflow_dispatch' && inputs.coverage ) || ( github.event_name == 'schedule' && github.repository == 'canonical/lxd' )) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed

--- a/lxd/idmap/shift_linux.go
+++ b/lxd/idmap/shift_linux.go
@@ -394,7 +394,6 @@ static int create_detached_idmapped_mount(const char *path, const char *fstype)
 	if (ret < 0)
 		return -errno;
 
-	close(fd_userns);
 	return 0;
 }
 */


### PR DESCRIPTION
fd_userns was given an __attribute__((__cleanup__(... with a closer using __do_close, but it was also manually closed prior to return and the fd was not reset to EBADF. This resulted in a double-close. If a concurrently running daemon thread opened a file after the first close but before the second and it was assigned the same file descriptor, this would result in the new file being inadvertently closed. This issue was responsible for the flakiness in test_concurrent and certain failures in standalone_storage which occurred when multiple instances were started concurrently


(cherry picked from commit b7476600afcd62c33825e032c2e7d872fc1e8fbc)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
