### PR TITLE
lxd/instance/drivers/qemu: Bind-mount lxd-agent into VM config drive

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -597,6 +597,15 @@ func (d *qemu) configDriveMountPath() string {
 
 // configDriveMountPathClear attempts to unmount the config drive bind mount and remove the directory.
 func (d *qemu) configDriveMountPathClear() error {
+	// Unmount the nested lxd-agent bind mount first, otherwise the parent mount is busy.
+	agentMntPath := filepath.Join(d.configDriveMountPath(), "lxd-agent")
+	if filesystem.IsMountPoint(agentMntPath) {
+		err := storageDrivers.TryUnmount(agentMntPath, unix.MNT_DETACH)
+		if err != nil {
+			return fmt.Errorf("Failed unmounting lxd-agent bind mount %q: %w", agentMntPath, err)
+		}
+	}
+
 	return device.DiskMountClear(d.configDriveMountPath())
 }
 
@@ -1280,8 +1289,17 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 		volatileSet["volatile.uuid.generation"] = vmGenUUID
 	}
 
+	// Resolve the host lxd-agent once so the config drive placeholder and the bind mount
+	// below agree on the same binary. Empty if the agent is not installed.
+	lxdAgentSrcPath, err := d.lxdAgentSourcePath()
+	if err != nil {
+		err = fmt.Errorf("Failed resolving lxd-agent path: %w", err)
+		op.Done(err)
+		return err
+	}
+
 	// Generate the config drive.
-	err = d.generateConfigShare()
+	err = d.generateConfigShare(lxdAgentSrcPath)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -1497,6 +1515,19 @@ func (d *qemu) start(ctx context.Context, stateful bool, op *operationlock.Insta
 		err = fmt.Errorf("Failed mounting device mount path %q for config drive: %w", configMntPath, err)
 		op.Done(err)
 		return err
+	}
+
+	// Bind-mount the host lxd-agent over the placeholder so its bytes come from the host,
+	// not the quota'd config volume (see generateConfigShare). This intentionally pins the
+	// running daemon's agent revision for the VM's lifetime, as the daemon does for itself.
+	if lxdAgentSrcPath != "" {
+		agentDstPath := filepath.Join(configMntPath, "lxd-agent")
+		err = device.DiskMount(lxdAgentSrcPath, agentDstPath, false, "", []string{"ro"}, "none")
+		if err != nil {
+			err = fmt.Errorf("Failed mounting lxd-agent into config drive: %w", err)
+			op.Done(err)
+			return err
+		}
 	}
 
 	// Setup virtiofsd for the config drive mount path.
@@ -3109,11 +3140,22 @@ func (d *qemu) spiceCmdlineConfig() string {
 	return "unix=on,disable-ticketing=on,addr=" + d.spicePath()
 }
 
+// lxdAgentSourcePath returns the resolved path to the host lxd-agent binary, or an empty
+// string if it is not installed (the VM then starts without an up-to-date agent).
+func (d *qemu) lxdAgentSourcePath() (string, error) {
+	srcPath, err := exec.LookPath("lxd-agent")
+	if err != nil {
+		return "", nil
+	}
+
+	return filepath.EvalSymlinks(srcPath)
+}
+
 // generateConfigShare generates the config share directory that will be exported to the VM via
 // a 9P share. Due to the unknown size of templates inside the images this directory is created
 // inside the VM's config volume so that it can be restricted by quota.
 // Requires the instance be mounted before calling this function.
