### PR TITLE
lxd/cluster: Use member address for cluster link bootstrap

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -378,6 +378,7 @@ UID
 UIDs
 unconfigured
 unevictable
+unicast
 unixgram
 unmanaged
 unmount

--- a/doc/howto/cluster_links_create.md
+++ b/doc/howto/cluster_links_create.md
@@ -10,6 +10,19 @@ myst:
 {ref}`Cluster links <exp-cluster-links>` connect separate LXD clusters.
 There are three link types (bidirectional, unidirectional, and public), each with a different creation flow.
 
+## Network addresses
+
+Cluster links use LXD's existing HTTPS listeners. On a clustered server, link trust tokens
+and bidirectional activation requests advertise the local member's `cluster.https_address`,
+including its port. Address refresh subsequently discovers the remote cluster's member addresses.
+These addresses must be reachable from the linked cluster.
+
+On a standalone server, bootstrap addresses come from `core.https_address`. A wildcard
+listener includes the host's global unicast addresses, which can include internal networks.
+Configure a specific `core.https_address` to restrict these advertised addresses. This also
+restricts the core HTTPS listener; cluster links do not create a separate listener or select
+an outbound source interface.
+
 (howto-cluster-links-auth)=
 ## Prepare authentication
 

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -990,6 +990,23 @@ func clusterLinkCreatePending(s *state.State, r *http.Request, req api.ClusterLi
 	return response.SyncResponseLocation(true, token, lc.Source)
 }
 
+// clusterLinkListenAddresses returns bootstrap addresses for cluster-link tokens and activation.
+// Clustered servers advertise their member address, while standalone servers use the HTTPS listener.
+func clusterLinkListenAddresses(clustered bool, httpsAddress string, clusterAddress string) ([]string, error) {
+	address := httpsAddress
+	configKey := "core.https_address"
+	if clustered {
+		address = clusterAddress
+		configKey = "cluster.https_address"
+	}
+
+	if address == "" {
+		return nil, api.StatusErrorf(http.StatusBadRequest, "Cannot determine advertised address: %q is not configured", configKey)
+	}
+
+	return util.ListenAddresses(address)
+}
+
 // clusterLinkCreateActive handles a request to create an active cluster link (name and trust token provided).
 // It validates the remote cluster certificate, creates the identity and cluster link locally, then activates the pending cluster link on the remote cluster.
 func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLinksPost, clusterLinkType dbCluster.ClusterLinkType, networkCert *shared.CertInfo, notify identityNotificationFunc, requestor *api.EventLifecycleRequestor, trustToken *api.CertificateAddToken) response.Response {
@@ -1017,6 +1034,11 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 	clusterCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
 
 	fingerprint, err := validateIdentityCert(networkCert, clusterCert)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	listenAddresses, err := clusterLinkListenAddresses(s.ServerClustered, s.LocalConfig.HTTPSAddress(), s.LocalConfig.ClusterAddress())
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1083,12 +1105,6 @@ func clusterLinkCreateActive(s *state.State, r *http.Request, req api.ClusterLin
 			logger.Warn("Failed cleaning up cluster link after activation failure", logger.Ctx{"err": err, "clusterLinkName": req.Name, "fingerprint": fingerprint})
 		}
 	})
-
-	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
-	listenAddresses, err := util.ListenAddresses(localHTTPSAddress)
-	if err != nil {
-		return response.InternalError(err)
-	}
 
 	activationErrs := make([]error, 0, len(trustToken.Addresses))
 

