### PR TITLE
lxd/instance: Use moveMount() when it's available (stable-5.21)

### DIFF
--- a/lxd/include/mount_utils.h
+++ b/lxd/include/mount_utils.h
@@ -28,6 +28,12 @@
 #define OPEN_TREE_CLOEXEC O_CLOEXEC
 #endif
 
+// Reuses the generic AT_* namespace: tells open_tree() to clone the whole
+// mount subtree (equivalent to the legacy MS_REC flag for bind mounts).
+#ifndef AT_RECURSIVE
+#define AT_RECURSIVE 0x8000
+#endif
+
 // fsmount() flags
 #ifndef FSMOUNT_CLOEXEC
 #define FSMOUNT_CLOEXEC 0x00000001

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7893,7 +7893,9 @@ func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idma
 }
 
 func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
-	if d.state.OS.IdmappedMounts && idmapType == idmap.IdmapStorageIdmapped {
+	// Prefer open_tree()/move_mount() whenever the kernel supports it (which
+	// d.state.OS.IdmappedMounts establishes)
+	if d.state.OS.IdmappedMounts {
 		return d.moveMount(source, target, fstype, flags, idmapType)
 	}
 

--- a/lxd/main_forkmount.go
+++ b/lxd/main_forkmount.go
@@ -405,7 +405,18 @@ static void do_move_forkmount(int pidfd, int ns_fd)
 		if (mnt_fd < 0)
 			die("fsmount");
 	} else {
-		mnt_fd = lxd_open_tree(-EBADF, src, OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
+		unsigned int open_tree_flags = OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE;
+
+		// MS_REC (set for recursive/"rbind" disk devices) has no
+		// MOUNT_ATTR_* equivalent: it has to be requested on open_tree()
+		// itself via AT_RECURSIVE, or nested mounts under src are silently
+		// left behind by the clone.
+		// This does not affect the cold-plug path which is handled by liblxc
+		// that already handles MS_REC correctly.
+		if (old_mntflags & MS_REC)
+			open_tree_flags |= AT_RECURSIVE;
+
+		mnt_fd = lxd_open_tree(-EBADF, src, open_tree_flags);
 		if (mnt_fd < 0)
 			die("open_tree");
 	}
@@ -415,13 +426,22 @@ static void do_move_forkmount(int pidfd, int ns_fd)
 		die("preserve userns");
 
 	if (strcmp(idmapType, "idmapped") == 0) {
+		unsigned int mount_setattr_flags = AT_EMPTY_PATH;
 		struct lxc_mount_attr attr = {
 			.attr_set	= MOUNT_ATTR_IDMAP,
 			.userns_fd	= fd_userns,
 
 		};
 
-		ret = lxd_mount_setattr(mnt_fd, "", AT_EMPTY_PATH, &attr, sizeof(attr));
+		// recursive=true can be combined with shift=true (disk device
+		// validation only rejects recursive+readonly): without AT_RECURSIVE
+		// here too, MOUNT_ATTR_IDMAP only applies to the top-level mount and
+		// any submount cloned from src via AT_RECURSIVE above keeps its
+		// original, unshifted host ownership.
+		if (old_mntflags & MS_REC)
+			mount_setattr_flags |= AT_RECURSIVE;
+
+		ret = lxd_mount_setattr(mnt_fd, "", mount_setattr_flags, &attr, sizeof(attr));
 		if (ret)
 			die("idmap mount");
 	}

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -15,18 +15,18 @@ test_container_devices_disk() {
   lxc delete foo
 }
 
-_container_devices_disk_shift() {
+_container_devices_idmapped_mounts_supported() {
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
   # `tmpfs` does not support idmapped mounts on kernels older than 6.3
   if [ "${LXD_TMPFS:-0}" = "1" ] && ! runsMinimumKernel 6.3; then
     echo "==> SKIP: tmpfs (LXD_TMPFS=${LXD_TMPFS}) idmapped mount requires a kernel >= 6.3"
-    return
+    return 1
   fi
 
   if [ -n "${LXD_IDMAPPED_MOUNTS_DISABLE:-}" ]; then
-    return
+    return 1
   fi
 
   if [ "${lxd_backend}" = "zfs" ]; then
@@ -35,7 +35,7 @@ _container_devices_disk_shift() {
     if [ "$(printf '%s\n' "$zfs_version" "2.2" | sort -V | head -n1)" = "$zfs_version" ]; then
       if [ "$zfs_version" != "2.2" ]; then
         echo "ZFS version is less than 2.2. Skipping idmapped mounts tests."
-        return
+        return 1
       else
         echo "ZFS version is 2.2. Idmapped mounts are supported with ZFS."
       fi
@@ -43,6 +43,12 @@ _container_devices_disk_shift() {
       echo "ZFS version is greater than 2.2. Idmapped mounts are supported with ZFS."
     fi
   fi
+
+  return 0
+}
+
+_container_devices_disk_shift() {
+  _container_devices_idmapped_mounts_supported || return
 
   # Test basic shifting
   mkdir -p "${TEST_DIR}/shift-source"

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -5,6 +5,7 @@ test_container_devices_disk() {
 
   _container_devices_disk_shift
   _container_devices_disk_mount
+  _container_devices_disk_recursive
   _container_devices_raw_mount_options
   _container_devices_disk_ceph
   _container_devices_disk_cephfs
@@ -140,6 +141,62 @@ _container_devices_disk_mount() {
 
   echo "Cleanup."
   lxc stop -f foo
+}
+
+_container_devices_disk_recursive() {
+  lxc start foo
+
+  sub_test "Hot-plug a recursive disk device and verify a submount nested in its source is visible too"
+  # A source with a submount nested inside it (rather than a plain
+  # directory), with recursive=true. The submount must be visible in the
+  # instance too, not just the top-level mount.
+  mkdir -p "${TEST_DIR}/recursive-source/nested"
+  echo top-level-file > "${TEST_DIR}/recursive-source/top"
+  mount -t tmpfs tmpfs "${TEST_DIR}/recursive-source/nested"
+  echo nested-file > "${TEST_DIR}/recursive-source/nested/marker"
+
+  lxc config device add foo recursive-mount disk source="${TEST_DIR}/recursive-source" path=/mnt/recursive recursive=true
+  [ "$(lxc exec foo -- cat /mnt/recursive/top)" = "top-level-file" ]
+  [ "$(lxc exec foo -- cat /mnt/recursive/nested/marker)" = "nested-file" ]
+  lxc config device remove foo recursive-mount
+
+  umount "${TEST_DIR}/recursive-source/nested"
+  lxc stop foo -f
+
+  # The top-level source below is a plain path under TEST_DIR, same as
+  # _container_devices_disk_shift()'s basic-shifting phase, so it needs the
+  # same idmapped-mount eligibility check (e.g. TEST_DIR itself can be tmpfs
+  # via LXD_TMPFS=1, which only gained idmapped mount support in 6.3).
+  _container_devices_idmapped_mounts_supported || return
+
+  sub_test "Hot-plug a recursive AND shifted disk device and verify the nested submount is shifted too"
+  # recursive=true and shift=true can be combined. A submount nested under
+  # the top-level mount should be shifted too. Use a loopback ext4 mount
+  # (rather than tmpfs) for the nested submount specifically, so that part
+  # doesn't additionally depend on whatever filesystem TEST_DIR happens to
+  # be on: ext4 has supported idmapped mounts since they were introduced
+  # (5.12), unlike tmpfs which only gained support in 6.3.
+  configure_loop_device recursive_shift_loop_file recursive_shift_loop_device
+  # shellcheck disable=SC2154
+  mkfs.ext4 -q "${recursive_shift_loop_device}"
+
+  mkdir -p "${TEST_DIR}/recursive-shift-source/nested"
+  touch "${TEST_DIR}/recursive-shift-source/top"
+  chown 123:456 "${TEST_DIR}/recursive-shift-source/top"
+  mount "${recursive_shift_loop_device}" "${TEST_DIR}/recursive-shift-source/nested"
+  touch "${TEST_DIR}/recursive-shift-source/nested/marker"
+  chown 123:456 "${TEST_DIR}/recursive-shift-source/nested/marker"
+
+  lxc start foo
+  lxc config device add foo recursive-shift-mount disk source="${TEST_DIR}/recursive-shift-source" path=/mnt/recursive-shift recursive=true shift=true
+  [ "$(lxc exec foo -- stat -c '%u:%g' /mnt/recursive-shift/top)" = "123:456" ]
+  [ "$(lxc exec foo -- stat -c '%u:%g' /mnt/recursive-shift/nested/marker)" = "123:456" ]
+  lxc config device remove foo recursive-shift-mount
+  lxc stop foo -f
+
+  umount "${TEST_DIR}/recursive-shift-source/nested"
+  # shellcheck disable=SC2154
+  deconfigure_loop_device "${recursive_shift_loop_file}" "${recursive_shift_loop_device}"
 }
 
 _container_devices_raw_mount_options() {


### PR DESCRIPTION
lxd/instance: Use moveMount() when it's available (#18899)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
