### PR TITLE
client/images: sanitize server-provided image file names (From Incus) (stable-4.0)

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/lxd/shared"
@@ -266,7 +267,8 @@ func lxdDownloadImage(fingerprint string, uri string, userAgent string, client *
 		return nil, err
 	}
 	resp.MetaSize = size
-	resp.MetaName = filename
+	// Basename the server-provided name to prevent path traversal.
+	resp.MetaName = filepath.Base(filename)
 
 	// Check the hash
 	hash := fmt.Sprintf("%x", sha256.Sum(nil))

--- a/client/lxd_images_test.go
+++ b/client/lxd_images_test.go
@@ -1,0 +1,154 @@
+package lxd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newUnifiedImageResponse(t *testing.T, filename string, content []byte) *http.Response {
+	t.Helper()
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":        []string{"application/octet-stream"},
+			"Content-Disposition": []string{`attachment; filename="` + filename + `"`},
+		},
+		Body: io.NopCloser(bytes.NewReader(content)),
+	}
+}
+
+func newSplitImageResponse(t *testing.T, metaName string, metaContent []byte, rootfsName string, rootfsContent []byte) *http.Response {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+
+	part, err := mw.CreateFormFile("metadata", metaName)
+	require.NoError(t, err)
+	_, err = part.Write(metaContent)
+	require.NoError(t, err)
+
+	part, err = mw.CreateFormFile("rootfs", rootfsName)
+	require.NoError(t, err)
+	_, err = part.Write(rootfsContent)
+	require.NoError(t, err)
+
+	require.NoError(t, mw.Close())
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{mw.FormDataContentType()}},
+		Body:       io.NopCloser(body),
+	}
+}
+
+func fingerprint(t *testing.T, contents ...[]byte) string {
+	t.Helper()
+	hash := sha256.New()
+	for _, content := range contents {
+		_, err := hash.Write(content)
+		require.NoError(t, err)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func TestLXDDownloadImageSanitizesNames(t *testing.T) {
+	metaContent := []byte("metadata")
+	rootfsContent := []byte("rootfs")
+	uFp := fingerprint(t, metaContent)
+	sFp := fingerprint(t, metaContent, rootfsContent)
+	fpToAddr := func(fp string) string { return "http://localhost/1.0/images/" + fp + "/export" }
+
+	tests := []struct {
+		name           string
+		response       func(t *testing.T) *http.Response
+		fp             string
+		wantMetaName   string
+		wantRootfsName string
+	}{
+		{
+			name: "unified image with an absolute path",
+			response: func(t *testing.T) *http.Response {
+				return newUnifiedImageResponse(t, "/etc/cron.d/evil.tar.gz", metaContent)
+			},
+			fp:           uFp,
+			wantMetaName: "evil.tar.gz",
+		},
+		{
+			name: "unified image with a trailing slash",
+			response: func(t *testing.T) *http.Response {
+				return newUnifiedImageResponse(t, "/etc/cron.d/evil.tar.gz/", metaContent)
+			},
+			fp:           uFp,
+			wantMetaName: "evil.tar.gz",
+		},
+
+		{
+			name: "unified image with a relative path",
+			response: func(t *testing.T) *http.Response {
+				return newUnifiedImageResponse(t, "../../evil.tar.gz", metaContent)
+			},
+			fp:           uFp,
+			wantMetaName: "evil.tar.gz",
+		},
+		{
+			name: "split image with absolute and relative paths",
+			response: func(t *testing.T) *http.Response {
+				return newSplitImageResponse(t, "/etc/cron.d/evil.tar.gz", metaContent, "../../evil.squashfs", rootfsContent)
+			},
+			fp:             sFp,
+			wantMetaName:   "evil.tar.gz",
+			wantRootfsName: "evil.squashfs",
+		},
+		{
+			name: "split image with trailing slashes",
+			response: func(t *testing.T) *http.Response {
+				return newSplitImageResponse(t, "/etc/cron.d/evil.tar.gz/", metaContent, "/evil.squashfs/", rootfsContent)
+			},
+			fp:             sFp,
+			wantMetaName:   "evil.tar.gz",
+			wantRootfsName: "evil.squashfs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest, err := os.Create(filepath.Join(t.TempDir(), "target.meta"))
+			require.NoError(t, err)
+			defer func() { _ = dest.Close() }()
+
+			destRootfs, err := os.Create(filepath.Join(t.TempDir(), "target.rootfs"))
+			require.NoError(t, err)
+			defer func() { _ = destRootfs.Close() }()
+
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return tt.response(t), nil
+			})}
+
+			req := ImageFileRequest{MetaFile: io.WriteSeeker(dest), RootfsFile: io.WriteSeeker(destRootfs)}
+			resp, err := lxdDownloadImage(tt.fp, fpToAddr(tt.fp), "", client, req)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantMetaName, resp.MetaName)
+			assert.Equal(t, tt.wantRootfsName, resp.RootfsName)
+		})
+	}
+}

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -118,8 +119,8 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 			return nil, err
 		}
 
