### PR TITLE
Replicator status table

### DIFF
--- a/lxd/api_replicators.go
+++ b/lxd/api_replicators.go
@@ -200,9 +200,14 @@ func replicatorsGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading replicator configs: %w", err)
 		}
 
+		statuses, err := dbCluster.GetLastReplicatorStatuses(ctx, tx.Tx(), projectFilter)
+		if err != nil {
+			return fmt.Errorf("Failed loading replicator statuses: %w", err)
+		}
+
 		apiReplicatorsTx := make([]*api.Replicator, 0, len(replicators))
 		for _, replicator := range replicators {
-			apiReplicatorsTx = append(apiReplicatorsTx, replicator.ToAPI(allConfigs))
+			apiReplicatorsTx = append(apiReplicatorsTx, replicator.ToAPI(allConfigs, statuses))
 		}
 
 		apiReplicators = apiReplicatorsTx
@@ -301,7 +306,15 @@ func replicatorGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
 
-		apiReplicator = dbReplicator.ToAPI(config)
+		statuses := make(map[int64]dbCluster.ReplicatorsStatusRow)
+		lastStatus, err := dbCluster.GetLastReplicatorStatus(ctx, tx.Tx(), dbReplicator.Row.ID)
+		if err == nil {
+			statuses[dbReplicator.Row.ID] = *lastStatus
+		} else if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed loading replicator status: %w", err)
+		}
+
+		apiReplicator = dbReplicator.ToAPI(config, statuses)
 		return nil
 	})
 	if err != nil {
@@ -629,7 +642,15 @@ func replicatorStatePut(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
 
-		apiReplicator = dbReplicator.ToAPI(config)
+		statuses := make(map[int64]dbCluster.ReplicatorsStatusRow)
+		lastStatus, err := dbCluster.GetLastReplicatorStatus(ctx, tx.Tx(), dbReplicator.Row.ID)
+		if err == nil {
+			statuses[dbReplicator.Row.ID] = *lastStatus
+		} else if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed loading replicator status: %w", err)
+		}
+
+		apiReplicator = dbReplicator.ToAPI(config, statuses)
 		return nil
 	})
 	if err != nil {
@@ -641,30 +662,25 @@ func replicatorStatePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Replicator %q has no cluster link configured", name))
 	}
 
-	opArgs, err := prepareReplicatorRunOperationArgs(r.Context(), s, projectName, name, clusterLinkName, restore, dbReplicator.Row.ID)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	// Set status to Running before scheduling the operation. The operation's RunHook writes
-	// the terminal status (Completed/Failed) when it finishes. If the project has no instances,
-	// the RunHook can complete synchronously inside ScheduleUserOperationFromRequest before it
-	// returns, writing the terminal status first. By setting Running here, that terminal write
-	// always comes after Running, so the status is never left stuck at Running.
+	// Create a status entry for the replicator to update.
+	var runID int64
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return dbCluster.UpdateReplicatorLastRun(ctx, tx.Tx(), dbReplicator.Row.ID, time.Now(), api.ReplicatorStatusRunning)
+		runID, err = dbCluster.CreateNewReplicatorStatus(ctx, tx.Tx(), dbReplicator.Row.ID, time.Now(), api.ReplicatorStatusRunning, dbCluster.ReplicatorRunModeManual)
+		return err
 	})
 	if err != nil {
-		logger.Warn("Failed updating replicator last run status to running", logger.Ctx{"name": name, "project": projectName, "err": err})
+		return response.SmartError(fmt.Errorf("Failed creating status data for replicator run: %w", err))
+	}
+
+	opArgs, err := prepareReplicatorRunOperationArgs(r.Context(), s, projectName, name, clusterLinkName, restore, runID)
+	if err != nil {
+		handleReplicatorSchedulingError(s, projectName, name, runID, err)
+		return response.SmartError(err)
 	}
 
 	op, err := operations.ScheduleUserOperationFromRequest(s, r, *opArgs)
 	if err != nil {
-		// Revert Running to Failed so the status doesn't get stuck.
-		_ = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-			return dbCluster.UpdateReplicatorLastRunStatus(ctx, tx.Tx(), dbReplicator.Row.ID, api.ReplicatorStatusFailed)
-		})
-
+		handleReplicatorSchedulingError(s, projectName, name, runID, err)
 		return response.SmartError(err)
 	}
 
@@ -696,7 +712,15 @@ func updateReplicator(d *Daemon, r *http.Request, isPatch bool) response.Respons
 			return fmt.Errorf("Failed loading replicator config: %w", err)
 		}
 
