### PR TITLE
Auth: Enforce viewership when granting entitlements

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -7201,10 +7201,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the certificate.
 
 `can_edit`
-: Grants permission to edit the certificate.
+: Grants permission to view and edit the certificate.
 
 `can_delete`
-: Grants permission to delete the certificate.
+: Grants permission to view and delete the certificate.
 
 
 <!-- entity group certificate end -->
@@ -7213,10 +7213,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the cluster link.
 
 `can_edit`
-: Grants permission to edit the cluster link.
+: Grants permission to view and edit the cluster link.
 
 `can_delete`
-: Grants permission to delete the cluster link.
+: Grants permission to view and delete the cluster link.
 
 
 <!-- entity group cluster_link end -->
@@ -7225,10 +7225,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the group. Identities can always view groups that they are a member of.
 
 `can_edit`
-: Grants permission to edit the group.
+: Grants permission to view and edit the group.
 
 `can_delete`
-: Grants permission to delete the group.
+: Grants permission to view and delete the group.
 
 
 <!-- entity group group end -->
@@ -7237,10 +7237,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the identity.
 
 `can_edit`
-: Grants permission to edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of.
+: Grants permission to view and edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of.
 
 `can_delete`
-: Grants permission to delete the identity.
+: Grants permission to view and delete the identity.
 
 
 <!-- entity group identity end -->
@@ -7249,19 +7249,19 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the identity provider group.
 
 `can_edit`
-: Grants permission to edit the identity provider group.
+: Grants permission to view and edit the identity provider group.
 
 `can_delete`
-: Grants permission to delete the identity provider group.
+: Grants permission to view and delete the identity provider group.
 
 
 <!-- entity group identity_provider_group end -->
 <!-- entity group image start -->
 `can_edit`
-: Grants permission to edit the image.
+: Grants permission to view and edit the image.
 
 `can_delete`
-: Grants permission to delete the image.
+: Grants permission to view and delete the image.
 
 `can_view`
 : Grants permission to view the image.
@@ -7270,10 +7270,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group image end -->
 <!-- entity group image_alias start -->
 `can_edit`
-: Grants permission to edit the image alias.
+: Grants permission to view and edit the image alias.
 
 `can_delete`
-: Grants permission to delete the image alias.
+: Grants permission to view and delete the image alias.
 
 `can_view`
 : Grants permission to view the image alias.
@@ -7288,10 +7288,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the instance, to access files, start a terminal or console session, and to manage snapshots and backups.
 
 `can_edit`
-: Grants permission to edit the instance.
+: Grants permission to view and edit the instance.
 
 `can_delete`
-: Grants permission to delete the instance.
+: Grants permission to view and delete the instance.
 
 `can_view`
 : Grants permission to view the instance and any snapshots or backups it might have.
@@ -7321,10 +7321,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group instance end -->
 <!-- entity group network start -->
 `can_edit`
-: Grants permission to edit the network.
+: Grants permission to view and edit the network.
 
 `can_delete`
-: Grants permission to delete the network.
+: Grants permission to view and delete the network.
 
 `can_view`
 : Grants permission to view the network.
@@ -7333,10 +7333,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group network end -->
 <!-- entity group network_acl start -->
 `can_edit`
-: Grants permission to edit the network ACL.
+: Grants permission to view and edit the network ACL.
 
 `can_delete`
-: Grants permission to delete the network ACL.
+: Grants permission to view and delete the network ACL.
 
 `can_view`
 : Grants permission to view the network ACL.
@@ -7345,10 +7345,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group network_acl end -->
 <!-- entity group network_zone start -->
 `can_edit`
-: Grants permission to edit the network zone.
+: Grants permission to view and edit the network zone.
 
 `can_delete`
-: Grants permission to delete the network zone.
+: Grants permission to view and delete the network zone.
 
 `can_view`
 : Grants permission to view the network zone.
@@ -7357,10 +7357,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group network_zone end -->
 <!-- entity group placement_group start -->
 `can_edit`
-: Grants permission to edit the placement group.
+: Grants permission to view and edit the placement group.
 
 `can_delete`
-: Grants permission to delete the placement group.
+: Grants permission to view and delete the placement group.
 
 `can_view`
 : Grants permission to view the placement group.
@@ -7369,10 +7369,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group placement_group end -->
 <!-- entity group profile start -->
 `can_edit`
-: Grants permission to edit the profile.
+: Grants permission to view and edit the profile.
 
 `can_delete`
-: Grants permission to delete the profile.
+: Grants permission to view and delete the profile.
 
 `can_view`
 : Grants permission to view the profile.
@@ -7390,10 +7390,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view the project.
 
 `can_edit`
-: Grants permission to edit the project.
+: Grants permission to view and edit the project.
 
 `can_delete`
-: Grants permission to delete the project.
+: Grants permission to view and delete the project.
 
 `image_manager`
 : Grants permission to create, view, edit, and delete all images belonging to the project.
@@ -7405,10 +7405,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view images.
 
 `can_edit_images`
-: Grants permission to edit images.
+: Grants permission to view and edit images.
 
 `can_delete_images`
-: Grants permission to delete images.
+: Grants permission to view and delete images.
 
 `image_alias_manager`
 : Grants permission to create, view, edit, and delete all image aliases belonging to the project.
@@ -7420,10 +7420,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view image aliases.
 
 `can_edit_image_aliases`
-: Grants permission to edit image aliases.
+: Grants permission to view and edit image aliases.
 
 `can_delete_image_aliases`
-: Grants permission to delete image aliases.
+: Grants permission to view and delete image aliases.
 
 `instance_manager`
 : Grants permission to create, view, edit, and delete all instances belonging to the project.
@@ -7435,10 +7435,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view instances.
 
 `can_edit_instances`
-: Grants permission to edit instances.
+: Grants permission to view and edit instances.
 
 `can_delete_instances`
-: Grants permission to delete instances.
+: Grants permission to view and delete instances.
 
 `can_operate_instances`
 : Grants permission to view instances, manage their state, manage their snapshots and backups, start terminal or console sessions, and access their files.
@@ -7453,10 +7453,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view networks.
 
 `can_edit_networks`
-: Grants permission to edit networks.
+: Grants permission to view and edit networks.
 
 `can_delete_networks`
-: Grants permission to delete networks.
+: Grants permission to view and delete networks.
 
 `network_acl_manager`
 : Grants permission to create, view, edit, and delete all network ACLs belonging to the project.
@@ -7468,10 +7468,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view network ACLs.
 
 `can_edit_network_acls`
-: Grants permission to edit network ACLs.
+: Grants permission to view and edit network ACLs.
 
 `can_delete_network_acls`
-: Grants permission to delete network ACLs.
+: Grants permission to view and delete network ACLs.
 
 `network_zone_manager`
 : Grants permission to create, view, edit, and delete all network zones belonging to the project.
@@ -7483,10 +7483,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view network zones.
 
 `can_edit_network_zones`
-: Grants permission to edit network zones.
+: Grants permission to view and edit network zones.
 
 `can_delete_network_zones`
-: Grants permission to delete network zones.
+: Grants permission to view and delete network zones.
 
 `profile_manager`
 : Grants permission to create, view, edit, and delete all profiles belonging to the project.
@@ -7498,10 +7498,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view profiles.
 
 `can_edit_profiles`
-: Grants permission to edit profiles.
+: Grants permission to view and edit profiles.
 
 `can_delete_profiles`
-: Grants permission to delete profiles.
+: Grants permission to view and delete profiles.
 
 `storage_volume_manager`
 : Grants permission to create, view, edit, and delete all storage volumes belonging to the project.
@@ -7513,10 +7513,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view storage volumes.
 
 `can_edit_storage_volumes`
-: Grants permission to edit storage volumes.
+: Grants permission to view and edit storage volumes.
 
 `can_delete_storage_volumes`
-: Grants permission to delete storage volumes.
+: Grants permission to view and delete storage volumes.
 
 `storage_bucket_manager`
 : Grants permission to create, view, edit, and delete all storage buckets belonging to the project.
@@ -7528,10 +7528,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view storage buckets.
 
 `can_edit_storage_buckets`
-: Grants permission to edit storage buckets.
+: Grants permission to view and edit storage buckets.
 
 `can_delete_storage_buckets`
-: Grants permission to delete storage buckets.
+: Grants permission to view and delete storage buckets.
 
 `placement_group_manager`
 : Grants permission to create, view, edit, and delete all placement groups belonging to the project.
@@ -7543,10 +7543,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view placement groups.
 
 `can_edit_placement_groups`
-: Grants permission to edit placement groups.
+: Grants permission to view and edit placement groups.
 
 `can_delete_placement_groups`
-: Grants permission to delete placement groups.
+: Grants permission to view and delete placement groups.
 
 `replicator_manager`
 : Grants permission to create, view, edit, and delete all replicators belonging to the project.
@@ -7558,10 +7558,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view replicators.
 
 `can_edit_replicators`
-: Grants permission to edit replicators.
+: Grants permission to view and edit replicators.
 
 `can_delete_replicators`
-: Grants permission to delete replicators.
+: Grants permission to view and delete replicators.
 
 `can_view_operations`
 : Grants permission to view operations relating to the project.
@@ -7576,10 +7576,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group project end -->
 <!-- entity group replicator start -->
 `can_edit`
-: Grants permission to edit the replicator.
+: Grants permission to view and edit the replicator.
 
 `can_delete`
-: Grants permission to delete the replicator.
+: Grants permission to view and delete the replicator.
 
 `can_view`
 : Grants permission to view the replicator.
@@ -7609,10 +7609,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view identities.
 
 `can_edit_identities`
-: Grants permission to edit identities. Note that clients with this permission are able to elevate their own privileges.
+: Grants permission to view and edit identities. Note that clients with this permission are able to elevate their own privileges.
 
 `can_delete_identities`
-: Grants permission to delete identities.
+: Grants permission to view and delete identities.
 
 `can_create_groups`
 : Grants permission to create authorization groups.
@@ -7621,10 +7621,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view authorization groups.
 
 `can_edit_groups`
-: Grants permission to edit authorization groups. Note that clients with this permission are able to elevate their own privileges.
+: Grants permission to view and edit authorization groups. Note that clients with this permission are able to elevate their own privileges.
 
 `can_delete_groups`
-: Grants permission to delete authorization groups.
+: Grants permission to view and delete authorization groups.
 
 `can_create_identity_provider_groups`
 : Grants permission to create identity provider groups.
@@ -7633,10 +7633,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view identity provider groups.
 
 `can_edit_identity_provider_groups`
