### PR TITLE
lxd/instance/drivers/lxc: `s/stopForkfile/StopForkFile/` (stable-5.21)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2982,7 +2982,7 @@ func (d *lxc) Restart(timeout time.Duration) error {
 func (d *lxc) Rebuild(img *api.Image, op *operations.Operation) error {
 	// Rebuild assumes instance is stopped.  But a stopped instance could still have a running
 	// forkfile.  So stop the forkfile.
-	d.stopForkfile(false)
+	d.StopForkFile(false)
 	return d.rebuildCommon(d, img, op)
 }
 


### PR DESCRIPTION
Fixes 10bd3d3cb95d8b3d32da2772edf2eec8c73b51c5