-		apiReplicator = dbReplicator.ToAPI(config)
+		statuses := make(map[int64]dbCluster.ReplicatorsStatusRow)
+		lastStatus, err := dbCluster.GetLastReplicatorStatus(ctx, tx.Tx(), dbReplicator.Row.ID)
+		if err == nil {
+			statuses[dbReplicator.Row.ID] = *lastStatus
+		} else if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return fmt.Errorf("Failed loading replicator status: %w", err)
+		}
+
+		apiReplicator = dbReplicator.ToAPI(config, statuses)
 		return nil
 	})
 	if err != nil {
@@ -938,10 +962,17 @@ func replicatorStateGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		status = api.ReplicatorStatusPending
-		if dbReplicator.Row.LastRunStatus != "" {
-			status = dbReplicator.Row.LastRunStatus
+		lastStatus, err := dbCluster.GetLastReplicatorStatus(ctx, tx.Tx(), dbReplicator.Row.ID)
+		if err != nil {
+			// If not found, there is no status for the replicator yet, so return nil (status pending).
+			if api.StatusErrorCheck(err, http.StatusNotFound) {
+				return nil
+			}
+
+			return err
 		}
 
+		status = lastStatus.Status
 		return nil
 	})
 	if err != nil {

--- a/lxd/db/cluster/generated.go
+++ b/lxd/db/cluster/generated.go
@@ -954,8 +954,6 @@ func (r Replicator) SelectColumns() []string {
 		"replicators.name",
 		"replicators.project_id",
 		"replicators.description",
-		"replicators.last_run_date",
-		"replicators.last_run_status",
 		"projects.name",
 	}
 }
@@ -970,7 +968,7 @@ func (r Replicator) Joins() []string {
 // ScanArgs implements [query.ScanArger] for [Replicator].
 // This returns references to struct fields in definition order.
 func (r *Replicator) ScanArgs() []any {
-	return []any{&r.Row.ID, &r.Row.Name, &r.Row.ProjectID, &r.Row.Description, &r.Row.LastRunDate, &r.Row.LastRunStatus, &r.ProjectName}
+	return []any{&r.Row.ID, &r.Row.Name, &r.Row.ProjectID, &r.Row.Description, &r.ProjectName}
 }
 
 // TableName returns the table name for [ReplicatorRow] entities.
@@ -985,8 +983,6 @@ func (r ReplicatorRow) SelectColumns() []string {
 		"replicators.name",
 		"replicators.project_id",
 		"replicators.description",
-		"replicators.last_run_date",
-		"replicators.last_run_status",
 	}
 }
 
