### PR TITLE
test/suites: Fix authorization test failure

### DIFF
--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -894,8 +894,12 @@ fine_grained_authorization() {
   # Check we are only able to view public configuration.
   # Here we explicitly a setting that contains an actual password.
   lxc config set loki.auth.password bar
-  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 2'
-  curl -k "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata | .config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 2'
+
+  # Authenticated user sees the clusters volatile.uuid plus public OIDC configuration.
+  lxc_remote query "${remote}:/1.0" | jq --exit-status '.config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 3'
+
+  # Untrusted caller only sees the public OIDC configuration.
+  curl -k "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata | .config."oidc.issuer" == "'"${oidc_issuer}"'" and .config."oidc.device.client.id" == "device" and (.config | length) == 2' # Untrusted caller does not see volatile.uuid, but sees public OIDC config.
 
   # Check we are not able to set any server config currently.
   ! lxc_remote config set "${remote}:" loki.auth.password bar2 || false


### PR DESCRIPTION
Fixes a valid test failure due to the volatile.uuid of a cluster being shown to authenticated users without can_edit on server (see #19031). This was an innocuous change and the failure was missed amongst other test flakiness.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
