### PR TITLE
lxd/network/driver_ovn: expose stats on traffic

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -35,6 +35,7 @@ import (
 	"github.com/canonical/lxd/lxd/network/openvswitch"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -195,15 +196,51 @@ func (n *ovn) State() (*api.NetworkState, error) {
 		mtu = 1500
 	}
 
+	counters, err := n.counters()
+	if err != nil {
+		return nil, err
+	}
+
 	return &api.NetworkState{
 		Addresses: addresses,
-		Counters:  api.NetworkStateCounters{},
+		Counters:  counters,
 		Hwaddr:    hwaddr,
 		Mtu:       mtu,
 		State:     "up",
 		Type:      "broadcast",
 		OVN:       &api.NetworkStateOVN{Chassis: chassis},
 	}, nil
+}
+
+// counters returns the aggregated traffic counters for the OVN network from the instance NICs attached
+// to the current member.
+func (n *ovn) counters() (api.NetworkStateCounters, error) {
+	counters := api.NetworkStateCounters{}
+	filter := dbCluster.InstanceFilter{Node: &n.state.ServerName}
+
+	err := UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+		hostName := inst.Config[fmt.Sprintf("volatile.%s.host_name", nicName)]
+		if hostName == "" {
+			return nil
+		}
+
+		hostCounters, err := resources.GetNetworkCounters(hostName)
+		if err != nil {
+			return fmt.Errorf("Failed getting network counters for %q: %w", hostName, err)
+		}
+
+		counters.BytesReceived += hostCounters.BytesReceived
+		counters.BytesSent += hostCounters.BytesSent
+		counters.PacketsReceived += hostCounters.PacketsReceived
+		counters.PacketsSent += hostCounters.PacketsSent
+
+		return nil
+	}, filter)
+	if err != nil {
+		return counters, err
+	}
+
+	return counters, nil
 }
 
 // uplinkRoutes parses ipv4.routes and ipv6.routes settings for an uplink network into a slice of *net.IPNet.


### PR DESCRIPTION
# Done
- lxd/network/driver_ovn: expose stats on traffic
- Previously, network status would always return 0 on OVN networks
- surprisingly simple to get the stats from the system

Fixes https://github.com/canonical/lxd-ui/issues/2275

Tested locally and can see `Network usage` is reporting stats for OVN:

```
root@ovn-latest:~# lxc network ls
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
|  NAME   |  TYPE  | MANAGED |      IPV4       |           IPV6            | DESCRIPTION | USED BY |  STATE  |
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
| abc     | ovn    | YES     | 10.60.117.1/24  | fd42:5395:c400:b1bf::1/64 |             | 3       | CREATED |
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
| br-int  | bridge | NO      |                 |                           |             | 0       |         |
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
| lxdbr0  | bridge | YES     | 10.102.252.1/24 | fd42:eba4:2b67:ebe::1/64  |             | 1       | CREATED |
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
| lxdovn1 | bridge | NO      |                 |                           |             | 0       |         |
+---------+--------+---------+-----------------+---------------------------+-------------+---------+---------+
root@ovn-latest:~# lxc network info abc
Name: abc
MAC address: 00:16:3e:ea:cd:55
MTU: 1442
State: up
Type: broadcast

IP addresses:
  inet  10.60.117.1/24 (link)
  inet6 fd42:5395:c400:b1bf::1/64 (link)

Network usage:
  Bytes received: 8.51kB
  Bytes sent: 8.89kB
  Packets received: 82
  Packets sent: 82

OVN:
  Chassis: ovn-latest.lxd
  ```
