### PR TITLE
doc: Follow abbreviation best practices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3550,7 +3550,7 @@ LXD CLI (`lxc`). For this reason, if the client configured for LXD in the identi
 client cannot be used by CLI users.
 
 This extension adds a new {config:option}`server-oidc:oidc.device.client.id` configuration key for the CLI to use. An
-administrator can create two clients in the identity provider, one for LXD UI requiring a secret (and {abbr}`PKCE <Proof Key for Code Exchange>`),
+administrator can create two clients in the identity provider, one for the LXD UI requiring a secret and {abbr}`PKCE` (Proof Key for Code Exchange),
 and one for the CLI that enables the device authorization grant and does not require a secret. The device client ID will
 be public to the CLI, falling back to {config:option}`server-oidc:oidc.client.id`. This configuration option cannot be
 set unless {config:option}`server-oidc:oidc.client.id` is set.

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -23,7 +23,7 @@ The following authentication methods are supported:
 :title: LXD token based remote authentication
 ```
 
-When using {abbr}`TLS (Transport Layer Security)` client certificates for authentication, both the client and the server will generate a key pair the first time they're launched.
+When using {abbr}`TLS` (Transport Layer Security) client certificates for authentication, both the client and the server will generate a key pair the first time they're launched.
 The server will use that key pair for all HTTPS connections to the LXD socket.
 The client will use its certificate as a client certificate for any client-server communication.
 
@@ -62,12 +62,12 @@ See {ref}`server-expose` and {ref}`server-authenticate` for instructions on how 
 (authentication-pki)=
 ### Using a PKI system
 
-In a {abbr}`PKI (Public key infrastructure)` setup, a system administrator manages a central PKI that issues client certificates for all the LXD clients and server certificates for all the LXD daemons.
+In a {abbr}`PKI` (Public key infrastructure) setup, a system administrator manages a central PKI that issues client certificates for all the LXD clients and server certificates for all the LXD daemons.
 
-In PKI mode, TLS authentication requires that client certificates are signed be the {abbr}`CA (Certificate authority)`.
-This requirement does not apply to clients that authenticate via [OIDC](authentication-openid).
+In PKI mode, TLS authentication requires that client certificates are signed be the {abbr}`CA` (Certificate authority).
+This requirement does not apply to clients that authenticate via [{abbr}`OIDC` (OpenID Connect)](authentication-openid).
 
-The steps for enabling PKI mode differ slightly depending on whether you use an ACME provider in addition (see {ref}`authentication-server-certificate`).
+The steps for enabling PKI mode differ slightly depending on whether you use an {abbr}`ACME` (Automatic Certificate Management Environment) provider in addition (see {ref}`authentication-server-certificate`).
 
 `````{tabs}
 ````{group-tab} Only PKI
@@ -129,7 +129,7 @@ A client with a CA-signed certificate that has been revoked, and is present in `
 (authentication-openid)=
 ## OpenID Connect authentication
 
-LXD supports using [OpenID Connect](https://openid.net/developers/how-connect-works/) to authenticate users through an {abbr}`OIDC (OpenID Connect)` Identity Provider.
+LXD supports using [OpenID Connect](https://openid.net/developers/how-connect-works/) to authenticate users through an OIDC Identity Provider.
 
 To configure LXD to use OIDC authentication, set the [`oidc.*`](server-options-oidc) server configuration options.
 See the {ref}`how-to guides <howto-oidc>` for more information.
@@ -149,7 +149,7 @@ OIDC clients must be granted access by an administrator, see {ref}`fine-grained-
 (authentication-server-certificate)=
 ## TLS server certificate
 