-: Grants permission to edit identity provider groups. Note that clients with this permission are able to elevate their own privileges.
+: Grants permission to view and edit identity provider groups. Note that clients with this permission are able to elevate their own privileges.
 
 `can_delete_identity_provider_groups`
-: Grants permission to delete identity provider groups.
+: Grants permission to view and delete identity provider groups.
 
 `storage_pool_manager`
 : Grants permission to create, edit, and delete storage pools.
@@ -7660,10 +7660,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view projects, and all resources within those projects.
 
 `can_edit_projects`
-: Grants permission to edit projects, and all resources within those projects.
+: Grants permission to view and edit projects, and all resources within those projects.
 
 `can_delete_projects`
-: Grants permission to delete projects.
+: Grants permission to view and delete projects.
 
 `can_override_cluster_target_restriction`
 : If a project is configured with `restricted.cluster.target`, clients with this permission can override the restriction.
@@ -7693,19 +7693,19 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 : Grants permission to view cluster links.
 
 `can_edit_cluster_links`
-: Grants permission to edit cluster links.
+: Grants permission to view and edit cluster links.
 
 `can_delete_cluster_links`
-: Grants permission to delete cluster links.
+: Grants permission to view and delete cluster links.
 
 
 <!-- entity group server end -->
 <!-- entity group storage_bucket start -->
 `can_edit`
-: Grants permission to edit the storage bucket.
+: Grants permission to view and edit the storage bucket.
 
 `can_delete`
-: Grants permission to delete the storage bucket.
+: Grants permission to view and delete the storage bucket.
 
 `can_view`
 : Grants permission to view the storage bucket.
@@ -7723,10 +7723,10 @@ When enabled, if the source volume is a clone, the new volume will be promoted t
 <!-- entity group storage_pool end -->
 <!-- entity group storage_volume start -->
 `can_edit`
-: Grants permission to edit the storage volume.
+: Grants permission to view and edit the storage volume.
 
 `can_delete`
-: Grants permission to delete the storage volume.
+: Grants permission to view and delete the storage volume.
 
 `can_view`
 : Grants permission to view the storage volume and any snapshots or backups it might have.

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -8,11 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"runtime"
 	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -116,14 +114,16 @@ func (e *embeddedOpenFGA) load(ctx context.Context, opts Opts) error {
 	return nil
 }
 
-// GetViewableProjects accepts a list of permissions and returns a list of projects that a member of a group with these permissions is able to view.
-func (e *embeddedOpenFGA) GetViewableProjects(ctx context.Context, permissions []api.Permission) ([]string, error) {
+// CheckContextualPermission checks that a member of a group with the given list of permissions has the given entitlement on the given entity URL.
+// The OpenFGA datastore is effectively disabled for this call. Instead, all tuples are passed in contextually.
+// It returns a boolean to indicate if the permission is allowed, and an error if any internal error occurred.
+func (e *embeddedOpenFGA) CheckContextualPermission(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement, permissions []api.Permission) (bool, error) {
 	// Explicitly set the OpenFGA request cache to nil for this call.
-	//
-	// Why? Because the OpenFGA datastore will load a cache that is optimised for permission checking an individual request.
-	// In this case we are asking the datastore to enumerate projects based on contextual tuples.
-	// The cache is not useful for this, so we don't want to trigger loading it.
+	// This is safety to ensure that permissions of the current user are not considered for this authorization check.
 	ctx = context.WithValue(ctx, request.CtxOpenFGARequestCache, nil)
+
+	// Set a context key to indicate to the datastore that it should not return anything. All tuples will be passed contextually.
+	ctx = context.WithValue(ctx, request.CtxOpenFGAContextualTuplesOnly, true)
 
 	// "member" is the relation between identities and groups.
 	// Only group members can have relations to other openfga types in the model.
@@ -132,64 +132,139 @@ func (e *embeddedOpenFGA) GetViewableProjects(ctx context.Context, permissions [
 
 	// Construct a list objects request using a dummy identity as a member of a dummy group.
 	//
-	// Why? We're checking that, if this group *were* to exist, which projects would members of it be able to view?
+	// We're checking that, if this group *were* to exist, whether a member of the group will have the given entitlement on the given entity.
 	// Neither the group nor the identity have to exist, all tuples are passed contextually.
-	// Note that we do still need to conform to our datastore implementations' expectation about the format of tuples,
-	// which is why we're passing URLs and not random strings.
-	userObject := string(entity.TypeIdentity) + ":" + entity.IdentityURL("foo", "bar").String()
 	groupObject := string(entity.TypeAuthGroup) + ":" + entity.AuthGroupURL("dummy").String()
-	req := &openfgav1.ListObjectsRequest{
-		StoreId:  dummyDatastoreULID,
-		Type:     entity.TypeProject.String(),
-		Relation: string(auth.EntitlementCanView),
-		User:     userObject,
-		ContextualTuples: &openfgav1.ContextualTupleKeys{
-			TupleKeys: []*openfgav1.TupleKey{
-				{
-					// The dummy identity is a member of the dummy group.
-					User:     userObject,
-					Relation: memberRelation,
-					Object:   groupObject,
-				},
-			},
+	userObject := string(entity.TypeIdentity) + ":" + entity.IdentityURL("foo", "bar").String()
+
+	// The first contextual tuple will relate the dummy identity to the dummy group as a member.
+	contextualTuples := []*openfgav1.TupleKey{
+		{
+			User:     userObject,
+			Relation: memberRelation,
+			Object:   groupObject,
 		},
 	}
 
-	// Add a contextual tuple for each given permission
+	// Parse the input URL. We need to add contextual tuples that will relate the given entity up the hierarchy of the authorization model.
+	// E.g. If it is an instance, we will add tuples relating the instance to its project, and the project to the server.
+	eType, project, location, args, err := entity.ParseURL(entityURL.URL)
+	if err != nil {
+		return false, err
+	}
+
+	entityURLStr := entityURL.String()
+	switch eType {
+	case entity.TypeInstanceBackup, entity.TypeInstanceSnapshot:
+		if len(args) < 1 {
+			return false, errors.New("No instance name for snapshot or backup")
+		}
+
+		// Relate the instance backup or snapshot up the hierarchy back to the server.
+		instanceURLStr := entity.InstanceURL(project, args[0]).String()
+		projectURLStr := entity.ProjectURL(project).String()
+		contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
+			User:     string(entity.TypeInstance) + ":" + instanceURLStr,
+			Relation: string(entity.TypeInstance),
+			Object:   string(eType) + ":" + entityURLStr,
+		}, &openfgav1.TupleKey{
+			User:     string(entity.TypeProject) + ":" + projectURLStr,
+			Relation: string(entity.TypeProject),
+			Object:   string(entity.TypeInstance) + ":" + instanceURLStr,
+		}, &openfgav1.TupleKey{
+			User:     string(entity.TypeServer) + ":" + entity.ServerURL().String(),
+			Relation: string(entity.TypeServer),
+			Object:   string(entity.TypeProject) + ":" + projectURLStr,
+		})
+	case entity.TypeStorageVolumeBackup, entity.TypeStorageVolumeSnapshot:
+		if len(args) < 3 {
+			return false, errors.New("Missing path parameters for storage volume snapshot or backup URL")
+		}
+
+		// Relate the storage volume backup or snapshot up the hierarchy back to the server.
+		projectURLStr := entity.ProjectURL(project).String()
+		storageVolumeURLStr := entity.StorageVolumeURL(project, location, args[0], args[1], args[2]).String()
+		contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
+			User:     string(entity.TypeStorageVolume) + ":" + storageVolumeURLStr,
+			Relation: string(entity.TypeStorageVolume),
+			Object:   string(eType) + ":" + entityURLStr,
+		}, &openfgav1.TupleKey{
+			User:     string(entity.TypeProject) + ":" + projectURLStr,
+			Relation: string(entity.TypeProject),
+			Object:   string(entity.TypeStorageVolume) + ":" + storageVolumeURLStr,
+		}, &openfgav1.TupleKey{
+			User:     string(entity.TypeServer) + ":" + entity.ServerURL().String(),
+			Relation: string(entity.TypeServer),
+			Object:   string(entity.TypeProject) + ":" + projectURLStr,
+		})
+
+	default:
+		// For all other entities, we can relate them back up the hierarchy by checking if they are project specific.
+		projectSpecific, err := eType.RequiresProject()
+		if err != nil {
+			return false, err
+		}
+
+		if projectSpecific {
+			// Project specific entities need to be related to the project and the project to the server.
+			projectURLStr := entity.ProjectURL(project).String()
+			contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
+				User:     string(entity.TypeProject) + ":" + projectURLStr,
+				Relation: string(entity.TypeProject),
+				Object:   string(eType) + ":" + entityURLStr,
+			}, &openfgav1.TupleKey{
+				User:     string(entity.TypeServer) + ":" + entity.ServerURL().String(),
+				Relation: string(entity.TypeServer),
+				Object:   string(entity.TypeProject) + ":" + projectURLStr,
+			})
+		} else if eType != entity.TypeServer {
+			// Any other non-server entity just needs to be related to the server.
+			contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
+				User:     string(entity.TypeServer) + ":" + entity.ServerURL().String(),
+				Relation: string(entity.TypeServer),
+				Object:   string(eType) + ":" + entityURLStr,
+			})
+		}
+	}
+
+	// Add a contextual tuple for each given permission. These tuples grant members of the dummy group (i.e. our dummy identity)
+	// the given list of permissions.
 	for _, permission := range permissions {
-		req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
+		contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
 			User:     groupObject + "#" + memberRelation, // Members of the dummy group have permission, not the group itself.
 			Relation: permission.Entitlement,
 			Object:   permission.EntityType + ":" + permission.EntityReference,
 		})
 	}
 
+	// Compose the OpenFGA check request. This checks if the dummy identity has the given entitlement on the given
+	// entity, given all the contextual tuples above.
+	req := &openfgav1.CheckRequest{
+		StoreId: dummyDatastoreULID,
+		TupleKey: &openfgav1.CheckRequestTupleKey{
+			User:     userObject,
+			Relation: string(entitlement),
+			Object:   string(eType) + ":" + entityURLStr,
+		},
+		ContextualTuples: &openfgav1.ContextualTupleKeys{
+			TupleKeys: contextualTuples,
+		},
+	}
+
 	// Perform the check.
