### PR TITLE
lxd: Cluster link address refresh should run on standalone LXD

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2041,6 +2041,9 @@ func (d *Daemon) init() (err error) {
 
 		// Synchronize operations with the database (minutely)
 		d.tasks.Add(synchronizeOperationsTask(d.State))
+
+		// Refresh cluster link volatile addresses (daily).
+		d.tasks.Add(autoRefreshClusterLinkVolatileAddressesTask(d.State))
 	}
 
 	// Load Ubuntu Pro configuration before starting any instances.
@@ -2159,9 +2162,6 @@ func (d *Daemon) startClusterTasks() {
 
 	// Remove expired OIDC sessions
 	d.clusterTasks.Add(pruneExpiredOIDCSessionsTask(d.State))
-
-	// Refresh cluster link volatile addresses (daily).
-	d.clusterTasks.Add(autoRefreshClusterLinkVolatileAddressesTask(d.State))
 
 	// Start all background tasks
 	d.clusterTasks.Start(d.shutdownCtx)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
