### PR TITLE
Fix stacked tmpfs shmounts; Moving devlxd to shmounts; Migrate old devlxd path to new path (stable-5.21)

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1903,6 +1903,11 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("Failed loading local instances: %w", err)
 		}
 
+		err = patchesApply(d, patchPostInstancesLoaded)
+		if err != nil {
+			return err
+		}
+
 		// Register devices on running instances to receive events and reconnect to VM monitor sockets.
 		// This should come after the event handler go routines have been started.
 		devicesRegister(instances)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1707,7 +1707,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 			_, err = files.Lstat(relativeTargetPath)
 			if err == nil {
-				err := d.removeMount(mount.TargetPath)
+				err := d.RemoveMount(mount.TargetPath)
 				if err != nil {
 					return fmt.Errorf("Error unmounting the device path inside container: %s", err)
 				}
@@ -4530,7 +4530,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 					reverter.Add(func() { _ = files.Close() })
 					_, err = files.Lstat("/dev/lxd")
 					if err == nil {
-						err = d.removeMount("/dev/lxd")
+						err = d.RemoveMount("/dev/lxd")
 						if err != nil {
 							return err
 						}
@@ -7857,7 +7857,10 @@ func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
 	return nil
 }
 
-func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+// MoveMount attaches source onto target inside the running container using
+// move_mount, without going through the /dev/.lxd-mounts staging area that
+// insertMountLXC and insertMountLXD rely on.
+func (d *lxc) MoveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {
@@ -7908,7 +7911,7 @@ func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType id
 	// Prefer open_tree()/move_mount() whenever the kernel supports it (which
 	// d.state.OS.IdmappedMounts establishes)
 	if d.state.OS.IdmappedMounts {
-		return d.moveMount(source, target, fstype, flags, idmapType)
+		return d.MoveMount(source, target, fstype, flags, idmapType)
 	}
 
 	if d.state.OS.LXCFeatures["mount_injection_file"] && idmapType == idmap.IdmapStorageNone {
@@ -7918,7 +7921,8 @@ func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType id
 	return d.insertMountLXD(source, target, fstype, flags, -1, idmapType)
 }
 
-func (d *lxc) removeMount(mount string) error {
+// RemoveMount unmounts the given path inside the running container.
+func (d *lxc) RemoveMount(mount string) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -191,6 +191,8 @@ type Container interface {
 	DevptsFd() (*os.File, error)
 	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 	StopForkFile(force bool)
+	MoveMount(source string, target string, fstype string, flags int, idmapType idmap.IdmapStorageType) error
+	RemoveMount(mount string) error
 }
 
 // VM interface is for VM specific functions.

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -46,6 +46,7 @@ const (
 	patchPreDaemonStorage
 	patchPostDaemonStorage
 	patchPostNetworks
+	patchPostInstancesLoaded
 )
 
 /*

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
@@ -23,12 +24,15 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/network"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
 	storagePools "github.com/canonical/lxd/lxd/storage"
 	storageDrivers "github.com/canonical/lxd/lxd/storage/drivers"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -104,6 +108,7 @@ var patches = []patch{
 	{name: "pool_fix_default_permissions", stage: patchPostDaemonStorage, run: patchDefaultStoragePermissions},
 	{name: "storage_update_powerflex_snapshot_prefix", stage: patchPostDaemonStorage, run: patchUpdatePowerFlexSnapshotPrefix},
 	{name: "event_entitlement_rename", stage: patchPreLoadClusterConfig, run: patchEventEntitlementNames},
+	{name: "instance_reattach_shared_devlxd_shmounts", stage: patchPostInstancesLoaded, run: patchReattachSharedDevLXDMounts},
 }
 
 type patch struct {
@@ -1635,6 +1640,144 @@ func patchEventEntitlementNames(name string, d *Daemon) error {
 
 		return nil
 	})
+}
+
+// reattachSharedDevLXDMount re-establishes the devLXD bind-mount that the daemon
+// shares with a running container.
+//
+// /dev/lxd is a bind-mount, made in the container's mount namespace, of a tmpfs
+// that LXD mounts in its own. When LXD runs from the snap that per-snap namespace
+// is discarded on every refresh, so the incoming daemon can come up with a brand
+// new filesystem while a container that survived the refresh still holds a
+// bind-mount of the previous one. Such a container ends up with an empty /dev/lxd,
+// because the outgoing daemon unlinked the devLXD socket on its way down.
+//
+// This is a no-op whenever the container's mount and the daemon's current
+// filesystem are still backed by the same device ID — the common case once devlxd
+// persists across a refresh, or when the container was started by the currently
+// running daemon.  See issue #18194.
+// The caller is responsible for only passing containers that have devLXD enabled.
+func reattachSharedDevLXDMount(inst instance.Container) error {
+	pid := inst.InitPID()
+	if inst.IsSnapshot() || pid <= 0 {
+		return nil
+	}
+
+	source := shared.VarPath("devlxd")
+	expected, err := filesystem.StatDeviceID(source)
+	if err != nil {
+		logger.Warn("Skipped re-attaching devLXD mount, cannot stat the source", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "err": err})
+		return nil
+	}
+
+	// Look the mount up in the container's mount namespace rather than our own,
+	// which means reading the container's mountinfo and routing the path through
+	// /proc/<pid>/root so both describe the same mount tree.
+	const target = "/dev/lxd"
+	mountinfo := fmt.Sprintf("/proc/%d/mountinfo", pid)
+	fields, err := filesystem.GetMountinfo(mountinfo, fmt.Sprintf("/proc/%d/root%s", pid, target))
+	if err != nil {
+		// Either target does not exist in the container or its mountinfo could
+		// not be read or parsed: we don't know what is mounted there, so don't
+		// touch it.
+		logger.Warn("Skipped re-attaching devLXD mount, cannot look up the container's mount", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "mountinfo": mountinfo, "err": err})
+		return nil
+	}
+
+	if len(fields) < 5 {
+		logger.Warn("Skipped re-attaching devLXD mount, mountinfo entry too short", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "mountinfo": mountinfo, "fields": len(fields)})
+		return nil
+	}
+
+	// Field 2 is the device ID of the mount found and field 4 its mount point.
+	actual := fields[2]
+	if actual == expected {
+		return nil
+	}
+
+	// The lookup resolves to the mount target lives in, so a mount point other
+	// than target itself means nothing is mounted there and there is nothing
+	// stale to drop first.
+	stale := fields[4] == target
+
+	logCtx := logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "source": source, "target": target, "expected": expected, "actual": actual}
+	logger.Info("Re-attaching devLXD mount", logCtx)
+
+	if stale {
+		// Drop the stale mount first so the new one doesn't end up stacked on it.
+		err = inst.RemoveMount(target)
+		if err != nil {
+			// Not fatal: the new mount shadows whatever is left underneath for
+			// path resolution (mountinfo's "last match wins"), and the container
+			// needs a working mount more than it needs a clean mount table.
+			logger.Warn("Failed dropping the stale devLXD mount; re-attaching over it", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "target": target, "err": err})
+		}
+	}
+
+	// MoveMount is used rather than the insertMount paths because those hand the
+	// mount over to the container through /dev/.lxd-mounts, which the same
+	// refresh leaves stale and which this does not repair. move-mount needs no
+	// staging area.
+	err = inst.MoveMount(source, target, "none", unix.MS_BIND, idmap.IdmapStorageNone)
+	if err != nil {
+		return fmt.Errorf("Failed re-attaching %q onto %q: %w", source, target, err)
+	}
+
+	return nil
+}
+
+// patchReattachSharedDevLXDMounts re-establishes the devLXD bind-mount for any container that was
+// already running when the daemon started, so containers left holding a mount of a filesystem a
+// prior daemon owned (across a snap refresh, before the persistence fix from #18194) get repaired
+// once during the upgrade to this version.
+//
+// This is a soft patch: it never returns an error, so a failure to repair can't stop the daemon
+// from starting. The trade-off is that it still counts as applied, so anything left unrepaired
+// stays that way rather than being retried on the next start.
+func patchReattachSharedDevLXDMounts(name string, d *Daemon) error {
+	instances, err := instance.LoadNodeAll(d.State(), instancetype.Container)
+	if err != nil {
+		logger.Error("Failed loading instances, skipping devLXD mount re-attach", logger.Ctx{"name": name, "err": err})
+		return nil
+	}
+
+	var attempted int
+	var failedIDs []int
+
+	for _, inst := range instances {
+		if !inst.IsRunning() {
+			continue
+		}
+
+		c, isContainer := inst.(instance.Container)
+		if !isContainer {
+			continue
+		}
+
+		// Mirrors the condition under which the devLXD mount entry is added to
+		// the container's liblxc config.
+		if shared.IsTrueOrEmpty(c.ExpandedConfig()["security.devlxd"]) {
+			attempted++
+
+			// Best-effort: a failure here leaves this one instance no worse off
+			// than before this repair existed (it just keeps whatever mount it
+			// already had), and must not stop the other instances from being
+			// repaired.
+			err := reattachSharedDevLXDMount(c)
+			if err != nil {
+				failedIDs = append(failedIDs, inst.ID())
+				logger.Warn("Failed re-attaching devLXD mount", logger.Ctx{"id": inst.ID(), "project": inst.Project().Name, "instance": inst.Name(), "err": err})
+			}
+		}
+	}
+
+	if len(failedIDs) > 0 {
+		logger.Warn("Patch finished re-attaching devLXD mounts with failures", logger.Ctx{"name": name, "attempted": attempted, "failedInstanceIDs": failedIDs})
+	} else {
+		logger.Info("Patch finished re-attaching devLXD mounts", logger.Ctx{"name": name, "attempted": attempted})
+	}
+
+	return nil
 }
 
 // Patches end here

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -62,7 +62,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 
 		// Get underlying btrfs mount options.
-		mountinfo, err := filesystem.GetMountinfo(volPath)
+		mountinfo, err := filesystem.GetMountinfo("/proc/self/mountinfo", volPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -225,15 +226,39 @@ func ResolveMountOptions(options []string) (uintptr, string) {
 	return mountFlags, strings.Join(mountOptions, ",")
 }
 
-// GetMountinfo tracks down the mount entry for the path and returns all MountInfo fields.
-func GetMountinfo(path string) ([]string, error) {
+// ErrNoMountInfoEntry is returned by GetMountinfo when the mountinfo file held no
+// entry for the path. Callers that need to tell this apart from a real failure to
+// read or parse the file should check for it with errors.Is rather than treating
+// every returned error the same way.
+var ErrNoMountInfoEntry = errors.New("No mountinfo entry found")
+
+// GetMountinfo tracks down the mount entry for the path in the given mountinfo
+// file and returns all MountInfo fields. Entries holding fewer than 5 fields are
+// never matched, so the slice returned always has at least the 5 fields up to and
+// including the mount point.
+//
+// The path is located by stat'ing it and matching the mount ID the kernel reports
+// against the first field of each entry, so both arguments have to describe the
+// same mount tree. Pass "/proc/self/mountinfo" to look a path up in the caller's
+// own mount namespace. To look one up in another process' mount namespace, pass
+// that process' "/proc/<pid>/mountinfo" together with a path routed through
+// "/proc/<pid>/root": a bare path would be resolved in the caller's namespace,
+// whose mount IDs do not appear in the other process' file.
+//
+// The entry returned is the mount the path lives in, which is not necessarily one
+// mounted at the path itself. To tell those apart, compare the returned mount
+// point (field 4) against the path as the mountinfo file spells it, which is not
+// always the path passed in: mount points are written relative to the root of the
+// namespace the file describes, so a path routed through "/proc/<pid>/root"
+// appears there with that prefix stripped.
+func GetMountinfo(mountinfoPath string, path string) ([]string, error) {
 	stat := &unix.Statx_t{}
 	err := unix.Statx(0, path, 0, 0, stat)
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := os.Open("/proc/self/mountinfo")
+	f, err := os.Open(mountinfoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -242,21 +267,25 @@ func GetMountinfo(path string) ([]string, error) {
 
 	statMountID := strconv.FormatUint(stat.Mnt_id, 10)
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
 
 		tokens := strings.Fields(line)
-		if len(tokens) < 5 {
-			continue
+		if len(tokens) >= 5 && tokens[0] == statMountID {
+			return tokens, nil
 		}
 
-		if tokens[0] == statMountID {
-			return tokens, nil
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, err
 		}
 	}
 
-	return nil, errors.New("No mountinfo entry found")
+	return nil, ErrNoMountInfoEntry
 }
 
 // MkdirAllOwner creates a directory named path, along with any necessary parents, in root.
@@ -314,4 +343,19 @@ func MkdirAllOwner(root *os.Root, path string, perm os.FileMode, uid int, gid in
 	}
 
 	return nil
+}
+
+// StatDeviceID stats path and returns the device ID (major:minor) of the
+// filesystem it lives on, in the same form as the third field of a mountinfo
+// entry. Other helpers that derive information from a path by stat'ing it should
+// follow the same StatXxx naming.
+func StatDeviceID(path string) (string, error) {
+	var st unix.Stat_t
+
+	err := unix.Stat(path, &st)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev))), nil
 }

--- a/lxd/storage/filesystem/fs_test.go
+++ b/lxd/storage/filesystem/fs_test.go
@@ -4,8 +4,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMkdirAllOwner(t *testing.T) {
@@ -173,4 +177,130 @@ func TestMkdirAllOwnerRootEscapeProtection(t *testing.T) {
 			t.Fatalf("Expected no outside directory at %q, got stat error: %v", outsidePaths[i], statErr)
 		}
 	}
+}
+
+func TestStatDeviceID(t *testing.T) {
+	dir := t.TempDir()
+
+	fileA := filepath.Join(dir, "a")
+	fileB := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(fileA, nil, 0600))
+	require.NoError(t, os.WriteFile(fileB, nil, 0600))
+
+	idA, err := StatDeviceID(fileA)
+	require.NoError(t, err)
+	assert.Regexp(t, `^\d+:\d+$`, idA)
+
+	// Two paths on the same filesystem report the same device ID.
+	idB, err := StatDeviceID(fileB)
+	require.NoError(t, err)
+	assert.Equal(t, idA, idB)
+
+	_, err = StatDeviceID(filepath.Join(dir, "does-not-exist"))
+	assert.Error(t, err)
+}
+
+func TestGetMountinfo(t *testing.T) {
+	dir := t.TempDir()
+
+	fields, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(fields), 5)
+
+	// dir is not itself a mount point, so the entry found is the mount it lives
+	// in and its mount point (field 4) is an ancestor of dir.
+	assert.True(t, strings.HasPrefix(dir, fields[4]), "mount point %q is not an ancestor of %q", fields[4], dir)
+
+	t.Run("path not in the given mountinfo file", func(t *testing.T) {
+		// A well-formed mountinfo file that simply holds no entry for dir's mount,
+		// which is what reading another mount namespace's file would look like if
+		// the path had been resolved in the caller's namespace instead.
+		path := filepath.Join(t.TempDir(), "mountinfo")
+		require.NoError(t, os.WriteFile(path, []byte("66 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"), 0600))
+
+		_, err := GetMountinfo(path, dir)
+		assert.ErrorIs(t, err, ErrNoMountInfoEntry)
+	})
+
+	t.Run("missing mountinfo file", func(t *testing.T) {
+		// A real I/O error, as opposed to "no entry": callers need to be able to
+		// tell the two apart.
+		_, err := GetMountinfo(filepath.Join(t.TempDir(), "does-not-exist"), dir)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoMountInfoEntry)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		_, err := GetMountinfo("/proc/self/mountinfo", filepath.Join(dir, "does-not-exist"))
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestGetMountinfoLongLine(t *testing.T) {
+	dir := t.TempDir()
+
+	// Take the real mount ID for dir so the synthetic file below can hold an
+	// entry that the stat inside GetMountinfo will match.
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	// A real overlayfs mount concatenates one entry per lowerdir into its
+	// superblock options field, so its mountinfo line can be far longer than
+	// bufio.Scanner's default 64 KiB. An unrelated line that long, appearing
+	// before the line being looked for, must not stop the scan from reaching it.
+	// Deliberately past 1 MiB as well, so this stays a test of "no line length
+	// limit" rather than of some particular larger buffer size.
+	longOptions := "rw,lowerdir=" + strings.Repeat("/var/lib/lxd/storage-pools/default/images/deadbeef/rootfs:", 40000)
+	require.Greater(t, len(longOptions), 1024*1024)
+
+	// Appending a digit keeps this distinct from dir's own mount ID.
+	unrelatedID := mountID + "0"
+
+	mountinfo := "" +
+		unrelatedID + " 25 0:11 / /some/unrelated/overlay rw,relatime shared:1 - overlay overlay " + longOptions + "\n" +
+		mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
+}
+
+func TestGetMountinfoNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	// The matching entry is the last line and has no trailing newline, so it is
+	// only seen if the final short read is examined rather than discarded.
+	mountinfo := mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
+}
+
+func TestGetMountinfoMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+
+	current, err := GetMountinfo("/proc/self/mountinfo", dir)
+	require.NoError(t, err)
+	mountID := current[0]
+
+	mountinfo := "" +
+		"garbage short line\n" +
+		"\n" +
+		mountID + " 25 0:58 / /dev/lxd rw,relatime shared:32 - tmpfs tmpfs rw,size=1024k,mode=711\n"
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(path, []byte(mountinfo), 0600))
+
+	fields, err := GetMountinfo(path, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0:58", fields[2])
 }

--- a/shmounts/setup-shmounts.c
+++ b/shmounts/setup-shmounts.c
@@ -207,6 +207,7 @@ int setup_ns() {
 int main() {
 	bool setup = true;
 	bool run_media = false;
+	const char *tmpmount;
 	int fd = -1;
 	int nsfd_current = -1, nsfd_old = -1, nsfd_host = -1, nsfd_shmounts = -1;
 	FILE *mounts;
@@ -267,30 +268,31 @@ int main() {
 		run_media = true;
 	}
 
+	// Pick the temporary mountpoint. This has to be a path that snapd
+	// exposes to the snap mntns with propagation from the host mntns, as
+	// the bind-mount we create below is made in the host mntns but has to
+	// be visible from the snap mntns so that it can be bind-mounted onto
+	// its final destination there. Both /media and /run/media qualify:
+	// /media is bind-mounted from the host and /run is a slave of the
+	// host's /run at the point where daemon.start calls us.
+	//
+	// The same path must be used on both sides. Using /run/media on one
+	// side and /media on the other made this fail with ENOENT on every
+	// host that has a /run/media directory (any host with udisks2
+	// installed), which silently disabled shmounts persistence and left a
+	// stacked bind-mount behind on every daemon start.
+	tmpmount = run_media ? "/run/media/.lxd-shmounts" : "/media/.lxd-shmounts";
+
 	// Create temporary mountpoint
-	if (run_media) {
-		if (mkdir("/run/media/.lxd-shmounts", 0700) < 0 && errno != EEXIST) {
-			fprintf(stderr, "Failed to create /run/media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
-	} else {
-		if (mkdir("/media/.lxd-shmounts", 0700) < 0 && errno != EEXIST) {
-			fprintf(stderr, "Failed to create /media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
+	if (mkdir(tmpmount, 0700) < 0 && errno != EEXIST) {
+		fprintf(stderr, "Failed to create %s: %s\n", tmpmount, strerror(errno));
+		return -1;
 	}
 
 	// Bind-mount onto temporary mountpoint
-	if (run_media) {
-		if (mount("/var/snap/lxd/common/shmounts", "/run/media/.lxd-shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-			fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to /run/media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
-	} else {
-		if (mount("/var/snap/lxd/common/shmounts", "/media/.lxd-shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-			fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to /media/.lxd-shmounts: %s\n", strerror(errno));
-			return -1;
-		}
+	if (mount("/var/snap/lxd/common/shmounts", tmpmount, NULL, MS_BIND|MS_REC, NULL) < 0) {
+		fprintf(stderr, "Failed to bind-mount /var/snap/lxd/common/shmounts to %s: %s\n", tmpmount, strerror(errno));
+		return -1;
 	}
 
 	// Attach to the snapd mntns
@@ -300,20 +302,20 @@ int main() {
 	}
 
 	// Bind-mount onto final destination
-	if (mount("/media/.lxd-shmounts", "/var/snap/lxd/common/shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
-		fprintf(stderr, "Failed to bind-mount /media/.lxd-shmounts to /var/snap/lxd/common/shmounts: %s\n", strerror(errno));
+	if (mount(tmpmount, "/var/snap/lxd/common/shmounts", NULL, MS_BIND|MS_REC, NULL) < 0) {
+		fprintf(stderr, "Failed to bind-mount %s to /var/snap/lxd/common/shmounts: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
 	// Mark temporary mountpoint private
-	if (mount("none", "/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL) < 0) {
-		fprintf(stderr, "Failed to mark /media/.lxd-shmounts as private: %s\n", strerror(errno));
+	if (mount("none", tmpmount, NULL, MS_REC|MS_PRIVATE, NULL) < 0) {
+		fprintf(stderr, "Failed to mark %s as private: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
 	// Get rid of the temporary mountpoint from snapd mntns
-	if (umount2("/media/.lxd-shmounts", MNT_DETACH) < 0) {
-		fprintf(stderr, "Failed to unmount /media/.lxd-shmounts: %s\n", strerror(errno));
+	if (umount2(tmpmount, MNT_DETACH) < 0) {
+		fprintf(stderr, "Failed to unmount %s: %s\n", tmpmount, strerror(errno));
 		return -1;
 	}
 
@@ -324,20 +326,11 @@ int main() {
 	}
 
 	// Attempt to cleanup mount there too (may be gone or may be there)
-	if (run_media) {
-		mount("none", "/run/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL);
-		umount2("/run/media/.lxd-shmounts", MNT_DETACH);
-	} else {
-		mount("none", "/media/.lxd-shmounts", NULL, MS_REC|MS_PRIVATE, NULL);
-		umount2("/media/.lxd-shmounts", MNT_DETACH);
-	}
+	mount("none", tmpmount, NULL, MS_REC|MS_PRIVATE, NULL);
+	umount2(tmpmount, MNT_DETACH);
 
 	// Attempt to remove the temporary mountpoint
-	if (run_media) {
-		rmdir("/run/media/.lxd-shmounts");
-	} else {
-		rmdir("/media/.lxd-shmounts");
-	}
+	rmdir(tmpmount);
 
 	// Attempt to attach to previous LXD mntns
 	nsfd_old = open("/var/snap/lxd/common/ns/mntns", O_RDONLY);

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -153,6 +153,27 @@ if ! mountpoint -q "${SNAP_COMMON}/shmounts"; then
     fi
 fi
 
+# Make the devLXD socket directory live in the persistent shmounts path.
+#
+# Running containers get this directory bind-mounted onto /dev/lxd, so the
+# filesystem behind it has to outlive the daemon. LXD mounts a tmpfs there
+# itself when the path isn't already a mountpoint, but that tmpfs lives in the
+# per-snap mount namespace which snapd discards on refresh: the new daemon then
+# gets a brand new tmpfs and every already-running container is left holding a
+# bind-mount of the old, now empty, one.
+if ! mountpoint -q "${SNAP_COMMON}/lxd/devlxd"; then
+    echo "==> Making devLXD use the persistent shmounts path"
+    mkdir -p "${SNAP_COMMON}/shmounts/devlxd"
+    chmod 0755 "${SNAP_COMMON}/shmounts/devlxd"
+    mkdir -p "${SNAP_COMMON}/lxd/devlxd"
+    chmod 0755 "${SNAP_COMMON}/lxd/devlxd"
+    # A bind-mount is needed here instead of symlink because filesystem.IsMountPoint
+    # returns false for symlink which causes it to stack mount another tmpfs over it.
+    if ! mount -o bind "${SNAP_COMMON}/shmounts/devlxd" "${SNAP_COMMON}/lxd/devlxd"; then
+        echo "====> Failed to make devLXD persistent, continuing without"
+    fi
+fi
+
 # Fix lsmod/modprobe
 echo "==> Setting up kmod wrapper"
 mountpoint -q /bin/kmod && umount -l /bin/kmod


### PR DESCRIPTION
Fix stacked tmpfs shmounts; Moving devlxd to shmounts; Migrate old devlxd path to new path (#18194)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