-	resp, err := e.server.ListObjects(ctx, req)
+	resp, err := e.server.Check(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed listing OpenFGA tuples: %w", err)
-	}
-
-	// This will be a list where each element is the form "project:/1.0/projects/{name}"
-	projectObjects := resp.GetObjects()
-
-	// Parse the object list to return a list of project names.
-	projects := make([]string, 0, len(projectObjects))
-	for _, obj := range projectObjects {
-		u, err := url.Parse(strings.TrimPrefix(obj, entity.TypeProject.String()+":"))
-		if err != nil {
-			return nil, fmt.Errorf("Invalid project url %q returned from list object request", err)
+		// Unwrap the internal error directly and return it to the caller. We are not concerned about a permission issue
+		// here because the caller is editing a group, so is already a user with high privilege.
+		openFGAInternalError, ok := errors.AsType[openFGAErrors.InternalError](err)
+		if ok {
+			err = openFGAInternalError.Unwrap()
 		}
 
-		_, project, _, _, err := entity.ParseURL(*u)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid project url %q returned from list object request", err)
-		}
-
-		projects = append(projects, project)
+		return false, fmt.Errorf("Failed checking contextual permission: %w", err)
 	}
 
-	return projects, nil
+	return resp.GetAllowed(), nil
 }
 
 // CheckPermission checks whether the user who sent the request has the given entitlement on the given entity using the

--- a/lxd/auth/drivers/openfga_model.openfga
+++ b/lxd/auth/drivers/openfga_model.openfga
@@ -5,13 +5,13 @@ type identity
     define server: [server]
 
     # Grants permission to view the identity.
