### PR TITLE
github: use new and safer `$/.` syntax for self-repo ref (zizmor)

### DIFF
--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Install LXD build dependencies
       if: ${{ steps.check-build.outputs.needed == 'true' }}
-      uses: ./.github/actions/install-lxd-builddeps
+      uses: $/.github/actions/install-lxd-builddeps
 
     - name: Build LXD dependencies
       if: ${{ steps.check-build.outputs.needed == 'true' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,13 +83,13 @@ jobs:
       # Install C headers and build tools needed to compile LXD's CGO code (Go only).
       - name: Install LXD build dependencies
         if: matrix.language == 'go'
-        uses: ./.github/actions/install-lxd-builddeps
+        uses: $/.github/actions/install-lxd-builddeps
 
       # Build or restore dqlite/liblxc from the daily cache (Go only). On a cache
       # miss the action builds from the checked-out workspace.
       - name: Build or restore dqlite/liblxc dependencies
         if: matrix.language == 'go'
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,10 +44,10 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install build dependencies
-        uses: ./.github/actions/install-lxd-builddeps
+        uses: $/.github/actions/install-lxd-builddeps
 
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
 
       - name: Tune disk performance
-        uses: ./.github/actions/tune-disk-performance
+        uses: $/.github/actions/tune-disk-performance
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
@@ -121,7 +121,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && runner.debug == '1' && !cancelled() }}
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -137,7 +137,7 @@ jobs:
           python-version: '3.x'  # satisfied by any 3.x version already installed
 
       - name: Install build dependencies
-        uses: ./.github/actions/install-lxd-builddeps
+        uses: $/.github/actions/install-lxd-builddeps
 
       - name: Download go dependencies
         run: |
@@ -173,7 +173,7 @@ jobs:
 
       # In code-tests, this action warms the cache for the system-tests job
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
 
@@ -231,13 +231,13 @@ jobs:
         if: env.GOCOVERDIR != '' && github.repository == 'canonical/lxd'
 
       - name: Prime cache with external test images
-        uses: ./.github/actions/download-images
+        uses: $/.github/actions/download-images
         with:
           prime-cache-only: true
           image-cache-dir: ${{ env.IMAGE_CACHE_DIR }}
 
       - name: Prime cache with snap dependencies
-        uses: ./.github/actions/download-snaps
+        uses: $/.github/actions/download-snaps
         with:
           prime-cache-only: true
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
@@ -324,30 +324,30 @@ jobs:
           persist-credentials: false
 
       - name: Tune disk performance
-        uses: ./.github/actions/tune-disk-performance
+        uses: $/.github/actions/tune-disk-performance
 
       - name: Reclaim some memory
-        uses: ./.github/actions/reclaim-memory
+        uses: $/.github/actions/reclaim-memory
 
       - name: Remove docker
-        uses: ./.github/actions/disable-docker
+        uses: $/.github/actions/disable-docker
 
       - name: Install runtime dependencies
-        uses: ./.github/actions/install-lxd-runtimedeps
+        uses: $/.github/actions/install-lxd-runtimedeps
 
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
 
       # Restore the cache warmed in code-tests job
       - name: Download external test images
-        uses: ./.github/actions/download-images
+        uses: $/.github/actions/download-images
         with:
           image-cache-dir: ${{ env.IMAGE_CACHE_DIR }}
 
       # Restore the cache warmed in code-tests job
       - name: Download snap dependencies
-        uses: ./.github/actions/download-snaps
+        uses: $/.github/actions/download-snaps
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -366,13 +366,13 @@ jobs:
 
       - name: Setup MicroCeph
         if: ${{ contains(matrix.backends, 'ceph') || matrix.backends == 'all' }}
-        uses: ./.github/actions/setup-microceph
+        uses: $/.github/actions/setup-microceph
         with:
           osd-count: 3
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Setup MicroOVN
-        uses: ./.github/actions/setup-microovn
+        uses: $/.github/actions/setup-microovn
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -589,7 +589,7 @@ jobs:
           persist-credentials: false
 
       - name: Tune disk performance
-        uses: ./.github/actions/tune-disk-performance
+        uses: $/.github/actions/tune-disk-performance
 
       - name: Checkout lxd-ci
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -600,15 +600,15 @@ jobs:
           persist-credentials: false
 
       - name: Reclaim some memory
