### PR TITLE
Config with cluster UUID

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -274,7 +274,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	// If not authenticated, return now.
 	if !requestor.IsTrusted() {
-		srv.Config = s.GlobalConfig.DumpPublic()
+		srv.Config = s.GlobalConfig.DumpPublic(false)
 		return response.SyncResponseETag(true, srv, nil)
 	}
 
@@ -445,7 +445,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		fullSrv.Config = s.GlobalConfig.DumpPublic()
+		fullSrv.Config = s.GlobalConfig.DumpPublic(true)
 	} else {
 		daemonConfig, err := daemonConfigRender(s)
 		if err != nil {

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -281,7 +281,7 @@ func (c *Config) Dump() map[string]string {
 
 // DumpPublic returns a map of publicly visible configuration keys and values ready to add to the public (or non-admin)
 // API response.
-func (c *Config) DumpPublic() map[string]any {
+func (c *Config) DumpPublic(trusted bool) map[string]any {
 	conf := make(map[string]any, 4)
 	issuer, _, _, _, audience, _, deviceClientID := c.OIDCServer()
 	if issuer != "" && deviceClientID != "" {
@@ -295,6 +295,13 @@ func (c *Config) DumpPublic() map[string]any {
 	userMicrocloud := c.m.GetString("user.microcloud")
 	if userMicrocloud != "" {
 		conf["user.microcloud"] = userMicrocloud
+	}
+
+	if trusted {
+		clusterUUID := c.ClusterUUID()
+		if clusterUUID != "" {
+			conf["volatile.uuid"] = clusterUUID
+		}
 	}
 
 	// Return nil if no public configuration.

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -62,6 +62,28 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	}, config.Dump())
 }
 
+func TestConfig_DumpPublicUnauthenticated(t *testing.T) {
+	tx, cleanup := db.NewTestClusterTx(t)
+	defer cleanup()
+
+	config, err := clusterConfig.Load(context.Background(), tx)
+	require.NoError(t, err)
+
+	publicConfig := config.DumpPublic(false)
+	assert.NotContains(t, publicConfig, "volatile.uuid")
+}
+
+func TestConfig_DumpPublicAuthenticated(t *testing.T) {
+	tx, cleanup := db.NewTestClusterTx(t)
+	defer cleanup()
+
+	config, err := clusterConfig.Load(context.Background(), tx)
+	require.NoError(t, err)
+
+	publicConfig := config.DumpPublic(true)
+	assert.Equal(t, config.ClusterUUID(), publicConfig["volatile.uuid"])
+}
+
 // Offline threshold must be greater than the heartbeat interval.
 func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)


### PR DESCRIPTION
# Done
* add cluster uuid to `GET /1.0` response *only if* the user is authenticated.

```
lxc query /1.0 | jq .config
{
  //...
  "volatile.uuid": "019ffac4-7431-7ba8-87ac-8f2626dd6a32"
}
```