### PR TITLE
Restrict image reuse to cached images with identical image source (release-6.9)

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/canonical/lxd/client"
@@ -221,16 +222,30 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 				return nil, fmt.Errorf("Failed adding transferred image %q to local cluster member: %w", imgInfo.Fingerprint, err)
 			}
 		}
-	} else if response.IsNotFoundError(err) {
+	} else if response.IsNotFoundError(err) && args.SetCached && !args.UserRequested && alias != fp && info != nil {
+		// If the image is a candidate to be cached, is not a user requested image copy, has an alias, and we have got the image info from the
+		// given image source, check if we already have the image cached with an identical source.
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			// Check if the image already exists in some other project.
-			_, imgInfo, err = tx.GetImageFromAnyProject(ctx, fp)
-
+			_, imgInfo, err = cluster.GetCachedImageWithSource(ctx, tx.Tx(), fp, args.Server, protocol, alias, args.Certificate)
 			return err
 		})
 		if err == nil {
+			// If there is a cached image already with an identical source, we'll create a record for it in this project.
+			// We need to overwrite all fields of the image with those from the given image source, so that no properties are copied from the other project.
 			var nodeAddress string
 			otherProject := imgInfo.Project
+
+			imgInfo.Project = args.ProjectName
+			imgInfo.Fingerprint = info.Fingerprint
+			imgInfo.Filename = info.Filename
+			imgInfo.Size = info.Size
+			imgInfo.Public = args.Public
+			imgInfo.AutoUpdate = args.AutoUpdate
+			imgInfo.Architecture = info.Architecture
+			imgInfo.CreatedAt = info.CreatedAt
+			imgInfo.ExpiresAt = info.ExpiresAt
+			imgInfo.Properties = info.Properties
+			imgInfo.Type = info.Type
 
 			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				// Check if the image is available locally or it's on another node. Do this before creating
@@ -375,16 +390,33 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 		return nil, err
 	}
 
+	// Check if the file already exists. This can happen if redownloading an image that already exists but is not marked
+	// as cached, or if downloading an identical image from a different source. We have a local lock on the image, so this
+	// is not subject to time-of-check time-of-use errors.
+	var imageFileExists bool
+	_, err = destRoot.Stat(fp)
+	if err == nil {
+		imageFileExists = true
+	}
+
 	defer func() { _ = destRoot.Close() }()
 
-	destFile, err := destRoot.Create(fp)
+	// Set up file names. Use temporary names if the file already exists so that an existing image is not corrupted on
+	// partial download.
+	destFileName := fp
+	destRootfsFileName := fp + ".rootfs"
+	if imageFileExists {
+		destFileName = destFileName + ".tmp"
+		destRootfsFileName = destRootfsFileName + ".tmp"
+	}
+
+	destFile, err := destRoot.Create(destFileName)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() { _ = destFile.Close() }()
 
-	destRootfsFileName := fp + ".rootfs"
 	destRootfsFile, err := destRoot.Create(destRootfsFileName)
 	if err != nil {
 		return nil, err
@@ -396,7 +428,7 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 	defer reverter.Fail()
 
 	reverter.Add(func() {
-		_ = destRoot.Remove(fp)
+		_ = destRoot.Remove(destFileName)
 		_ = destRoot.Remove(destRootfsFileName)
 	})
 
@@ -477,6 +509,22 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 	err = destRootfsFile.Close()
 	if err != nil {
 		return nil, err
+	}
+
+	// Deduplicate image files in case of a re-download
+	if imageFileExists {
+		err = destRoot.Rename(destFileName, strings.TrimSuffix(destFileName, ".tmp"))
+		if err != nil {
+			return nil, err
+		}
+
+		// Only deduplicate the rootfs file for non-unified images (since we have already deleted it otherwise).
+		if resp.RootfsSize > 0 {
+			err = destRoot.Rename(destRootfsFileName, strings.TrimSuffix(destRootfsFileName, ".tmp"))
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Override visiblity

--- a/lxd/db/cluster/images.go
+++ b/lxd/db/cluster/images.go
@@ -5,6 +5,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -169,6 +170,13 @@ var ImageSourceProtocol = map[int]string{
 	2: "simplestreams",
 }
 
+// imageSourceProtocolCode maps image source protocol names to database codes.
+var imageSourceProtocolCode = map[string]int{
+	"lxd":           0,
+	"direct":        1, // Deprecated: kept for backward compatibility with existing data.
+	"simplestreams": 2,
+}
+
 // GetImageSource returns the image source with the given ID.
 func GetImageSource(ctx context.Context, tx *sql.Tx, imageID int) (int, *api.ImageSource, error) {
 	q := `SELECT id, server, protocol, certificate, alias FROM images_source WHERE image_id=?`
@@ -216,4 +224,50 @@ func GetImageSource(ctx context.Context, tx *sql.Tx, imageID int) (int, *api.Ima
 	}
 
 	return source.ID, result, nil
+}
+
+// GetCachedImageWithSource gets a cached image with the given fingerprint and source details.
+func GetCachedImageWithSource(ctx context.Context, tx *sql.Tx, fingerprint string, server string, protocol string, alias string, certificate string) (int, *api.Image, error) {
+	protocolCode, ok := imageSourceProtocolCode[protocol]
+	if !ok {
+		return -1, nil, api.StatusErrorf(http.StatusBadRequest, "Unknown protocol %q", protocol)
+	}
+
+	q := `
+SELECT
+	images.id,
+	projects.name,
+	images.fingerprint,
+	images.type,
+	images.size,
+	images.public,
+	images.architecture,
+	images.creation_date,
+	images.expiry_date,
+	images.upload_date,
+	images.cached,
+	images.last_use_date,
+	images.auto_update
+FROM images
+JOIN projects ON images.project_id = projects.id
+JOIN images_source ON images.id = images_source.image_id
+WHERE images.cached = 1 AND images.fingerprint = ? AND images_source.server = ? AND images_source.protocol = ? AND images_source.alias = ? AND images_source.certificate = ?`
+
+	var image Image
+	row := tx.QueryRowContext(ctx, q, fingerprint, server, protocolCode, alias, certificate)
+	err := row.Scan(&image.ID, &image.Project, &image.Fingerprint, &image.Type, &image.Size, &image.Public, &image.Architecture, &image.CreationDate, &image.ExpiryDate, &image.UploadDate, &image.Cached, &image.LastUseDate, &image.AutoUpdate)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Image not found")
+		}
+
+		return -1, nil, fmt.Errorf("Failed getting cached image with source: %w", err)
+	}
+
+	apiImage, err := image.ToAPI(ctx, tx, "")
+	if err != nil {
+		return -1, nil, fmt.Errorf("Failed getting image API details: %w", err)
+	}
+
+	return image.ID, apiImage, nil
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
