### PR TITLE
Makefile: Immediately-evaluate env variables to prevent performance problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ DOMAIN=lxd
 VERSION=$(or ${CUSTOM_VERSION},$(shell grep "var Version" shared/version/flex.go | cut -d'"' -f2))
 ARCHIVE=lxd-$(VERSION).tar
 HASH := \#
-TAG_SQLITE3=$(shell printf "$(HASH)include <dqlite.h>\nvoid main(){dqlite_node_id n = 1;}" | $(CC) ${CGO_CFLAGS} -o /dev/null -xc - >/dev/null 2>&1 && echo "libsqlite3")
 GOPATH ?= $(shell go env GOPATH)
+# Expand immediately so the "go env" call runs once per make invocation.
+GOPATH := $(GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
@@ -11,6 +12,7 @@ GOMIN=1.26.7
 GOTOOLCHAIN=local
 export GOTOOLCHAIN
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)
+GOCOVERDIR := $(GOCOVERDIR)
 ifeq "$(GOCOVERDIR)" ""
 	COVER=
 	COVER_TEST=
@@ -19,6 +21,7 @@ else
 	COVER_TEST=-test.gocoverdir="$(GOCOVERDIR)"
 endif
 ARCH ?= $(shell uname -m)
+ARCH := $(ARCH)
 DQLITE_BRANCH=v1.18.x
 LIBLXC_BRANCH=main
 
@@ -36,6 +39,7 @@ export CGO_LDFLAGS ?= -L$(DQLITE_PATH)/.libs/ -L$(LIBLXC_PATH)/lib/$(ARCH)-linux
 export LD_LIBRARY_PATH ?= $(DQLITE_PATH)/.libs/:$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/
 export PKG_CONFIG_PATH ?= $(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/pkgconfig
 export CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
+TAG_SQLITE3 := $(shell printf "$(HASH)include <dqlite.h>\nvoid main(){dqlite_node_id n = 1;}" | $(CC) ${CGO_CFLAGS} -o /dev/null -xc - >/dev/null 2>&1 && echo "libsqlite3")
 
 .PHONY: default
 default: all


### PR DESCRIPTION
This change fixes a regression in makefile performance most apparent on tab-completion, eg "make sta"+tab, which takes several seconds to evaluate with Make 4.4 and without the changes. Changes in Make 4.4 cause $(shell...) environments to inherit exported variables, such that if `GOPATH = $(shell go env GOPATH)`, then `$(shell go env GOPATH)` will be evaluated in any subsequent `$(shell...)` command, including ones implicit in other recursively assigned variables. Since we do not depend on the recursive assignment here,  make an immediate assignment right after the conditional one. Tab-completion with Make 4.4/Ubuntu 26.04.1 reverts to normal performance.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