-func (d *qemu) generateConfigShare() error {
+func (d *qemu) generateConfigShare(lxdAgentSrcPath string) error {
 	configDrivePath := filepath.Join(d.Path(), "config")
 
 	// Create config drive dir if doesn't exist, if it does exist, leave it around so we don't regenerate all
@@ -3123,61 +3165,20 @@ func (d *qemu) generateConfigShare() error {
 		return err
 	}
 
-	// Add the VM agent.
-	lxdAgentSrcPath, err := exec.LookPath("lxd-agent")
-	if err != nil {
-		d.logger.Warn("lxd-agent not found, skipping its inclusion in the VM config drive", logger.Ctx{"err": err})
+	// Keep only a placeholder here; the real binary is bind-mounted over it in start() so it
+	// never occupies the quota'd config volume. Only touch it when a host agent exists to mount
+	// later, else leave any existing binary in place.
+	if lxdAgentSrcPath == "" {
+		d.logger.Warn("lxd-agent not found, skipping its inclusion in the VM config drive")
 	} else {
-		// Install agent into config drive dir if found.
-		lxdAgentSrcPath, err = filepath.EvalSymlinks(lxdAgentSrcPath)
-		if err != nil {
-			return err
-		}
-
-		lxdAgentSrcInfo, err := os.Stat(lxdAgentSrcPath)
-		if err != nil {
-			return fmt.Errorf("Failed getting info for lxd-agent source %q: %w", lxdAgentSrcPath, err)
-		}
-
+		// O_TRUNC reclaims the space used by a full binary copied by an older LXD version.
 		lxdAgentInstallPath := filepath.Join(configDrivePath, "lxd-agent")
-		lxdAgentNeedsInstall := true
-
-		lxdAgentInstallInfo, err := os.Stat(lxdAgentInstallPath)
-		if err == nil {
-			if lxdAgentInstallInfo.ModTime().Equal(lxdAgentSrcInfo.ModTime()) && lxdAgentInstallInfo.Size() == lxdAgentSrcInfo.Size() {
-				lxdAgentNeedsInstall = false
-			}
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("Failed getting info for existing lxd-agent install %q: %w", lxdAgentInstallPath, err)
+		f, err := os.OpenFile(lxdAgentInstallPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0500)
+		if err != nil {
+			return fmt.Errorf("Failed creating lxd-agent placeholder %q: %w", lxdAgentInstallPath, err)
 		}
 
-		// Only install the lxd-agent into config drive if the existing one is different to the source one.
-		// Otherwise we would end up copying it again and this can cause unnecessary snapshot usage.
-		if lxdAgentNeedsInstall {
-			d.logger.Debug("Installing lxd-agent", logger.Ctx{"srcPath": lxdAgentSrcPath, "installPath": lxdAgentInstallPath})
-			err = shared.FileCopy(lxdAgentSrcPath, lxdAgentInstallPath)
-			if err != nil {
-				return err
-			}
-
-			err = os.Chmod(lxdAgentInstallPath, 0500)
-			if err != nil {
-				return err
-			}
-
-			err = os.Chown(lxdAgentInstallPath, 0, 0)
-			if err != nil {
-				return err
-			}
-
-			// Ensure we copy the source file's timestamps so they can be used for comparison later.
-			err = os.Chtimes(lxdAgentInstallPath, lxdAgentSrcInfo.ModTime(), lxdAgentSrcInfo.ModTime())
-			if err != nil {
-				return fmt.Errorf("Failed setting lxd-agent timestamps: %w", err)
-			}
-		} else {
-			d.logger.Debug("Skipping lxd-agent install as unchanged", logger.Ctx{"srcPath": lxdAgentSrcPath, "installPath": lxdAgentInstallPath})
-		}
+		_ = f.Close()
 	}
 
 	agentCert, agentKey, clientCert, _, err := d.generateAgentCert()

--- a/test/suites/vm.sh
+++ b/test/suites/vm.sh
@@ -204,6 +204,28 @@ test_vm_pcie_bus() {
   lxc exec v1 -- mount -t virtiofs config /mnt
   ! lxc exec v1 -- touch /mnt/foo || false
 
+  # lxd-agent is bind-mounted in, not copied into the quota'd config volume (issue #16694):
+  # placeholder stays 0 bytes on disk while the VM still sees the full binary via the share.
+  [ "$(stat -c %s "${LXD_DIR}/virtual-machines/v1/config/lxd-agent")" = "0" ]
+  [ "$(lxc exec v1 -- stat -c %s /mnt/lxd-agent)" -gt "0" ]
+  lxc exec v1 -- umount /mnt
+
+  # Simulate the pre-fix upgrade path: an older LXD left a full agent copy in the quota'd config
+  # volume. The placeholder is a plain file on the host (the bind mount lives elsewhere), so seed
+  # it here and assert the next startup truncates it back to 0 to reclaim the space (#16694).
+  echo "stale agent copy" > "${LXD_DIR}/virtual-machines/v1/config/lxd-agent"
+
+  # The bind mount is present in the daemon's mount table while v1 runs, and gone once stopped.
+  local LXD_PID
+  LXD_PID="$(< "${LXD_DIR}/lxd.pid")"
+  grep -qsF "config.mount/lxd-agent" "/proc/${LXD_PID}/mountinfo"
+  prepare_vm_for_hard_stop v1
+  lxc stop -f v1
+  ! grep -qsF "config.mount/lxd-agent" "/proc/${LXD_PID}/mountinfo" || false
+  lxc start v1
+  waitInstanceReady v1
+  [ "$(stat -c %s "${LXD_DIR}/virtual-machines/v1/config/lxd-agent")" = "0" ]
+
   sub_test "Check that limits.max_bus_ports config option enforces the number of allowed PCIe devices"
 
   # The default value for "limits.max_bus_ports" is 8 ports.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.


Fixes #16694

The `lxd-agent` binary was copied into each VM's config drive, which lives in the size-limited config volume. Because the binary changes on snap refresh and snapshots pin old copies (CoW), the volume eventually fills up and the VM fails to start with `no space left on device`. Now a zero-byte placeholder is kept in the volume and the real host `lxd-agent` is bind-mounted over it at start, so its bytes never occupy the quota'd volume (as in lxc/incus#263). The nested mount is unmounted before the config mount on cleanup.

Verified with a new `vm.sh` check (on-disk agent stays 0 bytes, guest sees the full binary), plus daemon build, `go vet`, golangci-lint and unit tests.