-		parts := strings.Split(meta.Path, "/")
-		resp.MetaName = parts[len(parts)-1]
+		// Basename the server-provided name to prevent path traversal.
+		resp.MetaName = filepath.Base(meta.Path)
 		resp.MetaSize = size
 	}
 
@@ -176,8 +177,8 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 					return nil, err
 				}
 
-				parts := strings.Split(rootfs.Path, "/")
-				resp.RootfsName = parts[len(parts)-1]
+				// Basename the server-provided name to prevent path traversal.
+				resp.RootfsName = filepath.Base(rootfs.Path)
 				resp.RootfsSize = size
 				downloaded = true
 			}
@@ -190,8 +191,8 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 				return nil, err
 			}
 
-			parts := strings.Split(rootfs.Path, "/")
-			resp.RootfsName = parts[len(parts)-1]
+			// Basename the server-provided name to prevent path traversal.
+			resp.RootfsName = filepath.Base(rootfs.Path)
 			resp.RootfsSize = size
 		}
 	}

--- a/client/simplestreams_images_test.go
+++ b/client/simplestreams_images_test.go
@@ -1,0 +1,272 @@
+package lxd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared/simplestreams"
+)
+
+func computeCombinedFingerprint(metaContent []byte, rootfsContent []byte) string {
+	hash := sha256.New()
+	_, _ = hash.Write(metaContent)
+	_, _ = hash.Write(rootfsContent)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func newTestSimpleStreamsServer(t *testing.T, metaPath string, metaContent []byte, rootfsPath string, rootfsContent []byte, combinedFingerprint string, sourceRootfs []byte, deltaContent []byte) *httptest.Server {
+	t.Helper()
+
+	metaHash := sha256.Sum256(metaContent)
+	rootfsHash := sha256.Sum256(rootfsContent)
+	currentItems := map[string]simplestreams.ProductVersionItem{
+		"lxd.tar.xz": {
+			FileType:              "lxd.tar.xz",
+			HashSha256:            hex.EncodeToString(metaHash[:]),
+			Size:                  int64(len(metaContent)),
+			Path:                  metaPath,
+			LXDHashSha256SquashFs: combinedFingerprint,
+		},
+		"root.squashfs": {
+			FileType:   "squashfs",
+			HashSha256: hex.EncodeToString(rootfsHash[:]),
+			Size:       int64(len(rootfsContent)),
+			Path:       rootfsPath,
+		},
+	}
+
+	versions := map[string]simplestreams.ProductVersion{
+		"20260102_0000": {
+			Items: currentItems,
+		},
+	}
+
+	if deltaContent != nil {
+		sourceMeta := []byte("old-metadata")
+		sourceMetaHash := sha256.Sum256(sourceMeta)
+		sourceRootfsHash := sha256.Sum256(sourceRootfs)
+		sourceFingerprint := computeCombinedFingerprint(sourceMeta, sourceRootfs)
+		deltaHash := sha256.Sum256(deltaContent)
+
+		versions["20260101_0000"] = simplestreams.ProductVersion{
+			Items: map[string]simplestreams.ProductVersionItem{
+				"lxd.tar.xz": {
+					FileType:              "lxd.tar.xz",
+					HashSha256:            hex.EncodeToString(sourceMetaHash[:]),
+					Size:                  int64(len(sourceMeta)),
+					Path:                  "images/test/old-meta.tar.xz",
+					LXDHashSha256SquashFs: sourceFingerprint,
+				},
+				"root.squashfs": {
+					FileType:   "squashfs",
+					HashSha256: hex.EncodeToString(sourceRootfsHash[:]),
+					Size:       int64(len(sourceRootfs)),
+					Path:       "images/test/old-rootfs.squashfs",
+				},
+			},
+		}
+
+		currentItems["root.squashfs.vcdiff"] = simplestreams.ProductVersionItem{
+			FileType:   "squashfs.vcdiff",
+			HashSha256: hex.EncodeToString(deltaHash[:]),
+			Size:       int64(len(deltaContent)),
+			Path:       "images/test/rootfs.vcdiff",
+			DeltaBase:  "20260101_0000",
+		}
+	}
+
+	products := simplestreams.Products{
+		ContentID: "images",
+		DataType:  "image-downloads",
+		Format:    "products:1.0",
+		Products: map[string]simplestreams.Product{
+			"test:amd64:default": {
+				Aliases:         "test",
+				Architecture:    "amd64",
+				OperatingSystem: "Test",
+				Release:         "test",
+				ReleaseTitle:    "Test",
+				Versions:        versions,
+			},
+		},
+	}
+
+	productsJSON, err := json.Marshal(products)
+	require.NoError(t, err)
+
+	index := simplestreams.Stream{
+		Index: map[string]simplestreams.StreamIndex{
+			"images": {
+				DataType: "image-downloads",
+				Path:     "streams/v1/images.json",
+				Products: []string{"test:amd64:default"},
+			},
+		},
+		Format: "index:1.0",
+	}
+
+	indexJSON, err := json.Marshal(index)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/streams/v1/index.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(indexJSON)
+	})
+
+	mux.HandleFunc("/streams/v1/images.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(productsJSON)
+	})
+
+	mux.HandleFunc(path.Clean("/"+metaPath), func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(metaContent)
+	})
+
+	mux.HandleFunc(path.Clean("/"+rootfsPath), func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rootfsContent)
+	})
+
+	if deltaContent != nil {
+		mux.HandleFunc("/images/test/rootfs.vcdiff", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(deltaContent)
+		})
+	}
+
+	return httptest.NewTLSServer(mux)
+}
+
+func newTestSimpleStream(server *httptest.Server) *ProtocolSimpleStreams {
+	return &ProtocolSimpleStreams{
+		ssClient:      simplestreams.NewClient(server.URL, *server.Client(), "test"),
+		http:          server.Client(),
+		httpHost:      server.URL,
+		httpUserAgent: "test",
+	}
+}
+
+func newImageTargets(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+
+	metaFile, err := os.Create(filepath.Join(t.TempDir(), "meta"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = metaFile.Close() })
+
+	rootfsFile, err := os.Create(filepath.Join(t.TempDir(), "rootfs"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootfsFile.Close() })
+
+	return metaFile, rootfsFile
+}
+
+func TestGetImageFileSanitizesFilePaths(t *testing.T) {
+	metaContent := []byte("fake-metadata-content")
+	rootfsContent := []byte("fake-rootfs-content")
+	combinedFingerprint := computeCombinedFingerprint(metaContent, rootfsContent)
+
+	tests := []struct {
+		name           string
+		metaPath       string
+		rootfsPath     string
+		wantMetaName   string
+		wantRootfsName string
+	}{
+		{
+			name:           "absolute paths",
+			metaPath:       "/etc/cron.d/evil.tar.xz",
+			rootfsPath:     "/etc/cron.d/evil.squashfs",
+			wantMetaName:   "evil.tar.xz",
+			wantRootfsName: "evil.squashfs",
+		},
+		{
+			name:           "relative traversal paths",
+			metaPath:       "images/../../evil.tar.xz",
+			rootfsPath:     "images/../../../evil.squashfs",
+			wantMetaName:   "evil.tar.xz",
+			wantRootfsName: "evil.squashfs",
+		},
+		{
+			name:           "trailing slashes",
+			metaPath:       "images/test/evil.tar.xz/",
+			rootfsPath:     "images/test/evil.squashfs/",
+			wantMetaName:   "evil.tar.xz",
+			wantRootfsName: "evil.squashfs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestSimpleStreamsServer(t, tt.metaPath, metaContent, tt.rootfsPath, rootfsContent, combinedFingerprint, nil, nil)
+			defer server.Close()
+
+			metaFile, rootfsFile := newImageTargets(t)
+			resp, err := newTestSimpleStream(server).GetImageFile(combinedFingerprint, ImageFileRequest{
+				MetaFile:   metaFile,
+				RootfsFile: rootfsFile,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMetaName, resp.MetaName)
+			assert.Equal(t, tt.wantRootfsName, resp.RootfsName)
+		})
+	}
+}
+
+func TestGetImageFileDeltaSanitizesRootfsPath(t *testing.T) {
+	if _, err := exec.LookPath("xdelta3"); err != nil {
+		t.Skip("Missing xdelta3")
+	}
+
+	sourceRootfs := []byte("source-rootfs-content-for-delta-test")
+	newRootfs := []byte("new-rootfs-content-for-delta-test")
+	newMeta := []byte("new-metadata-content")
+
+	tmpDir := t.TempDir()
+	sourcePath := filepath.Join(tmpDir, "source.squashfs")
+	newPath := filepath.Join(tmpDir, "new.squashfs")
+	deltaPath := filepath.Join(tmpDir, "delta.vcdiff")
+	require.NoError(t, os.WriteFile(sourcePath, sourceRootfs, 0600))
+	require.NoError(t, os.WriteFile(newPath, newRootfs, 0600))
+
+	output, err := exec.Command("xdelta3", "-f", "-e", "-s", sourcePath, newPath, deltaPath).CombinedOutput()
+	require.NoError(t, err, "xdelta3 encode failed: %s", string(output))
+
+	deltaContent, err := os.ReadFile(deltaPath)
+	require.NoError(t, err)
+
+	combinedFingerprint := computeCombinedFingerprint(newMeta, newRootfs)
+	server := newTestSimpleStreamsServer(t, "images/test/meta.tar.xz", newMeta, "/etc/cron.d/evil.squashfs/", newRootfs, combinedFingerprint, sourceRootfs, deltaContent)
+	defer server.Close()
+
+	sourceMeta := []byte("old-metadata")
+	sourceFingerprint := computeCombinedFingerprint(sourceMeta, sourceRootfs)
+	cachedRootfsPath := filepath.Join(tmpDir, "cached-rootfs.squashfs")
+	require.NoError(t, os.WriteFile(cachedRootfsPath, sourceRootfs, 0600))
+
+	metaFile, rootfsFile := newImageTargets(t)
+	resp, err := newTestSimpleStream(server).GetImageFile(combinedFingerprint, ImageFileRequest{
+		MetaFile:   metaFile,
+		RootfsFile: rootfsFile,
+		DeltaSourceRetriever: func(fingerprint string, filename string) string {
+			if fingerprint == sourceFingerprint && filename == "rootfs" {
+				return cachedRootfsPath
+			}
+
+			return ""
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "meta.tar.xz", resp.MetaName)
+	assert.Equal(t, "evil.squashfs", resp.RootfsName)
+	assert.Equal(t, int64(len(newRootfs)), resp.RootfsSize)
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

This sanitizes the server-supplied MetaName in the response to an lxd image request to include only a possible file name and no path components. There are also new unit tests to verify the behavior.

This addresses GHSA-g4cm-f533-78hq.