### PR TITLE
Restrict image reuse to cached images with identical image source (stable-5.0)

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
@@ -196,10 +197,27 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 				return nil, fmt.Errorf("Failed adding transferred image %q to local cluster member: %w", imgInfo.Fingerprint, err)
 			}
 		}
-	} else if response.IsNotFoundError(err) {
-		// Check if the image already exists in some other project.
-		_, imgInfo, err = s.DB.Cluster.GetImageFromAnyProject(fp)
+	} else if response.IsNotFoundError(err) && args.SetCached && alias != fp && info != nil {
+		// If the image is a candidate to be cached, is not a user requested image copy, has an alias, and we have got the image info from the
+		// given image source, check if we already have the image cached with an identical source.
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_, imgInfo, err = tx.GetCachedImageWithSource(ctx, fp, args.Server, protocol, alias, args.Certificate)
+			return err
+		})
 		if err == nil {
+			// If there is a cached image already with an identical source, we'll create a record for it in this project.
+			// We need to overwrite all fields of the image with those from the given image source, so that no properties are copied from the other project.
+			imgInfo.Fingerprint = info.Fingerprint
+			imgInfo.Filename = info.Filename
+			imgInfo.Size = info.Size
+			imgInfo.Public = args.Public
+			imgInfo.AutoUpdate = args.AutoUpdate
+			imgInfo.Architecture = info.Architecture
+			imgInfo.CreatedAt = info.CreatedAt
+			imgInfo.ExpiresAt = info.ExpiresAt
+			imgInfo.Properties = info.Properties
+			imgInfo.Type = info.Type
+
 			// Check if the image is available locally or it's on another node. Do this before creating
 			// the missing DB record so we don't include ourself in the search results.
 			nodeAddress, err := s.DB.Cluster.LocateImage(imgInfo.Fingerprint)
@@ -301,16 +319,33 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 		return nil, err
 	}
 
-	defer destRoot.Close()
+	// Check if the file already exists. This can happen if redownloading an image that already exists but is not marked
+	// as cached, or if downloading an identical image from a different source. We have a local lock on the image, so this
+	// is not subject to time-of-check time-of-use errors.
+	var imageFileExists bool
+	_, err = destRoot.Stat(fp)
+	if err == nil {
+		imageFileExists = true
+	}
 
-	destFile, err := destRoot.Create(fp)
+	defer func() { _ = destRoot.Close() }()
+
+	// Set up file names. Use temporary names if the file already exists so that an existing image is not corrupted on
+	// partial download.
+	destFileName := fp
+	destRootfsFileName := fp + ".rootfs"
+	if imageFileExists {
+		destFileName = destFileName + ".tmp"
+		destRootfsFileName = destRootfsFileName + ".tmp"
+	}
+
+	destFile, err := destRoot.Create(destFileName)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() { _ = destFile.Close() }()
 
-	destRootfsFileName := fp + ".rootfs"
 	destRootfsFile, err := destRoot.Create(destRootfsFileName)
 	if err != nil {
 		return nil, err
@@ -322,7 +357,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 	defer reverter.Fail()
 
 	reverter.Add(func() {
-		_ = destRoot.Remove(fp)
+		_ = destRoot.Remove(destFileName)
 		_ = destRoot.Remove(destRootfsFileName)
 	})
 
@@ -349,6 +384,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 		op.SetCanceler(canceler)
 	}
 
