### PR TITLE
Avoid microceph's `latest/edge` due to incompatibilies

### DIFF
--- a/.github/actions/download-snaps/action.yml
+++ b/.github/actions/download-snaps/action.yml
@@ -35,7 +35,9 @@ inputs:
     required: false
   microceph-channel:
     description: MicroCeph snap channel to seed the cache with
-    default: "latest/edge"
+    # XXX: avoid Ceph 20.2.4 due to new authentication for CVE-2025-30156 not compatible with the ceph-common version shipped in the LXD snap
+    # Revert to latest/edge once https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817 is fixed and propagated in the LXD snap
+    default: "tentacle/stable"
     required: false
   microovn-channel:
     description: MicroOVN snap channel to seed the cache with

--- a/.github/actions/download-snaps/action.yml
+++ b/.github/actions/download-snaps/action.yml
@@ -9,6 +9,38 @@ inputs:
   snap-cache-dir:
     description: Where to save the snap dependencies
     required: true
+  snapd-channel:
+    description: snapd snap channel to seed the cache with
+    default: "latest/beta"
+    required: false
+  core26-channel:
+    description: core26 snap channel to seed the cache with
+    default: "latest/candidate"
+    required: false
+  core24-channel:
+    description: core24 snap channel to seed the cache with
+    default: "latest/candidate"
+    required: false
+  core22-channel:
+    description: core22 snap channel to seed the cache with
+    default: "latest/candidate"
+    required: false
+  lxd-lts-channel:
+    description: LXD LTS snap channel to seed the cache with
+    default: "5.21/edge"
+    required: false
+  lxd-channel:
+    description: LXD snap channel to seed the cache with
+    default: "latest/edge"
+    required: false
+  microceph-channel:
+    description: MicroCeph snap channel to seed the cache with
+    default: "latest/edge"
+    required: false
+  microovn-channel:
+    description: MicroOVN snap channel to seed the cache with
+    default: "latest/edge"
+    required: false
 
 runs:
   using: composite
@@ -43,6 +75,14 @@ runs:
       if: ${{ steps.cache-snaps.outputs.cache-hit != 'true' }}
       env:
         SNAP_CACHE_DIR: ${{ inputs.snap-cache-dir }}
+        INPUTS_SNAPD_CHANNEL: ${{ inputs.snapd-channel }}
+        INPUTS_CORE26_CHANNEL: ${{ inputs.core26-channel }}
+        INPUTS_CORE24_CHANNEL: ${{ inputs.core24-channel }}
+        INPUTS_CORE22_CHANNEL: ${{ inputs.core22-channel }}
+        INPUTS_LXD_LTS_CHANNEL: ${{ inputs.lxd-lts-channel }}
+        INPUTS_LXD_CHANNEL: ${{ inputs.lxd-channel }}
+        INPUTS_MICROCEPH_CHANNEL: ${{ inputs.microceph-channel }}
+        INPUTS_MICROOVN_CHANNEL: ${{ inputs.microovn-channel }}
       shell: bash
       run: |
         set -eux
@@ -62,14 +102,14 @@ runs:
         . test/includes/snap.sh
 
         # Seed the snap dependencies cache
-        download_snap snapd "latest/beta"
-        download_snap core26 "latest/candidate"
-        download_snap core24 "latest/candidate"
-        download_snap core22 "latest/candidate"
-        download_snap lxd "5.21/edge"
-        download_snap lxd
-        download_snap microceph
-        download_snap microovn
+        download_snap snapd "${INPUTS_SNAPD_CHANNEL}"
+        download_snap core26 "${INPUTS_CORE26_CHANNEL}"
+        download_snap core24 "${INPUTS_CORE24_CHANNEL}"
+        download_snap core22 "${INPUTS_CORE22_CHANNEL}"
+        download_snap lxd "${INPUTS_LXD_LTS_CHANNEL}"
+        download_snap lxd "${INPUTS_LXD_CHANNEL}"
+        download_snap microceph "${INPUTS_MICROCEPH_CHANNEL}"
+        download_snap microovn "${INPUTS_MICROOVN_CHANNEL}"
 
     # Only save if there wasn't an exact cache hit, AND the code is running on the main repo (not an untrusted fork)
     - name: Save snaps cache

--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -4,7 +4,9 @@ description: Setup MicroCeph using loop device(s)
 inputs:
   microceph-channel:
     description: MicroCeph snap channel to install
-    default: "latest/edge"
+    # XXX: avoid Ceph 20.2.4 due to new authentication for CVE-2025-30156 not compatible with the ceph-common version shipped in the LXD snap
+    # Revert the default to latest/edge once https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817 is fixed and propagated in the LXD snap
+    default: "tentacle/stable"
     required: false
   osd-count:
     description: Number of OSDs to add to MicroCeph