--- a/lxd/api_cluster_link_test.go
+++ b/lxd/api_cluster_link_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -233,4 +236,49 @@ func TestClusterLinkValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClusterLinkListenAddresses(t *testing.T) {
+	tests := []struct {
+		name           string
+		clustered      bool
+		httpsAddress   string
+		clusterAddress string
+		want           []string
+		wantErr        string
+	}{
+		{name: "clustered wildcard HTTPS", clustered: true, httpsAddress: "0.0.0.0:8443", clusterAddress: "192.0.2.1:9443", want: []string{"192.0.2.1:9443"}},
+		{name: "clustered distinct HTTPS", clustered: true, httpsAddress: "192.0.2.2:8443", clusterAddress: "192.0.2.1:9443", want: []string{"192.0.2.1:9443"}},
+		{name: "clustered IPv6", clustered: true, httpsAddress: "[::]:8443", clusterAddress: "[2001:db8::1]:9443", want: []string{"[2001:db8::1]:9443"}},
+		{name: "clustered default port", clustered: true, clusterAddress: "192.0.2.1", want: []string{"192.0.2.1:8443"}},
+		{name: "clustered HTTPS disabled", clustered: true, clusterAddress: "192.0.2.1:9443", want: []string{"192.0.2.1:9443"}},
+		{name: "clustered missing address", clustered: true, httpsAddress: "0.0.0.0:8443", wantErr: "Cannot determine advertised address: \"cluster.https_address\" is not configured"},
+		{name: "standalone explicit HTTPS", httpsAddress: "192.0.2.2:9443", clusterAddress: "192.0.2.1:8443", want: []string{"192.0.2.2:9443"}},
+		{name: "standalone IPv6", httpsAddress: "[2001:db8::2]:9443", want: []string{"[2001:db8::2]:9443"}},
+		{name: "standalone default port", httpsAddress: "192.0.2.2", want: []string{"192.0.2.2:8443"}},
+		{name: "standalone HTTPS disabled", clusterAddress: "192.0.2.1:8443", wantErr: "Cannot determine advertised address: \"core.https_address\" is not configured"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addresses, err := clusterLinkListenAddresses(tt.clustered, tt.httpsAddress, tt.clusterAddress)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.True(t, api.StatusErrorCheck(err, http.StatusBadRequest))
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, addresses)
+		})
+	}
+
+	t.Run("standalone wildcard retains listener discovery", func(t *testing.T) {
+		want, err := util.ListenAddresses("0.0.0.0:9443")
+		require.NoError(t, err)
+
+		addresses, err := clusterLinkListenAddresses(false, "0.0.0.0:9443", "192.0.2.1:8443")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, want, addresses)
+	})
 }

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -787,17 +787,22 @@ func createIdentityTLSTrusted(ctx context.Context, s *state.State, peerCertifica
 }
 
 func createCertificateAddToken(s *state.State, clientName string, identityType string) (*api.CertificateAddToken, error) {
-	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
+	var addresses []string
+	var err error
+	if identityType == api.IdentityTypeCertificateClusterLink {
+		addresses, err = clusterLinkListenAddresses(s.ServerClustered, s.LocalConfig.HTTPSAddress(), s.LocalConfig.ClusterAddress())
+	} else {
+		localHTTPSAddress := s.LocalConfig.HTTPSAddress()
 
-	// Tokens are useless if the server isn't listening (how will the untrusted client contact the server?)
-	if localHTTPSAddress == "" {
-		return nil, api.NewStatusError(http.StatusBadRequest, "Cannot issue token when server is not listening on network")
+		// Tokens are useless if the server is not listening on the network.
+		if localHTTPSAddress == "" {
+			return nil, api.NewStatusError(http.StatusBadRequest, "Cannot issue token when server is not listening on network")
+		}
+
+		// Include all HTTPS listener addresses so clients can find a reachable endpoint.
+		addresses, err = util.ListenAddresses(localHTTPSAddress)
 	}
 
-	// Get all addresses the server is listening on. This is encoded in the certificate token,
-	// so that the client will not have to specify a server address. The client will iterate
-	// through all these addresses until it can connect to one of them.
-	addresses, err := util.ListenAddresses(localHTTPSAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -5582,6 +5582,22 @@ test_clustering_link_auth() {
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -cwF 'node1')" = 1 ]
 
+  sub_test "Check client tokens retain the core HTTPS address"
+
+  LXD_ONE_CORE_ADDR="127.0.0.1:$(local_tcp_port)"
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.https_address "${LXD_ONE_CORE_ADDR}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth identity create tls/link-address-client --quiet | base64 -d | jq --exit-status --arg address "${LXD_ONE_CORE_ADDR}" '.addresses == [$address]'
+  LXD_DIR="${LXD_ONE_DIR}" lxc auth identity delete tls/link-address-client
+
+  sub_test "Check cluster link tokens work without a core HTTPS listener"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset core.https_address
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create cluster-only --quiet | base64 -d | jq --exit-status --arg address "${LXD_ONE_ADDR}" '.addresses == [$address]'
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete cluster-only
+
+  # Keep the member address explicit while exposing the core API on all IPv4 interfaces.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set core.https_address "0.0.0.0:${LXD_ONE_ADDR##*:}"
+
   sub_test "Check local cluster link deletion with pending identity"
 
   # Create pending cluster link on LXD_ONE
@@ -5605,6 +5621,9 @@ test_clustering_link_auth() {
   # Create pending cluster link on LXD_ONE
   LXD_ONE_TRUST_TOKEN="$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --quiet)"
 
+  sub_test "Check cluster link token advertises only the cluster address"
+  echo "${LXD_ONE_TRUST_TOKEN}" | base64 -d | jq --exit-status --arg address "${LXD_ONE_ADDR}" '.addresses == [$address]'
+
   # Check that the cluster link identity on LXD_ONE is pending
   [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc auth identity list --format csv | grep -cF 'Cluster link certificate (pending)')" = 1 ]
 
@@ -5617,9 +5636,17 @@ test_clustering_link_auth() {
   # Get the address of LXD_TWO.
   LXD_TWO_ADDR="$(LXD_DIR="${LXD_TWO_DIR}" lxc config get core.https_address)"
 
+  sub_test "Check standalone cluster link tokens use the core HTTPS address"
+
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link create standalone-address --quiet | base64 -d | jq --exit-status --arg address "${LXD_TWO_ADDR}" '.addresses == [$address]'
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster link delete standalone-address
+
   # Enable clustering on LXD_TWO.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster enable node2
   [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -cwF 'node2')" = 1 ]
+
+  # Keep the member address explicit while exposing the core API on all IPv4 interfaces.
+  LXD_DIR="${LXD_TWO_DIR}" lxc config set core.https_address "0.0.0.0:${LXD_TWO_ADDR##*:}"
 
   sub_test "Check failed cluster link activation rolls back local trust state"
 
@@ -5660,6 +5687,15 @@ test_clustering_link_auth() {
 
   # Check that LXD_ONE trusts LXD_TWO
   LXD_CONF="${LXD_TWO_DIR}" CERTNAME="cluster" CACERT="${LXD_ONE_DIR}/cluster.crt" trusted_curl "https://${LXD_ONE_ADDR}/1.0" | jq --exit-status '.metadata.auth == "trusted"'
+
+  sub_test "Check cluster link addresses after activation and refresh"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/cluster/links/lxd_two | jq --exit-status --arg address "${LXD_TWO_ADDR}" '.config["volatile.addresses"] == $address'
+  LXD_DIR="${LXD_TWO_DIR}" lxc query /1.0/cluster/links/lxd_one | jq --exit-status --arg address "${LXD_ONE_ADDR}" '.config["volatile.addresses"] == $address'
+  LXD_DIR="${LXD_ONE_DIR}" lxc query -X POST --raw --wait /internal/testing/cluster/link/refresh-volatile-addresses
+  LXD_DIR="${LXD_TWO_DIR}" lxc query -X POST --raw --wait /internal/testing/cluster/link/refresh-volatile-addresses
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/cluster/links/lxd_two | jq --exit-status --arg address "${LXD_TWO_ADDR}" '.config["volatile.addresses"] == $address'
+  LXD_DIR="${LXD_TWO_DIR}" lxc query /1.0/cluster/links/lxd_one | jq --exit-status --arg address "${LXD_ONE_ADDR}" '.config["volatile.addresses"] == $address'
 
   sub_test "Check cluster link config get/set/unset"
 
@@ -5733,6 +5769,12 @@ test_clustering_link_info() {
   cert="$(cert_to_yaml "${LXD_ONE_DIR}/cluster.crt")"
   spawn_lxd_and_join_cluster "${cert}" 5 1 "${LXD_ONE_DIR}"
   LXD_DIR="${LXD_THREE_DIR}" lxc query -X POST --raw --wait /internal/testing/cluster/link/refresh-volatile-addresses
+
+  sub_test "Check refreshed link addresses match cluster membership"
+
+  local member_addresses
+  member_addresses="$(LXD_DIR="${LXD_ONE_DIR}" lxc query '/1.0/cluster/members?recursion=1' | jq --exit-status '[.[].url | ltrimstr("https://")] | sort')"
+  LXD_DIR="${LXD_THREE_DIR}" lxc query /1.0/cluster/links/lxd_one | jq --exit-status --argjson addresses "${member_addresses}" '(.config["volatile.addresses"] | split(",") | sort) == $addresses'
 
   sub_test "Check cluster link info reports active members"
 


### PR DESCRIPTION
Cluster-link tokens and activation callbacks now advertise the local member's `cluster.https_address`, avoiding unrelated interfaces from wildcard core listeners. Standalone servers continue using `core.https_address` (expanded for wildcards). Successful refresh replaces bootstrap addresses with one address per remote cluster member; bidirectional activation attempts this immediately, followed by scheduled refreshes.

Fixes #18962.