+	var metaFileSize, rootfsSize int64
 	if protocol == "lxd" || protocol == "simplestreams" {
 		// Compatibility with older LXD servers
 		if info.Type == "" {
@@ -387,42 +423,9 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 			return nil, err
 		}
 
-		// Truncate down to size
-		if resp.RootfsSize > 0 {
-			err = destRootfsFile.Truncate(resp.RootfsSize)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		err = destFile.Truncate(resp.MetaSize)
-		if err != nil {
-			return nil, err
-		}
-
-		// Deal with unified images
-		if resp.RootfsSize == 0 {
-			err := destRoot.Remove(destRootfsFileName)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		err = destFile.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		err = destRootfsFile.Close()
-		if err != nil {
-			return nil, err
-		}
+		rootfsSize = resp.RootfsSize
+		metaFileSize = resp.MetaSize
 	} else if protocol == "direct" {
-		err := destRoot.Remove(destRootfsFileName)
-		if err != nil {
-			return nil, err
-		}
-
 		// Setup HTTP client
 		httpClient, err := util.HTTPClient(args.Certificate, s.Proxy)
 		if err != nil {
@@ -493,13 +496,55 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 		info.ExpiresAt = time.Unix(imageMeta.ExpiryDate, 0)
 		info.Properties = imageMeta.Properties
 		info.Type = imageType
+	} else {
+		return nil, fmt.Errorf("Unsupported protocol: %v", protocol)
+	}
 
-		err = destFile.Close()
+	// Remove rootfs file if it has zero size (unified image)
+	// Otherwise truncate to expected size.
+	if rootfsSize == 0 {
+		err := destRoot.Remove(destRootfsFileName)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		return nil, fmt.Errorf("Unsupported protocol: %v", protocol)
+		err = destRootfsFile.Truncate(rootfsSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if metaFileSize != 0 {
+		err = destFile.Truncate(metaFileSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = destFile.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	err = destRootfsFile.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// Deduplicate image files in case of a re-download
+	if imageFileExists {
+		err = destRoot.Rename(destFileName, strings.TrimSuffix(destFileName, ".tmp"))
+		if err != nil {
+			return nil, err
+		}
+
+		// Only deduplicate the rootfs file for non-unified images (since we have already deleted it otherwise).
+		if rootfsSize > 0 {
+			err = destRoot.Rename(destRootfsFileName, strings.TrimSuffix(destRootfsFileName, ".tmp"))
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Override visiblity

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1236,3 +1236,67 @@ func (c *ClusterTx) GetProjectsUsingImage(ctx context.Context, fingerprint strin
 
 	return imgProjectNames, nil
 }
+
+// GetCachedImageWithSource gets a cached image with the given fingerprint and source details.
+func (c *ClusterTx) GetCachedImageWithSource(ctx context.Context, fingerprint string, server string, protocol string, alias string, certificate string) (int, *api.Image, error) {
+	var protocolCode uint8
+	switch protocol {
+	case "lxd":
+		protocolCode = 0
+	case "direct":
+		protocolCode = 1
+	case "simplestreams":
+		protocolCode = 2
+	default:
+		return -1, nil, api.StatusErrorf(http.StatusBadRequest, "Unknown protocol %q", protocol)
+	}
+
+	q := `
+SELECT
+	images.id,
+	projects.name,
+	images.fingerprint,
+	images.type,
+	images.size,
+	images.public,
+	images.architecture,
+	images.creation_date,
+	images.expiry_date,
+	images.upload_date,
+	images.cached,
+	images.last_use_date,
+	images.auto_update
+FROM images
+JOIN projects ON images.project_id = projects.id
+JOIN images_source ON images.id = images_source.image_id
+WHERE images.cached = 1 AND images.fingerprint = ? AND images_source.server = ? AND images_source.protocol = ? AND images_source.alias = ? AND images_source.certificate = ?`
+
+	var object cluster.Image
+	row := c.Tx().QueryRowContext(ctx, q, fingerprint, server, protocolCode, alias, certificate)
+	err := row.Scan(&object.ID, &object.Project, &object.Fingerprint, &object.Type, &object.Size, &object.Public, &object.Architecture, &object.CreationDate, &object.ExpiryDate, &object.UploadDate, &object.Cached, &object.LastUseDate, &object.AutoUpdate)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Image not found")
+		}
+
+		return -1, nil, fmt.Errorf("Failed getting cached image with source: %w", err)
+	}
+
+	var image api.Image
+	image.Fingerprint = object.Fingerprint
+	image.Filename = object.Filename
+	image.Size = object.Size
+	image.Cached = object.Cached
+	image.Public = object.Public
+	image.AutoUpdate = object.AutoUpdate
+
+	err = c.imageFill(
+		ctx, object.ID, &image,
+		&object.CreationDate.Time, &object.ExpiryDate.Time, &object.LastUseDate.Time,
+		&object.UploadDate, object.Architecture, object.Type)
+	if err != nil {
+		return -1, nil, fmt.Errorf("Fill image details: %w", err)
+	}
+
+	return object.ID, &image, nil
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
