### PR TITLE
Fix a unit test fd clean up race condition.

### DIFF
--- a/lxd/endpoints/network_test.go
+++ b/lxd/endpoints/network_test.go
@@ -53,6 +53,7 @@ func TestEndpoints_NetworkSocketBasedActivation(t *testing.T) {
 
 	file, err := listener.File()
 	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
 
 	setupSocketBasedActivation(endpoints, file)
 


### PR DESCRIPTION
Fixes a leaked fd causing clean up failure.  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