--- a/.github/actions/setup-microceph/setup-microceph.sh
+++ b/.github/actions/setup-microceph/setup-microceph.sh
@@ -176,7 +176,9 @@ setup_microceph() {
     return 1
   fi
   local osd_count="${2:-1}"
-  local channel="${3:-latest/edge}"
+  # XXX: avoid Ceph 20.2.4 due to new authentication for CVE-2025-30156 not compatible with the ceph-common version shipped in the LXD snap
+  # Revert the default to latest/edge once https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817 is fixed and propagated in the LXD snap
+  local channel="${3:-tentacle/stable}"
 
   install_microceph "${channel}"
   configure_microceph "${disk}" "${osd_count}"

--- a/.github/actions/setup-microceph/setup-microceph.sh
+++ b/.github/actions/setup-microceph/setup-microceph.sh
@@ -10,6 +10,7 @@ install_microceph() {
       . test/includes/snap.sh
       install_snap snapd latest/beta
       install_snap core24 latest/candidate
+      install_snap core26 latest/candidate
       install_snap microceph "${channel}"
   else
     timeout 20m snap install microceph --channel="${channel}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,9 @@ env:
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed
   IMAGE_CACHE_DIR: "/home/runner/image-cache"
   SNAP_CACHE_DIR: "/home/runner/snap-cache"
+  # XXX: avoid Ceph 20.2.4 due to new authentication for CVE-2025-30156 not compatible with the ceph-common version shipped in the LXD snap
+  # Revert to latest/edge once https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817 is fixed and propagated in the LXD snap
+  MICROCEPH_SNAP_CHANNEL: "tentacle/stable"
 
 permissions:
   contents: read
@@ -241,6 +244,7 @@ jobs:
         with:
           prime-cache-only: true
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
 
       - name: Upload system test dependencies
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -350,6 +354,7 @@ jobs:
         uses: $/.github/actions/download-snaps
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
 
       - name: Download system test dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -368,6 +373,7 @@ jobs:
         if: ${{ contains(matrix.backends, 'ceph') || matrix.backends == 'all' }}
         uses: $/.github/actions/setup-microceph
         with:
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
           osd-count: 3
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -628,6 +634,7 @@ jobs:
         uses: $/.github/actions/download-snaps
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
 
       - name: Download system test dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -663,6 +670,7 @@ jobs:
         if: ${{ matrix.test == 'conversion' || matrix.test == 'storage-buckets' || matrix.test == 'storage-vm ceph' || matrix.test == 'storage-volumes-vm' }}
         uses: $/.github/actions/setup-microceph
         with:
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
           osd-count: 3
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
@@ -1142,6 +1150,8 @@ jobs:
 
       - name: Setup MicroCeph
         uses: $/.github/actions/setup-microceph
+        with:
+          microceph-channel: ${{ env.MICROCEPH_SNAP_CHANNEL }}
 
       - name: Setup MicroOVN
         uses: $/.github/actions/setup-microovn

--- a/test/includes/snap-helpers.sh
+++ b/test/includes/snap-helpers.sh
@@ -186,15 +186,18 @@ install_deps() (
     fi
 )
 
-# install_microceph: install MicroCeph snap.
+# install_microceph: install MicroCeph snap from the channel specified by
+# MICROCEPH_SNAP_CHANNEL. Defaults to tentacle/stable.
+# XXX: avoid Ceph 20.2.4 due to new authentication for CVE-2025-30156 not compatible with the ceph-common version shipped in the LXD snap
+# Revert the default to latest/edge once https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817 is fixed and propagated in the LXD snap
 install_microceph() (
     # Wait for snapd seeding
     waitSnapdSeed
 
     if snap list microceph 2>/dev/null; then
-        snap refresh microceph --channel="${MICROCEPH_SNAP_CHANNEL:-latest/edge}" --cohort=+
+        snap refresh microceph --channel="${MICROCEPH_SNAP_CHANNEL:-tentacle/stable}" --cohort=+
     else
-        snap install microceph --channel="${MICROCEPH_SNAP_CHANNEL:-latest/edge}" --cohort=+
+        snap install microceph --channel="${MICROCEPH_SNAP_CHANNEL:-tentacle/stable}" --cohort=+
     fi
 )
 


### PR DESCRIPTION
20.2.4 comes with a new authentication mechanism (addressing [CVE-2025-30156](https://docs.ceph.com/en/latest/security/CVE-2025-30156)) that not compatible with the `ceph-common` version shipped in the LXD snap.

This is only temporary as there is a [SRU ongoing](https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2166817) which will have provide newer `ceph-common` version to Ubuntu 26.04 which will allow shipping new tooling in the LXD snap.