### PR TITLE
lxc/completion: Add fallback for bash-completion 2.12+ and core26

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -18,6 +19,172 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
+
+// XXX: Workaround for Cobra (spf13/cobra#2213) and bash-completion >= 2.12 under snap confinement.
+// bashCompletionFallback is prepended to Cobra's generated bash completion script.
+// In bash-completion >= 2.12 (shipped in Ubuntu 26.04 / core26), internal functions
+// were renamed (_init_completion -> _comp_initialize, _get_comp_words_by_ref -> _comp_get_words)
+// and moved to 000_bash_completion_compat.bash, which is not available in snap confinement
+// when the host /etc is mounted. Provide guarded compatibility wrappers when absent.
+const bashCompletionFallback = `# bash-completion compatibility fallback.
+if ! declare -F _init_completion >/dev/null 2>&1; then
+    if declare -F _comp_initialize >/dev/null 2>&1; then
+        _init_completion() {
+            local was_split
+            _comp_initialize "$@"
+            local rc=$?
+            local flag OPTIND=1 OPTARG="" OPTERR=0
+            while getopts "n:e:o:i:s" flag "$@"; do
+                case $flag in
+                    [neoi]) ;;
+                    s)
+                        if [[ $was_split ]]; then
+                            split=true
+                        else
+                            split=false
+                        fi
+                        break
+                        ;;
+                esac
+            done
+
+            return "$rc"
+        }
+
+    fi
+fi
+
+if ! declare -F _get_comp_words_by_ref >/dev/null 2>&1; then
+    if declare -F _comp_get_words >/dev/null 2>&1; then
+        _get_comp_words_by_ref() {
+            _comp_get_words "$@"
+        }
+
+    else
+        # Pure-bash word reassembly fallback for environments without bash-completion.
+        _get_comp_words_by_ref() {
+            local exclude="" i w issep attach="" preblank j=-1
+            local line="$COMP_LINE"
+            local -a rebuilt=()
+            local rcword="$COMP_CWORD"
+            if [[ "$1" == "-n" ]]; then
+                exclude="$2"
+                shift 2
+            fi
+
+            for ((i = 0; i < ${#COMP_WORDS[@]}; i++)); do
+                w="${COMP_WORDS[$i]}"
+                preblank=""
+                if [[ "$line" == [[:blank:]]* ]]; then
+                    preblank=1
+                fi
+
+                line="${line#*"$w"}"
+                issep=""
+                if [[ -n "$w" && -n "$exclude" && -z "${w//[$exclude]/}" ]]; then
+                    issep=1
+                fi
+
+                if [[ $j -ge 1 && -z "$preblank" && ( -n "$issep" || -n "$attach" ) ]]; then
+                    rebuilt[$j]="${rebuilt[$j]}$w"
+                else
+                    j=$((j + 1))
+                    rebuilt[$j]="$w"
+                fi
+
+                if [[ $i -eq $COMP_CWORD ]]; then
+                    rcword=$j
+                fi
+
+                attach="$issep"
+            done
+
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                cur)
+                    cur="${rebuilt[$rcword]}"
+                    ;;
+                prev)
+                    prev=""
+                    if [[ $rcword -gt 0 ]]; then
+                        prev="${rebuilt[$((rcword - 1))]}"
+                    fi
+                    ;;
+                words)
+                    words=("${rebuilt[@]}")
+                    ;;
+                cword)
+                    cword="$rcword"
+                    ;;
+                esac
+                shift
+            done
+
+            return 0
+        }
+
+    fi
+fi
+
+if ! declare -F _filedir >/dev/null 2>&1; then
+    if declare -F _comp_compgen >/dev/null 2>&1; then
+        _filedir() {
+            _comp_compgen -a filedir "$@"
+        }
+
+    fi
+fi
+
+`
+
+// setupBashCompletion initializes Cobra's default completion command and wraps
+// its bash subcommand to prepend bashCompletionFallback to the output script.
+func setupBashCompletion(app *cobra.Command) {
+	app.InitDefaultCompletionCmd("completion")
+
+	var completionCmd *cobra.Command
+	for _, cmd := range app.Commands() {
+		if cmd.Name() == "completion" {
+			completionCmd = cmd
+			break
+		}
+	}
+
+	if completionCmd == nil {
+		return
+	}
+
+	var bashCmd *cobra.Command
+	for _, cmd := range completionCmd.Commands() {
+		if cmd.Name() == "bash" {
+			bashCmd = cmd
+			break
+		}
+	}
+
+	if bashCmd == nil {
+		return
+	}
+
+	bashCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		_, err := io.WriteString(out, bashCompletionFallback)
+		if err != nil {
+			return err
+		}
+
+		noDesc := false
+		flag := cmd.Flags().Lookup("no-descriptions")
+		if flag != nil {
+			v, err := cmd.Flags().GetBool("no-descriptions")
+			if err == nil {
+				noDesc = v
+			}
+		}
+
+		return cmd.Root().GenBashCompletionV2(out, !noDesc)
+	}
+}
 
 // handleCompletionError should always be returned when an error occurs in a cobra.CompletionFunc.
 // If the BASH_COMP_DEBUG_FILE environment variable is set, it logs the error message there before returning