-    define can_view: [identity, service_account, group#member] or can_view_identities from server
+    define can_view: [identity, service_account, group#member] or can_edit or can_delete or can_view_identities from server
 
-    # Grants permission to edit the identity. To edit an identity, it is additionally required that the caller is
+    # Grants permission to view and edit the identity. To edit an identity, it is additionally required that the caller is
     # able to view all groups that the identity is a member of.
     define can_edit: [identity, service_account, group#member] or can_edit_identities from server
 
-    # Grants permission to delete the identity.
+    # Grants permission to view and delete the identity.
     define can_delete: [identity, service_account, group#member] or can_delete_identities from server
 type service_account
 type group
@@ -20,24 +20,24 @@ type group
     define member: [identity, service_account]
 
     # Grants permission to view the group. Identities can always view groups that they are a member of.
-    define can_view: [identity, service_account, group#member] or member or can_view_groups from server
+    define can_view: [identity, service_account, group#member] or member or can_edit or can_delete or can_view_groups from server
 
-    # Grants permission to edit the group.
+    # Grants permission to view and edit the group.
     define can_edit: [identity, service_account, group#member] or can_edit_groups from server
 
-    # Grants permission to delete the group.
+    # Grants permission to view and delete the group.
     define can_delete: [identity, service_account, group#member] or can_delete_groups from server
 type identity_provider_group
   relations
     define server: [server]
 
     # Grants permission to view the identity provider group.
-    define can_view: [identity, service_account, group#member] or can_view_identity_provider_groups from server
+    define can_view: [identity, service_account, group#member] or can_edit or can_delete or can_view_identity_provider_groups from server
 
-    # Grants permission to edit the identity provider group.
+    # Grants permission to view and edit the identity provider group.
     define can_edit: [identity, service_account, group#member] or can_edit_identity_provider_groups from server
 
-    # Grants permission to delete the identity provider group.
+    # Grants permission to view and delete the identity provider group.
     define can_delete: [identity, service_account, group#member] or can_delete_identity_provider_groups from server
 type server
   relations
@@ -66,10 +66,10 @@ type server
     # Grants permission to view identities.
     define can_view_identities: [identity, service_account, group#member] or permission_manager or admin or viewer
 
-    # Grants permission to edit identities. Note that clients with this permission are able to elevate their own privileges.
+    # Grants permission to view and edit identities. Note that clients with this permission are able to elevate their own privileges.
     define can_edit_identities: [identity, service_account, group#member] or permission_manager or admin
 
-    # Grants permission to delete identities.
+    # Grants permission to view and delete identities.
     define can_delete_identities: [identity, service_account, group#member] or permission_manager or admin
 
     # Grants permission to create authorization groups.
@@ -78,11 +78,11 @@ type server
     # Grants permission to view authorization groups.
     define can_view_groups: [identity, service_account, group#member] or permission_manager or admin or viewer
 
-    # Grants permission to edit authorization groups. Note that clients with this permission are able to elevate their
+    # Grants permission to view and edit authorization groups. Note that clients with this permission are able to elevate their
     # own privileges.
     define can_edit_groups: [identity, service_account, group#member] or permission_manager or admin
 
-    # Grants permission to delete authorization groups.
+    # Grants permission to view and delete authorization groups.
     define can_delete_groups: [identity, service_account, group#member] or permission_manager or admin
 
     # Grants permission to create identity provider groups.
@@ -91,11 +91,11 @@ type server
     # Grants permission to view identity provider groups.
     define can_view_identity_provider_groups: [identity, service_account, group#member] or permission_manager or admin or viewer
 
-    # Grants permission to edit identity provider groups. Note that clients with this permission are able to elevate
+    # Grants permission to view and edit identity provider groups. Note that clients with this permission are able to elevate
     # their own privileges.
     define can_edit_identity_provider_groups: [identity, service_account, group#member] or permission_manager or admin
 
-    # Grants permission to delete identity provider groups.
+    # Grants permission to view and delete identity provider groups.
     define can_delete_identity_provider_groups: [identity, service_account, group#member] or permission_manager or admin
 
     # Grants permission to create, edit, and delete storage pools.
@@ -119,10 +119,10 @@ type server
     # Grants permission to view projects, and all resources within those projects.
     define can_view_projects: [identity, service_account, group#member] or project_manager or viewer or admin
 
-    # Grants permission to edit projects, and all resources within those projects.
+    # Grants permission to view and edit projects, and all resources within those projects.
     define can_edit_projects: [identity, service_account, group#member] or project_manager or admin
 
-    # Grants permission to delete projects.
+    # Grants permission to view and delete projects.
     define can_delete_projects: [identity, service_account, group#member] or project_manager or admin
 
     # If a project is configured with `restricted.cluster.target`, clients with this permission can override the restriction.
@@ -152,10 +152,10 @@ type server
     # Grants permission to view cluster links.
     define can_view_cluster_links: [identity, service_account, group#member] or admin or viewer
 
-    # Grants permission to edit cluster links.
+    # Grants permission to view and edit cluster links.
     define can_edit_cluster_links: [identity, service_account, group#member] or admin
 
-    # Grants permission to delete cluster links.
+    # Grants permission to view and delete cluster links.
     define can_delete_cluster_links: [identity, service_account, group#member] or admin
 type certificate
   relations
@@ -164,10 +164,10 @@ type certificate
     # Grants permission to view the certificate.
     define can_view: [identity, service_account, group#member] or can_edit or can_delete or can_view_identities from server
 
-    # Grants permission to edit the certificate.
+    # Grants permission to view and edit the certificate.
     define can_edit: [identity, service_account, group#member] or can_edit_identities from server
 
-    # Grants permission to delete the certificate.
+    # Grants permission to view and delete the certificate.
     define can_delete: [identity, service_account, group#member] or can_delete_identities from server
 type cluster_link
   relations
@@ -176,10 +176,10 @@ type cluster_link
     # Grants permission to view the cluster link.
     define can_view: [identity, service_account, group#member] or can_edit or can_delete or can_view_cluster_links from server
 
-    # Grants permission to edit the cluster link.
+    # Grants permission to view and edit the cluster link.
     define can_edit: [identity, service_account, group#member] or can_edit_cluster_links from server
 
-    # Grants permission to delete the cluster link.
+    # Grants permission to view and delete the cluster link.
     define can_delete: [identity, service_account, group#member] or can_delete_cluster_links from server
 type storage_pool
   relations
@@ -202,12 +202,12 @@ type project
     define viewer: [identity, service_account, group#member]
 
     # Grants permission to view the project.
-    define can_view: [identity, service_account, group#member] or viewer or operator or can_view_projects from server
+    define can_view: [identity, service_account, group#member] or viewer or operator or can_edit or can_delete or can_view_projects from server
 
-    # Grants permission to edit the project.
+    # Grants permission to view and edit the project.
     define can_edit: [identity, service_account, group#member] or can_edit_projects from server
 
-    # Grants permission to delete the project.
+    # Grants permission to view and delete the project.
     define can_delete: [identity, service_account, group#member] or can_delete_projects from server
 
     # Grants permission to create, view, edit, and delete all images belonging to the project.
@@ -219,10 +219,10 @@ type project
     # Grants permission to view images.
     define can_view_images: [identity, service_account, group#member] or operator or viewer or image_manager or can_view_projects from server
 
-    # Grants permission to edit images.
+    # Grants permission to view and edit images.
     define can_edit_images: [identity, service_account, group#member] or operator or image_manager or can_edit_projects from server
 
-    # Grants permission to delete images.
+    # Grants permission to view and delete images.
     define can_delete_images: [identity, service_account, group#member] or operator or image_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all image aliases belonging to the project.
@@ -234,10 +234,10 @@ type project
     # Grants permission to view image aliases.
     define can_view_image_aliases: [identity, service_account, group#member] or operator or viewer or image_alias_manager or can_view_projects from server
 
-    # Grants permission to edit image aliases.
+    # Grants permission to view and edit image aliases.
     define can_edit_image_aliases: [identity, service_account, group#member] or operator or image_alias_manager or can_edit_projects from server
 
-    # Grants permission to delete image aliases.
+    # Grants permission to view and delete image aliases.
     define can_delete_image_aliases: [identity, service_account, group#member] or operator or image_alias_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all instances belonging to the project.
@@ -249,10 +249,10 @@ type project
     # Grants permission to view instances.
     define can_view_instances: [identity, service_account, group#member] or operator or viewer or instance_manager or can_view_projects from server
 
-    # Grants permission to edit instances.
+    # Grants permission to view and edit instances.
     define can_edit_instances: [identity, service_account, group#member] or operator or instance_manager or can_edit_projects from server
 
-    # Grants permission to delete instances.
+    # Grants permission to view and delete instances.
     define can_delete_instances: [identity, service_account, group#member] or operator or instance_manager or can_edit_projects from server
 
     # Grants permission to view instances, manage their state, manage their snapshots and backups, start terminal or console sessions, and access their files.
@@ -267,10 +267,10 @@ type project
     # Grants permission to view networks.
     define can_view_networks: [identity, service_account, group#member] or operator or viewer or network_manager or can_view_projects from server
 
-    # Grants permission to edit networks.
+    # Grants permission to view and edit networks.
     define can_edit_networks: [identity, service_account, group#member] or operator or network_manager or can_edit_projects from server
 
-    # Grants permission to delete networks.
+    # Grants permission to view and delete networks.
     define can_delete_networks: [identity, service_account, group#member] or operator or network_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all network ACLs belonging to the project.
@@ -282,10 +282,10 @@ type project
     # Grants permission to view network ACLs.
     define can_view_network_acls: [identity, service_account, group#member] or operator or viewer or network_acl_manager or can_view_projects from server
 
-    # Grants permission to edit network ACLs.
+    # Grants permission to view and edit network ACLs.
     define can_edit_network_acls: [identity, service_account, group#member] or operator or network_acl_manager or can_edit_projects from server
 
-    # Grants permission to delete network ACLs.
+    # Grants permission to view and delete network ACLs.
     define can_delete_network_acls: [identity, service_account, group#member] or operator or network_acl_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all network zones belonging to the project.
@@ -297,10 +297,10 @@ type project
     # Grants permission to view network zones.
     define can_view_network_zones: [identity, service_account, group#member] or operator or viewer or network_zone_manager or can_view_projects from server
 
-    # Grants permission to edit network zones.
+    # Grants permission to view and edit network zones.
     define can_edit_network_zones: [identity, service_account, group#member] or operator or network_zone_manager or can_edit_projects from server
 
-    # Grants permission to delete network zones.
+    # Grants permission to view and delete network zones.
     define can_delete_network_zones: [identity, service_account, group#member] or operator or network_zone_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all profiles belonging to the project.
@@ -312,10 +312,10 @@ type project
     # Grants permission to view profiles.
     define can_view_profiles: [identity, service_account, group#member] or operator or viewer or profile_manager or can_view_projects from server
 
-    # Grants permission to edit profiles.
+    # Grants permission to view and edit profiles.
     define can_edit_profiles: [identity, service_account, group#member] or operator or profile_manager or can_edit_projects from server
 
-    # Grants permission to delete profiles.
+    # Grants permission to view and delete profiles.
     define can_delete_profiles: [identity, service_account, group#member] or operator or profile_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all storage volumes belonging to the project.
@@ -327,10 +327,10 @@ type project
     # Grants permission to view storage volumes.
     define can_view_storage_volumes: [identity, service_account, group#member] or operator or viewer or storage_volume_manager or can_view_projects from server
 
-    # Grants permission to edit storage volumes.
+    # Grants permission to view and edit storage volumes.
     define can_edit_storage_volumes: [identity, service_account, group#member] or operator or storage_volume_manager or can_edit_projects from server
 
-    # Grants permission to delete storage volumes.
+    # Grants permission to view and delete storage volumes.
     define can_delete_storage_volumes: [identity, service_account, group#member] or operator or storage_volume_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all storage buckets belonging to the project.
@@ -342,10 +342,10 @@ type project
     # Grants permission to view storage buckets.
     define can_view_storage_buckets: [identity, service_account, group#member] or operator or viewer or storage_bucket_manager or can_view_projects from server
 
-    # Grants permission to edit storage buckets.
+    # Grants permission to view and edit storage buckets.
     define can_edit_storage_buckets: [identity, service_account, group#member] or operator or storage_bucket_manager or can_edit_projects from server
 
-    # Grants permission to delete storage buckets.
+    # Grants permission to view and delete storage buckets.
     define can_delete_storage_buckets: [identity, service_account, group#member] or operator or storage_bucket_manager or can_edit_projects from server
 
 	# Grants permission to create, view, edit, and delete all placement groups belonging to the project.
@@ -357,10 +357,10 @@ type project
     # Grants permission to view placement groups.
     define can_view_placement_groups: [identity, service_account, group#member] or operator or viewer or placement_group_manager or can_view_projects from server
 
-    # Grants permission to edit placement groups.
+    # Grants permission to view and edit placement groups.
     define can_edit_placement_groups: [identity, service_account, group#member] or operator or placement_group_manager or can_edit_projects from server
 
-    # Grants permission to delete placement groups.
+    # Grants permission to view and delete placement groups.
     define can_delete_placement_groups: [identity, service_account, group#member] or operator or placement_group_manager or can_edit_projects from server
 
     # Grants permission to create, view, edit, and delete all replicators belonging to the project.
@@ -372,10 +372,10 @@ type project
     # Grants permission to view replicators.
     define can_view_replicators: [identity, service_account, group#member] or operator or viewer or replicator_manager or can_view_projects from server
 
-    # Grants permission to edit replicators.
+    # Grants permission to view and edit replicators.
     define can_edit_replicators: [identity, service_account, group#member] or operator or replicator_manager or can_edit_projects from server
 
-    # Grants permission to delete replicators.
+    # Grants permission to view and delete replicators.
     define can_delete_replicators: [identity, service_account, group#member] or operator or replicator_manager or can_edit_projects from server
 
     # Grants permission to view operations relating to the project.
@@ -390,10 +390,10 @@ type image
   relations
     define project: [project]
 
-    # Grants permission to edit the image.
+    # Grants permission to view and edit the image.
     define can_edit: [identity, service_account, group#member] or can_edit_images from project
 
-    # Grants permission to delete the image.
+    # Grants permission to view and delete the image.
     define can_delete: [identity, service_account, group#member] or can_delete_images from project
 
     # Grants permission to view the image.
@@ -402,10 +402,10 @@ type image_alias
   relations
     define project: [project]
 
-    # Grants permission to edit the image alias.
+    # Grants permission to view and edit the image alias.
     define can_edit: [identity, service_account, group#member] or can_edit_image_aliases from project
 
-    # Grants permission to delete the image alias.
+    # Grants permission to view and delete the image alias.
     define can_delete: [identity, service_account, group#member] or can_delete_image_aliases from project
 
     # Grants permission to view the image alias.
@@ -420,10 +420,10 @@ type instance
     # Grants permission to view the instance, to access files, start a terminal or console session, and to manage snapshots and backups.
     define operator: [identity, service_account, group#member]
 
-    # Grants permission to edit the instance.
+    # Grants permission to view and edit the instance.
     define can_edit: [identity, service_account, group#member] or can_edit_instances from project
 
-    # Grants permission to delete the instance.
+    # Grants permission to view and delete the instance.
     define can_delete: [identity, service_account, group#member] or can_delete_instances from project
 
     # Grants permission to view the instance and any snapshots or backups it might have.
@@ -468,10 +468,10 @@ type network
   relations
     define project: [project]
 
-    # Grants permission to edit the network.
+    # Grants permission to view and edit the network.
     define can_edit: [identity, service_account, group#member] or can_edit_networks from project
 
-    # Grants permission to delete the network.
+    # Grants permission to view and delete the network.
     define can_delete: [identity, service_account, group#member] or can_delete_networks from project
 
     # Grants permission to view the network.
@@ -480,10 +480,10 @@ type network_acl
   relations
     define project: [project]
 
-    # Grants permission to edit the network ACL.
+    # Grants permission to view and edit the network ACL.
     define can_edit: [identity, service_account, group#member] or can_edit_network_acls from project
 
-    # Grants permission to delete the network ACL.
+    # Grants permission to view and delete the network ACL.
     define can_delete: [identity, service_account, group#member] or can_delete_network_acls from project
 
     # Grants permission to view the network ACL.
@@ -492,10 +492,10 @@ type network_zone
   relations
     define project: [project]
 
-    # Grants permission to edit the network zone.
+    # Grants permission to view and edit the network zone.
     define can_edit: [identity, service_account, group#member] or can_edit_network_zones from project
 
-    # Grants permission to delete the network zone.
+    # Grants permission to view and delete the network zone.
     define can_delete: [identity, service_account, group#member] or can_delete_network_zones from project
 
     # Grants permission to view the network zone.
@@ -504,10 +504,10 @@ type profile
   relations
     define project: [project]
 
-    # Grants permission to edit the profile.
+    # Grants permission to view and edit the profile.
     define can_edit: [identity, service_account, group#member] or can_edit_profiles from project
 
-    # Grants permission to delete the profile.
+    # Grants permission to view and delete the profile.
     define can_delete: [identity, service_account, group#member] or can_delete_profiles from project
 
     # Grants permission to view the profile.
@@ -516,10 +516,10 @@ type storage_volume
   relations
     define project: [project]
 
-    # Grants permission to edit the storage volume.
+    # Grants permission to view and edit the storage volume.
     define can_edit: [identity, service_account, group#member] or can_edit_storage_volumes from project
 
-    # Grants permission to delete the storage volume.
+    # Grants permission to view and delete the storage volume.
     define can_delete: [identity, service_account, group#member] or can_delete_storage_volumes from project
 
     # Grants permission to view the storage volume and any snapshots or backups it might have.
@@ -549,10 +549,10 @@ type storage_bucket
   relations
     define project: [project]
 
-    # Grants permission to edit the storage bucket.
+    # Grants permission to view and edit the storage bucket.
     define can_edit: [identity, service_account, group#member] or can_edit_storage_buckets from project
 
-    # Grants permission to delete the storage bucket.
+    # Grants permission to view and delete the storage bucket.
     define can_delete: [identity, service_account, group#member] or can_delete_storage_buckets from project
 
     # Grants permission to view the storage bucket.
@@ -562,10 +562,10 @@ type placement_group
   relations
     define project: [project]
 
-    # Grants permission to edit the placement group.
+    # Grants permission to view and edit the placement group.
     define can_edit: [identity, service_account, group#member] or can_edit_placement_groups from project
 
-    # Grants permission to delete the placement group.
+    # Grants permission to view and delete the placement group.
     define can_delete: [identity, service_account, group#member] or can_delete_placement_groups from project
 
     # Grants permission to view the placement group.
@@ -575,10 +575,10 @@ type replicator
   relations
     define project: [project]
 
-    # Grants permission to edit the replicator.
+    # Grants permission to view and edit the replicator.
     define can_edit: [identity, service_account, group#member] or can_edit_replicators from project
 
-    # Grants permission to delete the replicator.
+    # Grants permission to view and delete the replicator.
     define can_delete: [identity, service_account, group#member] or can_delete_replicators from project
 
     # Grants permission to view the replicator.

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -61,9 +61,9 @@ func (t *tls) load(ctx context.Context, opts Opts) error {
 	return nil
 }
 
-// GetViewableProjects is not implemented for the TLS authorizer.
-func (t *tls) GetViewableProjects(ctx context.Context, permissions []api.Permission) ([]string, error) {
-	return nil, api.NewGenericStatusError(http.StatusNotImplemented)
+// CheckContextualPermission is not implemented for the TLS authorizer.
+func (t *tls) CheckContextualPermission(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement, permissions []api.Permission) (bool, error) {
+	return false, api.NewGenericStatusError(http.StatusNotImplemented)
 }
 
 // CheckPermission returns an error if the user does not have the given Entitlement on the given Object.

--- a/lxd/auth/entitlements_generated.go
+++ b/lxd/auth/entitlements_generated.go
@@ -327,55 +327,55 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 	entity.TypeCertificate: {
 		// Grants permission to view the certificate.
 		EntitlementCanView,
-		// Grants permission to edit the certificate.
+		// Grants permission to view and edit the certificate.
 		EntitlementCanEdit,
-		// Grants permission to delete the certificate.
+		// Grants permission to view and delete the certificate.
 		EntitlementCanDelete,
 	},
 	entity.TypeClusterLink: {
 		// Grants permission to view the cluster link.
 		EntitlementCanView,
-		// Grants permission to edit the cluster link.
+		// Grants permission to view and edit the cluster link.
 		EntitlementCanEdit,
-		// Grants permission to delete the cluster link.
+		// Grants permission to view and delete the cluster link.
 		EntitlementCanDelete,
 	},
 	entity.TypeAuthGroup: {
 		// Grants permission to view the group. Identities can always view groups that they are a member of.
 		EntitlementCanView,
-		// Grants permission to edit the group.
+		// Grants permission to view and edit the group.
 		EntitlementCanEdit,
-		// Grants permission to delete the group.
+		// Grants permission to view and delete the group.
 		EntitlementCanDelete,
 	},
 	entity.TypeIdentity: {
 		// Grants permission to view the identity.
 		EntitlementCanView,
-		// Grants permission to edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of.
+		// Grants permission to view and edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of.
 		EntitlementCanEdit,
-		// Grants permission to delete the identity.
+		// Grants permission to view and delete the identity.
 		EntitlementCanDelete,
 	},
 	entity.TypeIdentityProviderGroup: {
 		// Grants permission to view the identity provider group.
 		EntitlementCanView,
-		// Grants permission to edit the identity provider group.
+		// Grants permission to view and edit the identity provider group.
 		EntitlementCanEdit,
-		// Grants permission to delete the identity provider group.
+		// Grants permission to view and delete the identity provider group.
 		EntitlementCanDelete,
 	},
 	entity.TypeImage: {
-		// Grants permission to edit the image.
+		// Grants permission to view and edit the image.
 		EntitlementCanEdit,
-		// Grants permission to delete the image.
+		// Grants permission to view and delete the image.
 		EntitlementCanDelete,
 		// Grants permission to view the image.
 		EntitlementCanView,
 	},
 	entity.TypeImageAlias: {
-		// Grants permission to edit the image alias.
+		// Grants permission to view and edit the image alias.
 		EntitlementCanEdit,
-		// Grants permission to delete the image alias.
+		// Grants permission to view and delete the image alias.
 		EntitlementCanDelete,
 		// Grants permission to view the image alias.
 		EntitlementCanView,
@@ -385,9 +385,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementUser,
 		// Grants permission to view the instance, to access files, start a terminal or console session, and to manage snapshots and backups.
 		EntitlementOperator,
-		// Grants permission to edit the instance.
+		// Grants permission to view and edit the instance.
 		EntitlementCanEdit,
-		// Grants permission to delete the instance.
+		// Grants permission to view and delete the instance.
 		EntitlementCanDelete,
 		// Grants permission to view the instance and any snapshots or backups it might have.
 		EntitlementCanView,
@@ -407,41 +407,41 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanExec,
 	},
 	entity.TypeNetwork: {
-		// Grants permission to edit the network.
+		// Grants permission to view and edit the network.
 		EntitlementCanEdit,
-		// Grants permission to delete the network.
+		// Grants permission to view and delete the network.
 		EntitlementCanDelete,
 		// Grants permission to view the network.
 		EntitlementCanView,
 	},
 	entity.TypeNetworkACL: {
-		// Grants permission to edit the network ACL.
+		// Grants permission to view and edit the network ACL.
 		EntitlementCanEdit,
-		// Grants permission to delete the network ACL.
+		// Grants permission to view and delete the network ACL.
 		EntitlementCanDelete,
 		// Grants permission to view the network ACL.
 		EntitlementCanView,
 	},
 	entity.TypeNetworkZone: {
-		// Grants permission to edit the network zone.
+		// Grants permission to view and edit the network zone.
 		EntitlementCanEdit,
-		// Grants permission to delete the network zone.
+		// Grants permission to view and delete the network zone.
 		EntitlementCanDelete,
 		// Grants permission to view the network zone.
 		EntitlementCanView,
 	},
 	entity.TypePlacementGroup: {
-		// Grants permission to edit the placement group.
+		// Grants permission to view and edit the placement group.
 		EntitlementCanEdit,
-		// Grants permission to delete the placement group.
+		// Grants permission to view and delete the placement group.
 		EntitlementCanDelete,
 		// Grants permission to view the placement group.
 		EntitlementCanView,
 	},
 	entity.TypeProfile: {
-		// Grants permission to edit the profile.
+		// Grants permission to view and edit the profile.
 		EntitlementCanEdit,
-		// Grants permission to delete the profile.
+		// Grants permission to view and delete the profile.
 		EntitlementCanDelete,
 		// Grants permission to view the profile.
 		EntitlementCanView,
@@ -453,9 +453,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementViewer,
 		// Grants permission to view the project.
 		EntitlementCanView,
-		// Grants permission to edit the project.
+		// Grants permission to view and edit the project.
 		EntitlementCanEdit,
-		// Grants permission to delete the project.
+		// Grants permission to view and delete the project.
 		EntitlementCanDelete,
 		// Grants permission to create, view, edit, and delete all images belonging to the project.
 		EntitlementImageManager,
@@ -463,9 +463,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateImages,
 		// Grants permission to view images.
 		EntitlementCanViewImages,
-		// Grants permission to edit images.
+		// Grants permission to view and edit images.
 		EntitlementCanEditImages,
-		// Grants permission to delete images.
+		// Grants permission to view and delete images.
 		EntitlementCanDeleteImages,
 		// Grants permission to create, view, edit, and delete all image aliases belonging to the project.
 		EntitlementImageAliasManager,
@@ -473,9 +473,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateImageAliases,
 		// Grants permission to view image aliases.
 		EntitlementCanViewImageAliases,
-		// Grants permission to edit image aliases.
+		// Grants permission to view and edit image aliases.
 		EntitlementCanEditImageAliases,
-		// Grants permission to delete image aliases.
+		// Grants permission to view and delete image aliases.
 		EntitlementCanDeleteImageAliases,
 		// Grants permission to create, view, edit, and delete all instances belonging to the project.
 		EntitlementInstanceManager,
@@ -483,9 +483,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateInstances,
 		// Grants permission to view instances.
 		EntitlementCanViewInstances,
-		// Grants permission to edit instances.
+		// Grants permission to view and edit instances.
 		EntitlementCanEditInstances,
-		// Grants permission to delete instances.
+		// Grants permission to view and delete instances.
 		EntitlementCanDeleteInstances,
 		// Grants permission to view instances, manage their state, manage their snapshots and backups, start terminal or console sessions, and access their files.
 		EntitlementCanOperateInstances,
@@ -495,9 +495,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateNetworks,
 		// Grants permission to view networks.
 		EntitlementCanViewNetworks,
-		// Grants permission to edit networks.
+		// Grants permission to view and edit networks.
 		EntitlementCanEditNetworks,
-		// Grants permission to delete networks.
+		// Grants permission to view and delete networks.
 		EntitlementCanDeleteNetworks,
 		// Grants permission to create, view, edit, and delete all network ACLs belonging to the project.
 		EntitlementNetworkACLManager,
@@ -505,9 +505,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateNetworkACLs,
 		// Grants permission to view network ACLs.
 		EntitlementCanViewNetworkACLs,
-		// Grants permission to edit network ACLs.
+		// Grants permission to view and edit network ACLs.
 		EntitlementCanEditNetworkACLs,
-		// Grants permission to delete network ACLs.
+		// Grants permission to view and delete network ACLs.
 		EntitlementCanDeleteNetworkACLs,
 		// Grants permission to create, view, edit, and delete all network zones belonging to the project.
 		EntitlementNetworkZoneManager,
@@ -515,9 +515,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateNetworkZones,
 		// Grants permission to view network zones.
 		EntitlementCanViewNetworkZones,
-		// Grants permission to edit network zones.
+		// Grants permission to view and edit network zones.
 		EntitlementCanEditNetworkZones,
-		// Grants permission to delete network zones.
+		// Grants permission to view and delete network zones.
 		EntitlementCanDeleteNetworkZones,
 		// Grants permission to create, view, edit, and delete all profiles belonging to the project.
 		EntitlementProfileManager,
@@ -525,9 +525,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateProfiles,
 		// Grants permission to view profiles.
 		EntitlementCanViewProfiles,
-		// Grants permission to edit profiles.
+		// Grants permission to view and edit profiles.
 		EntitlementCanEditProfiles,
-		// Grants permission to delete profiles.
+		// Grants permission to view and delete profiles.
 		EntitlementCanDeleteProfiles,
 		// Grants permission to create, view, edit, and delete all storage volumes belonging to the project.
 		EntitlementStorageVolumeManager,
@@ -535,9 +535,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateStorageVolumes,
 		// Grants permission to view storage volumes.
 		EntitlementCanViewStorageVolumes,
-		// Grants permission to edit storage volumes.
+		// Grants permission to view and edit storage volumes.
 		EntitlementCanEditStorageVolumes,
-		// Grants permission to delete storage volumes.
+		// Grants permission to view and delete storage volumes.
 		EntitlementCanDeleteStorageVolumes,
 		// Grants permission to create, view, edit, and delete all storage buckets belonging to the project.
 		EntitlementStorageBucketManager,
@@ -545,9 +545,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateStorageBuckets,
 		// Grants permission to view storage buckets.
 		EntitlementCanViewStorageBuckets,
-		// Grants permission to edit storage buckets.
+		// Grants permission to view and edit storage buckets.
 		EntitlementCanEditStorageBuckets,
-		// Grants permission to delete storage buckets.
+		// Grants permission to view and delete storage buckets.
 		EntitlementCanDeleteStorageBuckets,
 		// Grants permission to create, view, edit, and delete all placement groups belonging to the project.
 		EntitlementPlacementGroupManager,
@@ -555,9 +555,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreatePlacementGroups,
 		// Grants permission to view placement groups.
 		EntitlementCanViewPlacementGroups,
-		// Grants permission to edit placement groups.
+		// Grants permission to view and edit placement groups.
 		EntitlementCanEditPlacementGroups,
-		// Grants permission to delete placement groups.
+		// Grants permission to view and delete placement groups.
 		EntitlementCanDeletePlacementGroups,
 		// Grants permission to create, view, edit, and delete all replicators belonging to the project.
 		EntitlementReplicatorManager,
@@ -565,9 +565,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateReplicators,
 		// Grants permission to view replicators.
 		EntitlementCanViewReplicators,
-		// Grants permission to edit replicators.
+		// Grants permission to view and edit replicators.
 		EntitlementCanEditReplicators,
-		// Grants permission to delete replicators.
+		// Grants permission to view and delete replicators.
 		EntitlementCanDeleteReplicators,
 		// Grants permission to view operations relating to the project.
 		EntitlementCanViewOperations,
@@ -577,9 +577,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanViewMetrics,
 	},
 	entity.TypeReplicator: {
-		// Grants permission to edit the replicator.
+		// Grants permission to view and edit the replicator.
 		EntitlementCanEdit,
-		// Grants permission to delete the replicator.
+		// Grants permission to view and delete the replicator.
 		EntitlementCanDelete,
 		// Grants permission to view the replicator.
 		EntitlementCanView,
@@ -599,25 +599,25 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateIdentities,
 		// Grants permission to view identities.
 		EntitlementCanViewIdentities,
-		// Grants permission to edit identities. Note that clients with this permission are able to elevate their own privileges.
+		// Grants permission to view and edit identities. Note that clients with this permission are able to elevate their own privileges.
 		EntitlementCanEditIdentities,
-		// Grants permission to delete identities.
+		// Grants permission to view and delete identities.
 		EntitlementCanDeleteIdentities,
 		// Grants permission to create authorization groups.
 		EntitlementCanCreateGroups,
 		// Grants permission to view authorization groups.
 		EntitlementCanViewGroups,
-		// Grants permission to edit authorization groups. Note that clients with this permission are able to elevate their own privileges.
+		// Grants permission to view and edit authorization groups. Note that clients with this permission are able to elevate their own privileges.
 		EntitlementCanEditGroups,
-		// Grants permission to delete authorization groups.
+		// Grants permission to view and delete authorization groups.
 		EntitlementCanDeleteGroups,
 		// Grants permission to create identity provider groups.
 		EntitlementCanCreateIdentityProviderGroups,
 		// Grants permission to view identity provider groups.
 		EntitlementCanViewIdentityProviderGroups,
-		// Grants permission to edit identity provider groups. Note that clients with this permission are able to elevate their own privileges.
+		// Grants permission to view and edit identity provider groups. Note that clients with this permission are able to elevate their own privileges.
 		EntitlementCanEditIdentityProviderGroups,
-		// Grants permission to delete identity provider groups.
+		// Grants permission to view and delete identity provider groups.
 		EntitlementCanDeleteIdentityProviderGroups,
 		// Grants permission to create, edit, and delete storage pools.
 		EntitlementStoragePoolManager,
@@ -633,9 +633,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateProjects,
 		// Grants permission to view projects, and all resources within those projects.
 		EntitlementCanViewProjects,
-		// Grants permission to edit projects, and all resources within those projects.
+		// Grants permission to view and edit projects, and all resources within those projects.
 		EntitlementCanEditProjects,
-		// Grants permission to delete projects.
+		// Grants permission to view and delete projects.
 		EntitlementCanDeleteProjects,
 		// If a project is configured with `restricted.cluster.target`, clients with this permission can override the restriction.
 		EntitlementCanOverrideClusterTargetRestriction,
@@ -655,15 +655,15 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanCreateClusterLinks,
 		// Grants permission to view cluster links.
 		EntitlementCanViewClusterLinks,
-		// Grants permission to edit cluster links.
+		// Grants permission to view and edit cluster links.
 		EntitlementCanEditClusterLinks,
-		// Grants permission to delete cluster links.
+		// Grants permission to view and delete cluster links.
 		EntitlementCanDeleteClusterLinks,
 	},
 	entity.TypeStorageBucket: {
-		// Grants permission to edit the storage bucket.
+		// Grants permission to view and edit the storage bucket.
 		EntitlementCanEdit,
-		// Grants permission to delete the storage bucket.
+		// Grants permission to view and delete the storage bucket.
 		EntitlementCanDelete,
 		// Grants permission to view the storage bucket.
 		EntitlementCanView,
@@ -675,9 +675,9 @@ var EntityTypeToEntitlements = map[entity.Type][]Entitlement{
 		EntitlementCanDelete,
 	},
 	entity.TypeStorageVolume: {
-		// Grants permission to edit the storage volume.
+		// Grants permission to view and edit the storage volume.
 		EntitlementCanEdit,
-		// Grants permission to delete the storage volume.
+		// Grants permission to view and delete the storage volume.
 		EntitlementCanDelete,
 		// Grants permission to view the storage volume and any snapshots or backups it might have.
 		EntitlementCanView,

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -36,8 +36,8 @@ type Authorizer interface {
 	// the entity.
 	GetPermissionChecker(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
 
-	// GetViewableProjects accepts a list of permissions and returns a list of projects that a member of a group with these permissions is able to view.
-	GetViewableProjects(ctx context.Context, permissions []api.Permission) ([]string, error)
+	// CheckContextualPermission checks that, with the given list of permissions, the given entitlement is allowed for the given entity URL.
+	CheckContextualPermission(ctx context.Context, entityURL *api.URL, entitlement Entitlement, permissions []api.Permission) (bool, error)
 }
 
 // IsDeniedError returns true if the error is not found or forbidden. This is because the CheckPermission method on

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -830,7 +830,13 @@ func deleteAuthGroup(d *Daemon, r *http.Request) response.Response {
 // validatePermissions checks that a) the entity type exists, b) the entitlement exists, c) then entity type matches the
 // entity reference (URL), and d) that the entitlement is valid for the entity type.
 func validatePermissions(ctx context.Context, s *state.State, permissions []api.Permission) ([]dbCluster.Permission, error) {
-	projectsWithViewPermissionRequired := make(map[string][]api.Permission, len(permissions))
+	// Compose a map of entity URLs where view permission is required. For example, if a permission is for an entity that is project specific,
+	// then the URL of the project is added to the map and the permission appended to the list. Later, we will check that a group with the input list of
+	// permissions can view the project. The list of permissions associated with the URL (map values) are only used for informative error messages.
+	// URLs are added to the map as string keys to prevent duplicates.
+	entityURLsWithViewPermissionRequired := make(map[string][]api.Permission, len(permissions))
+
+	// Populate database references for the input URLs. Ensuring we can find the entities in the database.
 	entityReferences := make(map[*api.URL]*dbCluster.EntityRef, len(permissions))
 	permissionToURL := make(map[api.Permission]*api.URL, len(permissions))
 	for _, permission := range permissions {
@@ -845,7 +851,7 @@ func validatePermissions(ctx context.Context, s *state.State, permissions []api.
 			return nil, api.StatusErrorf(http.StatusBadRequest, "Failed parsing permission with entity reference %q and entitlement %q: %w", permission.EntityReference, permission.Entitlement, err)
 		}
 
-		referenceEntityType, projectName, _, _, err := entity.ParseURL(*u)
+		referenceEntityType, projectName, location, args, err := entity.ParseURL(*u)
 		if err != nil {
 			return nil, api.StatusErrorf(http.StatusBadRequest, "Failed parsing permission with entity reference %q and entitlement %q: %w", permission.EntityReference, permission.Entitlement, err)
 		}
@@ -854,14 +860,34 @@ func validatePermissions(ctx context.Context, s *state.State, permissions []api.
 			return nil, api.StatusErrorf(http.StatusBadRequest, "Failed parsing permission with entity reference %q and entitlement %q: Entity type does not correspond to entity reference", permission.EntityReference, permission.Entitlement)
 		}
 
-		err = auth.ValidateEntitlement(entityType, auth.Entitlement(permission.Entitlement))
+		permissionEntitlement := auth.Entitlement(permission.Entitlement)
+		err = auth.ValidateEntitlement(entityType, permissionEntitlement)
 		if err != nil {
 			return nil, api.StatusErrorf(http.StatusBadRequest, "Failed validating group permission with entity reference %q and entitlement %q: %w", permission.EntityReference, permission.Entitlement, err)
 		}
 
+		// If the entitlement is not `can_view`, check that a group with these permissions can view the entity.
+		if permissionEntitlement != auth.EntitlementCanView {
+			// Only perform the check if `can_view` is valid for the entity type.
+			// E.g. If granting `can_edit` on a storage pool, we don't check that a group with these permissions can view
+			// the storage pool because there is no such entitlement.
+			err = auth.ValidateEntitlement(entityType, auth.EntitlementCanView)
+			if err == nil {
+				entityURL, err := referenceEntityType.URL(projectName, location, args...)
+				if err != nil {
+					return nil, err
+				}
+
+				entityURLString := entityURL.String()
+				entityURLsWithViewPermissionRequired[entityURLString] = append(entityURLsWithViewPermissionRequired[entityURLString], permission)
+			}
+		}
+
+		// If the entity type requires a project, check that a group with these permissions can view the project.
 		requiresProject, _ := entityType.RequiresProject()
-		if requiresProject || entityType == entity.TypeProject {
-			projectsWithViewPermissionRequired[projectName] = append(projectsWithViewPermissionRequired[projectName], permission)
+		if requiresProject {
+			projectURLString := entity.ProjectURL(projectName).String()
+			entityURLsWithViewPermissionRequired[projectURLString] = append(entityURLsWithViewPermissionRequired[projectURLString], permission)
 		}
 
 		apiURL := &api.URL{URL: *u}
@@ -869,22 +895,32 @@ func validatePermissions(ctx context.Context, s *state.State, permissions []api.
 		permissionToURL[permission] = apiURL
 	}
 
-	if len(projectsWithViewPermissionRequired) > 0 {
-		viewableProjects, err := s.Authorizer.GetViewableProjects(ctx, permissions)
+	// Check the group for consistency. A group permission that references a project specific entity is only allowed if the group can view the parent project.
+	// A group permission that references any entity (and whose entitlement is not "can_view") is only allowed if the group can view the entity.
+	for urlStr, perms := range entityURLsWithViewPermissionRequired {
+		u, err := url.Parse(urlStr)
 		if err != nil {
-			return nil, fmt.Errorf("Failed verifying that projects are viewable: %w", err)
+			// We should never hit this error because we've already parsed the URL above.
+			return nil, fmt.Errorf("Failed re-parsing entity URL during group consistency checks: %w", err)
 		}
 
-		for project, perms := range projectsWithViewPermissionRequired {
-			if !slices.Contains(viewableProjects, project) {
-				if len(perms) == 1 {
-					// Return an informative error message if possible.
-					return nil, api.StatusErrorf(http.StatusBadRequest, "Entitlement %q on entity type %q references project %q, but the project cannot be viewed by the group", perms[0].Entitlement, perms[0].EntityType, project)
-				}
-
-				return nil, api.StatusErrorf(http.StatusBadRequest, "Members of the group cannot view project %q, but %d permissions reference this project", project, len(perms))
-			}
+		// Check view permission on the entity contextually, so that the permission check is not conflated with permissions of the caller.
+		isAllowed, err := s.Authorizer.CheckContextualPermission(ctx, &api.URL{URL: *u}, auth.EntitlementCanView, permissions)
+		if err != nil {
+			return nil, err
 		}
+
+		// If members of the group can view the entity, we're good.
+		if isAllowed {
+			continue
+		}
+
+		// Otherwise, return an informative error message based on the offending permissions.
+		if len(perms) == 1 {
+			return nil, api.StatusErrorf(http.StatusBadRequest, "Entitlement %q on entity type %q references %q, but the entity cannot be viewed by the group", perms[0].Entitlement, perms[0].EntityType, urlStr)
+		}
+
+		return nil, api.StatusErrorf(http.StatusBadRequest, "Members of the group cannot view %q, but %d permissions reference this entity", urlStr, len(perms))
 	}
 
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/db/openfga/openfga.go
+++ b/lxd/db/openfga/openfga.go
@@ -85,6 +85,13 @@ type RequestCache struct {
 //   - If we change our design to use entity IDs directly, this method will need to change so that we can return the correct project ID.
 //     (Currently we don't need to as the project name is already in the URL).
 func (o *openfgaStore) Read(ctx context.Context, s string, key storage.ReadFilter, options storage.ReadOptions) (storage.TupleIterator, error) {
+	// If the request is intended for contextual tuples only, the caller has indicated that it has passed all relevant information
+	// to perform the check. Don't return any data.
+	contextualOnly, err := request.GetContextValue[bool](ctx, request.CtxOpenFGAContextualTuplesOnly)
+	if err == nil && contextualOnly {
+		return storage.NewStaticTupleIterator(nil), nil
+	}
+
 	obj := key.Object
 	relation := key.Relation
 	user := key.User
@@ -115,7 +122,7 @@ func (o *openfgaStore) Read(ctx context.Context, s string, key storage.ReadFilte
 	}
 
 	entityType := entity.Type(entityTypeStr)
-	err := entityType.Validate()
+	err = entityType.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("Read: Invalid object filter %q: %w", obj, err)
 	}
@@ -213,6 +220,13 @@ func (o *openfgaStore) Read(ctx context.Context, s string, key storage.ReadFilte
 //   - The tuples that this method is meant to return have been passed in contextually. So validate the input matches
 //     what is expected and return nil.
 func (o *openfgaStore) ReadUserTuple(ctx context.Context, store string, filter storage.ReadUserTupleFilter, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
+	// If the request is intended for contextual tuples only, the caller has indicated that it has passed all relevant information
+	// to perform the check. Don't return any data.
+	contextualOnly, err := request.GetContextValue[bool](ctx, request.CtxOpenFGAContextualTuplesOnly)
+	if err == nil && contextualOnly {
+		return nil, nil
+	}
+
 	// Expect the User field to be present.
 	user := filter.User
 	if user == "" {
@@ -338,6 +352,13 @@ func (o *openfgaStore) ensureCacheLoaded(ctx context.Context, cache *RequestCach
 //     that is defined for `server` `can_view`, which allows all identities access to `GET /1.0` and `GET /1.0/storage`.
 //     We check for this case before making any DB queries.
 func (o *openfgaStore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
+	// If the request is intended for contextual tuples only, the caller has indicated that it has passed all relevant information
+	// to perform the check. Don't return any data.
+	contextualOnly, err := request.GetContextValue[bool](ctx, request.CtxOpenFGAContextualTuplesOnly)
+	if err == nil && contextualOnly {
+		return storage.NewStaticTupleIterator(nil), nil
+	}
+
 	// Expect both an object and a relation.
 	if filter.Object == "" || filter.Relation == "" {
 		return nil, errors.New("ReadUsersetTuples: Filter must include both an object and a relation")
@@ -351,7 +372,7 @@ func (o *openfgaStore) ReadUsersetTuples(ctx context.Context, store string, filt
 	}
 
 	entityType := entity.Type(entityTypeStr)
-	err := entityType.Validate()
+	err = entityType.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("ReadUsersetTuples: Invalid object filter %q: %w", filter.Object, err)
 	}
@@ -497,6 +518,13 @@ WHERE auth_groups_permissions.entitlement = ? AND auth_groups_permissions.entity
 //   - In the third case, we need to get all permissions with the given entity type and entitlement that are associated with the given group.
 //   - For the fourth case we return nil, since we expect direct entitlements for identities to be passed in contextually.
 func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
+	// If the request is intended for contextual tuples only, the caller has indicated that it has passed all relevant information
+	// to perform the check. Don't return any data.
+	contextualOnly, err := request.GetContextValue[bool](ctx, request.CtxOpenFGAContextualTuplesOnly)
+	if err == nil && contextualOnly {
+		return storage.NewStaticTupleIterator(nil), nil
+	}
+
 	// Example expected input, case 1:
 	// filter.ObjectType = "certificate"
 	// filter.Relation = "server"
@@ -537,7 +565,7 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 	}
 
 	entityType := entity.Type(filter.ObjectType)
-	err := entityType.Validate()
+	err = entityType.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("ReadUsersetTuples: Invalid object filter %q: %w", entityType, err)
 	}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7911,11 +7911,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the certificate."
+					"description": "Grants permission to view and edit the certificate."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the certificate."
+					"description": "Grants permission to view and delete the certificate."
 				}
 			]
 		},
@@ -7928,11 +7928,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the cluster link."
+					"description": "Grants permission to view and edit the cluster link."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the cluster link."
+					"description": "Grants permission to view and delete the cluster link."
 				}
 			]
 		},
@@ -7945,11 +7945,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the group."
+					"description": "Grants permission to view and edit the group."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the group."
+					"description": "Grants permission to view and delete the group."
 				}
 			]
 		},
@@ -7962,11 +7962,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of."
+					"description": "Grants permission to view and edit the identity. To edit an identity, it is additionally required that the caller is able to view all groups that the identity is a member of."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the identity."
+					"description": "Grants permission to view and delete the identity."
 				}
 			]
 		},
@@ -7979,11 +7979,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the identity provider group."
+					"description": "Grants permission to view and edit the identity provider group."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the identity provider group."
+					"description": "Grants permission to view and delete the identity provider group."
 				}
 			]
 		},
@@ -7992,11 +7992,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the image."
+					"description": "Grants permission to view and edit the image."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the image."
+					"description": "Grants permission to view and delete the image."
 				},
 				{
 					"name": "can_view",
@@ -8009,11 +8009,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the image alias."
+					"description": "Grants permission to view and edit the image alias."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the image alias."
+					"description": "Grants permission to view and delete the image alias."
 				},
 				{
 					"name": "can_view",
@@ -8034,11 +8034,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the instance."
+					"description": "Grants permission to view and edit the instance."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the instance."
+					"description": "Grants permission to view and delete the instance."
 				},
 				{
 					"name": "can_view",
@@ -8079,11 +8079,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the network."
+					"description": "Grants permission to view and edit the network."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the network."
+					"description": "Grants permission to view and delete the network."
 				},
 				{
 					"name": "can_view",
@@ -8096,11 +8096,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the network ACL."
+					"description": "Grants permission to view and edit the network ACL."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the network ACL."
+					"description": "Grants permission to view and delete the network ACL."
 				},
 				{
 					"name": "can_view",
@@ -8113,11 +8113,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the network zone."
+					"description": "Grants permission to view and edit the network zone."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the network zone."
+					"description": "Grants permission to view and delete the network zone."
 				},
 				{
 					"name": "can_view",
@@ -8130,11 +8130,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the placement group."
+					"description": "Grants permission to view and edit the placement group."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the placement group."
+					"description": "Grants permission to view and delete the placement group."
 				},
 				{
 					"name": "can_view",
@@ -8147,11 +8147,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the profile."
+					"description": "Grants permission to view and edit the profile."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the profile."
+					"description": "Grants permission to view and delete the profile."
 				},
 				{
 					"name": "can_view",
@@ -8176,11 +8176,11 @@
 				},
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the project."
+					"description": "Grants permission to view and edit the project."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the project."
+					"description": "Grants permission to view and delete the project."
 				},
 				{
 					"name": "image_manager",
@@ -8196,11 +8196,11 @@
 				},
 				{
 					"name": "can_edit_images",
-					"description": "Grants permission to edit images."
+					"description": "Grants permission to view and edit images."
 				},
 				{
 					"name": "can_delete_images",
-					"description": "Grants permission to delete images."
+					"description": "Grants permission to view and delete images."
 				},
 				{
 					"name": "image_alias_manager",
@@ -8216,11 +8216,11 @@
 				},
 				{
 					"name": "can_edit_image_aliases",
-					"description": "Grants permission to edit image aliases."
+					"description": "Grants permission to view and edit image aliases."
 				},
 				{
 					"name": "can_delete_image_aliases",
-					"description": "Grants permission to delete image aliases."
+					"description": "Grants permission to view and delete image aliases."
 				},
 				{
 					"name": "instance_manager",
@@ -8236,11 +8236,11 @@
 				},
 				{
 					"name": "can_edit_instances",
-					"description": "Grants permission to edit instances."
+					"description": "Grants permission to view and edit instances."
 				},
 				{
 					"name": "can_delete_instances",
-					"description": "Grants permission to delete instances."
+					"description": "Grants permission to view and delete instances."
 				},
 				{
 					"name": "can_operate_instances",
@@ -8260,11 +8260,11 @@
 				},
 				{
 					"name": "can_edit_networks",
-					"description": "Grants permission to edit networks."
+					"description": "Grants permission to view and edit networks."
 				},
 				{
 					"name": "can_delete_networks",
-					"description": "Grants permission to delete networks."
+					"description": "Grants permission to view and delete networks."
 				},
 				{
 					"name": "network_acl_manager",
@@ -8280,11 +8280,11 @@
 				},
 				{
 					"name": "can_edit_network_acls",
-					"description": "Grants permission to edit network ACLs."
+					"description": "Grants permission to view and edit network ACLs."
 				},
 				{
 					"name": "can_delete_network_acls",
-					"description": "Grants permission to delete network ACLs."
+					"description": "Grants permission to view and delete network ACLs."
 				},
 				{
 					"name": "network_zone_manager",
@@ -8300,11 +8300,11 @@
 				},
 				{
 					"name": "can_edit_network_zones",
-					"description": "Grants permission to edit network zones."
+					"description": "Grants permission to view and edit network zones."
 				},
 				{
 					"name": "can_delete_network_zones",
-					"description": "Grants permission to delete network zones."
+					"description": "Grants permission to view and delete network zones."
 				},
 				{
 					"name": "profile_manager",
@@ -8320,11 +8320,11 @@
 				},
 				{
 					"name": "can_edit_profiles",
-					"description": "Grants permission to edit profiles."
+					"description": "Grants permission to view and edit profiles."
 				},
 				{
 					"name": "can_delete_profiles",
-					"description": "Grants permission to delete profiles."
+					"description": "Grants permission to view and delete profiles."
 				},
 				{
 					"name": "storage_volume_manager",
@@ -8340,11 +8340,11 @@
 				},
 				{
 					"name": "can_edit_storage_volumes",
-					"description": "Grants permission to edit storage volumes."
+					"description": "Grants permission to view and edit storage volumes."
 				},
 				{
 					"name": "can_delete_storage_volumes",
-					"description": "Grants permission to delete storage volumes."
+					"description": "Grants permission to view and delete storage volumes."
 				},
 				{
 					"name": "storage_bucket_manager",
@@ -8360,11 +8360,11 @@
 				},
 				{
 					"name": "can_edit_storage_buckets",
-					"description": "Grants permission to edit storage buckets."
+					"description": "Grants permission to view and edit storage buckets."
 				},
 				{
 					"name": "can_delete_storage_buckets",
-					"description": "Grants permission to delete storage buckets."
+					"description": "Grants permission to view and delete storage buckets."
 				},
 				{
 					"name": "placement_group_manager",
@@ -8380,11 +8380,11 @@
 				},
 				{
 					"name": "can_edit_placement_groups",
-					"description": "Grants permission to edit placement groups."
+					"description": "Grants permission to view and edit placement groups."
 				},
 				{
 					"name": "can_delete_placement_groups",
-					"description": "Grants permission to delete placement groups."
+					"description": "Grants permission to view and delete placement groups."
 				},
 				{
 					"name": "replicator_manager",
@@ -8400,11 +8400,11 @@
 				},
 				{
 					"name": "can_edit_replicators",
-					"description": "Grants permission to edit replicators."
+					"description": "Grants permission to view and edit replicators."
 				},
 				{
 					"name": "can_delete_replicators",
-					"description": "Grants permission to delete replicators."
+					"description": "Grants permission to view and delete replicators."
 				},
 				{
 					"name": "can_view_operations",
@@ -8425,11 +8425,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the replicator."
+					"description": "Grants permission to view and edit the replicator."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the replicator."
+					"description": "Grants permission to view and delete the replicator."
 				},
 				{
 					"name": "can_view",
@@ -8470,11 +8470,11 @@
 				},
 				{
 					"name": "can_edit_identities",
-					"description": "Grants permission to edit identities. Note that clients with this permission are able to elevate their own privileges."
+					"description": "Grants permission to view and edit identities. Note that clients with this permission are able to elevate their own privileges."
 				},
 				{
 					"name": "can_delete_identities",
-					"description": "Grants permission to delete identities."
+					"description": "Grants permission to view and delete identities."
 				},
 				{
 					"name": "can_create_groups",
@@ -8486,11 +8486,11 @@
 				},
 				{
 					"name": "can_edit_groups",
-					"description": "Grants permission to edit authorization groups. Note that clients with this permission are able to elevate their own privileges."
+					"description": "Grants permission to view and edit authorization groups. Note that clients with this permission are able to elevate their own privileges."
 				},
 				{
 					"name": "can_delete_groups",
-					"description": "Grants permission to delete authorization groups."
+					"description": "Grants permission to view and delete authorization groups."
 				},
 				{
 					"name": "can_create_identity_provider_groups",
@@ -8502,11 +8502,11 @@
 				},
 				{
 					"name": "can_edit_identity_provider_groups",
-					"description": "Grants permission to edit identity provider groups. Note that clients with this permission are able to elevate their own privileges."
+					"description": "Grants permission to view and edit identity provider groups. Note that clients with this permission are able to elevate their own privileges."
 				},
 				{
 					"name": "can_delete_identity_provider_groups",
-					"description": "Grants permission to delete identity provider groups."
+					"description": "Grants permission to view and delete identity provider groups."
 				},
 				{
 					"name": "storage_pool_manager",
@@ -8538,11 +8538,11 @@
 				},
 				{
 					"name": "can_edit_projects",
-					"description": "Grants permission to edit projects, and all resources within those projects."
+					"description": "Grants permission to view and edit projects, and all resources within those projects."
 				},
 				{
 					"name": "can_delete_projects",
-					"description": "Grants permission to delete projects."
+					"description": "Grants permission to view and delete projects."
 				},
 				{
 					"name": "can_override_cluster_target_restriction",
@@ -8582,11 +8582,11 @@
 				},
 				{
 					"name": "can_edit_cluster_links",
-					"description": "Grants permission to edit cluster links."
+					"description": "Grants permission to view and edit cluster links."
 				},
 				{
 					"name": "can_delete_cluster_links",
-					"description": "Grants permission to delete cluster links."
+					"description": "Grants permission to view and delete cluster links."
 				}
 			]
 		},
@@ -8595,11 +8595,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the storage bucket."
+					"description": "Grants permission to view and edit the storage bucket."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the storage bucket."
+					"description": "Grants permission to view and delete the storage bucket."
 				},
 				{
 					"name": "can_view",
@@ -8625,11 +8625,11 @@
 			"entitlements": [
 				{
 					"name": "can_edit",
-					"description": "Grants permission to edit the storage volume."
+					"description": "Grants permission to view and edit the storage volume."
 				},
 				{
 					"name": "can_delete",
-					"description": "Grants permission to delete the storage volume."
+					"description": "Grants permission to view and delete the storage volume."
 				},
 				{
 					"name": "can_view",

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -28,6 +28,10 @@ const (
 	// CtxOpenFGARequestCache is used to set a cache for the OpenFGA datastore to improve driver performance on a per request basis.
 	CtxOpenFGARequestCache CtxKey = "openfga_request_cache"
 
+	// CtxOpenFGAContextualTuplesOnly indicates to the OpenFGA datastore that it should not attempt to resolve an entity URL from the database.
+	// This is used for group permission consistency checks.
+	CtxOpenFGAContextualTuplesOnly CtxKey = "openfga_context_only"
+
 	// CtxSecurityEventBase carries the per-request OWASP audit fields used to
 	// populate security events emitted while handling a request.
 	CtxSecurityEventBase CtxKey = "security_event_base"

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -44,14 +44,20 @@ test_authorization() {
   # Instance permissions.
   ! lxc auth group permission add test-group instance c1 can_exec project=default || false # Not found
   lxc init --empty c1
-  ! lxc auth group permission add test-group instance c1 can_exec || false # No project
   ! lxc auth group permission add test-group instance c1 can_exec project=default || false # Cannot view default project
   lxc auth group permission add test-group project default can_view
+  ! lxc auth group permission add test-group instance c1 can_exec || false # No project
+  ! lxc auth group permission add test-group instance c1 can_exec project=default || false # Cannot view instance
+  lxc auth group permission add test-group instance c1 can_view project=default # Valid
+  ! lxc auth group permission remove test-group instance c1 can_exec project=default || false # No such permission
   lxc auth group permission add test-group instance c1 can_exec project=default # Valid
+  ! lxc auth group permission remove test-group instance c1 can_view || false # Can't remove viewership while exec perms held.
   lxc auth group permission remove test-group instance c1 can_exec project=default # Valid
   ! lxc auth group permission remove test-group instance c1 can_exec project=default || false # Already removed
   ! lxc auth group permission add test-group instance c1 not_an_instance_entitlement project=default || false # Invalid entitlement
-  lxc auth group permission remove test-group project default can_view
+  ! lxc auth group permission remove test-group project default can_view || false # Can't remove project viewership while group members can still view an instance inside it.
+  lxc auth group permission remove test-group instance c1 can_view project=default # Valid
+  lxc auth group permission remove test-group project default can_view # Valid
 
   # Instance snapshot permissions, these are not valid because permissions can only be granted on the parent instance.
   lxc snapshot c1 c1-snap
@@ -81,9 +87,9 @@ test_authorization() {
 
   # Test permission is removed automatically when instance is removed.
   lxc auth group permission add test-group project default can_view
-  lxc auth group permission add test-group instance c1 can_exec project=default # Valid
+  lxc auth group permission add test-group instance c1 can_edit project=default # Valid
   lxc rm c1 --force
-  [ "$(lxd sql global --format csv "SELECT COUNT(*) FROM auth_groups_permissions WHERE entitlement = 'can_exec'")" = 0 ] # Permission should be removed when instance is removed.
+  [ "$(lxd sql global --format csv "SELECT COUNT(*) FROM auth_groups_permissions WHERE entitlement = 'can_edit'")" = 0 ] # Permission should be removed when instance is removed.
   lxc auth group permission remove test-group project default can_view
 
   # Network permissions


### PR DESCRIPTION
When editing a group, it's possible to grant e.g. `can_exec` on an instance when the group cannot view the instance.

This PR fixes this by enforcing that the group `can_view` an entity for any permissions being granted that are not `can_view`. Additionally, it makes the authorization model more consistent, by always allowing `can_view` when `can_edit` or `can_delete` are granted. In summary, you can now have:
```bash
lxc auth group permission add g1 project default can_edit # works because `can_view` is granted via `can_edit`
lxc auth group permission add g1 instance c1 can_edit project=default # as above
lxc auth group permission add g1 instance c2 can_exec project=default # fails because group members can't view c2
```

Closes #16849 (it is no longer possible to grant `can_update_state` without `can_view`).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
