### PR TITLE
Fix zfs storage leak after shutdown due to lingering forkfile daemon (stable-5.0)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1997,7 +1997,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	// Wait for any file operations to complete.
 	// This is to avoid having an active mount by forkfile and so all file operations
 	// from this point will use the container's namespace rather than a chroot.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	// Mount instance root volume.
 	mountInfo, err := d.mount()
@@ -2714,7 +2714,7 @@ func (d *lxc) Stop(stateful bool) error {
 	}
 
 	// Forcefully stop any forkfile process if running.
-	d.stopForkfile(true)
+	d.StopForkFile(true)
 
 	// Release liblxc container once done.
 	defer func() {
@@ -3028,7 +3028,7 @@ func (d *lxc) onStop(args map[string]string) error {
 
 		// Wait for any file operations to complete.
 		// This is to required so we can actually unmount the container.
-		d.stopForkfile(false)
+		d.StopForkFile(false)
 
 		// Clean up devices.
 		d.cleanupDevices(false, "")
@@ -3528,7 +3528,7 @@ func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
 	}
 
 	// Wait for any file operations to complete to have a more consistent snapshot.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	return d.snapshotCommon(d, name, expiry, stateful)
 }
@@ -3613,7 +3613,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 
 	// Wait for any file operations to complete.
 	// This is required so we can actually unmount the container and restore its rootfs.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	// Initialize storage interface for the container and mount the rootfs for criu state check.
 	pool, err := storagePools.LoadByInstance(d.state, d)
@@ -3823,7 +3823,7 @@ func (d *lxc) delete(force bool) error {
 	// Wait for any file operations to complete.
 	// This is required so we can actually unmount the container and delete it.
 	if !d.IsSnapshot() {
-		d.stopForkfile(false)
+		d.StopForkFile(false)
 	}
 
 	// Delete any persistent warnings for instance.
@@ -7098,8 +7098,8 @@ func (d *lxc) FileSFTP() (*sftp.Client, error) {
 	return client, nil
 }
 
-// stopForkFile attempts to send SIGTERM (if force is true) or SIGINT to forkfile then waits for it to exit.
-func (d *lxc) stopForkfile(force bool) {
+// StopForkFile attempts to send SIGTERM (if force is true) or SIGINT to forkfile then waits for it to exit.
+func (d *lxc) StopForkFile(force bool) {
 	// Make sure that when the function exits, no forkfile is running by acquiring the lock (which indicates
 	// that forkfile isn't running and holding the lock) and then releasing it.
 	defer func() {
@@ -8280,7 +8280,7 @@ func (d *lxc) LockExclusive() (*operationlock.InstanceOperation, error) {
 	}
 
 	// Stop forkfile as otherwise it will hold the root volume open preventing unmount.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 
 	return op, err
 }

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -179,6 +179,7 @@ type Container interface {
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 	DevptsFd() (*os.File, error)
 	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
+	StopForkFile(force bool)
 }
 
 // VM interface is for VM specific functions.

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -456,6 +456,13 @@ func instancesShutdown(instances []instance.Instance) {
 	for i, inst := range instances {
 		// Skip stopped instances.
 		if !inst.IsRunning() {
+			// Stopped containers could still have a forkfile daemon running which could make
+			// the storage busy, causing unmount to fail, so make sure it is stopped.
+			c, isContainer := inst.(instance.Container)
+			if isContainer {
+				c.StopForkFile(true)
+			}
+
 			continue
 		}
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -374,6 +374,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_storage_driver_cephfs "cephfs storage driver"
     run_test test_storage_driver_dir "dir storage driver"
     run_test test_storage_driver_zfs "zfs storage driver"
+    run_test test_shutdown "shutdown"
     run_test test_resources "resources"
     run_test test_kernel_limits "kernel limits"
     run_test test_macaroon_auth "macaroon authentication"

--- a/test/suites/shutdown.sh
+++ b/test/suites/shutdown.sh
@@ -1,0 +1,38 @@
+test_shutdown() {
+  # shellcheck disable=2039,3043
+  local lxd_backend forkfile_pid_file forkfile_pid
+
+  lxd_backend=$(storage_backend "$LXD_DIR")
+  if [ "$lxd_backend" != "zfs" ]; then
+    echo "==> SKIP: test_shutdown only applies to the zfs storage driver"
+    return
+  fi
+
+  ensure_import_testimage
+
+  lxc init testimage i1
+
+  # Performing a file operation on a stopped instance makes LXD mount the instance's storage
+  # volume and spawn a forkfile daemon that keeps it mounted/busy for a short while afterwards.
+  echo "test" > "${TEST_DIR}/forkfile-test"
+  lxc file push "${TEST_DIR}/forkfile-test" i1/root/forkfile-test
+
+  forkfile_pid_file="${LXD_DIR}/logs/i1/forkfile.pid"
+  [ -f "${forkfile_pid_file}" ]
+  forkfile_pid=$(cat "${forkfile_pid_file}")
+  kill -0 "${forkfile_pid}"
+
+  # A full daemon shutdown must stop any lingering forkfile daemon left behind by a stopped
+  # instance, otherwise it can keep the instance's storage volume busy/mounted after LXD has
+  # exited, preventing the storage pool from being unmounted/exported cleanly.
+  shutdown_lxd "${LXD_DIR}"
+
+  if kill -0 "${forkfile_pid}" 2>/dev/null; then
+    echo "FAIL: forkfile daemon (pid ${forkfile_pid}) is still running after LXD shutdown"
+    false
+  fi
+
+  respawn_lxd "${LXD_DIR}" true
+
+  lxc delete -f i1
+}


### PR DESCRIPTION
Fix zfs storage leak after shutdown due to lingering forkfile daemon (#18362)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
