### PR TITLE
test/snap: make individual scripts directly callable

### DIFF
--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/testflinger/**'
       - 'test/includes/snap-helpers.sh'
       - 'test/includes/snap.sh'
-      - 'test/snap.sh'
+      - 'test/local-snap.sh'
       - 'test/snap/**'
   schedule:
     - cron: '38 6 */5 * *'

--- a/.github/workflows/testflinger/README.md
+++ b/.github/workflows/testflinger/README.md
@@ -4,8 +4,8 @@ This directory contains the scripts used for GPU testing (NVIDIA and AMD) via Gi
 The tests run on devices within Canonical's test farm.
 
 The NVIDIA and NVIDIA MIG templates clone the LXD revision that triggered the
-workflow and run the relevant script through `test/snap.sh`. The Ubuntu Core
-and AMD CDI templates test the selected store snap directly.
+workflow and run the relevant script under `test/snap/` directly. The Ubuntu
+Core and AMD CDI templates test the selected store snap directly.
 
 ## Run locally
 Running the tests locally is only possible if your machine has access to the Testflinger server.

--- a/.github/workflows/testflinger/nvidia-gpu-job.yml
+++ b/.github/workflows/testflinger/nvidia-gpu-job.yml
@@ -83,4 +83,4 @@ test_data:
     _run nvidia-smi
 
     _run git clone --depth=1 https://github.com/canonical/lxd.git
-    _run "cd lxd && git fetch --depth=1 origin $LXD_REF && git checkout --detach FETCH_HEAD && sudo -E ./test/snap.sh test/snap/gpu-container $SNAP_CHANNEL < /dev/null"
+    _run 'cd lxd && git fetch --depth=1 origin "${LXD_REF}" && git checkout --detach FETCH_HEAD && sudo -E ./test/snap/gpu-container "${SNAP_CHANNEL}" < /dev/null'

--- a/.github/workflows/testflinger/nvidia-mig-job.yml
+++ b/.github/workflows/testflinger/nvidia-mig-job.yml
@@ -90,4 +90,4 @@ test_data:
     wait-for-ssh --allow-degraded
 
     _run git clone --depth=1 https://github.com/canonical/lxd.git
-    _run "cd lxd && git fetch --depth=1 origin $LXD_REF && git checkout --detach FETCH_HEAD && sudo -E ./test/snap.sh test/snap/gpu-mig $SNAP_CHANNEL < /dev/null"
+    _run 'cd lxd && git fetch --depth=1 origin "${LXD_REF}" && git checkout --detach FETCH_HEAD && sudo -E ./test/snap/gpu-mig "${SNAP_CHANNEL}" < /dev/null'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -739,7 +739,7 @@ jobs:
           # It is appended (not prepended) so the snap's lxc/lxd wrappers keep precedence; the snap
           # lxc/lxd/lxd-agent coverage is collected separately via the sideloaded *.debug binaries.
           export PATH="${PATH}:/home/runner/go/bin"
-          sudo --preserve-env="${SUDO_PRESERVE_ENV}" ./test/snap.sh "test/snap/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
+          sudo --preserve-env="${SUDO_PRESERVE_ENV}" "./test/snap/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
 
           # Cleanly stopping `snap.lxd.daemon.service` will ensure that any Go
           # coverage data is flushed to disk and can be collected by the upload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ client/         Go client library
 shared/         Code shared across components
 test/
   suites/       Integration test suites (bash)