-        uses: ./.github/actions/reclaim-memory
+        uses: $/.github/actions/reclaim-memory
 
       - name: Reclaim disk space
         # This can take multiple minutes if the runner is busy/slow so only run it when/where absolutely needed.
         if: ${{ matrix.test == 'conversion' || matrix.test == 'vm-nesting' || startsWith(matrix.test, 'storage-') }}
-        uses: ./.github/actions/reclaim-disk-space
+        uses: $/.github/actions/reclaim-disk-space
 
       - name: Remove docker
-        uses: ./.github/actions/disable-docker
+        uses: $/.github/actions/disable-docker
 
       - name: "Disable br_netfilter"
         run: |
@@ -623,17 +623,17 @@ jobs:
 
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
 
       # Restore the cache warmed in code-tests job
       - name: Download external test images
-        uses: ./.github/actions/download-images
+        uses: $/.github/actions/download-images
         with:
           image-cache-dir: ${{ env.IMAGE_CACHE_DIR }}
 
       # Restore the cache warmed in code-tests job
       - name: Download snap dependencies
-        uses: ./.github/actions/download-snaps
+        uses: $/.github/actions/download-snaps
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -669,13 +669,13 @@ jobs:
 
       - name: Setup MicroCeph
         if: ${{ matrix.test == 'conversion' || matrix.test == 'storage-buckets' || matrix.test == 'storage-vm ceph' || matrix.test == 'storage-volumes-vm' }}
-        uses: ./.github/actions/setup-microceph
+        uses: $/.github/actions/setup-microceph
         with:
           osd-count: 3
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Setup MicroOVN
-        uses: ./.github/actions/setup-microovn
+        uses: $/.github/actions/setup-microovn
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -833,16 +833,16 @@ jobs:
           persist-credentials: false
 
       - name: Tune disk performance
-        uses: ./.github/actions/tune-disk-performance
+        uses: $/.github/actions/tune-disk-performance
 
       - name: Reclaim some memory
-        uses: ./.github/actions/reclaim-memory
+        uses: $/.github/actions/reclaim-memory
 
       - name: Remove docker
-        uses: ./.github/actions/disable-docker
+        uses: $/.github/actions/disable-docker
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -863,7 +863,7 @@ jobs:
 
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
 
@@ -875,7 +875,7 @@ jobs:
           path: /home/runner/go/bin
 
       - name: Install build dependencies
-        uses: ./.github/actions/install-lxd-builddeps
+        uses: $/.github/actions/install-lxd-builddeps
 
       - name: Install dependencies
         run: |
@@ -931,7 +931,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -1055,7 +1055,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -1118,7 +1118,7 @@ jobs:
           persist-credentials: false
 
       - name: Tune disk performance
-        uses: ./.github/actions/tune-disk-performance
+        uses: $/.github/actions/tune-disk-performance
 
       - name: Checkout LXD-UI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1150,13 +1150,13 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Install runtime dependencies
-        uses: ./.github/actions/install-lxd-runtimedeps
+        uses: $/.github/actions/install-lxd-runtimedeps
         with:
           optional: true
 
       # Restore the cache warmed in code-tests job
       - name: Build or restore dqlite/liblxc dependencies
-        uses: ./.github/actions/cache-dqlite-liblxc
+        uses: $/.github/actions/cache-dqlite-liblxc
         with:
           export-env: true
 
@@ -1168,10 +1168,10 @@ jobs:
           path: /home/runner/go/bin
 
       - name: Setup MicroCeph
-        uses: ./.github/actions/setup-microceph
+        uses: $/.github/actions/setup-microceph
 
       - name: Setup MicroOVN
-        uses: ./.github/actions/setup-microovn
+        uses: $/.github/actions/setup-microovn
 
       - name: Set exec perms on LXD binaries
         run: |
@@ -1307,7 +1307,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -1363,7 +1363,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Go
-        uses: ./.github/actions/setup-go
+        uses: $/.github/actions/setup-go
         with:
           snap-channel: ${{ inputs.go-snap-channel }}
 
@@ -1410,7 +1410,7 @@ jobs:
 
       # XXX: from this point onwards in this **specific job**, the private SSH key is
       #      available through the SSH_AUTH_SOCK environment variable.
-      - uses: ./.github/actions/lp-snap-build
+      - uses: $/.github/actions/lp-snap-build
         with:
           repo: "git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd"
           ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}" # zizmor: ignore[secrets-outside-env]


### PR DESCRIPTION
Leverage the new and safer syntax: https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/