-LXD supports issuing server certificates using {abbr}`ACME (Automatic Certificate Management Environment)` services, for example, [Let's Encrypt](https://letsencrypt.org/).
+LXD supports issuing server certificates using ACME services, for example, [Let's Encrypt](https://letsencrypt.org/).
 
 To enable this feature, set the following server configuration:
 
@@ -308,7 +308,7 @@ In the following scenarios, authentication is expected to fail.
 The server certificate might change in the following cases:
 
 - The server was fully reinstalled and therefore got a new certificate.
-- The connection is being intercepted ({abbr}`MITM (Machine in the middle)`).
+- The connection is being intercepted ({abbr}`MITM` (Machine in the middle)).
 
 In such cases, the client will refuse to connect to the server because the certificate fingerprint does not match the fingerprint in the configuration for this remote.
 

--- a/doc/dev-lxd.md
+++ b/doc/dev-lxd.md
@@ -33,7 +33,7 @@ This approach was discarded to avoid issues with file descriptor limits for host
 (dev-lxd-implementation-vms)=
 ### Virtual machines
 
-LXD on the host starts a HTTPS {abbr}`Vsock (Virtual Socket)` server.
+LXD on the host starts a HTTPS {abbr}`Vsock` (Virtual Socket) server.
 The LXD agent on the virtual machine communicates securely with the Vsock server using a certificate mounted in the VM's configuration drive.
 The LXD agent creates the socket at `/dev/lxd/sock` and proxies requests to the Vsock server.
 

--- a/doc/explanation/authorization.md
+++ b/doc/explanation/authorization.md
@@ -88,7 +88,7 @@ Identity types are a superset of TLS certificate types and additionally include 
 
 The name column displays the name of the identity.
 For TLS clients, this will be the name of the certificate.
-For OIDC clients this will be the name of the client as given by the {abbr}`IdP (identity provider)` (requested via the [profile scope](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes)).
+For OIDC clients this will be the name of the client as given by the {abbr}`IdP` (identity provider) (requested via the [profile scope](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes)).
 
 The identifier column displays a unique identifier for the identity within that authentication method.
 For TLS clients, this will be the certificate fingerprint.
@@ -139,7 +139,7 @@ When an OIDC client makes a request to LXD, any groups that can be extracted fro
 
 To configure IdP group mappings in LXD, first configure your IdP to add groups to identity and access tokens as a custom claim.
 This configuration depends on your IdP.
-In [{spellexception}`Auth0`](https://auth0.com/), for example, you can enable [{abbr}`RBAC (role-based access control)`](https://auth0.com/docs/manage-users/access-control/rbac) which will add a "permissions" claim to tokens. Then, configure {ref}`automatic mapping to LXD authorization groups <oidc-auth0-automatic-group-mapping>`.
+In [{spellexception}`Auth0`](https://auth0.com/), for example, you can enable [{abbr}`RBAC` (role-based access control)](https://auth0.com/docs/manage-users/access-control/rbac) which will add a "permissions" claim to tokens. Then, configure {ref}`automatic mapping to LXD authorization groups <oidc-auth0-automatic-group-mapping>`.
 In Keycloak, you can define a [mapper](https://forum.keycloak.org/t/anyway-to-include-user-groups-into-my-jwt-token/8715) to set Keycloak groups in the token. In [Pocket ID](https://pocket-id.org/docs), you can set up {ref}`custom claims <oidc-pocket-id-automatic-group-mapping>` in your admin dashboard.
 
 Then configure LXD to extract this claim.

--- a/doc/explanation/bpf.md
+++ b/doc/explanation/bpf.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-The {config:option}`instance-security:security.delegate_bpf` option enables the {abbr}`BPF (Berkeley Packet Filter)` functionality delegation mechanism, using a [BPF Token](https://docs.ebpf.io/linux/concepts/token). When enabled, LXD mounts a BPF File System (BPFFS) inside a container instance. This file system is configured with the `security.delegate_bpf.*` settings.
+The {config:option}`instance-security:security.delegate_bpf` option enables the {abbr}`BPF` (Berkeley Packet Filter) functionality delegation mechanism, using a [BPF Token](https://docs.ebpf.io/linux/concepts/token). When enabled, LXD mounts a BPF File System (BPFFS) inside a container instance. This file system is configured with the `security.delegate_bpf.*` settings.
 For example:
 
 ```
@@ -88,7 +88,7 @@ interface: lo        protocol: ICMP        127.0.0.1:2048(src) -> 127.0.0.1:4616
 interface: lo        protocol: ICMP        127.0.0.1:0(src) -> 127.0.0.1:48211(dst)
 ```
 
-We can see from this sample output that the ICMP packets were captured by the {abbr}`eBPF (extended Berkeley Capture Filter)` program and logged.
+We can see from this sample output that the ICMP packets were captured by the {abbr}`eBPF` (extended Berkeley Capture Filter) program and logged.
 
 ## Finding the right configuration
 

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -37,7 +37,7 @@ Containers
 : Containers are the default type for instances. They are implemented through the use of `liblxc` (LXC).
 
 Virtual machines
-: {abbr}`Virtual machines (VMs)` are natively supported since version 4.0 of LXD.
+: Virtual machines ({abbr}`VMs`) are natively supported since version 4.0 of LXD.
   Thanks to a built-in agent, they can be used almost like containers, with a similar set of features.
 
   LXD uses `qemu` to provide the VM functionality.

--- a/doc/explanation/networks.md
+++ b/doc/explanation/networks.md
@@ -5,7 +5,7 @@ There are different ways to connect your instances to the Internet. The easiest 
 
 ## Network devices
 
-To grant direct network access to an instance, you must assign it at least one network device, also called {abbr}`NIC (Network Interface Controller)`.
+To grant direct network access to an instance, you must assign it at least one network device, also called {abbr}`NIC` (Network Interface Controller).
 You can configure the network device in one of the following ways:
 
 - Use the default network bridge that you set up during the LXD initialization.

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -40,7 +40,7 @@ See {ref}`ref-releases-snap` for the currently supported releases as well as inf
 (security-daemon-access)=
 ## Access to the LXD daemon
 
-LXD is a daemon that can be accessed locally over a Unix socket or, if configured, remotely over a {abbr}`TLS (Transport Layer Security)` socket.
+LXD is a daemon that can be accessed locally over a Unix socket or, if configured, remotely over a {abbr}`TLS` (Transport Layer Security) socket.
 Anyone with access to the socket can fully control LXD, which includes the ability to attach host devices and file systems or to tweak the security features for all instances.
 
 Therefore, make sure to restrict the access to the daemon to trusted users.
@@ -62,7 +62,7 @@ The root user and all members of the `lxd` group can interact with the local dae
 (security_remote_access)=
 ### Access to the remote API
 
-By default, access to the daemon is only possible locally, but you can also {ref}`expose LXD to the network <server-expose>` on a {abbr}`TLS` (Transport Layer Security) socket. 
+By default, access to the daemon is only possible locally, but you can also {ref}`expose LXD to the network <server-expose>` on a TLS socket.
 Remote clients can then connect to LXD and access any image that is marked for public use.
 
 There are several ways to authenticate remote clients as trusted clients to allow them to access the API.
@@ -87,7 +87,7 @@ It has extra rights only on resources that it owns itself.
 This mechanism ensures that most security issues (for example, container escape or resource abuse) that might occur in a container apply just as well to a random unprivileged user, which means they are a generic kernel security bug rather than a LXD issue.
 
 ```{tip}
-If data sharing between containers isn't needed, you can enable {config:option}`instance-security:security.idmap.isolated`, which will use non-overlapping UID/GID maps for each container, preventing potential {abbr}`DoS (Denial of Service)` attacks on other containers.
+If data sharing between containers isn't needed, you can enable {config:option}`instance-security:security.idmap.isolated`, which will use non-overlapping UID/GID maps for each container, preventing potential {abbr}`DoS` (Denial of Service) attacks on other containers.
 ```
 
 ### Privileged containers
@@ -130,7 +130,7 @@ In this default configuration, whilst DNS names cannot not be spoofed, the insta
 In the default configuration, it is also possible for instances connected to the bridge to modify the LXD host's IPv6 routing table by sending (potentially malicious) IPv6 router advertisements to the bridge.
 This is because the `lxdbr0` interface is created with `/proc/sys/net/ipv6/conf/lxdbr0/accept_ra` set to `2`, meaning that the LXD host will accept router advertisements even though `forwarding` is enabled (see [`/proc/sys/net/ipv4/*` Variables](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) for more information).
 
-However, LXD offers several bridged {abbr}`NIC (Network interface controller)` security features that can be used to control the type of traffic that an instance is allowed to send onto the network.
+However, LXD offers several bridged {abbr}`NIC` (Network interface controller) security features that can be used to control the type of traffic that an instance is allowed to send onto the network.
 These NIC settings should be added to the profile that the instance is using, or they can be added to individual instances, as shown below.
 
 The following security features are available for bridged NICs:

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -4,7 +4,7 @@
 LXD stores its data in storage pools, divided into storage volumes of different content types (like images or instances).
 You could think of a storage pool as the disk that is used to store data, while storage volumes are different partitions on this disk that are used for specific purposes.
 
-In addition to storage volumes, there are storage buckets, which use the [Amazon {abbr}`S3 (Simple Storage Service)`](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html) protocol.
+In addition to storage volumes, there are storage buckets, which use the [Amazon {abbr}`S3` (Simple Storage Service)](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html) protocol.
 Like storage volumes, storage buckets are part of a storage pool.
 
 (storage-pools)=

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -139,7 +139,7 @@ If you are on earlier versions of Ubuntu, you should use a compatible LTS releas
 (faq-gpu-passthrough-stop)=
 ## Why does my VM stop responding when I try to pass through a GPU?
 
-If you try to pass through a GPU with a large amount of VRAM, the VM might stop responding during boot or fail to start. This is often caused by the default {abbr}`MMIO (Memory-Mapped Input/Output)` window size in QEMU being too small to map the GPU's memory.
+If you try to pass through a GPU with a large amount of VRAM, the VM might stop responding during boot or fail to start. This is often caused by the default {abbr}`MMIO` (Memory-Mapped Input/Output) window size in QEMU being too small to map the GPU's memory.
 
 To resolve this, stop the instance, then increase the available 64-bit PCI MMIO address space by setting the following values in {config:option}`instance-raw:raw.qemu`:
 
@@ -150,4 +150,4 @@ lxc config set <vm-name> raw.qemu='
 '
 ```
 
-These settings reserve sufficient 64-bit MMIO space in both the QEMU host and the guest firmware ({abbr}`OVMF (Open Virtual Machine Firmware)`), which is required for GPUs with large {abbr}`BARs (Base Address Registers)`.
+These settings reserve sufficient 64-bit MMIO space in both the QEMU host and the guest firmware ({abbr}`OVMF` (Open Virtual Machine Firmware)), which is required for GPUs with large {abbr}`BARs` (Base Address Registers).

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -6,19 +6,19 @@ discourse: lxc:[Network&#32;ACL&#32;logging](13223)
 # How to configure network ACLs
 
 ```{note}
-Network ACLs are available for the {ref}`OVN NIC type <nic-ovn>`, the {ref}`network-ovn` and the {ref}`network-bridge` (with some exceptions; see {ref}`network-acls-bridge-limitations`).
+Network {abbr}`ACLs` (Access Control Lists) are available for the [OVN {abbr}`NIC` (Network Interface Controller) type](nic-ovn), the {ref}`network-ovn` and the {ref}`network-bridge` (with some exceptions; see {ref}`network-acls-bridge-limitations`).
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=mu34G0cX6Io
 :title: LXD network ACLs
 ```
 
-Network {abbr}`ACLs (Access Control Lists)` define rules for controlling traffic:
+Network ACLs define rules for controlling traffic:
 
 - Between instances connected to the same network
 - To and from other networks
 
-Network ACLs can be assigned directly to the {abbr}`NIC (Network Interface Controller)` of an instance, or to a network. When assigned to a network, the ACL applies indirectly to all NICs connected to that network.
+Network ACLs can be assigned directly to the NIC of an instance, or to a network. When assigned to a network, the ACL applies indirectly to all NICs connected to that network.
 
 When an ACL is assigned to multiple instance NICs, either directly or indirectly, those NICs form a logical port group. You can use the name of that ACL to refer to that group in the traffic rules of other ACLs. For more information, see: {ref}`network-acls-selectors-subject-name`.
 
@@ -901,7 +901,7 @@ You can assign an ACL to a bridge or OVN network when {ref}`creating <network-cr
 
 ### Assign an ACL to the OVN NIC of an instance
 
-For {abbr}`NICs (Network Interface Cards)`, ACLs can only be used with the {ref}`OVN NIC type <nic-ovn>`.
+For NICs, ACLs can only be used with the {ref}`OVN NIC type <nic-ovn>`.
 
 An NIC is considered a type of instance {ref}`device <devices>`. For general information about configuring instance devices, see: {ref}`instances-configure-devices`.
 

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -6,7 +6,7 @@ discourse: lxc:[BGP&#32;address/route&#32;advertisement](11567)
 # How to configure LXD as a BGP server
 
 ```{note}
-The BGP server feature is available for the {ref}`network-bridge` and the {ref}`network-physical`.
+The {abbr}`BGP` (Border Gateway Protocol) server feature is available for the {ref}`network-bridge` and the {ref}`network-physical`.
 These network types are often used as the uplink network for an {ref}`network-ovn`, and you must configure the BGP peers on the uplink network.
 See {ref}`network-bgp-ovn` for instructions.
 ```
@@ -15,7 +15,7 @@ See {ref}`network-bgp-ovn` for instructions.
 :title: LXD and BGP
 ```
 
-{abbr}`BGP (Border Gateway Protocol)` is a protocol that allows exchanging routing information between autonomous systems.
+BGP is a protocol that allows exchanging routing information between autonomous systems.
 
 If you want to directly route external addresses to specific LXD servers or instances, you can configure LXD as a BGP server.
 LXD will then act as a BGP peer and advertise relevant routes and next hops to external routers, for example, your network router.
@@ -47,7 +47,7 @@ If you need this, filter prefixes on the upstream routers.
 To configure LXD as a BGP server, set the following server configuration options on all cluster members:
 
 - {config:option}`server-core:core.bgp_address` - the IP address for the BGP server
-- {config:option}`server-core:core.bgp_asn` - the {abbr}`ASN (Autonomous System Number)` for the local server
+- {config:option}`server-core:core.bgp_asn` - the {abbr}`ASN` (Autonomous System Number) for the local server
 - {config:option}`server-core:core.bgp_routerid` - the unique identifier for the BGP server
 
 For example, set the following values:
@@ -76,7 +76,7 @@ Therefore, you must configure BGP peers on the uplink network that contain the i
 Set the following configuration options on the uplink network:
 
 - `bgp.peers.<name>.address` - the peer address to be used by the downstream networks
-- `bgp.peers.<name>.asn` - the {abbr}`ASN (Autonomous System Number)` for the local server
+- `bgp.peers.<name>.asn` - the ASN for the local server
 - `bgp.peers.<name>.password` - an optional password for the peer session
 - `bgp.peers.<name>.holdtime` - an optional hold time for the peer session (in seconds)
 

--- a/doc/howto/network_ipam.md
+++ b/doc/howto/network_ipam.md
@@ -1,7 +1,7 @@
 (network-ipam)=
 # How to display IPAM information of a LXD deployment
 
-{abbr}`IPAM (IP Address Management)` is a method used to plan, track, and manage the information associated with a computer network's IP address space. In essence, it's a way of organizing, monitoring, and manipulating the IP space in a network.
+{abbr}`IPAM` (IP Address Management) is a method used to plan, track, and manage the information associated with a computer network's IP address space. In essence, it's a way of organizing, monitoring, and manipulating the IP space in a network.
 
 Checking the IPAM information for your LXD setup can help you debug networking issues. You can see which IP addresses are used for instances, network interfaces, forwards, and load balancers and use this information to track down where traffic is lost.
 

--- a/doc/howto/oidc_auth0.md
+++ b/doc/howto/oidc_auth0.md
@@ -35,7 +35,7 @@ Auth0 is a flexible, drop-in solution to add authentication and authorization se
          lxc config set oidc.client.id=<Client ID>
          lxc config set oidc.client.secret=<Client Secret>
 
-   - Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. Enter the credentials for Auth0.
+   - Now you can access the LXD UI with any browser and use {abbr}`SSO` (single sign-on) login. Enter the credentials for Auth0.
 
 1. Now create an application to be used by the LXD CLI. To do this, go back to {guilabel}`Applications` > {guilabel}`Applications` in the side panel and click {guilabel}`+ Create Application`.
    - Give the application a name, e.g. `LXD CLI`.

--- a/doc/howto/oidc_authentik.md
+++ b/doc/howto/oidc_authentik.md
@@ -62,7 +62,7 @@ This guide assumes that authentik is available over HTTPS, and that LXD is initi
 
    {config:option}`server-oidc:oidc.client.id` and {config:option}`server-oidc:oidc.client.secret` are used by the LXD UI, and {config:option}`server-oidc:oidc.device.client.id` is used by the LXD CLI. Setting `oidc.device.client.id` requires `oidc.client.id` to be set. {config:option}`server-oidc:oidc.audience` must be the client ID of the `LXD` provider, so that LXD accepts the tokens that authentik issues for both providers.
 
-Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. Enter the credentials for authentik.
+Now you can access the LXD UI with any browser and use {abbr}`SSO` (single sign-on) login. Enter the credentials for authentik.
 
 To use OIDC on the LXD CLI, run:
 

--- a/doc/howto/oidc_keycloak.md
+++ b/doc/howto/oidc_keycloak.md
@@ -47,6 +47,6 @@ Keycloak is a self-hosted open source tool for authentication. Keycloak supports
 
        lxc config set oidc.client.secret=<keycloak-client-secret>
 
-Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. To use OIDC on the LXD CLI, run `lxc remote add <remote-name> <LXD address> --auth-type oidc` and point a browser to the displayed URL (with user_code) to authenticate.
+Now you can access the LXD UI with any browser and use {abbr}`SSO` (single sign-on) login. To use OIDC on the LXD CLI, run `lxc remote add <remote-name> <LXD address> --auth-type oidc` and point a browser to the displayed URL (with user_code) to authenticate.
 
 Users authenticated through Keycloak have no default permissions in the LXD UI. Set up {ref}`LXD authorization groups <manage-permissions>` to grant access to projects and instances and map a LXD authorization group to the user. Note that the user object in LXD is only created on the first login of that user to LXD.

--- a/doc/howto/oidc_ory.md
+++ b/doc/howto/oidc_ory.md
@@ -27,7 +27,7 @@ Ory Hydra is an easy solution to authenticate users for the LXD UI. It supports 
 
        lxc config set oidc.issuer=https://<ory-id>.projects.oryapis.com
 
-Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login.
+Now you can access the LXD UI with any browser and use {abbr}`SSO` (single sign-on) login.
 
 No users exist within ORY by default. New users can use the sign-up link during login. Alternatively, configure Google, Facebook, Microsoft, GitHub, Apple, or another social sign-in provider as described in the [ORY documentation](https://www.ory.com/docs/kratos/social-signin/overview).
 

--- a/doc/howto/oidc_pocket_id.md
+++ b/doc/howto/oidc_pocket_id.md
@@ -54,7 +54,7 @@ Pocket ID is a modern, self-hosted OIDC provider distributed as a single Go bina
     - From the {guilabel}`Users` section, select the user created in step 6 to the group and click {guilabel}`Save`.
     - From the {guilabel}`Allowed OIDC Clients` section, select the client created in step 4 and click {guilabel}`Save`.
 
-Now you can access the LXD UI with any browser and use {abbr}`SSO (single sign-on)` login. To use OIDC on the LXD CLI, run `lxc remote add <remote-name> <LXD address> --auth-type oidc` and point a browser to the displayed URL to authenticate.
+Now you can access the LXD UI with any browser and use {abbr}`SSO` (single sign-on) login. To use OIDC on the LXD CLI, run `lxc remote add <remote-name> <LXD address> --auth-type oidc` and point a browser to the displayed URL to authenticate.
 
 By default, Pocket ID only has an admin user. Follow the [Pocket ID guide](https://pocket-id.org/docs/setup/user-management) to add users manually or sync with an LDAP source.
 

--- a/doc/howto/security_harden.md
+++ b/doc/howto/security_harden.md
@@ -33,7 +33,7 @@ Also see {ref}`howto-security-harden-restricted-group`.
 (howto-security-harden-remote)=
 ### Harden remote API access
 
-For {ref}`authentication`, LXD can use either {abbr}`TLS (Transport Layer Security)` client certificates or OpenID Connect:
+For {ref}`authentication`, LXD can use either {abbr}`TLS` (Transport Layer Security) client certificates or OpenID Connect:
 
 - Client certificates:
    - Ensure that only clients with certificates issued by your trusted Certificate Authority (CA) can connect. The {config:option}`server-core:core.trust_ca_certificates` option is `false` by default. To prevent auto-trusting of CA-signed certificates, ensure it remains disabled.
@@ -107,7 +107,7 @@ By default, LXD containers are unprivileged. If you need to use privileged conta
 (howto-security-harden-instance-resource-limits)=
 ### Set instance resource limits
 
-There are multiple {ref}`instance-options-limits` that can be configured for instances. To decrease the potential damage from DoS attacks, set reasonable limits.
+There are multiple {ref}`instance-options-limits` that can be configured for instances. To decrease the potential damage from {abbr}`DoS` (Denial of Service) attacks, set reasonable limits.
 
 This is especially important for containers and their {config:option}`instance-resource-limits:limits.cpu`, {config:option}`instance-resource-limits:limits.memory`, and {config:option}`instance-resource-limits:limits.processes` options, which by default are set without limits. Review the {ref}`instance-options-limits` reference guide for other options you might want to restrict.
 
@@ -121,7 +121,7 @@ Setting this option to `true` is especially dangerous in combination with {confi
 (howto-security-harden-isolate)=
 ### Isolate containers
 
-If a set of containers do not need to share data with each other, enable the instance option {config:option}`instance-security:security.idmap.isolated` on each one. This configures them to use unique UID/GID maps, preventing potential {abbr}`DoS (Denial of Service)` attacks from one container to another. Only unprivileged containers can use this option.
+If a set of containers do not need to share data with each other, enable the instance option {config:option}`instance-security:security.idmap.isolated` on each one. This configures them to use unique UID/GID maps, preventing potential DoS attacks from one container to another. Only unprivileged containers can use this option.
 
 (howto-security-profiles)=
 ### Use profiles

--- a/doc/reference/devices_tpm.md
+++ b/doc/reference/devices_tpm.md
@@ -10,7 +10,7 @@ The `tpm` device type is supported for both containers and VMs.
 It supports hotplugging only for containers, not for VMs.
 ```
 
-TPM devices enable access to a {abbr}`TPM (Trusted Platform Module)` emulator.
+{abbr}`TPM` (Trusted Platform Module) devices enable access to a TPM emulator.
 
 TPM devices can be used to validate the boot process and ensure that no steps in the boot chain have been tampered with, and they can securely generate and store encryption keys.
 

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -30,7 +30,7 @@ This method prevents conflicting leases when copying an instance, and thus makes
 
 If you're using IPv6 for your bridge network, you should use a prefix size of 64.
 
-Larger subnets (i.e., using a prefix smaller than 64) should work properly too, but they aren't typically that useful for {abbr}`SLAAC (Stateless Address Auto-configuration)`.
+Larger subnets (i.e., using a prefix smaller than 64) should work properly too, but they aren't typically that useful for {abbr}`SLAAC` (Stateless Address Auto-configuration).
 
 Smaller subnets are in theory possible (when using stateful DHCPv6 for IPv6 allocation), but they aren't properly supported by `dnsmasq` and might cause problems.
 If you must create a smaller subnet, use static allocation or another standalone router advertisement daemon.

--- a/doc/reference/network_macvlan.md
+++ b/doc/reference/network_macvlan.md
@@ -2,7 +2,7 @@
 # Macvlan network
 
 <!-- Include start macvlan intro -->
-Macvlan is a virtual {abbr}`LAN (Local Area Network)` that you can use if you want to assign several IP addresses to the same network interface, basically splitting up the network interface into several sub-interfaces with their own IP addresses.
+Macvlan is a virtual {abbr}`LAN` (Local Area Network) that you can use if you want to assign several IP addresses to the same network interface, basically splitting up the network interface into several sub-interfaces with their own IP addresses.
 You can then assign IP addresses based on the randomly generated MAC addresses.
 <!-- Include end macvlan intro -->
 

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -6,12 +6,12 @@ discourse: lxc:[OVN&#32;high&#32;availability&#32;cluster&#32;tutorial](11033)
 # OVN network
 
 <!-- Include start OVN intro -->
-{abbr}`OVN (Open Virtual Network)` is a software-defined networking system that supports virtual network abstraction.
+{abbr}`OVN` (Open Virtual Network) is a software-defined networking system that supports virtual network abstraction.
 You can use it to build your own private cloud.
 See [`www.ovn.org`](https://www.ovn.org/) for more information.
 <!-- Include end OVN intro -->
 
-The `ovn` network type allows to create logical networks using the OVN {abbr}`SDN (software-defined networking)`.
+The `ovn` network type allows to create logical networks using the OVN {abbr}`SDN` (software-defined networking).
 This kind of network can be useful for labs and multi-tenant environments where the same logical subnets are used in multiple discrete networks.
 
 A LXD OVN network can be connected to an existing managed {ref}`network-bridge` or {ref}`network-physical` to gain access to the wider network.

--- a/doc/reference/network_sriov.md
+++ b/doc/reference/network_sriov.md
@@ -2,7 +2,7 @@
 # SR-IOV network
 
 <!-- Include start SR-IOV intro -->
-{abbr}`SR-IOV (Single root I/O virtualization)` is a hardware standard that allows a single network card port to appear as several virtual network interfaces in a virtualized environment.
+{abbr}`SR-IOV` (Single root I/O virtualization) is a hardware standard that allows a single network card port to appear as several virtual network interfaces in a virtualized environment.
 <!-- Include end SR-IOV intro -->
 
 The `sriov` network type allows to specify presets to use when connecting instances to a parent interface.

--- a/doc/reference/storage_alletra.md
+++ b/doc/reference/storage_alletra.md
@@ -3,7 +3,7 @@
 
 [HPE Alletra](https://www.hpe.com/emea_europe/en/hpe-alletra.html) is a storage solution. It offers the consumption of redundant block storage across the network.
 
-LXD supports connecting to HPE Alletra storage through {abbr}`NVMe/TCP (Non-Volatile Memory Express over Transmission Control Protocol)`.
+LXD supports connecting to HPE Alletra storage through {abbr}`NVMe/TCP` (Non-Volatile Memory Express over Transmission Control Protocol).
 In addition, HPE Alletra offers copy-on-write snapshots, thin provisioning, and other features.
 
 Using HPE Alletra with LXD requires a HPE Alletra WSAPI version `1`. Additionally, ensure that the required kernel modules for the selected protocol are installed on your host system.
@@ -36,7 +36,7 @@ On the other hand, using remote storage has significant advantages in a cluster 
 
 When creating a new storage pool using the `alletra` driver, LXD automatically discovers the array's qualified name and target address.
 Upon successful discovery, LXD attaches all volumes that are connected to the HPE Alletra host that is associated with a specific LXD server.
-HPE Alletra hosts and volume connections ({abbr}`vLUNs (virtual Logical Unit Numbers)`) are fully managed by LXD.
+HPE Alletra hosts and volume connections ({abbr}`vLUNs` (virtual Logical Unit Numbers)) are fully managed by LXD.
 
 Volume snapshots are also supported by HPE Alletra.
 When a volume with at least one snapshot is copied, LXD sequentially creates snapshots on the destination volume from snapshots on the source volume.

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -5,7 +5,7 @@
 :title: Btrfs storage and LXD
 ```
 
-{abbr}`Btrfs (B-tree file system)` is a local file system based on the {abbr}`COW (copy-on-write)` principle.
+{abbr}`Btrfs` (B-tree file system) is a local file system based on the {abbr}`COW` (copy-on-write) principle.
 COW means that data is stored to a different block after it has been modified instead of overwriting the existing data, reducing the risk of data corruption.
 Unlike other file systems, Btrfs is extent-based, which means that it stores data in contiguous areas of memory.
 

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -10,7 +10,7 @@ discourse: lxc:[Introducing&#32;MicroCeph](15457)
 ```
 
 <!-- Include start Ceph intro -->
-[Ceph](https://ceph.io/en/) is an open-source storage platform that stores its data in a storage cluster based on {abbr}`RADOS (Reliable Autonomic Distributed Object Store)`.
+[Ceph](https://ceph.io/en/) is an open-source storage platform that stores its data in a storage cluster based on {abbr}`RADOS` (Reliable Autonomic Distributed Object Store).
 It is highly scalable and, as a distributed system without a single point of failure, very reliable.
 
 ```{tip}
@@ -20,14 +20,14 @@ If you want to quickly set up a basic Ceph cluster, check out [MicroCeph](https:
 Ceph provides different components for block storage and for file systems.
 <!-- Include end Ceph intro -->
 
-Ceph {abbr}`RBD (RADOS Block Device)` is Ceph's block storage component that distributes data and workload across the Ceph cluster.
+Ceph {abbr}`RBD` (RADOS Block Device) is Ceph's block storage component that distributes data and workload across the Ceph cluster.
 It uses thin provisioning, which means that it is possible to over-commit resources.
 
 ## Terminology
 
 <!-- Include start Ceph terminology -->
 Ceph uses the term *object* for the data that it stores.
-The daemon that is responsible for storing and managing data is the *Ceph {abbr}`OSD (Object Storage Daemon)`*.
+The daemon that is responsible for storing and managing data is the *Ceph {abbr}`OSD` (Object Storage Daemon)*.
 Ceph's storage is divided into *pools*, which are logical partitions for storing objects.
 They are also referred to as *data pools*, *storage pools* or *OSD pools*.
 <!-- Include end Ceph terminology -->

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -15,7 +15,7 @@ discourse: lxc:[Introducing&#32;MicroCeph](15457)
     :end-before: <!-- Include end Ceph intro -->
 ```
 
-{abbr}`CephFS (Ceph File System)` is Ceph's file system component that provides a robust, fully-featured POSIX-compliant distributed file system.
+{abbr}`CephFS` (Ceph File System) is Ceph's file system component that provides a robust, fully-featured POSIX-compliant distributed file system.
 Internally, it maps files to Ceph objects and stores file metadata (for example, file ownership, directory paths, access permissions) in a separate data pool.
 
 ## Terminology

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -5,7 +5,7 @@
 :title: LVM storage and LXD
 ```
 
-{abbr}`LVM (Logical Volume Manager)` is a storage management framework rather than a file system.
+{abbr}`LVM` (Logical Volume Manager) is a storage management framework rather than a file system.
 It is used to manage physical storage devices, allowing you to create a number of logical storage volumes that use and virtualize the underlying physical storage devices.
 
 Note that it is possible to over-commit the physical storage in the process, to allow flexibility for scenarios where not all available storage is in use at the same time.

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -17,14 +17,14 @@ LXD supports both PowerFlex 4 and 5.
 
 ## Terminology
 
-PowerFlex groups various so-called {abbr}`SDS (storage data servers)` under logical groups within a protection domain.
+PowerFlex groups various so-called {abbr}`SDS` (storage data servers) under logical groups within a protection domain.
 Those SDS are the hosts that contribute storage capacity to the PowerFlex cluster.
 A *protection domain* contains storage pools, which represent a set of physical storage devices from different SDS.
 LXD creates its volumes in those storage pools.
 
 You can take a snapshot of any volume in PowerFlex, which will create an independent copy of the parent volume.
 PowerFlex volumes get added as a drive to the respective LXD host the volume got mapped to.
-In case of NVMe/TCP, the LXD host connects to one or multiple NVMe {abbr}`SDT (storage data targets)` provided by PowerFlex.
+In case of NVMe/TCP, the LXD host connects to one or multiple NVMe {abbr}`SDT` (storage data targets) provided by PowerFlex.
 Those SDT run as components on the PowerFlex storage layer.
 In case of SDC, the LXD hosts don't set up any connection by themselves.
 Instead they depend on the SDC to make the volumes available on the system for consumption.

--- a/doc/reference/storage_pure.md
+++ b/doc/reference/storage_pure.md
@@ -3,7 +3,7 @@
 
 [Pure Storage](https://www.everpuredata.com/) is a software-defined storage solution. It offers the consumption of redundant block storage across the network.
 
-LXD supports connecting to Pure Storage storage clusters through two protocols: either {abbr}`iSCSI (Internet Small Computer Systems Interface)` or {abbr}`NVMe/TCP (Non-Volatile Memory Express over Transmission Control Protocol)`.
+LXD supports connecting to Pure Storage storage clusters through two protocols: either {abbr}`iSCSI` (Internet Small Computer Systems Interface) or {abbr}`NVMe/TCP` (Non-Volatile Memory Express over Transmission Control Protocol).
 In addition, Pure Storage offers copy-on-write snapshots, thin provisioning, and other features.
 
 To use Pure Storage with LXD requires a Pure Storage API version of at least `2.21`, corresponding to a minimum Purity//FA version of `6.4.2`.

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -9,7 +9,7 @@ discourse: lxc:[ZFS&#32;block&#32;mode](15872)
 :title: ZFS storage and LXD
 ```
 
-{abbr}`ZFS (Zettabyte file system)` combines both physical volume management and a file system.
+{abbr}`ZFS` (Zettabyte file system) combines both physical volume management and a file system.
 A ZFS installation can span across a series of storage devices and is very scalable, allowing you to add disks to expand the available space in the storage pool immediately.
 
 ZFS is a block-based file system that protects against data corruption by using checksums to verify, confirm and correct every operation.

--- a/doc/reference/uefi_variables.md
+++ b/doc/reference/uefi_variables.md
@@ -4,7 +4,7 @@ discourse: "[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](423
 
 # UEFI variables for VMs
 
-{abbr}`UEFI (Unified Extensible Firmware Interface)` variables store and represent configuration settings of the UEFI firmware.
+{abbr}`UEFI` (Unified Extensible Firmware Interface) variables store and represent configuration settings of the UEFI firmware.
 See [UEFI](https://en.wikipedia.org/wiki/UEFI) for more information.
 
 You can see a list of UEFI variables on your system by running `ls -l /sys/firmware/efi/efivars/`.

--- a/doc/reference/vm_live_migration_internals.md
+++ b/doc/reference/vm_live_migration_internals.md
@@ -5,7 +5,7 @@ discourse: "[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)
 (vm-live-migration-internals)=
 # VM live migration implementation
 
-{ref}`live-migration` in LXD is achieved by streaming instance state from a source {abbr}`QEMU (Quick Emulator)` to a target QEMU. VM live migration is supported for all storage pool types.
+{ref}`live-migration` in LXD is achieved by streaming instance state from a source {abbr}`QEMU` (Quick Emulator) to a target QEMU. VM live migration is supported for all storage pool types.
 
 API extension: `migration_vm_live`
 


### PR DESCRIPTION
Move abbreviation expansions out of abbr roles so they remain visible in prose. Define abbreviations at their first prose occurrence and avoid repeating later expansions, Keep headings concise and handle linked, reversed, and repeated abbreviation cases without changing their intended meaning.

Headings, front matter, directive metadata, and comments were not treated as explanatory prose. When the first prose occurrence appeared inside link text, the abbreviation and its visible expansion were kept within that link. Reversed constructions such as “Virtual machines (VMs)” were corrected so the role applies to the abbreviation itself.

Closes canonical/open-documentation-academy#372.

Testing
make doc
make doc-lint
make doc-woke
make doc-spelling
git diff --check

make doc-linkcheck was also run. Its only failure was a timeout from the pre-existing HPE Alletra URL in doc/reference/storage_alletra.md; this change does not modify that URL.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