@@ -998,17 +994,17 @@ func (r ReplicatorRow) Joins() []string {
 // ScanArgs implements [query.ScanArger] for [ReplicatorRow].
 // This returns references to struct fields in definition order.
 func (r *ReplicatorRow) ScanArgs() []any {
-	return []any{&r.ID, &r.Name, &r.ProjectID, &r.Description, &r.LastRunDate, &r.LastRunStatus}
+	return []any{&r.ID, &r.Name, &r.ProjectID, &r.Description}
 }
 
 // CreateValues returns a list of values from [ReplicatorRow] entities matching the bind arguments in [CreateStmt].
 func (r ReplicatorRow) CreateValues() []any {
-	return []any{r.Name, r.ProjectID, r.Description, r.LastRunDate, r.LastRunStatus}
+	return []any{r.Name, r.ProjectID, r.Description}
 }
 
 // UpdateValues returns a list of values from [ReplicatorRow] entities matching the columns in [UpdateStmt].
 func (r ReplicatorRow) UpdateValues() []any {
-	return []any{r.Name, r.ProjectID, r.Description, r.LastRunDate, r.LastRunStatus}
+	return []any{r.Name, r.ProjectID, r.Description}
 }
 
 // PKColumns returns the column names for the primary key of a [ReplicatorRow] entity used during an update.
@@ -1025,10 +1021,72 @@ func (r ReplicatorRow) PKValues() []any {
 
 // CreateStmt returns a query that creates a [ReplicatorRow] entity.
 func (r ReplicatorRow) CreateStmt() string {
-	return "INSERT INTO replicators (name, project_id, description, last_run_date, last_run_status) VALUES (?, ?, ?, ?, ?)"
+	return "INSERT INTO replicators (name, project_id, description) VALUES (?, ?, ?)"
 }
 
 // UpdateStmt returns a query that updates a [ReplicatorRow] by primary key.
 func (r ReplicatorRow) UpdateStmt() string {
-	return "UPDATE replicators SET name = ?, project_id = ?, description = ?, last_run_date = ?, last_run_status = ? "
+	return "UPDATE replicators SET name = ?, project_id = ?, description = ? "
+}
+
+// TableName returns the table name for [ReplicatorsStatusRow] entities.
+func (r ReplicatorsStatusRow) TableName() string {
+	return "replicators_status"
+}
+
+// SelectColumns returns a slice of column names for [ReplicatorsStatusRow] entities.
+func (r ReplicatorsStatusRow) SelectColumns() []string {
+	return []string{
+		"replicators_status.id",
+		"replicators_status.mode",
+		"replicators_status.status",
+		"replicators_status.started_date",
+		"replicators_status.finished_date",
+		"replicators_status.snapshot_started_date",
+		"replicators_status.snapshot_finished_date",
+		"replicators_status.replicator_id",
+	}
+}
+
+// Joins returns a slice of join expressions for [ReplicatorsStatusRow].
+func (r ReplicatorsStatusRow) Joins() []string {
+	return []string{}
+}
+
+// ScanArgs implements [query.ScanArger] for [ReplicatorsStatusRow].
+// This returns references to struct fields in definition order.
+func (r *ReplicatorsStatusRow) ScanArgs() []any {
+	return []any{&r.ID, &r.Mode, &r.Status, &r.StartedDate, &r.FinishedDate, &r.SnapshotStartedDate, &r.SnapshotFinishedDate, &r.ReplicatorID}
+}
+
+// CreateValues returns a list of values from [ReplicatorsStatusRow] entities matching the bind arguments in [CreateStmt].
+func (r ReplicatorsStatusRow) CreateValues() []any {
+	return []any{r.Mode, r.Status, r.StartedDate, r.FinishedDate, r.SnapshotStartedDate, r.SnapshotFinishedDate, r.ReplicatorID}
+}
+
+// UpdateValues returns a list of values from [ReplicatorsStatusRow] entities matching the columns in [UpdateStmt].
+func (r ReplicatorsStatusRow) UpdateValues() []any {
+	return []any{r.Status, r.FinishedDate, r.SnapshotStartedDate, r.SnapshotFinishedDate}
+}
+
+// PKColumns returns the column names for the primary key of a [ReplicatorsStatusRow] entity used during an update.
+// The returned slice must have the same number of elements as PKValues.
+func (r ReplicatorsStatusRow) PKColumns() []string {
+	return []string{"id"}
+}
+
+// PKValues returns the values for the primary key of a [ReplicatorsStatusRow] entity used during an update.
+// The returned slice must have the same number of elements as PKColumns.
+func (r ReplicatorsStatusRow) PKValues() []any {
+	return []any{r.ID}
+}
+
+// CreateStmt returns a query that creates a [ReplicatorsStatusRow] entity.
+func (r ReplicatorsStatusRow) CreateStmt() string {
+	return "INSERT INTO replicators_status (mode, status, started_date, finished_date, snapshot_started_date, snapshot_finished_date, replicator_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+}
+
+// UpdateStmt returns a query that updates a [ReplicatorsStatusRow] by primary key.
+func (r ReplicatorsStatusRow) UpdateStmt() string {
+	return "UPDATE replicators_status SET status = ?, finished_date = ?, snapshot_started_date = ?, snapshot_finished_date = ? "
 }

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -3,7 +3,9 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,15 +14,60 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 )
 
+// ReplicatorRunMode stores information about how a replicator run is initiated.
+type ReplicatorRunMode string
+
+const (
+	// ReplicatorRunModeManual represents a user requested "manual" run.
+	ReplicatorRunModeManual ReplicatorRunMode = "manual"
+
+	// ReplicatorRunModeScheduled indicates that the replicator run was triggered by the replicator's cron schedule.
+	ReplicatorRunModeScheduled ReplicatorRunMode = "scheduled"
+)
+
+const (
+	replicatorRunModeCodeManual    int64 = 0
+	replicatorRunModeCodeScheduled int64 = 1
+)
+
+// Scan implements [sql.Scanner] for [ReplicatorRunMode].
+func (r *ReplicatorRunMode) Scan(value any) error {
+	return query.ScanValue(value, r, false)
+}
+
+// ScanInteger implements [query.IntegerScanner] for [ReplicatorRunMode] which reduces duplication for [sql.Scanner] implementations.
+func (r *ReplicatorRunMode) ScanInteger(in int64) error {
+	switch in {
+	case replicatorRunModeCodeManual:
+		*r = ReplicatorRunModeManual
+	case replicatorRunModeCodeScheduled:
+		*r = ReplicatorRunModeScheduled
+	default:
+		return fmt.Errorf(`Unknown replicator mode code "%d"`, in)
+	}
+
+	return nil
+}
+
+// Value implements [driver.Valuer] for [ReplicatorRunMode].
+func (r ReplicatorRunMode) Value() (driver.Value, error) {
+	switch r {
+	case ReplicatorRunModeManual:
+		return replicatorRunModeCodeManual, nil
+	case ReplicatorRunModeScheduled:
+		return replicatorRunModeCodeScheduled, nil
+	default:
+		return nil, fmt.Errorf("Unknown replicator run mode %q", r)
+	}
+}
+
 // ReplicatorRow represents a single row of the replicators table.
 // db:model replicators
 type ReplicatorRow struct {
-	ID            int64        `db:"id"`
-	Name          string       `db:"name"`
-	ProjectID     int64        `db:"project_id"`
-	Description   string       `db:"description"`
-	LastRunDate   sql.NullTime `db:"last_run_date"`
-	LastRunStatus string       `db:"last_run_status"`
+	ID          int64  `db:"id"`
+	Name        string `db:"name"`
+	ProjectID   int64  `db:"project_id"`
+	Description string `db:"description"`
 }
 
 // APIName implements [query.APINamer] for API friendly error messages.
@@ -44,6 +91,35 @@ func ReplicatorsConfigStore() *query.EntityConfigStore {
 		ConfigTable:               "replicators_config",
 		ConfigTableEntityIDColumn: "replicator_id",
 	}
+}
+
+// ReplicatorsStatusRow represents a row of the replicators_status table.
+// db:model replicators_status
+type ReplicatorsStatusRow struct {
+	ID int64 `db:"id"`
+
+	// db:omit update
+	Mode   ReplicatorRunMode `db:"mode"`
+	Status string            `db:"status"`
+
+	// db:omit update
+	StartedDate          time.Time    `db:"started_date"`
+	FinishedDate         sql.NullTime `db:"finished_date"`
+	SnapshotStartedDate  sql.NullTime `db:"snapshot_started_date"`
+	SnapshotFinishedDate sql.NullTime `db:"snapshot_finished_date"`
+
+	// db:omit update
+	ReplicatorID int64 `db:"replicator_id"`
+}
+
+// APIName implements [query.APINamer] for API friendly error messages.
+func (ReplicatorsStatusRow) APIName() string {
+	return "Replicator status"
+}
+
+// APIPluralName implements [query.APIPluralNamer] for API friendly error messages (to avoid misspelling the plural of the [APIName] by appending an "s").
+func (ReplicatorsStatusRow) APIPluralName() string {
+	return "Replicator statuses"
 }
 
 // ToAPI converts the [Replicator] to an [api.Replicator].

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -246,4 +245,43 @@ func FinalizeReplicatorStatus(ctx context.Context, tx *sql.Tx, runID int64, stat
 	}
 
 	return err
+}
+
+// GetLastReplicatorStatuses gets the most recent [ReplicatorsStatusRow] for all [Replicator] entries in the given project,
+// or for all projects if no project name is provided.
+func GetLastReplicatorStatuses(ctx context.Context, tx *sql.Tx, projectName *string) (map[int64]ReplicatorsStatusRow, error) {
+	var b strings.Builder
+	var args []any
+
+	if projectName != nil {
+		b.WriteString(`
+JOIN replicators ON replicators_status.replicator_id = replicators.id
+JOIN projects ON replicators.project_id = projects.id`)
+	}
+
+	b.WriteString(`
+WHERE replicators_status.id IN (
+	SELECT MAX(id) FROM replicators_status GROUP BY replicator_id
+)`)
+
+	if projectName != nil {
+		b.WriteString(" AND projects.name = ?")
+		args = []any{*projectName}
+	}
+
+	result := make(map[int64]ReplicatorsStatusRow)
+	err := query.SelectFunc[ReplicatorsStatusRow](ctx, tx, b.String(), func(row ReplicatorsStatusRow) error {
+		result[row.ReplicatorID] = row
+		return nil
+	}, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed querying for last replicator statuses: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetLastReplicatorStatus gets the most recent [ReplicatorsStatusRow] for the [Replicator] with the given ID.
+func GetLastReplicatorStatus(ctx context.Context, tx *sql.Tx, replicatorID int64) (*ReplicatorsStatusRow, error) {
+	return query.SelectOne[ReplicatorsStatusRow](ctx, tx, "WHERE replicators_status.replicator_id = ? ORDER BY replicators_status.id DESC LIMIT 1", replicatorID)
 }

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -217,14 +217,33 @@ func GetReplicatorsAndURLs(ctx context.Context, tx *sql.Tx, projectName *string,
 	return replicators, replicatorURLs, nil
 }
 
-// UpdateReplicatorLastRun updates the last_run_date and last_run_status fields of the replicator with the given ID.
-func UpdateReplicatorLastRun(ctx context.Context, tx *sql.Tx, id int64, date time.Time, status string) error {
-	_, err := tx.ExecContext(ctx, `UPDATE replicators SET last_run_date=?, last_run_status=? WHERE id=?`, date, status, id)
-	return err
+// CreateNewReplicatorStatus creates a new [ReplicatorsStatusRow] with the given replicator ID, start date, status, and mode.
+func CreateNewReplicatorStatus(ctx context.Context, tx *sql.Tx, replicatorID int64, startedDate time.Time, status string, mode ReplicatorRunMode) (int64, error) {
+	return query.Create(ctx, tx, ReplicatorsStatusRow{
+		Mode:         mode,
+		Status:       status,
+		StartedDate:  startedDate,
+		ReplicatorID: replicatorID,
+	})
 }
 
-// UpdateReplicatorLastRunStatus updates only the last_run_status field of the replicator with the given ID.
-func UpdateReplicatorLastRunStatus(ctx context.Context, tx *sql.Tx, id int64, status string) error {
-	_, err := tx.ExecContext(ctx, `UPDATE replicators SET last_run_status=? WHERE id=?`, status, id)
+// FinalizeReplicatorStatus updates the [ReplicatorsStatusRow] with the given ID. It sets the status and finished_date columns.
+func FinalizeReplicatorStatus(ctx context.Context, tx *sql.Tx, runID int64, status string, finishedDate time.Time) error {
+	q := `UPDATE replicators_status SET status = ?, finished_date = ? WHERE id = ?`
+	res, err := tx.ExecContext(ctx, q, status, finishedDate, runID)
+
+	if err != nil {
+		return fmt.Errorf("Failed finalizing replicator run status: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed verifying replicator run status update: %w", err)
+	}
+
+	if rowsAffected != 1 {
+		return fmt.Errorf("Failed verifying replicator run status update: Expected to update 1 row, but updated %d", rowsAffected)
+	}
+
 	return err
 }

--- a/lxd/db/cluster/replicators.go
+++ b/lxd/db/cluster/replicators.go
@@ -122,7 +122,7 @@ func (ReplicatorsStatusRow) APIPluralName() string {
 }
 
 // ToAPI converts the [Replicator] to an [api.Replicator].
-func (r *Replicator) ToAPI(allConfigs map[int64]map[string]string) *api.Replicator {
+func (r *Replicator) ToAPI(allConfigs map[int64]map[string]string, lastStatuses map[int64]ReplicatorsStatusRow) *api.Replicator {
 	config := allConfigs[r.Row.ID]
 	if config == nil {
 		config = map[string]string{}
@@ -136,12 +136,10 @@ func (r *Replicator) ToAPI(allConfigs map[int64]map[string]string) *api.Replicat
 		LastRunStatus: api.ReplicatorStatusPending,
 	}
 
-	if r.Row.LastRunDate.Valid {
-		replicator.LastRunAt = r.Row.LastRunDate.Time
-	}
-
-	if r.Row.LastRunStatus != "" {
-		replicator.LastRunStatus = r.Row.LastRunStatus
+	lastStatus, ok := lastStatuses[r.Row.ID]
+	if ok {
+		replicator.LastRunAt = lastStatus.StartedDate
+		replicator.LastRunStatus = lastStatus.Status
 	}
 
 	return replicator

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -537,7 +537,7 @@ CREATE TABLE operations (
     FOREIGN KEY (parent) REFERENCES operations (id) ON DELETE CASCADE
 );
 CREATE UNIQUE INDEX operations_conflict_reference ON operations (conflict_reference)
-    WHERE conflict_reference != ""
+    WHERE conflict_reference != ''
     AND status_code IN (103,104);
 CREATE TABLE operations_resources (
     operation_id INTEGER NOT NULL,
@@ -617,8 +617,6 @@ CREATE TABLE replicators (
 	name TEXT NOT NULL,
 	project_id INTEGER NOT NULL,
 	description TEXT NOT NULL,
-	last_run_date DATETIME,
-	last_run_status TEXT NOT NULL,
 	UNIQUE(project_id, name),
 	FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 );
@@ -630,6 +628,19 @@ CREATE TABLE replicators_config (
 	PRIMARY KEY (replicator_id,
     key)
 ) WITHOUT ROWID;
+CREATE TABLE replicators_status (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    mode INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    started_date DATETIME NOT NULL,
+    finished_date DATETIME,
+    snapshot_started_date DATETIME,
+    snapshot_finished_date DATETIME,
+    replicator_id INTEGER NOT NULL,
+    FOREIGN KEY (replicator_id) REFERENCES replicators (id) ON DELETE CASCADE
+);
+CREATE INDEX replicators_status_replicator_id_id ON replicators_status (replicator_id,
+    id);
 CREATE TABLE secrets (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     entity_type INTEGER NOT NULL,
@@ -769,7 +780,7 @@ CREATE TRIGGER storage_volumes_check_id
   WHEN NEW.id IN (SELECT id FROM storage_volumes_snapshots)
   BEGIN
     SELECT RAISE(FAIL,
-    "invalid ID");
+    'invalid ID');
   END;
 CREATE TABLE "storage_volumes_config" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -795,7 +806,7 @@ CREATE TRIGGER storage_volumes_snapshots_check_id
   WHEN NEW.id IN (SELECT id FROM storage_volumes)
   BEGIN
     SELECT RAISE(FAIL,
-    "invalid ID");
+    'invalid ID');
   END;
 CREATE TABLE "storage_volumes_snapshots_config" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -826,5 +837,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (88, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (89, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -132,6 +132,107 @@ var updates = map[int]schema.Update{
 	86: updateFromV85,
 	87: updateFromV86,
 	88: updateFromV87,
+	89: updateFromV88,
+}
+
+func updateFromV88(ctx context.Context, tx *sql.Tx) error {
+	type replicatorStatus struct {
+		lastRunDate   sql.NullTime
+		lastRunStatus string
+	}
+
+	replicatorStatuses := make(map[int64]replicatorStatus)
+	err := query.Scan(ctx, tx, "SELECT id, last_run_status, last_run_date FROM replicators", func(scan func(dest ...any) error) error {
+		var rs replicatorStatus
+		var id int64
+		err := scan(&id, &rs.lastRunStatus, &rs.lastRunDate)
+		if err != nil {
+			return err
+		}
+
+		replicatorStatuses[id] = rs
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	replicatorConfigs, err := ReplicatorsConfigStore().GetAll(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	args := make([]any, 0, len(replicatorStatuses)*4)
+	values := make([]string, 0, len(replicatorStatuses))
+	for id, rs := range replicatorStatuses {
+		mode := replicatorRunModeCodeManual
+		if !rs.lastRunDate.Valid {
+			continue
+		}
+
+		values = append(values, query.Params(4))
+
+		config, ok := replicatorConfigs[id]
+		if !ok {
+			args = append(args, mode, rs.lastRunStatus, rs.lastRunDate.Time, id)
+			continue
+		}
+
+		schedule, ok := config["schedule"]
+		if !ok {
+			args = append(args, mode, rs.lastRunStatus, rs.lastRunDate.Time, id)
+			continue
+		}
+
+		specs := shared.SplitNTrimSpace(schedule, ", ", -1, true)
+		for _, spec := range specs {
+			isActive, err := shared.CronSpecIsActiveThisMinute(spec, rs.lastRunDate.Time)
+			if err == nil && isActive {
+				mode = replicatorRunModeCodeScheduled
+				break
+			}
+		}
+
+		args = append(args, mode, rs.lastRunStatus, rs.lastRunDate.Time, id)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+CREATE TABLE replicators_status (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    mode INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    started_date DATETIME NOT NULL,
+    finished_date DATETIME,
+    snapshot_started_date DATETIME,
+    snapshot_finished_date DATETIME,
+    replicator_id INTEGER NOT NULL,
+    FOREIGN KEY (replicator_id) REFERENCES replicators (id) ON DELETE CASCADE
+);
+
+-- Create an index allowing performant queries for last replicator status.
+-- We will often want MAX(id) by replicator_id.
+CREATE INDEX replicators_status_replicator_id_id ON replicators_status (replicator_id, id);
+`)
+	if err != nil {
+		return fmt.Errorf("Failed creating replicator status table: %w", err)
+	}
+
+	if len(values) > 0 {
+		_, err = tx.ExecContext(ctx, `INSERT INTO replicators_status (mode, status, started_date, replicator_id) VALUES `+strings.Join(values, ", "), args...)
+		if err != nil {
+			return fmt.Errorf("Failed moving replicator run statuses: %w", err)
+		}
+	}
+
+	_, err = tx.ExecContext(ctx, `
+ALTER TABLE replicators DROP COLUMN last_run_date;
+ALTER TABLE replicators DROP COLUMN last_run_status;
+`)
+	if err != nil {
+		return fmt.Errorf("Failed dropping replicator last run columns: %w", err)
+	}
+
+	return nil
 }
 
 func updateFromV87(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/replicator_run.go
+++ b/lxd/replicator_run.go
@@ -991,18 +991,15 @@ func runScheduledReplicators(ctx context.Context, s *state.State) error {
 
 // replicatorIsScheduledNow returns true if any of the (comma-separated) cron expressions in spec matches the provided minute.
 func replicatorIsScheduledNow(spec string, now time.Time) bool {
-	t := now.Truncate(time.Minute)
 	// Split on ", " (comma+space) to match validate.IsCron, preserving intra-field commas like "0,30 * * * *".
 	for _, s := range shared.SplitNTrimSpace(spec, ", ", -1, true) {
-		sched, err := cron.ParseStandard(s)
+		isActive, err := shared.CronSpecIsActiveThisMinute(s, now)
 		if err != nil {
 			logger.Warn("Failed parsing replicator schedule expression", logger.Ctx{"spec": s, "err": err})
 			continue
 		}
 
-		// Next(t - 1s) returns the next scheduled time strictly after t-1s.
-		// If t itself is a scheduled minute, that equals t.
-		if sched.Next(t.Add(-time.Second)).Equal(t) {
+		if isActive {
 			return true
 		}
 	}

--- a/lxd/replicator_run.go
+++ b/lxd/replicator_run.go
@@ -9,13 +9,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/robfig/cron/v3"
-
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
+	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/state"
@@ -62,8 +61,8 @@ const (
 	durableOperationInputKeyReplicatorInstanceID   operations.InputKey = "replicator_instance_id"
 	durableOperationInputKeyReplicatorInstanceName operations.InputKey = "replicator_instance_name"
 
-	// Finalization operation input. This updates the replicator row with the run status.
-	durableOperationInputKeyReplicatorID operations.InputKey = "replicator_id"
+	// Finalization operation input. This updates the [cluster.ReplicatorsStatusRow] with the run status.
+	durableOperationInputKeyReplicatorRunID operations.InputKey = "replicator_run_id"
 )
 
 func init() {
@@ -125,9 +124,9 @@ func loadSharedReplicatorDetails(ctx context.Context, op *operations.Operation) 
 }
 
 func replicatorFinalizeDurableOperationRunHook(_ context.Context, op *operations.Operation) error {
-	replicatorID, err := operations.GetOperationInputValue[int64](op, durableOperationInputKeyReplicatorID)
+	runID, err := operations.GetOperationInputValue[int64](op, durableOperationInputKeyReplicatorRunID)
 	if err != nil {
-		return fmt.Errorf("Failed getting replicator ID from operation inputs: %w", err)
+		return fmt.Errorf("Failed getting replicator run ID from operation inputs: %w", err)
 	}
 
 	// Iterate over all operations for the bulk replicator run.
@@ -141,9 +140,8 @@ func replicatorFinalizeDurableOperationRunHook(_ context.Context, op *operations
 	}
 
 	// Use a fresh context so the status write always completes, even if the operation context was cancelled.
-	// Only the status is updated here; last_run_date was already set when the operation started.
 	return op.State().DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return dbCluster.UpdateReplicatorLastRunStatus(ctx, tx.Tx(), replicatorID, runStatus)
+		return dbCluster.FinalizeReplicatorStatus(ctx, tx.Tx(), runID, runStatus, time.Now())
 	})
 }
 
@@ -446,7 +444,7 @@ func replicatorRunInstanceRestoreDurableOperationHook(ctx context.Context, op *o
 }
 
 // prepareReplicatorRunOperationArgs builds the operation used to run a replicator.
-func prepareReplicatorRunOperationArgs(ctx context.Context, s *state.State, projectName string, name string, clusterLinkName string, restore bool, replicatorID int64) (*operations.OperationArgs, error) {
+func prepareReplicatorRunOperationArgs(ctx context.Context, s *state.State, projectName string, name string, clusterLinkName string, restore bool, runID int64) (*operations.OperationArgs, error) {
 	// Load all DB state in a single transaction before any network I/O.
 	var clusterLink *api.ClusterLink
 	var targetCert *x509.Certificate
@@ -603,7 +601,7 @@ func prepareReplicatorRunOperationArgs(ctx context.Context, s *state.State, proj
 			}
 		}
 
-		return finalizeReplicatorRunOperationArgs(builder, projectName, replicatorURL, replicatorID)
+		return finalizeReplicatorRunOperationArgs(builder, projectName, replicatorURL, runID)
 	}
 
 	// For restore operations the project URL is used as the primary entity URL because the instance may exist on the
@@ -628,10 +626,10 @@ func prepareReplicatorRunOperationArgs(ctx context.Context, s *state.State, proj
 		}
 	}
 
-	return finalizeReplicatorRunOperationArgs(builder, projectName, replicatorURL, replicatorID)
+	return finalizeReplicatorRunOperationArgs(builder, projectName, replicatorURL, runID)
 }
 
-func finalizeReplicatorRunOperationArgs(builder *operations.BulkArgBuilder, projectName string, replicatorURL *api.URL, replicatorID int64) (*operations.OperationArgs, error) {
+func finalizeReplicatorRunOperationArgs(builder *operations.BulkArgBuilder, projectName string, replicatorURL *api.URL, runID int64) (*operations.OperationArgs, error) {
 	builder.IncrementStage()
 	err := builder.AddChildArgs(operations.OperationArgs{
 		ProjectName: projectName,
@@ -639,7 +637,7 @@ func finalizeReplicatorRunOperationArgs(builder *operations.BulkArgBuilder, proj
 		Class:       operationtype.OperationClassDurable,
 		EntityURL:   replicatorURL,
 	}, map[operations.InputKey]any{
-		durableOperationInputKeyReplicatorID: replicatorID,
+		durableOperationInputKeyReplicatorRunID: runID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed preparing replicator finalization operation: %w", err)
@@ -921,9 +919,14 @@ func runScheduledReplicators(ctx context.Context, s *state.State) error {
 			return fmt.Errorf("Failed loading replicator configs: %w", err)
 		}
 
+		lastStatuses, err := dbCluster.GetLastReplicatorStatuses(ctx, tx.Tx(), nil)
+		if err != nil {
+			return fmt.Errorf("Failed loading last replicator statuses: %w", err)
+		}
+
 		apiReplicatorsTx := make([]*api.Replicator, 0, len(replicators))
 		for _, replicator := range replicators {
-			apiReplicatorsTx = append(apiReplicatorsTx, replicator.ToAPI(allConfigs))
+			apiReplicatorsTx = append(apiReplicatorsTx, replicator.ToAPI(allConfigs, lastStatuses))
 		}
 
 		apiReplicators = apiReplicatorsTx
@@ -1016,41 +1019,62 @@ func triggerScheduledReplicator(ctx context.Context, s *state.State, replicator 
 		return fmt.Errorf("Replicator %q has no cluster link configured", replicator.Name)
 	}
 
-	opArgs, err := prepareReplicatorRunOperationArgs(ctx, s, replicator.Project, replicator.Name, clusterLinkName, false, row.Row.ID)
-	if err != nil {
+	// Create a ReplicatorsStatusRow for the replicator to update when it finishes
+	var runID int64
+	err := s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		runID, err = dbCluster.CreateNewReplicatorStatus(ctx, tx.Tx(), row.Row.ID, time.Now(), api.ReplicatorStatusRunning, dbCluster.ReplicatorRunModeScheduled)
 		return err
-	}
-
-	// Set status to Running before scheduling the operation. The operation's RunHook writes
-	// the terminal status (Completed/Failed) when it finishes. If the project has no instances,
-	// the RunHook can complete synchronously inside ScheduleServerOperation before it returns,
-	// writing the terminal status first. By setting Running here, that terminal write always
-	// comes after Running, so the status is never left stuck at Running.
-	err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return dbCluster.UpdateReplicatorLastRun(ctx, tx.Tx(), row.Row.ID, time.Now(), api.ReplicatorStatusRunning)
 	})
 	if err != nil {
-		logger.Warn("Failed updating replicator last run status to running", logger.Ctx{"replicator": replicator.Name, "project": replicator.Project, "err": err})
+		logger.Warn("Failed creating replicator run status data", logger.Ctx{"replicator": replicator.Name, "project": replicator.Project, "err": err})
+		return fmt.Errorf("Failed creating replicator run status data: %w", err)
+	}
+
+	opArgs, err := prepareReplicatorRunOperationArgs(ctx, s, replicator.Project, replicator.Name, clusterLinkName, false, runID)
+	if err != nil {
+		handleReplicatorSchedulingError(s, replicator.Project, replicator.Name, runID, err)
+		return err
 	}
 
 	op, err := operations.ScheduleServerOperation(s, *opArgs)
 	if err != nil {
+		handleReplicatorSchedulingError(s, replicator.Project, replicator.Name, runID, err)
 		if api.StatusErrorCheck(err, http.StatusConflict) {
 			logger.Warn("Skipping scheduled replicator, a run is already in progress", logger.Ctx{"replicator": replicator.Name, "project": replicator.Project})
-			// Don't revert Running: another operation is in progress and owns the status;
-			// it will write its own terminal state when it completes.
 			return nil
 		}
-
-		// Revert Running to Failed so the status doesn't get stuck.
-		_ = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
-			return dbCluster.UpdateReplicatorLastRunStatus(ctx, tx.Tx(), row.Row.ID, api.ReplicatorStatusFailed)
-		})
 
 		return fmt.Errorf("Failed scheduling replicator operation: %w", err)
 	}
 
 	return op.Wait(ctx)
+}
+
+// handleReplicatorSchedulingError finalizes or deletes the replicators_status row for the replicator run, depending on the error.
+// For conflict errors, a replicator is already running, so we don't want to pollute the API last_run_status of the replicator with a failure
+// while waiting for the running operation to finish. For all other errors, the row is set to a failure status and the time is recorded.
+func handleReplicatorSchedulingError(s *state.State, projectName string, replicatorName string, runID int64, err error) {
+	// If there is a conflict, the replicator is already running. In this case we don't want the last run status to be
+	// "failed", because it only failed due to an already running replication job. So we delete the replicators_status_row associated with the run.
+	if api.StatusErrorCheck(err, http.StatusConflict) {
+		err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return query.DeleteOne[dbCluster.ReplicatorsStatusRow](ctx, tx.Tx(), "WHERE id = ?", runID)
+		})
+		if err != nil {
+			logger.Warn("Failed deleting replicator status data when the operation failed to schedule due to conflict", logger.Ctx{"replicator": replicatorName, "project": projectName})
+		}
+
+		return
+	}
+
+	// Otherwise, we mark the run as failed, so that we know an attempt was made.
+	err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.FinalizeReplicatorStatus(ctx, tx.Tx(), runID, api.ReplicatorStatusFailed, time.Now())
+	})
+	if err != nil {
+		logger.Warn("Failed finalizing replicator status data when the operation failed to schedule", logger.Ctx{"replicator": replicatorName, "project": projectName})
+	}
 }
 
 // validateReplicatorModes checks the source and target replica modes for a run.

--- a/lxd/snapshot_common.go
+++ b/lxd/snapshot_common.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/robfig/cron/v3"
-
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 )
@@ -28,9 +26,10 @@ var SnapshotScheduleAliases = map[string]string{
 func snapshotIsScheduledNow(spec string, subjectID int64) bool {
 	var result = false
 
+	now := time.Now()
 	specs := buildCronSpecs(spec, subjectID)
 	for _, curSpec := range specs {
-		isNow, err := cronSpecIsNow(curSpec)
+		isNow, err := shared.CronSpecIsActiveThisMinute(curSpec, now)
 		if err == nil && isNow {
 			result = true
 		}
@@ -95,30 +94,4 @@ func getObfuscatedTimeValuesForSubject(subjectID int64) (minuteResult string, ho
 	}
 
 	return minuteResult, hourResult
-}
-
-func cronSpecIsNow(spec string) (bool, error) {
-	sched, err := cron.ParseStandard(spec)
-	if err != nil {
-		return false, fmt.Errorf("Could not parse cron %q", spec)
-	}
-
-	// Check if it's time to snapshot
-	now := time.Now()
-
-	// Truncate the time now back to the start of the minute.
-	// This is neded because the cron scheduler will add a minute to the scheduled time
-	// and we don't want the next scheduled time to roll over to the next minute and break
-	// the time comparison below.
-	now = now.Truncate(time.Minute)
-
-	// Calculate the next scheduled time based on the snapshots.schedule
-	// pattern and the time now.
-	next := sched.Next(now)
-
-	if !now.Add(time.Minute).Equal(next) {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/flosch/pongo2"
+	"github.com/robfig/cron/v3"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
@@ -1526,4 +1527,24 @@ func ShellQuote(in string) string {
 	// Replace ' with '\'' which translates to:
 	// [End literal string] + [Escaped single quote] + [Start new literal string]
 	return `'` + strings.ReplaceAll(in, `'`, `'\''`) + `'`
+}
+
+// CronSpecIsActiveThisMinute returns true if the next job on the cron schedule ticked over in the last minute.
+// E.g. If the cron specifies that a job should run every hour at 30 minutes past the hour, then this function
+// returns true if the given time is between 30 and 31 minutes past the hour.
+// This is used for tasks that run every minute and check if they have tasks to run according to a cron schedule.
+func CronSpecIsActiveThisMinute(spec string, now time.Time) (bool, error) {
+	sched, err := cron.ParseStandard(spec)
+	if err != nil {
+		return false, fmt.Errorf("Could not parse cron %q: %w", spec, err)
+	}
+
+	// We want to check if the cron spec indicates that a job should be run at the start of this minute, so truncate.
+	now = now.Truncate(time.Minute)
+
+	// Calculate the next scheduled job based on this minute minus one second.
+	next := sched.Next(now.Add(-time.Second))
+
+	// If this minute is equal to the time of the next job, the cron spec is active.
+	return now.Equal(next), nil
 }

--- a/test/godeps/client.list
+++ b/test/godeps/client.list
@@ -29,6 +29,7 @@ github.com/pkg/sftp
 github.com/pkg/sftp/internal/encoding/ssh/filexfer
 github.com/pkg/sftp/internal/encoding/ssh/filexfer/openssh
 github.com/pkg/xattr
+github.com/robfig/cron/v3
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
 github.com/sirupsen/logrus/hooks/writer

--- a/test/godeps/lxc-config.list
+++ b/test/godeps/lxc-config.list
@@ -31,6 +31,7 @@ github.com/pkg/sftp
 github.com/pkg/sftp/internal/encoding/ssh/filexfer
 github.com/pkg/sftp/internal/encoding/ssh/filexfer/openssh
 github.com/pkg/xattr
+github.com/robfig/cron/v3
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
 github.com/sirupsen/logrus/hooks/writer


### PR DESCRIPTION
Adds a `replicators_status` table in preparation for the addition of replicator metrics and updates API handlers to use it.

Depends on #18869 
Depends on #18897 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
