### PR TITLE
storage: Add NVMe/FC connector

### DIFF
--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -46,6 +46,11 @@ type session struct {
 
 	// addresses is a list of active addresses associated with the session.
 	addresses []string
+
+	// hostAddresses is a map of host addresses that already have an established path to the
+	// target, keyed by target address. It is populated only for NVMe/FC, where every local
+	// HBA that is zoned to a target port forms a path of its own.
+	hostAddresses map[string][]string
 }
 
 // Connector represents a storage connector that handles connections through

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -51,19 +51,67 @@ type session struct {
 // Connector represents a storage connector that handles connections through
 // appropriate storage subsystem.
 type Connector interface {
+	// Type returns the connector's type.
 	Type() string
+
+	// Transport returns the connector's transport type.
 	Transport() TransportType
+
+	// Version returns a version string identifying the connector's underlying tooling.
+	// A non-empty value indicates the connector is usable on this host.
 	Version() (string, error)
+
+	// QualifiedName returns the name that uniquely identifies the local host initiator.
 	QualifiedName() (string, error)
+
+	// LoadModules loads any required kernel modules for the connector.
 	LoadModules() error
-	Connect(ctx context.Context, targetQN string, targetAddrs ...string) (revert.Hook, error)
-	Disconnect(targetQN string) error
-	Discover(ctx context.Context, targetAddresses ...string) ([]any, error)
+
+	// Connect connects to targetName using protocol-specific target specifiers.
+	//
+	// Target name identifies the target to connect to.
+	// - For iSCSI this is the target IQN.
+	// - For NVMe/TCP and NVMe/FC this is the target NQN.
+	// - For SCSI/FC this is the target WWPN.
+	//
+	// Target specifiers are protocol-specific values needed to access the target.
+	// - For iSCSI and NVMe/TCP these are target addresses.
+	// - For NVMe/FC these are the array's FC target port addresses ("nn-<wwnn>:pn-<wwpn>").
+	// - For SCSI/FC these are LUNs.
+	Connect(ctx context.Context, targetName string, targetSpecifiers ...string) (revert.Hook, error)
+
+	// Disconnect disconnects from targetName.
+	//
+	// Target name uses the same protocol-specific identifier as [Connect].
+	Disconnect(targetName string) error
+
+	// Discover finds the targets available on the array.
+	//
+	// Discovery targets are the protocol-specific inputs used to reach the array and
+	// enumerate its targets.
+	// - For iSCSI these are portal addresses.
+	// - For NVMe/TCP these are discovery addresses.
+	// - For NVMe/FC these are the array's FC target port addresses ("nn-<wwnn>:pn-<wwpn>").
+	// - For SCSI/FC these are target WWPNs.
+	Discover(ctx context.Context, discoveryTargets ...string) ([]any, error)
+
+	// GetDiskDevicePath returns the device path of the disk that passes the provided filter function.
 	GetDiskDevicePath(diskPathFilter block.DevicePathFilterFunc) (string, error)
+
+	// WaitDiskDevicePath similar to [GetDiskDevicePath] returns the disk device path that
+	// passes the provided filter function. If no such device path is found, it waits for it to
+	// appear until the context is done.
 	WaitDiskDevicePath(ctx context.Context, diskPathFilter block.DevicePathFilterFunc) (string, error)
+
+	// WaitDiskDeviceResize waits for the disk device at the given path to report the new size
+	// in bytes.
 	WaitDiskDeviceResize(ctx context.Context, diskPath string, newSizeBytes int64) error
+
+	// RemoveDiskDevice ensures the disk device at the given path is removed from the host.
 	RemoveDiskDevice(ctx context.Context, devicePath string) error
-	findSession(targetQN string) (*session, error)
+
+	// findSession finds an active session for the given target.
+	findSession(targetName string) (*session, error)
 }
 
 // NewConnector instantiates a new connector of the given type, returning an error for unknown types.

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -15,6 +15,9 @@ const (
 	// TypeNVMeTCP represents an NVMe/TCP storage connector.
 	TypeNVMeTCP string = "nvme/tcp"
 
+	// TypeNVMeFC represents an NVMe over Fibre Channel storage connector.
+	TypeNVMeFC string = "nvme/fc"
+
 	// TypeSDC represents Dell SDC storage connector.
 	TypeSDC string = "sdc"
 
@@ -24,6 +27,12 @@ const (
 	// TypeSCSIFC represents a Fibre Channel storage connector.
 	TypeSCSIFC string = "scsi/fc"
 )
+
+// IsNVMe returns true if the given connector type uses the NVMe protocol,
+// regardless of the underlying transport (TCP or Fibre Channel).
+func IsNVMe(connectorType string) bool {
+	return connectorType == TypeNVMeTCP || connectorType == TypeNVMeFC
+}
 
 // TransportType represents the transport type of the storage connector.
 type TransportType string
@@ -128,6 +137,11 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 	switch connectorType {
 	case TypeNVMeTCP:
 		return &connectorNVMe{
+			common: common,
+		}, nil
+
+	case TypeNVMeFC:
+		return &connectorNVMeFC{
 			common: common,
 		}, nil
 

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -330,10 +330,6 @@ func (c *connectorISCSI) Discover(ctx context.Context, targetAddresses ...string
 			// Make sure addr has a port number for stable output.
 			addr = shared.EnsurePort(addr, ISCSIDefaultPort)
 
-			if addr != targetAddr {
-				continue
-			}
-
 			result = append(result, ISCSIDiscoveryLogRecord{
 				Address:        addr,
 				PortalGroupTag: tag,
@@ -342,7 +338,8 @@ func (c *connectorISCSI) Discover(ctx context.Context, targetAddresses ...string
 		}
 
 		if len(result) != 0 {
-			// We have already found something.
+			// The successful response lists every portal, so there is no need to query
+			// the remaining addresses.
 			break
 		}
 	}

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -313,27 +313,29 @@ func nvmeFindSession(targetQN string, transport TransportType) (*session, error)
 		// The "address" file contains one line per connection,
 		// each in format "traddr=<ip>,trsvcid=<port>,...".
 		for line := range bytes.SplitSeq(bytes.TrimSpace(fileBytes), []byte{'\n'}) {
-			parts := strings.Split(string(bytes.TrimSpace(line)), ",")
-
-			transportAddr := ""
-			for _, part := range parts {
-				addr, ok := strings.CutPrefix(part, "traddr=")
-				if ok {
-					transportAddr = addr
-					break
+			// Each line is a comma separated list of "<key>=<value>" pairs.
+			fields := make(map[string]string)
+			for part := range strings.SplitSeq(string(bytes.TrimSpace(line)), ",") {
+				key, value, found := strings.Cut(part, "=")
+				if found {
+					fields[key] = value
 				}
 			}
 
-			transportServiceID := NVMeDefaultTransportPort
-			for _, part := range parts {
-				port, ok := strings.CutPrefix(part, "trsvcid=")
-				if ok {
-					transportServiceID = port
-					break
-				}
+			transportAddr := fields["traddr"]
+			if transportAddr == "" {
+				continue
 			}
 
-			session.addresses = append(session.addresses, net.JoinHostPort(transportAddr, transportServiceID))
+			transportServiceID := fields["trsvcid"]
+			if transportServiceID == "" {
+				transportServiceID = NVMeDefaultTransportPort
+			}
+
+			targetAddr := net.JoinHostPort(transportAddr, transportServiceID)
+			if !slices.Contains(session.addresses, targetAddr) {
+				session.addresses = append(session.addresses, targetAddr)
+			}
 		}
 	}
 

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -63,15 +63,11 @@ type nvmeDiscoveryLog struct {
 	Records []NVMeDiscoveryLogRecord `json:"records"`
 }
 
-// nvmeFilterDiscoveryLog filters out entries from the provided discovery log
-// that do not describe NVMe targets with specified transport type.
-func nvmeFilterDiscoveryLog(log *nvmeDiscoveryLog, transportType string) {
-	if len(log.Records) == 0 {
-		return
-	}
-
-	filteredRecords := make([]NVMeDiscoveryLogRecord, 0, len(log.Records))
-	for _, record := range log.Records {
+// nvmeFilterDiscoveryLog filters out the discovery log records that do not
+// describe NVMe targets with specified transport type.
+func nvmeFilterDiscoveryLog(records []NVMeDiscoveryLogRecord, transportType string) []NVMeDiscoveryLogRecord {
+	filtered := make([]NVMeDiscoveryLogRecord, 0, len(records))
+	for _, record := range records {
 		if record.SubType != SubtypeNVMESubsys {
 			continue
 		}
@@ -80,24 +76,25 @@ func nvmeFilterDiscoveryLog(log *nvmeDiscoveryLog, transportType string) {
 			continue
 		}
 
-		filteredRecords = append(filteredRecords, record)
+		filtered = append(filtered, record)
 	}
 
-	log.Records = filteredRecords
+	return filtered
 }
 
 // nvmeNormalizeDiscoveryLog sets the default transport port on TCP discovery
-// entries that do not specify one.
-func nvmeNormalizeDiscoveryLog(log *nvmeDiscoveryLog) {
-	if len(log.Records) == 0 {
-		return
+// records that do not specify one.
+func nvmeNormalizeDiscoveryLog(records []NVMeDiscoveryLogRecord) []NVMeDiscoveryLogRecord {
+	normalized := make([]NVMeDiscoveryLogRecord, 0, len(records))
+	for _, record := range records {
+		if record.TransportType == nvmeTransportTypeTCP && record.TransportServiceIdentifier == "" {
+			record.TransportServiceIdentifier = NVMeDefaultTransportPort
+		}
+
+		normalized = append(normalized, record)
 	}
 
-	for i := range log.Records {
-		if log.Records[i].TransportType == nvmeTransportTypeTCP && log.Records[i].TransportServiceIdentifier == "" {
-			log.Records[i].TransportServiceIdentifier = NVMeDefaultTransportPort
-		}
-	}
+	return normalized
 }
 
 // Type returns the type of the connector.
@@ -387,8 +384,8 @@ func (c *connectorNVMe) Discover(ctx context.Context, targetAddresses ...string)
 			return nil, fmt.Errorf("Failed unmarshaling the returned discovery log entries from %q: %w", targetAddr, err)
 		}
 
-		nvmeFilterDiscoveryLog(&discoveryLog, nvmeTransportTypeTCP)
-		nvmeNormalizeDiscoveryLog(&discoveryLog)
+		discoveryLog.Records = nvmeFilterDiscoveryLog(discoveryLog.Records, nvmeTransportTypeTCP)
+		discoveryLog.Records = nvmeNormalizeDiscoveryLog(discoveryLog.Records)
 
 		// Unmarshaling the response from the discovery succeeded, break the loop.
 		break

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -269,8 +269,9 @@ func nvmeFindSession(targetQN string, transport TransportType) (*session, error)
 	}
 
 	session := &session{
-		id:       sessionID,
-		targetQN: targetQN,
+		id:            sessionID,
+		targetQN:      targetQN,
+		hostAddresses: make(map[string][]string),
 	}
 
 	basePath := "/sys/class/nvme"
@@ -310,8 +311,9 @@ func nvmeFindSession(targetQN string, transport TransportType) (*session, error)
 		}
 
 		// Extract the addresses from the file.
-		// The "address" file contains one line per connection,
-		// each in format "traddr=<ip>,trsvcid=<port>,...".
+		// The "address" file contains one line per connection.
+		// For TCP each line has the format "traddr=<ip>,trsvcid=<port>,...".
+		// For Fibre Channel it has the format "traddr=nn-<wwnn>:pn-<wwpn>,...".
 		for line := range bytes.SplitSeq(bytes.TrimSpace(fileBytes), []byte{'\n'}) {
 			// Each line is a comma separated list of "<key>=<value>" pairs.
 			fields := make(map[string]string)
@@ -327,14 +329,28 @@ func nvmeFindSession(targetQN string, transport TransportType) (*session, error)
 				continue
 			}
 
-			transportServiceID := fields["trsvcid"]
-			if transportServiceID == "" {
-				transportServiceID = NVMeDefaultTransportPort
-			}
+			if transport == TransportFC {
+				if !slices.Contains(session.addresses, transportAddr) {
+					session.addresses = append(session.addresses, transportAddr)
+				}
 
-			targetAddr := net.JoinHostPort(transportAddr, transportServiceID)
-			if !slices.Contains(session.addresses, targetAddr) {
-				session.addresses = append(session.addresses, targetAddr)
+				// Record which local HBA this path originates from, so that the
+				// paths of the remaining HBAs can still be established while this
+				// one is already connected.
+				hostAddr := fields["host_traddr"]
+				if hostAddr != "" && !slices.Contains(session.hostAddresses[transportAddr], hostAddr) {
+					session.hostAddresses[transportAddr] = append(session.hostAddresses[transportAddr], hostAddr)
+				}
+			} else {
+				transportServiceID := fields["trsvcid"]
+				if transportServiceID == "" {
+					transportServiceID = NVMeDefaultTransportPort
+				}
+
+				targetAddr := net.JoinHostPort(transportAddr, transportServiceID)
+				if !slices.Contains(session.addresses, targetAddr) {
+					session.addresses = append(session.addresses, targetAddr)
+				}
 			}
 		}
 	}

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -85,10 +85,8 @@ func nvmeFilterDiscoveryLog(log *nvmeDiscoveryLog, transportType string) {
 	log.Records = filteredRecords
 }
 
-// nvmeNormalizeDiscoveryLog normalizes NVMe discovery log:
-//   - For entries with TCP transport type ensure all port numbers (transport
-//     service identifiers) are set. For non specified ports function uses
-//     the default transport port number.
+// nvmeNormalizeDiscoveryLog sets the default transport port on TCP discovery
+// entries that do not specify one.
 func nvmeNormalizeDiscoveryLog(log *nvmeDiscoveryLog) {
 	if len(log.Records) == 0 {
 		return
@@ -128,7 +126,6 @@ func (c *connectorNVMe) Version() (string, error) {
 }
 
 // LoadModules loads the NVMe/TCP kernel modules.
-// Returns true if the modules can be loaded.
 func (c *connectorNVMe) LoadModules() error {
 	err := util.LoadModule("nvme_fabrics")
 	if err != nil {

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -53,6 +53,7 @@ const (
 // Transport type definitions (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L73).
 const (
 	nvmeTransportTypeTCP = "tcp"
+	nvmeTransportTypeFC  = "fc"
 )
 
 // SubtypeNVMESubsys defines an NVMe subsystem type (from https://github.com/linux-nvme/libnvme/blob/97886cb68d238ccbbed804a275851f63e490b22f/src/nvme/fabrics.c#L99).
@@ -111,6 +112,11 @@ func (c *connectorNVMe) Transport() TransportType {
 
 // Version returns the version of the NVMe CLI.
 func (c *connectorNVMe) Version() (string, error) {
+	return nvmeVersion()
+}
+
+// nvmeVersion returns the version of the NVMe CLI.
+func nvmeVersion() (string, error) {
 	// Detect and record the version of the NVMe CLI.
 	out, err := shared.RunCommand(context.Background(), "nvme", "version")
 	if err != nil {
@@ -136,10 +142,15 @@ func (c *connectorNVMe) LoadModules() error {
 }
 
 // QualifiedName returns a custom NQN generated from the server UUID.
+func (c *connectorNVMe) QualifiedName() (string, error) {
+	return nvmeQualifiedName(c.serverUUID), nil
+}
+
+// nvmeQualifiedName returns a custom host NQN generated from the server UUID.
 // Getting the NQN from /etc/nvme/hostnqn would require the nvme-cli
 // package to be installed on the host.
-func (c *connectorNVMe) QualifiedName() (string, error) {
-	return "nqn.2014-08.org.nvmexpress:uuid:" + c.serverUUID, nil
+func nvmeQualifiedName(serverUUID string) string {
+	return "nqn.2014-08.org.nvmexpress:uuid:" + serverUUID
 }
 
 // Connect establishes a connection with the target on the given address.
@@ -175,6 +186,11 @@ func (c *connectorNVMe) Connect(ctx context.Context, targetQN string, targetAddr
 
 // Disconnect terminates a connection with the target.
 func (c *connectorNVMe) Disconnect(targetQN string) error {
+	return nvmeDisconnect(c, targetQN)
+}
+
+// nvmeDisconnect terminates a connection with the target.
+func nvmeDisconnect(c Connector, targetQN string) error {
 	// Find an existing NVMe session.
 	session, err := c.findSession(targetQN)
 	if err != nil {
@@ -213,6 +229,11 @@ func (c *connectorNVMe) Disconnect(targetQN string) error {
 // found the function determines addresses of the active connections by checking
 // "/sys/class/nvme", and returns a non-nil result (except if an error occurs).
 func (c *connectorNVMe) findSession(targetQN string) (*session, error) {
+	return nvmeFindSession(targetQN, c.Transport())
+}
+
+// nvmeFindSession implements the session lookup shared by all NVMe connectors.
+func nvmeFindSession(targetQN string, transport TransportType) (*session, error) {
 	// Base path for NVMe sessions/subsystems.
 	subsysBasePath := "/sys/class/nvme-subsystem"
 

--- a/lxd/storage/connectors/connector_nvme_fc.go
+++ b/lxd/storage/connectors/connector_nvme_fc.go
@@ -1,0 +1,298 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/revert"
+)
+
+var _ Connector = &connectorNVMeFC{}
+
+type connectorNVMeFC struct {
+	common
+}
+
+// Type returns the type of the connector.
+func (c *connectorNVMeFC) Type() string {
+	return TypeNVMeFC
+}
+
+// Transport returns the transport type of the connector.
+func (c *connectorNVMeFC) Transport() TransportType {
+	return TransportFC
+}
+
+// Version returns the version of the NVMe CLI.
+func (c *connectorNVMeFC) Version() (string, error) {
+	return nvmeVersion()
+}
+
+// LoadModules loads the NVMe/FC kernel modules.
+func (c *connectorNVMeFC) LoadModules() error {
+	err := util.LoadModule("nvme_fabrics")
+	if err != nil {
+		return err
+	}
+
+	return util.LoadModule("nvme_fc")
+}
+
+// QualifiedName returns a custom host NQN generated from the server UUID.
+func (c *connectorNVMeFC) QualifiedName() (string, error) {
+	return nvmeQualifiedName(c.serverUUID), nil
+}
+
+// Connect establishes a connection with the target subsystem over the FC fabric.
+// The provided target addresses are the subsystem's FC transport addresses ("nn-<wwnn>:pn-<wwpn>").
+// Each target port is connected through every local FC HBA that can reach it, establishing a path
+// per local HBA for multipathing.
+func (c *connectorNVMeFC) Connect(ctx context.Context, targetQN string, targetAddresses ...string) (revert.Hook, error) {
+	hostNQN, err := c.QualifiedName()
+	if err != nil {
+		return nil, err
+	}
+
+	hostAddrs, err := nvmeLocalFCTransportAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	connectFunc := func(ctx context.Context, session *session, targetAddr string) error {
+		// Local HBAs that do not have a path to this target port yet.
+		missingHostAddrs := nvmeFCMissingPaths(session, targetAddr, hostAddrs)
+		if len(missingHostAddrs) == 0 {
+			// Every local HBA is already connected to the target port.
+			return nil
+		}
+
+		// An already established path counts as connected, so that a target port whose
+		// remaining HBAs are unreachable does not fail an otherwise healthy connection.
+		connected := len(missingHostAddrs) < len(hostAddrs)
+
+		// Attempt to connect the target port through every local HBA that is still
+		// missing a path. A port is generally reachable only through the HBAs it is
+		// zoned to, so failures on the other HBAs are expected and ignored as long as
+		// one path succeeds.
+		var lastErr error
+		for _, hostAddr := range missingHostAddrs {
+			_, err := shared.RunCommand(ctx, "nvme", "connect", "--transport", "fc", "--traddr", targetAddr, "--host-traddr", hostAddr, "--nqn", targetQN, "--hostnqn", hostNQN, "--hostid", c.serverUUID)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			connected = true
+		}
+
+		if !connected {
+			return fmt.Errorf("Failed connecting to target %q on %q via NVMe/FC: %w", targetQN, targetAddr, lastErr)
+		}
+
+		return nil
+	}
+
+	return connect(ctx, c, targetQN, targetAddresses, connectFunc)
+}
+
+// Disconnect terminates a connection with the target.
+func (c *connectorNVMeFC) Disconnect(targetQN string) error {
+	return nvmeDisconnect(c, targetQN)
+}
+
+// findSession returns an active NVMe subsystem that matches the given targetQN.
+func (c *connectorNVMeFC) findSession(targetQN string) (*session, error) {
+	return nvmeFindSession(targetQN, c.Transport())
+}
+
+// Discover returns the NVMe subsystems reachable over the FC fabric.
+//
+// The provided target addresses are the array's NVMe FC target ports (obtained from the storage array).
+// For each target address, the discovery is run against every local FC HBA until one succeeds.
+// The array's discovery controller returns the full set of subsystem ports, so a single successful
+// discovery per target is sufficient.
+func (c *connectorNVMeFC) Discover(ctx context.Context, targetAddresses ...string) ([]any, error) {
+	hostNQN, err := c.QualifiedName()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set a deadline for the overall discovery.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	hostAddrs, err := nvmeLocalFCTransportAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	var discoveryLog nvmeDiscoveryLog
+	seen := make(map[string]struct{})
+
+	for _, targetAddr := range targetAddresses {
+		for _, hostAddr := range hostAddrs {
+			stdout, err := shared.RunCommand(ctx, "nvme", "discover", "--transport", "fc", "--traddr", targetAddr, "--host-traddr", hostAddr, "--hostnqn", hostNQN, "--hostid", c.serverUUID, "--output-format", "json")
+			if err != nil {
+				// The target is not reachable through this local HBA.
+				logger.Warn("Failed connecting to NVMe/FC discovery target", logger.Ctx{"target_address": targetAddr, "host_address": hostAddr, "err": err})
+				continue
+			}
+
+			// Successful discovery of log entries returns output as JSON object.
+			if !strings.HasPrefix(strings.TrimSpace(stdout), "{") {
+				logger.Warn("Failed finding discovery log entries", logger.Ctx{"target_address": targetAddr})
+				continue
+			}
+
+			var log nvmeDiscoveryLog
+			err = json.Unmarshal([]byte(stdout), &log)
+			if err != nil {
+				return nil, fmt.Errorf("Failed unmarshaling the returned discovery log entries from %q: %w", targetAddr, err)
+			}
+
+			records := nvmeFilterDiscoveryLog(log.Records, nvmeTransportTypeFC)
+
+			// Accumulate unique records.
+			for _, record := range records {
+				key := record.SubNQN + "|" + record.TransportAddress
+				_, ok := seen[key]
+				if ok {
+					continue
+				}
+
+				seen[key] = struct{}{}
+				discoveryLog.Records = append(discoveryLog.Records, record)
+			}
+
+			// The discovery controller returned the full log for this target,
+			// so there is no need to try the remaining local HBAs.
+			break
+		}
+	}
+
+	if len(discoveryLog.Records) == 0 {
+		return nil, errors.New("Failed fetching a discovery log record from any of the FC targets")
+	}
+
+	result := make([]any, 0, len(discoveryLog.Records))
+	for _, value := range discoveryLog.Records {
+		result = append(result, value)
+	}
+
+	return result, nil
+}
+
+// WaitDiskDevicePath waits for the mapped device to appear and returns its path.
+func (c *connectorNVMeFC) WaitDiskDevicePath(ctx context.Context, diskPathFilter block.DevicePathFilterFunc) (string, error) {
+	return block.WaitDiskDevicePath(ctx, nvmeDiskDevicePrefix, diskPathFilter)
+}
+
+// GetDiskDevicePath returns the path of the mapped device if it exists.
+func (c *connectorNVMeFC) GetDiskDevicePath(diskPathFilter block.DevicePathFilterFunc) (string, error) {
+	return block.GetDiskDevicePath(nvmeDiskDevicePrefix, diskPathFilter)
+}
+
+// RemoveDiskDevice does nothing. Device is removed when volume is unmapped on the storage array.
+func (c *connectorNVMeFC) RemoveDiskDevice(ctx context.Context, devicePath string) error {
+	return nil
+}
+
+// WaitDiskDeviceResize waits until the disk device reflects the new size.
+func (c *connectorNVMeFC) WaitDiskDeviceResize(ctx context.Context, diskPath string, newSizeBytes int64) error {
+	return block.WaitDiskDeviceResize(ctx, diskPath, newSizeBytes)
+}
+
+// nvmeFCMissingPaths returns the local host addresses that do not have an established path
+// to the given target address yet (each local HBA forms a separate path).
+func nvmeFCMissingPaths(session *session, targetAddr string, hostAddrs []string) []string {
+	var connectedHostAddrs []string
+	if session != nil {
+		// Target addresses are compared case insensitively, as the requested one
+		// originates from the storage array while the connected ones are reported
+		// by the kernel.
+		for addr, hostAddrs := range session.hostAddresses {
+			if strings.EqualFold(addr, targetAddr) {
+				connectedHostAddrs = append(connectedHostAddrs, hostAddrs...)
+			}
+		}
+	}
+
+	missing := make([]string, 0, len(hostAddrs))
+	for _, hostAddr := range hostAddrs {
+		isConnected := slices.ContainsFunc(connectedHostAddrs, func(addr string) bool {
+			// Host addresses are compared case insensitively, as the local ones are
+			// assembled from sysfs while the connected ones are reported by the kernel.
+			return strings.EqualFold(addr, hostAddr)
+		})
+
+		if !isConnected {
+			missing = append(missing, hostAddr)
+		}
+	}
+
+	return missing
+}
+
+// nvmeFCTransportAddress builds an NVMe/FC transport address ("nn-<wwnn>:pn-<wwpn>")
+// from the FC node name and port name as reported by sysfs (e.g. "0x2000..").
+func nvmeFCTransportAddress(nodeName string, portName string) string {
+	return "nn-" + strings.TrimSpace(nodeName) + ":pn-" + strings.TrimSpace(portName)
+}
+
+// nvmeLocalFCTransportAddresses returns the NVMe/FC transport addresses
+// ("nn-<wwnn>:pn-<wwpn>") of the local FC HBA ports that are online. These are
+// used as host transport addresses when discovering and connecting to targets.
+func nvmeLocalFCTransportAddresses() ([]string, error) {
+	fcHostBasePath := "/sys/class/fc_host"
+
+	hosts, err := os.ReadDir(fcHostBasePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, errors.New("No FC host adapters found")
+		}
+
+		return nil, fmt.Errorf("Failed reading FC hosts: %w", err)
+	}
+
+	var addresses []string
+	for _, host := range hosts {
+		hostPath := filepath.Join(fcHostBasePath, host.Name())
+
+		// Skip ports that are not online.
+		stateBytes, err := os.ReadFile(filepath.Join(hostPath, "port_state"))
+		if err != nil || strings.TrimSpace(string(stateBytes)) != "Online" {
+			continue
+		}
+
+		nodeName, err := os.ReadFile(filepath.Join(hostPath, "node_name"))
+		if err != nil {
+			return nil, err
+		}
+
+		portName, err := os.ReadFile(filepath.Join(hostPath, "port_name"))
+		if err != nil {
+			return nil, err
+		}
+
+		address := nvmeFCTransportAddress(string(nodeName), string(portName))
+		addresses = append(addresses, address)
+	}
+
+	if len(addresses) == 0 {
+		return nil, errors.New("No online local FC HBA ports found")
+	}
+
+	return addresses, nil
+}

--- a/lxd/storage/connectors/connector_nvme_fc_test.go
+++ b/lxd/storage/connectors/connector_nvme_fc_test.go
@@ -1,0 +1,128 @@
+package connectors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_nvmeFCMissingPaths(t *testing.T) {
+	const targetA = "nn-0x20000024ff123456:pn-0x21000024ff123456"
+	const targetB = "nn-0x20000024ff654321:pn-0x21000024ff654321"
+
+	const hbaA = "nn-0x20000090fae0b99a:pn-0x10000090fae0b99a"
+	const hbaB = "nn-0x20000090fae0b99b:pn-0x10000090fae0b99b"
+
+	tests := []struct {
+		name       string
+		session    *session
+		targetAddr string
+		hostAddrs  []string
+		want       []string
+	}{
+		{
+			name:       "No session yet connects through every HBA",
+			session:    nil,
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaA, hbaB},
+		},
+		{
+			name:       "Session without any path to the target port",
+			session:    &session{hostAddresses: map[string][]string{}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaA, hbaB},
+		},
+		{
+			name:       "Session covering only one HBA still connects the other",
+			session:    &session{hostAddresses: map[string][]string{targetA: {hbaA}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaB},
+		},
+		{
+			name:       "Session covering every HBA connects nothing",
+			session:    &session{hostAddresses: map[string][]string{targetA: {hbaA, hbaB}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{},
+		},
+		{
+			name:       "Paths of another target port are not considered",
+			session:    &session{hostAddresses: map[string][]string{targetB: {hbaA, hbaB}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaA, hbaB},
+		},
+		{
+			name:       "Target addresses are matched case insensitively",
+			session:    &session{hostAddresses: map[string][]string{strings.ToUpper(targetA): {hbaA}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaB},
+		},
+		{
+			name:       "Host addresses are matched case insensitively",
+			session:    &session{hostAddresses: map[string][]string{targetA: {strings.ToUpper(hbaA)}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA, hbaB},
+			want:       []string{hbaB},
+		},
+		{
+			name:       "Session with a path through an HBA that is no longer online",
+			session:    &session{hostAddresses: map[string][]string{targetA: {hbaA, hbaB}}},
+			targetAddr: targetA,
+			hostAddrs:  []string{hbaA},
+			want:       []string{},
+		},
+		{
+			name:       "No online HBAs",
+			session:    &session{hostAddresses: map[string][]string{targetA: {hbaA}}},
+			targetAddr: targetA,
+			hostAddrs:  nil,
+			want:       []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, nvmeFCMissingPaths(test.session, test.targetAddr, test.hostAddrs))
+		})
+	}
+}
+
+func Test_nvmeFCTransportAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		portName string
+		want     string
+	}{
+		{
+			name:     "Plain sysfs values",
+			nodeName: "0x20000024ff123456",
+			portName: "0x21000024ff123456",
+			want:     "nn-0x20000024ff123456:pn-0x21000024ff123456",
+		},
+		{
+			name:     "Trailing newlines from sysfs read",
+			nodeName: "0x20000024ff123456\n",
+			portName: "0x21000024ff123456\n",
+			want:     "nn-0x20000024ff123456:pn-0x21000024ff123456",
+		},
+		{
+			name:     "Surrounding whitespace",
+			nodeName: "  0x20000024ff123456  ",
+			portName: "  0x21000024ff123456  ",
+			want:     "nn-0x20000024ff123456:pn-0x21000024ff123456",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, nvmeFCTransportAddress(test.nodeName, test.portName))
+		})
+	}
+}


### PR DESCRIPTION
Connector changes extracted from PowerStore PR https://github.com/canonical/lxd/pull/18817.

This mainly adds NVMe/FC connector, which can then be used by PowerStore and EverPure implementation.