### PR TITLE
test/suites/concurrent: remove pointless instance state check

### DIFF
--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -81,7 +81,7 @@ readonly test_group_replicator_storage=(
 
 readonly test_group_instance=(
     "cloud_init"
-    "concurrent"  # Disabled as flaky.
+    "concurrent"
     "concurrent_exec"
     "console"
     "console_vm"

--- a/test/suites/concurrent.sh
+++ b/test/suites/concurrent.sh
@@ -7,8 +7,6 @@ test_concurrent() {
     name=concurrent-${1}
 
     lxc launch testimage --quiet "${name}"
-    # XXX: `[ "$(lxc list -f csv -c s "${name}")" = "RUNNING" ]` is too fast and leads to races with exec/delete
-    lxc list --fast "${name}" | grep -wF RUNNING
     [ "$(echo abc | lxc exec "${name}" -- cat)" = "abc" ]
     lxc delete --force "${name}"
   }


### PR DESCRIPTION
Commit b7476600afcd62c33825e032c2e7d872fc1e8fbc should have fixed the underlying issue so it should be safe to use the faster variant.