### PR TITLE
Project network profile isolation

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4184,7 +4184,7 @@ This setting applies to both images and image aliases.
 :initialvaluedesc: "`false`"
 :shortdesc: "Whether to use a separate set of networks for the project"
 :type: "bool"
-
+This feature requires `features.profiles` to be enabled.
 ```
 
 ```{config:option} features.networks.zones project-features

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1837,7 +1837,7 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 		//  shortdesc: Whether to use a separate set of storage buckets for the project
 		"features.storage.buckets": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=project; group=features; key=features.networks)
-		//
+		// This feature requires `features.profiles` to be enabled.
 		// ---
 		//  type: bool
 		//  defaultdesc: `false`
@@ -2279,6 +2279,12 @@ func projectValidateConfig(ctx context.Context, s *state.State, config map[strin
 		if err != nil {
 			return fmt.Errorf("Invalid project configuration key %q value: %w", k, err)
 		}
+	}
+
+	// Ensure that projects with their own networks also have their own profiles. Otherwise the profiles of the
+	// default project could reference networks that do not exist in this project.
+	if shared.IsTrue(config["features.networks"]) && shared.IsFalseOrEmpty(config["features.profiles"]) {
+		return errors.New("Projects without their own profiles cannot have their own networks")
 	}
 
 	// Ensure that restricted projects have their own profiles. Otherwise restrictions in this project could

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4692,7 +4692,7 @@
 						"features.networks": {
 							"defaultdesc": "`false`",
 							"initialvaluedesc": "`false`",
-							"longdesc": "",
+							"longdesc": "This feature requires `features.profiles` to be enabled.",
 							"shortdesc": "Whether to use a separate set of networks for the project",
 							"type": "bool"
 						}

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -726,7 +726,7 @@ test_network_ovn() {
   echo "Create project for following tests."
   lxc project create testovn \
     -c features.images=false \
-    -c features.profiles=false \
+    -c features.profiles=true \
     -c features.storage.volumes=false
 
   lxc project switch testovn
@@ -738,7 +738,6 @@ test_network_ovn() {
   lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}"=3 limits.networks.uplink_ips.ipv6."${uplink_network}"=3
 
   # We cannot restrict a project with uplink IP limits set.
-  lxc project set testovn features.profiles true # Needed to restrict project
   ! lxc project set testovn restricted true || false
   lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}"= limits.networks.uplink_ips.ipv6."${uplink_network}"=
 
@@ -795,7 +794,6 @@ test_network_ovn() {
   ! lxc project unset testovn restricted.networks.uplinks || false # Cannot unset while having limits set for the uplink network.
   lxc project set testovn restricted false
   lxc project set testovn restricted.networks.uplinks= limits.networks.uplink_ips.ipv4."${uplink_network}"= limits.networks.uplink_ips.ipv6."${uplink_network}"=
-  lxc project set testovn features.profiles false
 
   echo "Create an OVN network isolated in a project."
   project_ovn_network="project-ovn$$"

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -485,6 +485,20 @@ test_projects_profiles_default() {
 
   # Ensure failure when --network and features.networks=true used together
   ! lxc project create bar --network lxdbr0 -c features.networks=true || false
+
+  sub_test "features.networks requires features.profiles"
+
+  # Ensure failure when features.networks=true and features.profiles=false used together
+  ! lxc project create bar -c features.networks=true -c features.profiles=false || false
+
+  # Ensure features.profiles cannot be disabled while features.networks is enabled
+  lxc project create bar -c features.networks=true
+  ! lxc project set bar features.profiles false || false
+  ! lxc project unset bar features.profiles || false
+
+  # Disabling both features at once is allowed
+  lxc project set bar features.networks=false features.profiles=false
+  lxc project delete bar
 }
 
 # Use private images in a project.


### PR DESCRIPTION
## Done

- Project network isolation makes it mandatory to also have profile isolation enabled

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
