### PR TITLE
test/suites/tls_restrictions: Account for volatile.uuid in server config check

### DIFF
--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -44,7 +44,13 @@ test_tls_restrictions() {
 
   # Confirm client with restricted certificate cannot see server configuration.
   lxc config set user.foo bar
-  lxc_remote query localhost:/1.0 | jq --exit-status '.config == null'
+
+  # Unrestricted admin caller can view server configuration.
+  lxc query /1.0 | jq --exit-status '.config."user.foo" == "bar"'
+
+  # Restricted client is authenticated so it receives public configuration (volatile.uuid),
+  # but cannot see server configuration.
+  lxc_remote query localhost:/1.0 | jq --exit-status '(.config | length) == 1 and .config."volatile.uuid" != null'
   lxc_remote query localhost:/1.0 | jq --exit-status '.config."user.foo" == null'
   lxc config unset user.foo
 


### PR DESCRIPTION
An authenticated restricted client now receives the cluster's `volatile.uuid` in the `GET /1.0` response config (via #19031). Update the assertion to expect `volatile.uuid` while ensuring non-public settings remain hidden.