### PR TITLE
lxd/api_replicators: Preserve protected config keys during refresh

### DIFF
--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -1572,10 +1572,18 @@ func replicateInstance(ctx context.Context, s *state.State, op *operations.Opera
 			return fmt.Errorf("Failed getting instance %q from hosting cluster member: %w", instName, err)
 		}
 
+		// Carry forward the protected volatile keys of the destination copy, as the refresh
+		// payload is applied as the full desired target configuration.
+		destPut := srcInstInfo.Writable()
+		err = applyRemoteRefreshTargetConfig(dstClient, instName, &destPut)
+		if err != nil {
+			return err
+		}
+
 		// Set up a push-mode migration sink on the destination.
 		destOp, err := dstClient.CreateInstance(api.InstancesPost{
 			Name:        instName,
-			InstancePut: srcInstInfo.Writable(),
+			InstancePut: destPut,
 			Type:        api.InstanceType(srcInstInfo.Type),
 			Source: api.InstanceSource{
 				Type:    api.SourceTypeMigration,
@@ -1646,13 +1654,21 @@ func replicateInstance(ctx context.Context, s *state.State, op *operations.Opera
 		return fmt.Errorf("Unexpected result from source instance render for %q", instName)
 	}
 
+	// Carry forward the protected volatile keys of the destination copy, as the refresh payload
+	// is applied as the full desired target configuration.
+	destPut := srcInstInfo.Writable()
+	err = applyRemoteRefreshTargetConfig(dstClient, instName, &destPut)
+	if err != nil {
+		return err
+	}
+
 	// Set up a push-mode migration sink on the destination. In push mode the
 	// leader (source) connects outward to the destination, so the destination
 	// does not need to reach back into the leader. This is required when the
 	// destination project is restricted, which disallows pull-mode migrations.
 	destOp, err := dstClient.CreateInstance(api.InstancesPost{
 		Name:        instName,
-		InstancePut: srcInstInfo.Writable(),
+		InstancePut: destPut,
 		Type:        api.InstanceType(srcInstInfo.Type),
 		Source: api.InstanceSource{
 			Type:    api.SourceTypeMigration,

--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/operations"
@@ -1202,10 +1204,13 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 			// Instances on the local member (including unclustered servers) are handled
 			// directly below. This mirrors the logic in replicateInstance.
 			var memberAddress string
+			var localInst instance.Instance
 			for _, inst := range allInsts {
 				if inst.Name() == instName {
 					if inst.Location() != s.ServerName {
 						memberAddress = nodeAddressByName[inst.Location()]
+					} else {
+						localInst = inst
 					}
 
 					break
@@ -1220,10 +1225,18 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 
 				memberClient = memberClient.UseProject(projectName)
 
+				// Carry forward the protected volatile keys of the local copy, as the refresh
+				// payload is applied as the full desired target configuration.
+				restorePut := freshInst.Writable()
+				err = applyRemoteRefreshTargetConfig(memberClient, instName, &restorePut)
+				if err != nil {
+					return err
+				}
+
 				// Set up a push-mode migration sink on the hosting cluster member.
 				restoreOp, err := memberClient.CreateInstance(api.InstancesPost{
 					Name:        instName,
-					InstancePut: freshInst.Writable(),
+					InstancePut: restorePut,
 					Type:        api.InstanceType(freshInst.Type),
 					Source: api.InstanceSource{
 						Type:    api.SourceTypeMigration,
@@ -1281,19 +1294,24 @@ func prepareReplicatorRunOperation(ctx context.Context, s *state.State, projectN
 				return fmt.Errorf("Failed loading profiles for instance %q: %w", instName, err)
 			}
 
+			restorePut := freshInst.Writable()
+
+			// Carry forward the protected volatile keys of the local copy, as the refresh payload
+			// is applied as the full desired target configuration. The instance doesn't exist
+			// locally when it was created on the current leader cluster after the failover, in
+			// which case there is nothing to carry forward.
+			if localInst != nil {
+				err = applyLocalRefreshTargetConfig(localInst, &restorePut)
+				if err != nil {
+					return err
+				}
+			}
+
 			// Set up a push-mode migration sink locally so the leader pushes data to us.
 			migrateReq := &api.InstancesPost{
-				InstancePut: api.InstancePut{
-					Architecture: freshInst.Architecture,
-					Config:       freshInst.Config,
-					Devices:      freshInst.Devices,
-					Description:  freshInst.Description,
-					Ephemeral:    freshInst.Ephemeral,
-					Profiles:     freshInst.Profiles,
-					Stateful:     freshInst.Stateful,
-				},
-				Name: instName,
-				Type: api.InstanceType(freshInst.Type),
+				InstancePut: restorePut,
+				Name:        instName,
+				Type:        api.InstanceType(freshInst.Type),
 				Source: api.InstanceSource{
 					Type:    api.SourceTypeMigration,
 					Mode:    "push",
@@ -1451,6 +1469,59 @@ func replicatorCheckInstancesStopped(allInsts []instance.Instance) error {
 			return fmt.Errorf("Instance %q is running, stop all project instances before restoring", inst.Name())
 		}
 	}
+
+	return nil
+}
+
+// applyRefreshTargetConfig merges protected target-only keys (such as the volatile idmap keys) from
+// the existing target instance into a refresh request payload. The server treats a refresh payload as
+// the full desired target configuration (see the "instance_refresh_config" API extension), so keys
+// that exist on the target but are missing from the payload are seen as deletions and rejected.
+func applyRefreshTargetConfig(put *api.InstancePut, target api.Instance) {
+	// Copy the maps before mutating them. A payload derived from a locally rendered instance
+	// shares its config map with the instance's own in-memory config (see (*lxc).Render), so
+	// mutating it in place would corrupt the source instance.
+	put.Config = maps.Clone(put.Config)
+	if put.Devices != nil {
+		put.Devices = deviceConfig.NewDevices(put.Devices).CloneNative()
+	}
+
+	put.ApplyRefreshConfig(target)
+}
+
+// applyLocalRefreshTargetConfig renders a locally hosted refresh target instance and merges its
+// protected target-only keys into the refresh request payload.
+func applyLocalRefreshTargetConfig(target instance.Instance, put *api.InstancePut) error {
+	renderRes, _, err := target.Render()
+	if err != nil {
+		return fmt.Errorf("Failed rendering local instance %q: %w", target.Name(), err)
+	}
+
+	targetInfo, ok := renderRes.(*api.Instance)
+	if !ok {
+		return fmt.Errorf("Unexpected result from local instance render for %q", target.Name())
+	}
+
+	applyRefreshTargetConfig(put, *targetInfo)
+
+	return nil
+}
+
+// applyRemoteRefreshTargetConfig fetches the refresh target instance from the given server and merges
+// its protected target-only keys into the refresh request payload. If the target instance doesn't
+// exist yet the payload is left unchanged, as the server then falls back to creating the instance
+// from scratch.
+func applyRemoteRefreshTargetConfig(client lxd.InstanceServer, instName string, put *api.InstancePut) error {
+	target, _, err := client.GetInstance(instName)
+	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("Failed getting refresh target instance %q: %w", instName, err)
+	}
+
+	applyRefreshTargetConfig(put, *target)
 
 	return nil
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6459,6 +6459,16 @@ test_clustering_replicator_multi_member() {
 
   sub_test "Verify --restore rejects running instances on other members"
 
+  # c2 has never been started, so the copy replicated to the target cluster has no idmap keys.
+  # Start and stop it on node2 so only the source copy records an idmap: the restore below runs
+  # through the remote cluster member and must preserve that map rather than delete it.
+  local c2_idmap
+  [ "$(LXD_DIR="${LXD_THREE_DIR}" lxc config get c2 volatile.idmap.current --project replicator-project || echo fail)" = "" ]
+  LXD_DIR="${LXD_ONE_DIR}" lxc start c2 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc stop c2 --force --project replicator-project
+  c2_idmap="$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c2 volatile.idmap.current --project replicator-project)"
+  jq --exit-status 'type == "array" and length > 0' <<< "${c2_idmap}"
+
   # Simulate failover: source becomes standby, target becomes leader.
   LXD_DIR="${LXD_ONE_DIR}" lxc project demote-replica replicator-project --force
   LXD_DIR="${LXD_THREE_DIR}" lxc project promote-replica replicator-project --force
@@ -6488,6 +6498,9 @@ test_clustering_replicator_multi_member() {
   # Verify instances were restored to their original cluster members.
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c1,node1'
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c nL | grep -xF 'c2,node2'
+
+  # The restore ran through node2 for c2 and must have kept the idmap recorded there.
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c2 volatile.idmap.current --project replicator-project)" = "${c2_idmap}" ]
 
   # Cleanup: instances exist on both clusters after replication + restore.
   LXD_DIR="${LXD_THREE_DIR}" lxc delete c1 c2 --project replicator-project

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6125,20 +6125,32 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc profile device add default root disk path="/" pool="${pool_one}" --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device add default root disk path="/" pool="${pool_two}" --project replicator-project
 
-  sub_test "Initial replication: replicate c1 and c2 to LXD_TWO"
+  sub_test "Initial replication: replicate c1, c2, and c4 to LXD_TWO"
 
   LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1 --project replicator-project -d "${SMALL_ROOT_DISK}"
   LXD_DIR="${LXD_ONE_DIR}" lxc init --empty c2 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  # c4 is replicated while it has never been started, so the copy on LXD_TWO gets no idmap keys.
+  LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c4 --project replicator-project -d "${SMALL_ROOT_DISK}"
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq --exit-status '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
-  jq --exit-status '([., (.children? // [])[]] | length) == 4 and .status == "Success" and .child_count == 3 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  jq --exit-status '([., (.children? // [])[]] | length) == 5 and .status == "Success" and .child_count == 4 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
   # Each instance replication child operation names the instance it replicates.
-  jq --exit-status '[.children[] | select(.description == "Replicating instance") | .metadata.entity_url] | (length == 2 and all(test("^/1.0/instances/c\\d\\?project=replicator-project$")))' <<< "${bulk_op}"
+  jq --exit-status '[.children[] | select(.description == "Replicating instance") | .metadata.entity_url] | (length == 3 and all(test("^/1.0/instances/c\\d\\?project=replicator-project$")))' <<< "${bulk_op}"
   # The finalization stage references the replicator URL in its metadata
   jq --exit-status '[.children[] | select(.description == "Finalizing replicator") | .metadata.entity_url] | (length == 1 and .[0] == "/1.0/replicators/my-replicator?project=replicator-project")' <<< "${bulk_op}"
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c4,STOPPED'
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc config get c4 volatile.idmap.current --project replicator-project || echo fail)" = "" ]
+
+  # Start and stop c4 on LXD_ONE only, so volatile.idmap.current is recorded there but not on the
+  # replicated copy. The restore below must preserve this exact map.
+  local c4_idmap
+  LXD_DIR="${LXD_ONE_DIR}" lxc start c4 --project replicator-project
+  LXD_DIR="${LXD_ONE_DIR}" lxc stop c4 --force --project replicator-project
+  c4_idmap="$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c4 volatile.idmap.current --project replicator-project)"
+  jq --exit-status 'type == "array" and length > 0' <<< "${c4_idmap}"
 
   sub_test "Disaster: kill LXD_ONE and promote LXD_TWO to leader"
 
@@ -6161,6 +6173,11 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_TWO_DIR}" lxc project promote-replica replicator-project --force
   # Both clusters now have leader mode set. Verify instance creation is allowed on LXD_TWO.
   LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c3 --project replicator-project -d "${SMALL_ROOT_DISK}"
+  # c5 is created on the new leader and stays stopped until after the restore, so the copy
+  # restored onto LXD_ONE gets no idmap keys. It is started on LXD_TWO further down to set up
+  # the reverse case for the forward replication run.
+  LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc init testimage c5 --project replicator-project -d "${SMALL_ROOT_DISK}"
   # Verify LXD_TWO can start a replicated instance as the new leader.
   LXD_DIR="${LXD_TWO_DIR}" lxc start c1 --project replicator-project
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,RUNNING'
@@ -6204,29 +6221,45 @@ test_clustering_replicator_dr() {
   # c1 is still running on LXD_ONE after respawn; --restore must be rejected with a clear error.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project 2>&1)" = 'Error: Instance "c1" is running, stop all project instances before restoring' ]
 
-  sub_test "Restore: LXD_ONE is standby and restore c1, c2, and c3 from LXD_TWO"
+  sub_test "Restore: LXD_ONE is standby and restore c1, c2, c3, c4, and c5 from LXD_TWO"
 
   # c1 is running and must be stopped: the server rejects --restore if any local instance
   # is running to prevent partial restores. c2 is empty and already stopped.
   LXD_DIR="${LXD_ONE_DIR}" lxc stop c1 --force --project replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --restore --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq --exit-status '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
-  jq --exit-status '([., (.children? // [])[]] | length) == 5 and .status == "Success" and .child_count == 4 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  jq --exit-status '([., (.children? // [])[]] | length) == 7 and .status == "Success" and .child_count == 6 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
   # Restore child operations name the project, because c3 was created on the current leader cluster
   # during failover and is missing locally until the operation creates it. The instance each child
   # restores is reported in the metadata.
-  jq --exit-status '[.children[] | select(.description == "Restoring replicated instance") | .metadata.entity_url] | (length == 3 and all(test("^/1.0/instances/c\\d\\?project=replicator-project$")))' <<< "${bulk_op}"
+  jq --exit-status '[.children[] | select(.description == "Restoring replicated instance") | .metadata.entity_url] | (length == 5 and all(test("^/1.0/instances/c\\d\\?project=replicator-project$")))' <<< "${bulk_op}"
   # The finalization stage references the replicator URL in its metadata
   jq --exit-status '[.children[] | select(.description == "Finalizing replicator") | .metadata.entity_url] | (length == 1 and .[0] == "/1.0/replicators/my-replicator?project=replicator-project")' <<< "${bulk_op}"
-  # c1 and c2 are restored from LXD_TWO's current state; c3 (created on LXD_TWO during failover) is created from scratch.
+  # c1, c2 and c4 are restored from LXD_TWO's current state; c3 and c5 (created on LXD_TWO during
+  # failover) are created from scratch.
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
   LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c3,STOPPED'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c4,STOPPED'
+  LXD_DIR="${LXD_ONE_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c5,STOPPED'
+  # The restore must keep the idmap recorded on the local copy of c4 rather than deleting it,
+  # because the instance was never started on LXD_TWO.
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c4 volatile.idmap.current --project replicator-project)" = "${c4_idmap}" ]
 
   sub_test "Resume: demote LXD_TWO, promote LXD_ONE, verify replication resumes"
 
+  # Start and stop c5 on LXD_TWO while it is still the leader, so the replication target records an
+  # idmap that the restored copy on LXD_ONE doesn't have. The forward replication run below must
+  # keep it rather than trying to delete it.
+  local c5_idmap
+  LXD_DIR="${LXD_TWO_DIR}" lxc start c5 --project replicator-project
+  LXD_DIR="${LXD_TWO_DIR}" lxc stop c5 --force --project replicator-project
+  c5_idmap="$(LXD_DIR="${LXD_TWO_DIR}" lxc config get c5 volatile.idmap.current --project replicator-project)"
+  jq --exit-status 'type == "array" and length > 0' <<< "${c5_idmap}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c5 volatile.idmap.current --project replicator-project || echo fail)" = "" ]
+
   # Stop instances on LXD_TWO before demoting.
-  for i in c1 c2 c3; do
+  for i in c1 c2 c3 c4 c5; do
     if [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc list "${i}" --project replicator-project --format csv -c s 2>/dev/null)" = "RUNNING" ]; then
       LXD_DIR="${LXD_TWO_DIR}" lxc stop "${i}" --force --project replicator-project
     fi
@@ -6236,10 +6269,14 @@ test_clustering_replicator_dr() {
   LXD_DIR="${LXD_ONE_DIR}" lxc project promote-replica replicator-project
   LXD_DIR="${LXD_ONE_DIR}" lxc replicator run my-replicator --project replicator-project
   bulk_op="$(LXD_DIR="${LXD_ONE_DIR}" lxc query -X GET '/1.0/operations?project=replicator-project&recursion=2' | jq --exit-status '[.. | objects | select(.description == "Running replicator")] | max_by(.created_at)')"
-  jq --exit-status '([., (.children? // [])[]] | length) == 5 and .status == "Success" and .child_count == 4 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
+  jq --exit-status '([., (.children? // [])[]] | length) == 7 and .status == "Success" and .child_count == 6 and (all(.children[]; .status == "Success"))' <<< "${bulk_op}"
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c1,STOPPED'
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c2,STOPPED'
   LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c3,STOPPED'
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c4,STOPPED'
+  LXD_DIR="${LXD_TWO_DIR}" lxc list --project replicator-project -f csv -c ns | grep -xF 'c5,STOPPED'
+  # The replication run must keep the idmap recorded on the target copy of c5.
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc config get c5 volatile.idmap.current --project replicator-project)" = "${c5_idmap}" ]
 
   # Cleanup
   LXD_DIR="${LXD_TWO_DIR}" lxc profile device remove default root --project replicator-project


### PR DESCRIPTION
The replicator builds instance refresh payloads from the source instance, but the `instance_refresh_config` extension makes the server apply a refresh payload as the full desired target configuration. Protected volatile keys held only by the target were therefore seen as deletions and rejected:

```
Failed applying refresh target instance config: The protected "volatile.idmap.current" config key cannot be deleted
```

This broke `lxc replicator run --restore` for any instance started on one cluster but never on the other. Forward replication has the same asymmetry once a standby has been promoted and the instance started there.

Merges the target's protected keys into the payload of all four refresh paths — restore and replication, locally and remotely hosted instances. The config and device maps are copied first, as a payload rendered from a local instance shares its config map with that instance's own in-memory config.

Fixes #18677

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
