### PR TITLE
lxd/auth_groups: Allow adding server admin permission to admins group

### DIFF
--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -62,6 +62,27 @@ var authGroupCmd = APIEndpoint{
 	},
 }
 
+// isServerAdminPermission returns true if p grants the "admin" entitlement on the server entity.
+func isServerAdminPermission(p api.Permission) bool {
+	return p.EntityType == string(entity.TypeServer) && p.Entitlement == string(auth.EntitlementAdmin)
+}
+
+// hasServerAdminPermission returns true if permissions contains the server admin permission.
+func hasServerAdminPermission(permissions []api.Permission) bool {
+	return slices.ContainsFunc(permissions, isServerAdminPermission)
+}
+
+// validateAdminsGroupPermissions ensures that the desired permissions for the admins group consist of
+// exactly the server admin permission (and nothing else). This is used when creating the admins group or
+// when granting the server admin permission to an admins group that does not yet have it.
+func validateAdminsGroupPermissions(permissions []api.Permission) error {
+	if len(permissions) != 1 || !isServerAdminPermission(permissions[0]) {
+		return api.StatusErrorf(http.StatusBadRequest, "The admins group can only be granted the server admin permission")
+	}
+
+	return nil
+}
+
 func validateGroupName(name string) error {
 	if name == "" {
 		return api.StatusErrorf(http.StatusBadRequest, "Group name cannot be empty")
@@ -334,6 +355,16 @@ func createAuthGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// The admins group is a built-in group. It may be created without permissions (e.g. by users
+	// upgrading from a version of LXD that predates the built-in admins group), but if permissions
+	// are provided at creation time they must consist of exactly the server admin permission.
+	if group.Name == api.AuthGroupAdminsName && len(group.Permissions) > 0 {
+		err = validateAdminsGroupPermissions(group.Permissions)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	s := d.State()
 	validatedPermissions, err := validatePermissions(r.Context(), s, group.Permissions)
 	if err != nil {
@@ -478,9 +509,6 @@ func getAuthGroup(d *Daemon, r *http.Request) response.Response {
 func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 	groupName := r.PathValue("groupName")
 	var err error
-	if groupName == api.AuthGroupAdminsName {
-		return response.BadRequest(errors.New("The admins group cannot be modified"))
-	}
 
 	var groupPut api.AuthGroupPut
 	err = json.NewDecoder(r.Body).Decode(&groupPut)
@@ -518,6 +546,22 @@ func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 		err = util.EtagCheck(r, *apiGroup)
 		if err != nil {
 			return err
+		}
+
+		// The admins group is a built-in group with special semantics. Once it has been granted the
+		// server admin permission it becomes immutable. It may still be updated to grant the server
+		// admin permission if it does not yet have it (for example when the group has been created
+		// manually on an installation that was upgraded from a version of LXD that did not seed the
+		// admins group automatically).
+		if groupName == api.AuthGroupAdminsName {
+			if hasServerAdminPermission(apiGroup.Permissions) {
+				return api.StatusErrorf(http.StatusBadRequest, "The admins group cannot be modified")
+			}
+
+			err = validateAdminsGroupPermissions(groupPut.Permissions)
+			if err != nil {
+				return err
+			}
 		}
 
 		group.Description = groupPut.Description
@@ -577,9 +621,6 @@ func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
 	groupName := r.PathValue("groupName")
 	var err error
-	if groupName == api.AuthGroupAdminsName {
-		return response.BadRequest(errors.New("The admins group cannot be modified"))
-	}
 
 	var groupPut api.AuthGroupPut
 	err = json.NewDecoder(r.Body).Decode(&groupPut)
@@ -614,6 +655,22 @@ func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
 		err = util.EtagCheck(r, *apiGroup)
 		if err != nil {
 			return err
+		}
+
+		// The admins group is a built-in group with special semantics. Once it has been granted the
+		// server admin permission it becomes immutable. It may still be patched to grant the server
+		// admin permission if it does not yet have it (for example when the group has been created
+		// manually on an installation that was upgraded from a version of LXD that did not seed the
+		// admins group automatically).
+		if groupName == api.AuthGroupAdminsName {
+			if hasServerAdminPermission(apiGroup.Permissions) {
+				return api.StatusErrorf(http.StatusBadRequest, "The admins group cannot be modified")
+			}
+
+			err = validateAdminsGroupPermissions(groupPut.Permissions)
+			if err != nil {
+				return err
+			}
 		}
 
 		for _, permission := range groupPut.Permissions {

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -99,6 +99,64 @@ test_authorization() {
   lxc auth group permission remove test-group project default can_view
   lxc network rm n1
 
+  ### BUILT-IN ADMINS GROUP ###
+  admins_group="admins"
+  admins_url="/1.0/auth/groups/${admins_group}"
+  server_admin_permission='{"entity_type": "server", "url": "/1.0", "entitlement": "admin"}'
+  project_operator_permission='{"entity_type": "project", "url": "/1.0/projects/default", "entitlement": "operator"}'
+
+  sub_test "The admins group is seeded with the server admin permission and is immutable"
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+  [ "$("${_LXC}" query -X POST "${admins_url}" -d '{"name": "not-admins"}' 2>&1 >/dev/null)" = 'Error: The admins group cannot be renamed' ]
+  [ "$("${_LXC}" query -X DELETE "${admins_url}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be deleted' ]
+
+  # Even a no-op update is rejected while the group holds the server admin permission.
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be modified' ]
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d "{\"description\": \"Not allowed\", \"permissions\": [${server_admin_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be modified' ]
+  [ "$("${_LXC}" query -X PATCH "${admins_url}" -d "{\"permissions\": [${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be modified' ]
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+
+  sub_test "The admins group can be granted the server admin permission if it does not have it"
+  # Simulate an installation that was upgraded from a LXD version that did not seed the admins group permissions.
+  lxd sql global "DELETE FROM auth_groups_permissions WHERE auth_group_id = (SELECT id FROM auth_groups WHERE name = '${admins_group}')"
+  lxc query "${admins_url}" | jq --exit-status '.permissions == []'
+
+  # Only the server admin permission (and nothing else) may be granted.
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d '{"permissions": []}' 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d "{\"permissions\": [${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d "{\"permissions\": [${server_admin_permission}, ${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+  [ "$("${_LXC}" query -X PATCH "${admins_url}" -d "{\"permissions\": [${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+  lxc query "${admins_url}" | jq --exit-status '.permissions == []'
+
+  # PATCH with exactly the server admin permission is allowed, and makes the group immutable again.
+  lxc query -X PATCH "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}"
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+  [ "$("${_LXC}" query -X PATCH "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be modified' ]
+
+  # PUT with exactly the server admin permission is allowed too.
+  lxd sql global "DELETE FROM auth_groups_permissions WHERE auth_group_id = (SELECT id FROM auth_groups WHERE name = '${admins_group}')"
+  lxc query -X PUT "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}"
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+  [ "$("${_LXC}" query -X PUT "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group cannot be modified' ]
+
+  sub_test "The admins group can only be created with no permissions or the server admin permission"
+  # Simulate an installation that was upgraded from a LXD version that predates the built-in admins group.
+  lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM auth_groups WHERE name = '${admins_group}'"
+  [ "$("${_LXC}" query -X POST /1.0/auth/groups -d "{\"name\": \"${admins_group}\", \"permissions\": [${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+  [ "$("${_LXC}" query -X POST /1.0/auth/groups -d "{\"name\": \"${admins_group}\", \"permissions\": [${server_admin_permission}, ${project_operator_permission}]}" 2>&1 >/dev/null)" = 'Error: The admins group can only be granted the server admin permission' ]
+
+  # Creating the group without permissions is allowed, it can then be granted the server admin permission.
+  lxc auth group create "${admins_group}"
+  lxc query "${admins_url}" | jq --exit-status '.permissions == []'
+  lxc query -X PUT "${admins_url}" -d "{\"permissions\": [${server_admin_permission}]}"
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+
+  # Creating the group with exactly the server admin permission is allowed.
+  lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM auth_groups WHERE name = '${admins_group}'"
+  lxc query -X POST /1.0/auth/groups -d "{\"name\": \"${admins_group}\", \"description\": \"Server administrators\", \"permissions\": [${server_admin_permission}]}"
+  lxc query "${admins_url}" | jq --exit-status ".permissions == [${server_admin_permission}]"
+  lxc query "${admins_url}" | jq --exit-status '.description == "Server administrators"'
+
   ### IDENTITY MANAGEMENT ###
   lxc config trust show "${tls_user_fingerprint}"
   ! lxc auth identity group add "tls/${tls_user_fingerprint}" test-group || false # TLS identities cannot be added to groups (yet).


### PR DESCRIPTION
## Done

- lxd/auth_groups: Allow adding server admin permission to admins group
- This fixes a scenario where a user updated from an earlier LXD version that did not have the auth group `admins`. Previously, a user could create the `admins` group and use it. But never add permissions to it. Creating an empty permission group. This PR allows adding the `server admin` permission to the group if the group has no permissions.

Fixes https://github.com/canonical/lxd-ui/issues/2073

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
