### PR TITLE
Fix busy zfs preventing rebuild (stable-5.21)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2980,6 +2980,9 @@ func (d *lxc) Restart(timeout time.Duration) error {
 
 // Rebuild rebuilds the instance using the supplied image fingerprint as source.
 func (d *lxc) Rebuild(img *api.Image, op *operations.Operation) error {
+	// Rebuild assumes instance is stopped.  But a stopped instance could still have a running
+	// forkfile.  So stop the forkfile.
+	d.stopForkfile(false)
 	return d.rebuildCommon(d, img, op)
 }
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -761,6 +761,12 @@ test_basic_usage() {
   ! lxc config show c1 | grep -F 'image.' || false
   lxc delete c1 -f
 
+  # Test that rebuild succeeds after a file operation.
+  lxc init testimage c1
+  lxc file create c1/foo
+  lxc rebuild testimage c1
+  lxc delete c1
+
   # Test assigning an empty profile (with no root disk device) to an instance.
   lxc init testimage c1
   lxc profile create foo


### PR DESCRIPTION
Fix busy zfs preventing rebuild (#18629)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