--- a/lxc/completion_test.go
+++ b/lxc/completion_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBashCompletionFallbackPreamble(t *testing.T) {
+	app := &cobra.Command{Use: "lxc"}
+	setupBashCompletion(app)
+
+	buf := new(bytes.Buffer)
+	app.SetOut(buf)
+	app.SetArgs([]string{"completion", "bash"})
+
+	err := app.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "_init_completion()")
+	assert.Contains(t, out, "_get_comp_words_by_ref()")
+	assert.Contains(t, out, "_filedir()")
+	assert.Contains(t, out, "__start_lxc")
+	assert.Contains(t, out, "__complete")
+}
+
+func TestBashCompletionNoDescriptions(t *testing.T) {
+	app := &cobra.Command{Use: "lxc"}
+	setupBashCompletion(app)
+
+	buf := new(bytes.Buffer)
+	app.SetOut(buf)
+	app.SetArgs([]string{"completion", "bash", "--no-descriptions"})
+
+	err := app.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "_get_comp_words_by_ref()")
+	assert.Contains(t, out, "__completeNoDesc")
+}
+
+func TestBashCompletionInSubshell(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Bash completion subshell tests are Linux-specific")
+	}
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	app := &cobra.Command{Use: "lxc"}
+	setupBashCompletion(app)
+
+	buf := new(bytes.Buffer)
+	app.SetOut(buf)
+	app.SetArgs([]string{"completion", "bash"})
+
+	err = app.Execute()
+	require.NoError(t, err)
+	script := buf.String()
+
+	t.Run("core26 environment with bash-completion 2.12+", func(t *testing.T) {
+		// Simulates core26 where _comp_initialize and _comp_get_words exist, but _init_completion is undefined.
+		driver := `
+compopt() {
+    return 0
+}
+
+# Mock lxc to return deterministic completion results without invoking the host binary.
+lxc() {
+    if [[ "$1" == "__complete" ]]; then
+        echo "init"
+        echo ":4"
+    fi
+}
+
+_comp_initialize() {
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev=""
+    if [[ $COMP_CWORD -gt 0 ]]; then
+        prev="${COMP_WORDS[$((COMP_CWORD - 1))]}"
+    fi
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+    return 0
+}
+
+_comp_get_words() {
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+    return 0
+}
+
+_comp_compgen() {
+    return 0
+}
+
+source <(cat)
+
+if ! declare -F _init_completion >/dev/null 2>&1; then
+    echo "_init_completion not defined" >&2
+    exit 1
+fi
+
+if ! declare -F _get_comp_words_by_ref >/dev/null 2>&1; then
+    echo "_get_comp_words_by_ref not defined" >&2
+    exit 1
+fi
+
+if ! declare -F _filedir >/dev/null 2>&1; then
+    echo "_filedir not defined" >&2
+    exit 1
+fi
+
+# Simulate invocation
+COMP_WORDS=(lxc list "")
+COMP_CWORD=2
+COMP_LINE="lxc list "
+COMP_POINT=9
+set +e
+__start_lxc lxc list ""
+set -e
+[[ "${COMPREPLY[0]}" == "init" ]] || exit 7
+exit 0
+`
+		cmd := exec.Command(bashPath, "--noprofile", "--norc", "-e", "-c", driver)
+		cmd.Stdin = strings.NewReader(script)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "subshell failed: %s", string(out))
+	})
+
+	t.Run("bare bash without bash-completion", func(t *testing.T) {
+		// Simulates environment with no bash-completion package at all.
+		driver := `
+source <(cat)
+
+if ! declare -F _get_comp_words_by_ref >/dev/null 2>&1; then
+    echo "_get_comp_words_by_ref not defined" >&2
+    exit 1
+fi
+
+# Verify the pure-bash word reassembly fallback
+COMP_WORDS=(lxc list "")
+COMP_CWORD=2
+COMP_LINE="lxc list "
+COMP_POINT=9
+run_reassembly() {
+    local cur prev words cword
+    _get_comp_words_by_ref -n =: cur prev words cword || exit 1
+    [[ "$cur" == "" ]] || exit 2
+    [[ "$prev" == "list" ]] || exit 3
+    [[ "$cword" -eq 2 ]] || exit 4
+    [[ "${#words[@]}" -eq 3 ]] || exit 5
+}
+
+run_reassembly
+`
+		cmd := exec.Command(bashPath, "--noprofile", "--norc", "-e", "-c", driver)
+		cmd.Stdin = strings.NewReader(script)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "subshell failed: %s", string(out))
+	})
+
+	t.Run("existing bash-completion package not overwritten", func(t *testing.T) {
+		driver := `
+_init_completion() { echo "custom_init"; }
+_get_comp_words_by_ref() { echo "custom_words"; }
+_filedir() { echo "custom_filedir"; }
+
+source <(cat)
+
+[[ "$(_init_completion)" == "custom_init" ]] || exit 1
+[[ "$(_get_comp_words_by_ref)" == "custom_words" ]] || exit 2
+[[ "$(_filedir)" == "custom_filedir" ]] || exit 3
+`
+		cmd := exec.Command(bashPath, "--noprofile", "--norc", "-e", "-c", driver)
+		cmd.Stdin = strings.NewReader(script)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "subshell failed: %s", string(out))
+	})
+
+	t.Run("snapcraft completer sed transformation", func(t *testing.T) {
+		// Simulates the exact snapcraft pipeline from snap/snapcraft.yaml and executes
+		// the resulting completer script in a core26-like environment.
+		driver := `
+export TERM="${TERM:-dumb}"
+
+tput() {
+    echo 80
+}
+
+compopt() {
+    return 0
+}
+
+# Mock lxc to return deterministic completion results without invoking the host binary.
+lxc() {
+    if [[ "$1" == "__complete" ]]; then
+        echo "init"
+        echo ":4"
+    fi
+}
+
+set_cmds='s/^\s*complete.*__start_lxc /&lxd.lxc /'
+set_cols='s/# $COLUMNS.*/COLUMN="$(tput cols)"  \# store the current shell width./'
+set_compopt='s|$(type -t compopt)|"builtin"|'
+set_request_comp='s|requestComp="${words\[0\]} __complete ${args\[\*\]}"|requestComp="/snap/lxd/current/commands/lxc __complete ${args[*]}"|'
+
+transformed=$(sed -e "${set_cmds}" -e "${set_cols}" -e "${set_compopt}" -e "${set_request_comp}")
+
+# Verify snapcraft transformations applied
+echo "$transformed" | grep -F "lxd.lxc" >/dev/null || exit 1
+echo "$transformed" | grep -F "/snap/lxd/current/commands/lxc" >/dev/null || exit 2
+
+# Verify fallback is still present
+echo "$transformed" | grep -F "_get_comp_words_by_ref()" >/dev/null || exit 3
+echo "$transformed" | grep -F "_init_completion()" >/dev/null || exit 4
+
+# Now simulate core26 execution inside snap container
+_comp_initialize() {
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev=""
+    if [[ $COMP_CWORD -gt 0 ]]; then
+        prev="${COMP_WORDS[$((COMP_CWORD - 1))]}"
+    fi
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+    return 0
+}
+
+_comp_get_words() {
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+    return 0
+}
+
+_comp_compgen() {
+    return 0
+}
+
+# Replace target command path with lxc for test execution
+transformed_test="${transformed//\/snap\/lxd\/current\/commands\/lxc/lxc}"
+eval "$transformed_test"
+
+# Verify _init_completion was defined by the fallback
+declare -F _init_completion >/dev/null || exit 5
+declare -F _get_comp_words_by_ref >/dev/null || exit 6
+complete -p lxd.lxc >/dev/null || exit 7
+
+# Execute completion for lxd.lxc as snapd does
+COMP_WORDS=(lxd.lxc list "")
+COMP_CWORD=2
+COMP_LINE="lxd.lxc list "
+COMP_POINT=13
+set +e
+__start_lxc lxd.lxc list ""
+set -e
+[[ "${COMPREPLY[0]}" == "init" ]] || exit 8
+`
+		cmd := exec.Command(bashPath, "--noprofile", "--norc", "-e", "-c", driver)
+		cmd.Stdin = strings.NewReader(script)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "subshell failed: %s", string(out))
+	})
+}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -316,6 +316,9 @@ For help with any of those, simply call them with --help.`)
 		}
 	}
 
+	// Setup bash completion
+	setupBashCompletion(app)
+
 	// Help flags
 	app.Flags().BoolVar(&globalCmd.flagHelpAll, "all", false, "Show less common commands")
 	help.Flags().BoolVar(&globalCmd.flagHelpAll, "all", false, "Show less common commands")


### PR DESCRIPTION
Starting in bash-completion 2.12 (as shipped in Ubuntu 26.04 / core26), internal helper functions were renamed (_init_completion to _comp_initialize, _get_comp_words_by_ref to _comp_get_words, and _filedir to _comp_compgen -a filedir). Compatibility wrappers were moved to 000_bash_completion_compat.bash in /etc/bash_completion.d/.

Under snap confinement, the host's /etc is mounted over the snap's /etc, so this compatibility file is absent on hosts running earlier Ubuntu or non-Ubuntu releases. In addition, snapd's AppArmor profile only grants access to `/usr/share/bash-completion/bash_completion`. As a result, Cobra's bash completion fails with:

```
  _get_comp_words_by_ref: command not found
```

Prepend a guarded bash completion compatibility preamble when emitting the bash completion script. If the legacy helper functions are missing:
- Delegate _init_completion to _comp_initialize if present.
- Delegate _get_comp_words_by_ref to _comp_get_words if present, or use a pure-bash word-reassembly fallback for bare bash environments.
- Delegate _filedir to _comp_compgen -a filedir if present.

Closes #18703