-  snap/         Snap integration test scripts
-  snap.sh       Snap integration test runner
+  snap/         Snap integration test scripts (run directly)
+  local-snap.sh Snap integration test runner (sourced by test/snap/* scripts)
   lint/         Lint scripts
   includes/
     snap-helpers.sh  Shared snap integration test helpers
@@ -102,7 +102,7 @@ MicroOVN. See `test/README.md` for full setup instructions.
 sudo ./test/main.sh <suite-name>
 
 # Run a snap integration suite
-sudo -E ./test/snap.sh test/snap/cgroup latest/edge
+sudo -E ./test/snap/cgroup latest/edge
 ```
 
 ## Key conventions

--- a/test/README.md
+++ b/test/README.md
@@ -18,11 +18,11 @@ sudo -E ./main.sh
 
 ## Snap integration tests
 
-Snap integration test scripts are in `test/snap/`. Run them from the repository
-root with `test/snap.sh`:
+Snap integration test scripts are in `test/snap/` and can be run directly
+from the repository root:
 
 ```sh
-sudo -E ./test/snap.sh test/snap/cgroup latest/edge
+sudo -E ./test/snap/cgroup latest/edge
 ```
 
 The snap channel is optional and defaults to `latest/edge`. The runner installs
@@ -30,14 +30,14 @@ the selected store snap by default. To remove the installed LXD snap before a
 test run, which is useful for repeated local testing, set `PURGE_LXD`:
 
 ```sh
-sudo -E env PURGE_LXD=1 ./test/snap.sh test/snap/interception latest/edge
+sudo -E env PURGE_LXD=1 ./test/snap/interception latest/edge
 ```
 
 To reuse an installed LXD snap without installing or refreshing it, set
 `KEEP_LXD`:
 
 ```sh
-sudo -E env KEEP_LXD=1 ./test/snap.sh test/snap/interception latest/edge
+sudo -E env KEEP_LXD=1 ./test/snap/interception latest/edge
 ```
 
 ### Test a source build
@@ -47,23 +47,23 @@ enable sideloading:
 
 ```sh
 make
-sudo -E env LXD_SNAP_SIDELOAD=1 ./test/snap.sh test/snap/interception latest/edge
+sudo -E env LXD_SNAP_SIDELOAD=1 ./test/snap/interception latest/edge
 ```
 
 Set `LXD_SNAP_BINARY_DIR` to use binaries from a directory other than
 `$(go env GOPATH)/bin`:
 
 ```sh
-sudo -E env LXD_SNAP_SIDELOAD=1 LXD_SNAP_BINARY_DIR=/path/to/bin ./test/snap.sh test/snap/interception latest/edge
+sudo -E env LXD_SNAP_SIDELOAD=1 LXD_SNAP_BINARY_DIR=/path/to/bin ./test/snap/interception latest/edge
 ```
 
 To sideload individual binaries while testing an installed store snap, set the
 corresponding path:
 
 ```sh
-sudo -E env LXD_SIDELOAD_PATH=/path/to/lxd ./test/snap.sh test/snap/interception latest/edge
-sudo -E env LXC_SIDELOAD_PATH=/path/to/lxc ./test/snap.sh test/snap/interception latest/edge
-sudo -E env LXD_AGENT_SIDELOAD_PATH=/path/to/lxd-agent ./test/snap.sh test/snap/vm latest/edge
+sudo -E env LXD_SIDELOAD_PATH=/path/to/lxd ./test/snap/interception latest/edge
+sudo -E env LXC_SIDELOAD_PATH=/path/to/lxc ./test/snap/interception latest/edge
+sudo -E env LXD_AGENT_SIDELOAD_PATH=/path/to/lxd-agent ./test/snap/vm latest/edge
 ```
 
 ### Test a local snap
@@ -71,14 +71,14 @@ sudo -E env LXD_AGENT_SIDELOAD_PATH=/path/to/lxd-agent ./test/snap.sh test/snap/
 To test a locally built snap, set `LXD_SNAP_PATH`:
 
 ```sh
-sudo -E env LXD_SNAP_PATH=/path/to/lxd_0+git_amd64.snap ./test/snap.sh test/snap/interception latest/edge
+sudo -E env LXD_SNAP_PATH=/path/to/lxd_0+git_amd64.snap ./test/snap/interception latest/edge
 ```
 
 To use the system's ZFS tools instead of the tools bundled in the LXD snap, set
 `LXD_ZFS_EXTERNAL`:
 
 ```sh
-sudo -E env LXD_ZFS_EXTERNAL=1 ./test/snap.sh test/snap/interception latest/edge
+sudo -E env LXD_ZFS_EXTERNAL=1 ./test/snap/interception latest/edge
 ```
 
 ### Test OVN
@@ -87,10 +87,10 @@ The `network-ovn` suite can use the host's OVN packages or a chosen MicroOVN
 snap channel:
 
 ```sh
-sudo -E env OVN_SOURCE=deb PURGE_LXD=1 ./test/snap.sh test/snap/network-ovn latest/edge
-sudo -E env OVN_SOURCE=22.03/edge PURGE_LXD=1 ./test/snap.sh test/snap/network-ovn latest/edge
-sudo -E env OVN_SOURCE=24.03/edge PURGE_LXD=1 ./test/snap.sh test/snap/network-ovn latest/edge
-sudo -E env PURGE_LXD=1 ./test/snap.sh test/snap/network-ovn latest/edge
+sudo -E env OVN_SOURCE=deb PURGE_LXD=1 ./test/snap/network-ovn latest/edge
+sudo -E env OVN_SOURCE=22.03/edge PURGE_LXD=1 ./test/snap/network-ovn latest/edge
+sudo -E env OVN_SOURCE=24.03/edge PURGE_LXD=1 ./test/snap/network-ovn latest/edge
+sudo -E env PURGE_LXD=1 ./test/snap/network-ovn latest/edge
 ```
 
 The test host must have snapd installed and the command must run as root.

--- a/test/local-snap.sh
+++ b/test/local-snap.sh
@@ -1,49 +1,45 @@
 #!/bin/bash
+
+# This script is meant to be sourced by the test scripts under test/snap/,
+# not executed directly.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    echo "This script is not meant to be run directly." >&2
+    echo "Run a test script under test/snap/ instead, e.g.: sudo -E ./test/snap/cgroup" >&2
+    exit 1
+fi
+
+# Do nothing when the test environment is already set up: the inner wrapper
+# below re-sources the test script after setup.
+if [ -n "${LXD_SNAP_TEST_SETUP:-}" ]; then
+    return 0
+fi
+
+# The test script sourcing this file must itself be executed directly, not
+# sourced: a directly executed script has BASH_SOURCE[0] == $0.
+if [ "${BASH_SOURCE[1]:-}" != "${0}" ]; then
+    echo "Snap test scripts must be executed directly, not sourced." >&2
+    echo "E.g.: sudo -E ./test/snap/cgroup" >&2
+    return 1
+fi
+
+# Set shell options only after the guards above so that an accidentally
+# sourcing shell is left untouched.
 set -euo pipefail
 
-usage() {
-    cat << EOF
-Usage: sudo -E ./test/snap.sh test/snap/<suite> [snap-channel] [suite-arguments...]
-
-Run an LXD snap integration test. Set LXD_SNAP_SIDELOAD=1 to sideload binaries
-from LXD_SNAP_BINARY_DIR or \$(go env GOPATH)/bin.
-EOF
-}
-
-if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
-    usage
-    exit 0
-fi
-
-if [ "${EUID}" -ne 0 ]; then
-    echo "This script must be run as root." >&2
-    exit 1
-fi
-
-test_path="${1:-}"
-if [ -z "${test_path}" ]; then
-    usage >&2
-    exit 1
-fi
-
-case "${test_path}" in
-    test/snap/*)
-        ;;
-    *)
-        echo "Test path must be below test/snap/." >&2
-        exit 1
-        ;;
-esac
+# Identify the calling test script.
+test_script="$(realpath "${BASH_SOURCE[1]}")"
+test_name="$(basename "${test_script}")"
 
 script_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 repo_root="$(dirname "${script_dir}")"
 test_dir="$(realpath "${repo_root}/test/snap")"
-test_script="$(realpath -e "${repo_root}/${test_path}")"
+
+# Ensure the calling script is actually under test/snap/.
 case "${test_script}" in
     "${test_dir}"/*)
         ;;
     *)
-        echo "Test path must be below test/snap/." >&2
+        echo "Test script must be below test/snap/." >&2
         exit 1
         ;;
 esac
@@ -53,13 +49,17 @@ if ! [ -f "${test_script}" ]; then
     exit 1
 fi
 
-lxd_snap_channel="${2:-${LXD_SNAP_CHANNEL:-latest/edge}}"
-if [ "${#}" -gt 1 ]; then
-    shift 2
-else
+if [ "${EUID}" -ne 0 ]; then
+    echo "This script must be run as root." >&2
+    exit 1
+fi
+
+lxd_snap_channel="${1:-${LXD_SNAP_CHANNEL:-latest/edge}}"
+if [ "${#}" -gt 0 ]; then
     shift
 fi
 export LXD_SNAP_CHANNEL="${lxd_snap_channel}"
+export LXD_SNAP_TEST_SETUP=1
 
 # Wait for cloud-init to finish preparing the local VM environment.
 if command -v cloud-init > /dev/null && systemd-detect-virt --quiet --vm; then
@@ -89,8 +89,7 @@ echo '|/bin/sh -c $@ -- eval exec gzip --fast > /var/crash/%e.%p.gz' > /proc/sys
 . "${script_dir}/includes/coverage.sh"
 setup_gocoverdir
 
-test_name="$(basename "${test_script}")"
-
+# shellcheck disable=SC2317,SC2329 # Invoked via trap; false positive caused by the sourced-execution guard.
 cleanup() {
     local status=$?
 
@@ -106,6 +105,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "==> Running ${test_name} against ${lxd_snap_channel}" >&2
+status=0
 bash -euo pipefail -c '
     . "$1"
     . "$2"
@@ -117,4 +117,9 @@ bash -euo pipefail -c '
     test_script="$3"
     shift 3
     . "${test_script}" "$@"
-' bash "${repo_root}/test/includes/snap.sh" "${repo_root}/test/includes/snap-helpers.sh" "${test_script}" "${@}"
+' bash "${repo_root}/test/includes/snap.sh" "${repo_root}/test/includes/snap-helpers.sh" "${test_script}" "${@}" || status=$?
+
+# This script is sourced by the test script: exit here so the test script
+# body does not run again in the calling shell. The EXIT trap above handles
+# cleanup.
+exit "${status}"

--- a/test/overview.md
+++ b/test/overview.md
@@ -114,7 +114,7 @@ graph TD
 The **`snap-tests`** job validates LXD's behavior as a snap package across the
 configured Ubuntu releases.
 
-* **Test execution**: Runs the executable scripts in `test/snap/` through `test/snap.sh`.
+* **Test execution**: Runs the executable scripts in `test/snap/` directly (each script sources `test/local-snap.sh` for environment setup).
 * **LXD binary integration**: Sideloads the binaries built during the current run into the selected LXD snap, ensuring the tests exercise the proposed code.
 * **Infrastructure preparation**: Dynamically configures **MicroCeph** and **MicroOVN** to provide clustered storage and networking services needed for the snap-based integration tests.
 * **Matrix Dimensions**:
@@ -150,7 +150,7 @@ graph TD
         InfraCheck -- No --> SetupOVN[Setup MicroOVN]
         SetupCeph --> SetupOVN
 
-        SetupOVN --> ExecTest[Execute test/snap.sh test/snap/matrix.test]
+        SetupOVN --> ExecTest[Execute test/snap/matrix.test]
 
         ExecTest --> Uploads[Upload reports, crash dumps, & coverage data]
     end

--- a/test/snap/bgp
+++ b/test/snap/bgp
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 shopt -s inherit_errexit
 

--- a/test/snap/cgroup
+++ b/test/snap/cgroup
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Setup swap if none exist

--- a/test/snap/cloud-init
+++ b/test/snap/cloud-init
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install LXD

--- a/test/snap/cluster
+++ b/test/snap/cluster
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 shopt -s inherit_errexit
 

--- a/test/snap/container
+++ b/test/snap/container
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Install LXD

--- a/test/snap/container-copy
+++ b/test/snap/container-copy
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Tests for snap-specific regressions when rsyncing a container whose storage pool is mounted in the snap confinement.

--- a/test/snap/container-nesting
+++ b/test/snap/container-nesting
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install and setup LXD.

--- a/test/snap/conversion
+++ b/test/snap/conversion
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Source helper functions.

--- a/test/snap/cpu-vm
+++ b/test/snap/cpu-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 architecture="$(uname -m)"

--- a/test/snap/csi
+++ b/test/snap/csi
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Kubernetes cluster name used as a prefix for LXD and k8s resources.

--- a/test/snap/devlxd
+++ b/test/snap/devlxd
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install dependencies

--- a/test/snap/docker
+++ b/test/snap/docker
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install LXD

--- a/test/snap/efi-vm
+++ b/test/snap/efi-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 architecture="$(uname -m)"

--- a/test/snap/gpu-container
+++ b/test/snap/gpu-container
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: rockman

--- a/test/snap/gpu-mig
+++ b/test/snap/gpu-mig
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: torchtusk

--- a/test/snap/interception
+++ b/test/snap/interception
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Install dependencies

--- a/test/snap/lxd-consumers
+++ b/test/snap/lxd-consumers
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Integration test verifying that Canonical products relying on LXD keep working

--- a/test/snap/lxd-installer
+++ b/test/snap/lxd-installer
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 if [[ "${LXD_SNAP_CHANNEL}" =~ ^4\.0/ ]]; then

--- a/test/snap/lxd-user
+++ b/test/snap/lxd-user
@@ -25,7 +25,9 @@ lxc_user project list -f csv | grep '^user-5000.*,"User restricted project for "
 
 # Try to gracefully stop lxd-user daemon which allows coverage data to be
 # saved if needed.
-pkill -x lxd-user || pkill -x lxd-user.debug || true
+# Scope by user: this script's own process is also named "lxd-user" when
+# executed directly, and it runs as root so it must not be matched.
+pkill -x -u testuser lxd-user || pkill -x -u testuser lxd-user.debug || true
 
 # End the user session
 loginctl terminate-user testuser

--- a/test/snap/lxd-user
+++ b/test/snap/lxd-user
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 lxc_user() {

--- a/test/snap/network
+++ b/test/snap/network
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: luma

--- a/test/snap/network-bridge-firewall
+++ b/test/snap/network-bridge-firewall
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Install dependencies

--- a/test/snap/network-ovn
+++ b/test/snap/network-ovn
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 shopt -s inherit_errexit
 

--- a/test/snap/network-routed
+++ b/test/snap/network-routed
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install dependencies

--- a/test/snap/network-sriov
+++ b/test/snap/network-sriov
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: luma

--- a/test/snap/pylxd
+++ b/test/snap/pylxd
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Install LXD

--- a/test/snap/qemu-external-vm
+++ b/test/snap/qemu-external-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 architecture="$(uname -m)"

--- a/test/snap/snapd
+++ b/test/snap/snapd
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install lxd without starting daemon

--- a/test/snap/storage-buckets
+++ b/test/snap/storage-buckets
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install LXD

--- a/test/snap/storage-disks-vm
+++ b/test/snap/storage-disks-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eu
 
 # Install LXD

--- a/test/snap/storage-metadata
+++ b/test/snap/storage-metadata
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Checks the given backup file contents for format version 1.

--- a/test/snap/storage-vm
+++ b/test/snap/storage-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: hardhat

--- a/test/snap/storage-volumes-vm
+++ b/test/snap/storage-volumes-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install dependencies

--- a/test/snap/tpm-vm
+++ b/test/snap/tpm-vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install LXD

--- a/test/snap/ui
+++ b/test/snap/ui
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 BROWSER="${1:-chromium}"

--- a/test/snap/vm
+++ b/test/snap/vm
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install LXD

--- a/test/snap/vm-migration
+++ b/test/snap/vm-migration
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # Install dependencies

--- a/test/snap/vm-nesting
+++ b/test/snap/vm-nesting
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Runtime-resolved path; intentionally not followed.
+. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../local-snap.sh" || return 1
 set -eux
 
 # testflinger_queue: ficet


### PR DESCRIPTION
Also rename `test/snap.sh` to avoid sharing the same prefix as test scripts to
ensures smooth tab completion.